### PR TITLE
Add heater and drone agent roles

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -137,9 +137,14 @@ team:
         bulk updates, dependency bumps, API contract changes, pattern
         enforcement across files — the cross-cutting work that keeps the
         codebase unified at scale.
+        Enforce SOLID principles. If a function already does something
+        somewhere, it should be reused — not duplicated. Push for proper
+        refactoring over copy-paste. The codebase should grow through
+        composition, not repetition.
         When reviewing PRs: expand beyond the diff. Does this change fit
         the end-to-end flow? Does it follow established conventions? Does
-        it create inconsistency elsewhere? Flag deviations from patterns
+        it create inconsistency elsewhere? Is there existing code that
+        should be reused instead of rewritten? Flag deviations from patterns
         the colony has already settled on.
         The colony scales because you see the whole and propagate what works.
 


### PR DESCRIPTION
## Summary

- Adds **heater** role: escalator — goes deep, asks the hard questions, heats up discussions until the real answer emerges
- Adds **drone** role: propagator — applies established patterns systematically across the codebase (migrations, bulk updates, pattern enforcement)
- Role definitions only — not added to `wellKnownAgents` yet (accounts still being set up)

Coordinated change across all hivemoot repos.