### PR TITLE
cli: add command help usage examples

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -49,13 +49,13 @@ program
 
 Examples:
   $ hivemoot buzz
-    -> Show repo work summary (issues, PRs, notifications)
+    Show repo work summary (issues, PRs, notifications)
 
   $ hivemoot buzz --role scout
-    -> Get scout role instructions plus work summary
+    Get scout role instructions plus work summary
 
   $ hivemoot buzz --json
-    -> Output as JSON for scripts`,
+    Output as JSON for scripts`,
   )
   .action(buzzCommand);
 
@@ -70,10 +70,10 @@ program
 
 Examples:
   $ hivemoot roles
-    -> List all available roles and descriptions
+    List all available roles and descriptions
 
   $ hivemoot roles --json
-    -> Output role list as JSON`,
+    Output role list as JSON`,
   )
   .action(rolesCommand);
 
@@ -89,10 +89,10 @@ program
 
 Examples:
   $ hivemoot role scout
-    -> Print instructions for the scout role
+    Print instructions for the scout role
 
   $ hivemoot role engineer --json
-    -> Output a role definition as JSON`,
+    Output a role definition as JSON`,
   )
   .action(roleCommand);
 
@@ -115,13 +115,13 @@ program
 
 Examples:
   $ hivemoot watch --repo hivemoot/colony
-    -> Watch for mentions (polls every 5 minutes)
+    Watch for mentions (polls every 5 minutes)
 
   $ hivemoot watch --repo hivemoot/colony --once
-    -> Check mentions once and exit
+    Check mentions once and exit
 
   $ hivemoot watch --repo hivemoot/colony --interval 60
-    -> Watch with a 60-second polling interval`,
+    Watch with a 60-second polling interval`,
   )
   .action(watchCommand);
 
@@ -136,7 +136,7 @@ program
 
 Examples:
   $ hivemoot ack 22872795152:2026-02-15T20:35:59Z --state-file .hivemoot-watch.json
-    -> Mark a notification as processed in GitHub and local state`,
+    Mark a notification as processed in GitHub and local state`,
   )
   .action(ackCommand);
 


### PR DESCRIPTION
Fixes #10

Adds copy-paste examples to command help output for:
- `buzz`
- `roles`
- `role`
- `watch`
- `ack`

These examples reduce first-run friction by showing concrete invocation patterns directly in `--help` output.

## Example Output

### `buzz --help`
```
$ hivemoot buzz --help
Usage: hivemoot buzz [options]

Show repository status: issues, PRs, notifications

Options:
  --json                       Output as JSON
  --role <role>                Show role instructions in output
  --limit <n>                  Max items per section
  --fetch-limit <n>            Max issues/PRs to fetch from GitHub (default: 200)
  --repo <owner/repo>          Target repository (default: detect from git)
  -h, --help                   display help for command

Examples:
  $ hivemoot buzz
    Show repo work summary (issues, PRs, notifications)

  $ hivemoot buzz --role scout
    Get scout role instructions plus work summary

  $ hivemoot buzz --json
    Output as JSON for scripts
```

### `roles --help`
```
$ hivemoot roles --help
Usage: hivemoot roles [options]

List available roles from team config

Options:
  --json                       Output as JSON
  --repo <owner/repo>          Target repository (default: detect from git)
  -h, --help                   display help for command

Examples:
  $ hivemoot roles
    List all available roles and descriptions

  $ hivemoot roles --json
    Output role list as JSON
```

### `role --help`
```
$ hivemoot role --help
Usage: hivemoot role [options] <role>

Resolve a role to instructions from team config

Arguments:
  role                         Role to resolve (e.g. engineer, tech_lead)

Options:
  --json                       Output as JSON
  --repo <owner/repo>          Target repository (default: detect from git)
  -h, --help                   display help for command

Examples:
  $ hivemoot role scout
    Print instructions for the scout role

  $ hivemoot role engineer --json
    Output a role definition as JSON
```

### `watch --help`
```
$ hivemoot watch --help
Usage: hivemoot watch [options]

Watch for notifications and mentions

Options:
  --repo <owner/repo>          Target repository (default: detect from git)
  --interval <seconds>         Polling interval in seconds (default: 300)
  --once                       Check once and exit
  --state-file <path>          State file path (default: .hivemoot-watch.json)
  --reasons <list>             Notification reasons to watch (default: mention)
  -h, --help                   display help for command

Examples:
  $ hivemoot watch --repo hivemoot/colony
    Watch for mentions (polls every 5 minutes)

  $ hivemoot watch --repo hivemoot/colony --once
    Check mentions once and exit

  $ hivemoot watch --repo hivemoot/colony --interval 60
    Watch with a 60-second polling interval
```

### `ack --help`
```
$ hivemoot ack --help
Usage: hivemoot ack [options] <key>

Acknowledge a processed mention event (mark read + record in journal)

Arguments:
  key                          Composite key: threadId:updatedAt

Options:
  --state-file <path>          Path to the watch state file
  -h, --help                   display help for command

Examples:
  $ hivemoot ack 22872795152:2026-02-15T20:35:59Z --state-file .hivemoot-watch.json
    Mark a notification as processed in GitHub and local state
```

Validation run locally:
- `npm test` (464 tests passed)
- `npm run build`
- Manual checks of all --help outputs