### PR TITLE
feat(cli): track and display COMMENTED review count

### DIFF
--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -78,6 +78,7 @@ export interface RepoRef {
 export interface ReviewSummary {
   approvals: number;
   changesRequested: number;
+  commented: number;
 }
 
 export interface SummaryItem {

--- a/cli/src/output/formatter.ts
+++ b/cli/src/output/formatter.ts
@@ -82,6 +82,7 @@ function formatMeta(item: SummaryItem, sectionType: SectionType, currentUser: st
     if (item.review) {
       const segments = [`${item.review.approvals} approved`];
       if (item.review.changesRequested > 0) segments.push(chalk.red(`${item.review.changesRequested} changes-requested`));
+      if (item.review.commented > 0) segments.push(chalk.dim(`${item.review.commented} commented`));
       parts.push(kv("review", segments.join(", ")));
     }
     if (item.yourReview) {

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -164,7 +164,7 @@ describe("buildSummary()", () => {
     expect(summary.addressFeedback).toHaveLength(1);
     expect(summary.addressFeedback[0].number).toBe(150);
     expect(summary.addressFeedback[0].status).toBe("changes-requested");
-    expect(summary.addressFeedback[0].review).toEqual({ approvals: 1, changesRequested: 1 });
+    expect(summary.addressFeedback[0].review).toEqual({ approvals: 1, changesRequested: 1, commented: 0 });
     expect(summary.reviewPRs).toHaveLength(0);
   });
 
@@ -518,7 +518,7 @@ describe("buildSummary()", () => {
     expect(item.status).toBe("approved");
     expect(item.checks).toBe("passing");
     expect(item.mergeable).toBe("clean");
-    expect(item.review).toEqual({ approvals: 1, changesRequested: 0 });
+    expect(item.review).toEqual({ approvals: 1, changesRequested: 0, commented: 0 });
   });
 
   it("populates null checks when no statusCheckRollup", () => {

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -15,6 +15,7 @@ import {
   mergeStatus,
   approvalCount,
   changesRequestedCount,
+  commentCount,
   timeAgo,
   reviewContext,
   latestCommitAge,
@@ -125,6 +126,7 @@ function classifyPR(
   const review = {
     approvals: approvalCount(pr),
     changesRequested,
+    commented: commentCount(pr),
   };
 
   if (pr.isDraft) {

--- a/cli/src/summary/utils.ts
+++ b/cli/src/summary/utils.ts
@@ -183,6 +183,15 @@ export function changesRequestedCount(pr: GitHubPR): number {
   return count;
 }
 
+/** Count unique commented reviews (latest review per author). */
+export function commentCount(pr: GitHubPR): number {
+  let count = 0;
+  for (const state of latestReviewByAuthor(pr).values()) {
+    if (state === "COMMENTED") count++;
+  }
+  return count;
+}
+
 // ── Review context ────────────────────────────────────────────────
 
 export interface ReviewContext {


### PR DESCRIPTION
Fixes #31

Adds commented count to ReviewSummary and displays it in PR listings. This makes non-blocking feedback visible alongside approvals and change requests.

## Changes

- Add commented field to ReviewSummary type in types.ts
- Add commentCount() utility function in utils.ts  
- Update builder.ts to populate commented count from PR reviews
- Update formatter.ts to display commented reviews (dimmed)
- Update builder tests to expect commented field

## Example Output

Before: review: 3 approved, 1 changes-requested
After:  review: 3 approved, 1 changes-requested, 2 commented

This makes it clear when people have reviewed but left non-blocking comments, which was previously invisible in aggregate counts.

## Validation

- npm test (464 tests passed)
- npm run typecheck (clean)
- npm run build (succeeds)