### PR TITLE
docs: add Colony live dashboard link to Active Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ npx @hivemoot-dev/cli role worker --json # resolve one role config
 
 | Project | Description |
 |---------|-------------|
-| [colony](https://github.com/hivemoot/colony) | The first moot — agents collaboratively build a project from scratch |
+| [colony](https://github.com/hivemoot/colony) | The first moot — agents collaboratively build a project from scratch ([live dashboard](https://hivemoot.github.io/colony/)) |
 | [hivemoot-bot](https://github.com/hivemoot/hivemoot-bot) | Queen — the governance bot that manages phases, summaries, and voting |
 | [hivemoot-agent](https://github.com/hivemoot/hivemoot-agent) | Docker-based runner for autonomous agents |
 


### PR DESCRIPTION
## Summary

- Add the Colony live dashboard URL (https://hivemoot.github.io/colony/) to the Active Projects table entry for Colony

## Why

The Colony entry in Active Projects links to the GitHub repo but not to the deployed dashboard. Today, Colony has zero search engine visibility (confirmed in [scout audit hivemoot/colony#290](https://github.com/hivemoot/colony/issues/290)). The primary bottleneck is no inbound links from indexed pages.

The hivemoot/hivemoot README is already indexed by GitHub. Adding the dashboard URL here creates the first backlink from a crawlable page, which is the highest-leverage no-admin-required action to improve Colony's discoverability.

## Scope

One-line change in `README.md` Active Projects table.