### PR TITLE
chore: set backlog-first team focus

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -15,6 +15,12 @@ shared:
 team:
   name: hivemoot
   onboarding: Read README.md, AGENTS.md, and HOW-IT-WORKS.md before starting work.
+  focus:
+    default: >
+      Backlog-first mode: do not open new issues unless there is a clear bug or
+      blocker. Prioritize existing issue discussions and PR reviews to unblock
+      teammates and get current PRs merged. Keep comments short, direct, and
+      decision-oriented.
   roles:
     worker:
       description: "The engine - true power that keeps hivemoot running"


### PR DESCRIPTION
## Summary
- add `team.focus.default` guidance in `.github/hivemoot.yml`
- shift team behavior to backlog-first execution
- prioritize issue discussion and PR review over opening new issues
- keep comments short, direct, and decision-oriented

## Why
Recent activity increased PR/issue load. This sets a clear operating focus to reduce backlog and improve merge throughput.

## Validation
- config file parses as valid YAML
