### PR TITLE
Add default team focus for hivemoot buzz (MVP)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.13",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.13",
+      "version": "0.1.18",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^12.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "type": "module",
   "bin": {

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -148,7 +148,7 @@ describe("buzzCommand", () => {
 
     expect(mockedFormatStatus).toHaveBeenCalledWith(testSummary, undefined);
     expect(mockedFormatBuzz).not.toHaveBeenCalled();
-    expect(mockedLoadTeamConfig).not.toHaveBeenCalled();
+    expect(mockedLoadTeamConfig).toHaveBeenCalledWith(testRepo);
     expect(console.log).toHaveBeenCalledWith("REPO SUMMARY — hivemoot/test\n...");
   });
 
@@ -160,7 +160,7 @@ describe("buzzCommand", () => {
     expect(mockedJsonStatus).toHaveBeenCalledWith(testSummary);
     expect(console.log).toHaveBeenCalledWith('{"repo":"hivemoot/test"}');
     expect(mockedJsonBuzz).not.toHaveBeenCalled();
-    expect(mockedLoadTeamConfig).not.toHaveBeenCalled();
+    expect(mockedLoadTeamConfig).toHaveBeenCalledWith(testRepo);
   });
 
   it("passes --limit to formatter", async () => {
@@ -303,7 +303,16 @@ describe("buzzCommand", () => {
 
     await buzzCommand({});
 
-    expect(mockedBuildSummary).toHaveBeenCalledWith(testRepo, [], [], "testuser", expect.any(Date), expect.any(Map), expect.any(Map));
+    expect(mockedBuildSummary).toHaveBeenCalledWith(
+      testRepo,
+      [],
+      [],
+      "testuser",
+      expect.any(Date),
+      expect.any(Map),
+      expect.any(Map),
+      undefined,
+    );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
   });
@@ -317,7 +326,16 @@ describe("buzzCommand", () => {
 
     await buzzCommand({});
 
-    expect(mockedBuildSummary).toHaveBeenCalledWith(testRepo, [], [], "testuser", expect.any(Date), expect.any(Map), expect.any(Map));
+    expect(mockedBuildSummary).toHaveBeenCalledWith(
+      testRepo,
+      [],
+      [],
+      "testuser",
+      expect.any(Date),
+      expect.any(Map),
+      expect.any(Map),
+      undefined,
+    );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
   });
@@ -331,7 +349,16 @@ describe("buzzCommand", () => {
 
     await buzzCommand({});
 
-    expect(mockedBuildSummary).toHaveBeenCalledWith(testRepo, [], [], "", expect.any(Date), expect.any(Map), expect.any(Map));
+    expect(mockedBuildSummary).toHaveBeenCalledWith(
+      testRepo,
+      [],
+      [],
+      "",
+      expect.any(Date),
+      expect.any(Map),
+      expect.any(Map),
+      undefined,
+    );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain(
       "Could not determine GitHub user (auth failed) — drive sections, competition counts, and author highlighting are unavailable.",
@@ -365,7 +392,16 @@ describe("buzzCommand", () => {
 
     await buzzCommand({});
 
-    expect(mockedBuildSummary).toHaveBeenCalledWith(testRepo, [], [], "testuser", expect.any(Date), expect.any(Map), expect.any(Map));
+    expect(mockedBuildSummary).toHaveBeenCalledWith(
+      testRepo,
+      [],
+      [],
+      "testuser",
+      expect.any(Date),
+      expect.any(Map),
+      expect.any(Map),
+      undefined,
+    );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain(
       "Could not fetch issues (boom) or pull requests (boom2) — showing limited summary.",
@@ -454,7 +490,14 @@ describe("buzzCommand", () => {
 
     // buildSummary should be called with the votes map and notification map
     expect(mockedBuildSummary).toHaveBeenCalledWith(
-      testRepo, [votingIssue], [], "testuser", expect.any(Date), voteMap, expect.any(Map),
+      testRepo,
+      [votingIssue],
+      [],
+      "testuser",
+      expect.any(Date),
+      voteMap,
+      expect.any(Map),
+      undefined,
     );
   });
 
@@ -505,6 +548,27 @@ describe("buzzCommand", () => {
     expect(mockedFetchNotifications).toHaveBeenCalledWith(testRepo);
   });
 
+  it("starts data fetches before team config resolves", async () => {
+    let resolveConfig!: (config: typeof testTeamConfig) => void;
+    const configPromise = new Promise<typeof testTeamConfig>((resolve) => {
+      resolveConfig = resolve;
+    });
+    mockedLoadTeamConfig.mockReturnValue(configPromise);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    const run = buzzCommand({});
+    await Promise.resolve();
+
+    expect(mockedFetchIssues).toHaveBeenCalledWith(testRepo, 200);
+    expect(mockedFetchPulls).toHaveBeenCalledWith(testRepo, 200);
+    expect(mockedFetchCurrentUser).toHaveBeenCalled();
+    expect(mockedFetchNotifications).toHaveBeenCalledWith(testRepo);
+
+    resolveConfig(testTeamConfig);
+    await run;
+  });
+
   it("passes notification map to buildSummary", async () => {
     const notificationMap = new Map([[42, {
       threadId: "T42",
@@ -521,7 +585,14 @@ describe("buzzCommand", () => {
     await buzzCommand({});
 
     expect(mockedBuildSummary).toHaveBeenCalledWith(
-      testRepo, [], [], "testuser", expect.any(Date), expect.any(Map), notificationMap,
+      testRepo,
+      [],
+      [],
+      "testuser",
+      expect.any(Date),
+      expect.any(Map),
+      notificationMap,
+      undefined,
     );
   });
 
@@ -555,5 +626,87 @@ describe("buzzCommand", () => {
 
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).not.toContain("Could not fetch notifications — unread indicators unavailable.");
+  });
+
+  // ── Team focus ────────────────────────────────────────────────────
+
+  it("passes focus from team config to buildSummary", async () => {
+    const teamWithFocus = {
+      ...testTeamConfig,
+      focus: "Focus on PR reviews first.",
+    };
+    mockedLoadTeamConfig.mockResolvedValue(teamWithFocus);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    expect(focusArg).toBe("Focus on PR reviews first.");
+  });
+
+  it("passes undefined focus when team config has no focus", async () => {
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    expect(focusArg).toBeUndefined();
+  });
+
+  it("passes focus to buildSummary when using --role", async () => {
+    const teamWithFocus = {
+      ...testTeamConfig,
+      focus: "Ship bug fixes this cycle.",
+    };
+    mockedLoadTeamConfig.mockResolvedValue(teamWithFocus);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatBuzz.mockReturnValue("output");
+
+    await buzzCommand({ role: "engineer" });
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    expect(focusArg).toBe("Ship bug fixes this cycle.");
+  });
+
+  // ── Config loading graceful degradation ───────────────────────────
+
+  it("silently ignores missing config when no role is provided", async () => {
+    mockedLoadTeamConfig.mockRejectedValue(new CliError("No .github/hivemoot.yml found", "CONFIG_NOT_FOUND"));
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(focusArg).toBeUndefined();
+    expect(summaryArg.notes).not.toContain(expect.stringContaining("Could not load team config"));
+    expect(console.log).toHaveBeenCalledWith("output");
+  });
+
+  it("adds a warning note for non-missing team config errors when no role is provided", async () => {
+    mockedLoadTeamConfig.mockRejectedValue(new CliError("Config error: invalid YAML", "INVALID_CONFIG"));
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(focusArg).toBeUndefined();
+    expect(summaryArg.notes).toContain(
+      "Could not load team config (Config error: invalid YAML) — team focus guidance unavailable.",
+    );
+  });
+
+  it("throws loadTeamConfig error when role is provided", async () => {
+    mockedLoadTeamConfig.mockRejectedValue(new CliError("No .github/hivemoot.yml found", "CONFIG_NOT_FOUND"));
+
+    await expect(buzzCommand({ role: "engineer" })).rejects.toThrow(CliError);
+    await expect(buzzCommand({ role: "engineer" })).rejects.toMatchObject({
+      code: "CONFIG_NOT_FOUND",
+    });
   });
 });

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -1,4 +1,9 @@
-import { CliError, type BuzzOptions, type GitHubIssue } from "../config/types.js";
+import {
+  CliError,
+  type BuzzOptions,
+  type GitHubIssue,
+  type TeamConfig,
+} from "../config/types.js";
 import { loadTeamConfig } from "../config/loader.js";
 import { resolveRepo } from "../github/repo.js";
 import { fetchIssues } from "../github/issues.js";
@@ -20,12 +25,28 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   const repo = await resolveRepo(options.repo);
   const fetchLimit = options.fetchLimit ?? 200;
 
+  const teamConfigPromise = loadTeamConfig(repo);
+
+  let teamConfig: TeamConfig | undefined;
+  let teamConfigWarning: string | undefined;
+
+  // Fetch summary data in parallel with optional team config loading.
+  // Focus is additive and should not delay base status data.
   const [issuesResult, prsResult, userResult, notificationsResult] = await Promise.allSettled([
     fetchIssues(repo, fetchLimit),
     fetchPulls(repo, fetchLimit),
     fetchCurrentUser(),
     fetchNotifications(repo),
   ]);
+
+  try {
+    teamConfig = await teamConfigPromise;
+  } catch (err) {
+    if (options.role) throw err;
+    if (!(err instanceof CliError && err.code === "CONFIG_NOT_FOUND")) {
+      teamConfigWarning = `Could not load team config (${errorDetail(err)}) — team focus guidance unavailable.`;
+    }
+  }
 
   // If the primary fetches all failed, surface the most actionable CliError.
   if (
@@ -59,7 +80,16 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     voteFetchFailed = true;
   }
 
-  const summary = buildSummary(repo, issues, prs, currentUser, new Date(), votes, notifications);
+  const summary = buildSummary(
+    repo,
+    issues,
+    prs,
+    currentUser,
+    new Date(),
+    votes,
+    notifications,
+    teamConfig?.focus,
+  );
 
   if (issuesResult.status === "rejected" && prsResult.status === "rejected") {
     summary.notes.push(
@@ -85,6 +115,10 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     summary.notes.push("Could not fetch notifications — unread indicators unavailable.");
   }
 
+  if (teamConfigWarning) {
+    summary.notes.push(teamConfigWarning);
+  }
+
   if (issues.length >= fetchLimit) {
     summary.notes.push(`Only the first ${fetchLimit} issues were fetched. Use --fetch-limit to increase.`);
   }
@@ -93,7 +127,14 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   }
 
   if (options.role) {
-    const teamConfig = await loadTeamConfig(repo);
+    if (!teamConfig) {
+      throw new CliError(
+        "No .github/hivemoot.yml found. Run: hivemoot init",
+        "CONFIG_NOT_FOUND",
+        1,
+      );
+    }
+
     if (!Object.hasOwn(teamConfig.roles, options.role)) {
       const available = Object.keys(teamConfig.roles).join(", ");
       throw new CliError(
@@ -102,6 +143,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
         1,
       );
     }
+
     const roleConfig = teamConfig.roles[options.role];
 
     if (options.json) {

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -13,6 +13,11 @@ team:
   #   This project is ...
   #   Read CONTRIBUTING.md for contribution workflow and access model.
 
+  # focus: optional repo steering for buzz output
+  # focus:
+  #   # default is free-form focus text (does not change filters in MVP)
+  #   default: Focus on PR reviews first.
+
   roles:
     pm:
       description: "Product manager focused on user value and clarity"

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -352,6 +352,128 @@ describe("loadTeamConfig", () => {
     });
   });
 
+  // ── team.focus parsing ──────────────────────────────────────────
+
+  it("parses focus.default as a string", async () => {
+    const focusYaml = yaml.dump({
+      team: {
+        focus: { default: "Focus on PR reviews first." },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Focus on PR reviews first.");
+  });
+
+  it("returns undefined focus when focus key is absent", async () => {
+    mockedGh.mockResolvedValue(encode(validYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBeUndefined();
+  });
+
+  it("returns undefined focus when focus is a plain string (not nested object)", async () => {
+    const flatFocusYaml = yaml.dump({
+      team: {
+        focus: "prs-only",
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(flatFocusYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBeUndefined();
+  });
+
+  it("returns undefined focus when focus.default is missing", async () => {
+    const noDefaultYaml = yaml.dump({
+      team: {
+        focus: { other: "value" },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(noDefaultYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBeUndefined();
+  });
+
+  it("returns undefined focus when focus.default is empty or whitespace", async () => {
+    const emptyDefaultYaml = yaml.dump({
+      team: {
+        focus: { default: "   " },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(emptyDefaultYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBeUndefined();
+  });
+
+  it("trims whitespace from focus.default", async () => {
+    const paddedYaml = yaml.dump({
+      team: {
+        focus: { default: "  Review PRs  " },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(paddedYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Review PRs");
+  });
+
+  it("returns undefined focus when focus.default is not a string", async () => {
+    const numericDefaultYaml = yaml.dump({
+      team: {
+        focus: { default: 42 },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(numericDefaultYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBeUndefined();
+  });
+
+  it("returns undefined focus when focus is an array", async () => {
+    const arrayFocusYaml = yaml.dump({
+      team: {
+        focus: ["prs", "issues"],
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(arrayFocusYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBeUndefined();
+  });
+
   it("re-throws non-404 gh errors", async () => {
     const otherError = new CliError("Rate limited", "RATE_LIMITED");
     mockedGh.mockRejectedValue(otherError);

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -1,12 +1,28 @@
 import yaml from "js-yaml";
 import { gh } from "../github/client.js";
-import type { HivemootConfig, TeamConfig, RepoRef, RoleConfig } from "./types.js";
+import type {
+  HivemootConfig,
+  TeamConfig,
+  RepoRef,
+  RoleConfig,
+} from "./types.js";
 import { CliError } from "./types.js";
 
 const ROLE_SLUG_RE = /^[a-z][a-z0-9_]{0,49}$/;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_INSTRUCTIONS_LENGTH = 10_000;
 const MAX_ONBOARDING_LENGTH = 10_000;
+
+function parseTeamFocus(rawFocus: unknown): string | undefined {
+  if (!rawFocus || typeof rawFocus !== "object" || Array.isArray(rawFocus)) return undefined;
+
+  const focusObj = rawFocus as Record<string, unknown>;
+  const defaultValue = focusObj.default;
+  if (typeof defaultValue !== "string") return undefined;
+
+  const focusValue = defaultValue.trim();
+  return focusValue || undefined;
+}
 
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
   if (!raw.team) {
@@ -104,10 +120,13 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
     };
   }
 
+  const focus = parseTeamFocus(team.focus);
+
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
+    focus,
   };
 }
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -9,6 +9,7 @@ export interface TeamConfig {
   name?: string;
   onboarding?: string;
   roles: Record<string, RoleConfig>;
+  focus?: string;
 }
 
 export interface HivemootConfig {
@@ -141,6 +142,7 @@ export interface RepoSummary {
   draftPRs: SummaryItem[];
   addressFeedback: SummaryItem[];
   notifications: NotificationRef[];
+  focus?: string;
   notes: string[];
 }
 

--- a/cli/src/output/formatter.test.ts
+++ b/cli/src/output/formatter.test.ts
@@ -55,6 +55,15 @@ describe("formatBuzz()", () => {
     expect(output).toContain("alice");
   });
 
+  it("shows team focus in header when present", () => {
+    const withFocus: RepoSummary = {
+      ...summary,
+      focus: "Review PR backlog this week.",
+    };
+    const output = formatBuzz("engineer", role, withFocus);
+    expect(output).toContain("Team focus: Review PR backlog this week.");
+  });
+
   it("includes section dividers with counts", () => {
     const output = formatBuzz("engineer", role, summary);
     expect(output).toContain("VOTE ON ISSUES");
@@ -162,6 +171,15 @@ describe("formatStatus()", () => {
     const output = formatStatus(summary);
     expect(output).toContain("logged in as");
     expect(output).toContain("alice");
+  });
+
+  it("shows team focus in header when present", () => {
+    const withFocus: RepoSummary = {
+      ...summary,
+      focus: "Close critical bugs first.",
+    };
+    const output = formatStatus(withFocus);
+    expect(output).toContain("Team focus: Close critical bugs first.");
   });
 
   it("handles empty summary", () => {

--- a/cli/src/output/formatter.ts
+++ b/cli/src/output/formatter.ts
@@ -17,6 +17,10 @@ function formatTags(tags: string[]): string {
   return " " + tags.map((t) => chalk.magenta(`[${t}]`)).join(" ");
 }
 
+function formatFocusLine(focus: string): string {
+  return `Team focus: ${focus}`;
+}
+
 function kv(key: string, value: string | number): string {
   return `${key}: ${chalk.dim(String(value))}`;
 }
@@ -215,6 +219,7 @@ export function formatBuzz(
     summary.currentUser
       ? `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}, logged in as ${chalk.green(summary.currentUser)}`
       : `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}`,
+    ...(summary.focus ? [formatFocusLine(summary.focus)] : []),
     "",
     formatSummaryBody(summary, limit),
   );
@@ -227,6 +232,7 @@ export function formatStatus(summary: RepoSummary, limit?: number): string {
     summary.currentUser
       ? `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}, logged in as ${chalk.green(summary.currentUser)}`
       : `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}`,
+    ...(summary.focus ? [formatFocusLine(summary.focus)] : []),
     "",
     formatSummaryBody(summary, limit),
   ];

--- a/cli/src/output/json.ts
+++ b/cli/src/output/json.ts
@@ -1,5 +1,25 @@
 import type { RepoSummary, RoleConfig, TeamConfig } from "../config/types.js";
 
+function summaryPayload(summary: RepoSummary): Record<string, unknown> {
+  return {
+    notifications: summary.notifications,
+    repo: `${summary.repo.owner}/${summary.repo.repo}`,
+    currentUser: summary.currentUser,
+    driveDiscussion: summary.driveDiscussion,
+    driveImplementation: summary.driveImplementation,
+    voteOn: summary.voteOn,
+    discuss: summary.discuss,
+    implement: summary.implement,
+    unclassified: summary.unclassified ?? [],
+    reviewPRs: summary.reviewPRs,
+    draftPRs: summary.draftPRs,
+    addressFeedback: summary.addressFeedback,
+    needsHuman: summary.needsHuman,
+    ...(summary.focus ? { focus: summary.focus } : {}),
+    notes: summary.notes,
+  };
+}
+
 export function jsonBuzz(
   roleName: string,
   role: RoleConfig,
@@ -14,22 +34,7 @@ export function jsonBuzz(
         description: role.description,
         instructions: role.instructions,
       },
-      summary: {
-        notifications: summary.notifications,
-        repo: `${summary.repo.owner}/${summary.repo.repo}`,
-        currentUser: summary.currentUser,
-        driveDiscussion: summary.driveDiscussion,
-        driveImplementation: summary.driveImplementation,
-        voteOn: summary.voteOn,
-        discuss: summary.discuss,
-        implement: summary.implement,
-        unclassified: summary.unclassified ?? [],
-        reviewPRs: summary.reviewPRs,
-        draftPRs: summary.draftPRs,
-        addressFeedback: summary.addressFeedback,
-        needsHuman: summary.needsHuman,
-        notes: summary.notes,
-      },
+      summary: summaryPayload(summary),
     },
     null,
     2,
@@ -37,26 +42,7 @@ export function jsonBuzz(
 }
 
 export function jsonStatus(summary: RepoSummary): string {
-  return JSON.stringify(
-    {
-      notifications: summary.notifications,
-      repo: `${summary.repo.owner}/${summary.repo.repo}`,
-      currentUser: summary.currentUser,
-      driveDiscussion: summary.driveDiscussion,
-      driveImplementation: summary.driveImplementation,
-      voteOn: summary.voteOn,
-      discuss: summary.discuss,
-      implement: summary.implement,
-      unclassified: summary.unclassified ?? [],
-      reviewPRs: summary.reviewPRs,
-      draftPRs: summary.draftPRs,
-      addressFeedback: summary.addressFeedback,
-      needsHuman: summary.needsHuman,
-      notes: summary.notes,
-    },
-    null,
-    2,
-  );
+  return JSON.stringify(summaryPayload(summary), null, 2);
 }
 
 export function jsonRoles(teamConfig: TeamConfig): string {

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -114,43 +114,37 @@ function classifyPR(
   pr: GitHubPR,
   now: Date,
 ): { bucket: "reviewPRs" | "draftPRs" | "addressFeedback"; item: SummaryItem } {
-  const age = timeAgo(pr.createdAt, now);
-  const tags = pr.labels.map((l) => l.name);
-  const author = pr.author?.login ?? "ghost";
-  const comments = pr.comments.length;
-  const ciFailing = hasCIFailure(pr);
-  const checks = compactChecks(checkStatus(pr));
-  const merge = compactMergeable(mergeStatus(pr));
   const changesRequested = changesRequestedCount(pr);
-  const review = {
-    approvals: approvalCount(pr),
-    changesRequested,
+  const base: SummaryItem = {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    tags: pr.labels.map((l) => l.name),
+    author: pr.author?.login ?? "ghost",
+    comments: pr.comments.length,
+    age: timeAgo(pr.createdAt, now),
+    status: "pending",
+    checks: compactChecks(checkStatus(pr)),
+    mergeable: compactMergeable(mergeStatus(pr)),
+    review: { approvals: approvalCount(pr), changesRequested },
   };
 
   if (pr.isDraft) {
-    return {
-      bucket: "draftPRs",
-      item: { number: pr.number, title: pr.title, url: pr.url, tags, author, comments, age, status: "draft", checks, mergeable: merge, review },
-    };
+    return { bucket: "draftPRs", item: { ...base, status: "draft" } };
   }
 
-  if (ciFailing || pr.reviewDecision === "CHANGES_REQUESTED" || changesRequested > 0) {
-    let status: string;
-    if (pr.reviewDecision === "CHANGES_REQUESTED" || changesRequested > 0) status = "changes-requested";
-    else status = "pending";
-
-    return {
-      bucket: "addressFeedback",
-      item: { number: pr.number, title: pr.title, url: pr.url, tags, author, comments, age, status, checks, mergeable: merge, review },
-    };
+  if (hasCIFailure(pr) || pr.reviewDecision === "CHANGES_REQUESTED" || changesRequested > 0) {
+    const status = (pr.reviewDecision === "CHANGES_REQUESTED" || changesRequested > 0)
+      ? "changes-requested"
+      : "pending";
+    return { bucket: "addressFeedback", item: { ...base, status } };
   }
 
-  const status = pr.reviewDecision === "APPROVED" ? "approved" : "pending";
+  if (pr.reviewDecision === "APPROVED") {
+    return { bucket: "reviewPRs", item: { ...base, status: "approved" } };
+  }
 
-  return {
-    bucket: "reviewPRs",
-    item: { number: pr.number, title: pr.title, url: pr.url, tags, author, comments, age, status, checks, mergeable: merge, review },
-  };
+  return { bucket: "reviewPRs", item: base };
 }
 
 function buildCompetitionMap(prs: GitHubPR[], currentUser: string): Map<number, number> {
@@ -173,6 +167,7 @@ export function buildSummary(
   now: Date = new Date(),
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
+  focus?: string,
 ): RepoSummary {
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
@@ -230,7 +225,10 @@ export function buildSummary(
   const driveImplementation: SummaryItem[] = [];
 
   const filteredDiscuss = discuss.filter((item) => {
-    if (item.author === currentUser) { driveDiscussion.push(item); return false; }
+    if (item.author === currentUser) {
+      driveDiscussion.push(item);
+      return false;
+    }
     return true;
   });
 
@@ -243,16 +241,21 @@ export function buildSummary(
   });
 
   const filteredReviewPRs = reviewPRs.filter((item) => {
-    if (item.author === currentUser) { driveImplementation.push(item); return false; }
+    if (item.author === currentUser) {
+      driveImplementation.push(item);
+      return false;
+    }
     return true;
   });
 
   const filteredAddressFeedback = addressFeedback.filter((item) => {
-    if (item.author === currentUser) { driveImplementation.push(item); return false; }
+    if (item.author === currentUser) {
+      driveImplementation.push(item);
+      return false;
+    }
     return true;
   });
 
-  // Annotate all items with unread notification status and collect notification refs
   const sectionEntries: [string, SummaryItem[]][] = [
     ["needsHuman", needsHuman],
     ["driveDiscussion", driveDiscussion],
@@ -265,6 +268,8 @@ export function buildSummary(
     ["draftPRs", draftPRs],
     ["addressFeedback", filteredAddressFeedback],
   ];
+
+  // Annotate all items with unread notification status and collect notification refs
   const notificationRefs: NotificationRef[] = [];
   const matchedNumbers = new Set<number>();
 
@@ -335,6 +340,7 @@ export function buildSummary(
     draftPRs,
     addressFeedback: filteredAddressFeedback,
     notifications: notificationRefs,
+    focus,
     notes: [],
   };
 }


### PR DESCRIPTION
## Why
- Add repo-level focus steering so `hivemoot buzz` can surface team priorities.

## What changed
- `team.focus` now reads only the nested config form:

```yaml
team:
  focus:
    default: "Focus on PR review this cycle."
```

- The `focus` value is shown in buzz output and JSON output as steering context.
- No filtering behavior is applied yet in this PR (all sections remain visible).
- No runtime override flags/envs were added in this PR.

## Notes
- No shorthand `focus: prs-only` form.

Fixes #34
