### PR TITLE
feat(cli): track non-blocking review feedback count

### DIFF
--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -79,6 +79,7 @@ export interface RepoRef {
 export interface ReviewSummary {
   approvals: number;
   changesRequested: number;
+  commented: number;
 }
 
 export interface SummaryItem {

--- a/cli/src/output/formatter.test.ts
+++ b/cli/src/output/formatter.test.ts
@@ -14,7 +14,7 @@ const summary: RepoSummary = {
     { number: 45, title: "User Dashboard", tags: ["enhancement"], author: "bob", comments: 0, age: "3 days ago" },
     { number: 47, title: "Notifications", tags: [], author: "alice", comments: 0, age: "yesterday" },
   ],
-  reviewPRs: [{ number: 49, title: "Search", tags: ["feature"], author: "carol", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 } }],
+  reviewPRs: [{ number: 49, title: "Search", tags: ["feature"], author: "carol", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 } }],
   draftPRs: [],
   addressFeedback: [],
   unclassified: [],
@@ -157,6 +157,22 @@ describe("formatBuzz()", () => {
     expect(output).toContain("0 approved");
     expect(output).not.toContain("changes-requested");
   });
+
+  it("renders review feedback count as 'with feedback' when present", () => {
+    const withFeedback: RepoSummary = {
+      ...summary,
+      reviewPRs: [
+        {
+          ...summary.reviewPRs[0],
+          review: { approvals: 2, changesRequested: 0, commented: 1 },
+        },
+      ],
+    };
+
+    const output = formatStatus(withFeedback);
+    expect(output).toContain("review:");
+    expect(output).toContain("2 approved, 1 with feedback");
+  });
 });
 
 describe("formatStatus()", () => {
@@ -225,7 +241,7 @@ describe("formatStatus()", () => {
     const withDrafts: RepoSummary = {
       ...summary,
       draftPRs: [
-        { number: 53, title: "WIP settings panel", tags: [], author: "bob", comments: 2, age: "yesterday", status: "draft", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 } },
+        { number: 53, title: "WIP settings panel", tags: [], author: "bob", comments: 2, age: "yesterday", status: "draft", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 } },
       ],
     };
 
@@ -245,8 +261,8 @@ describe("DRIVE sections", () => {
       { number: 80, title: "My Discussion", tags: ["phase:discussion"], author: "alice", comments: 3, age: "2 days ago" },
     ],
     driveImplementation: [
-      { number: 61, title: "Alice PR", tags: [], author: "alice", comments: 0, age: "yesterday", status: "draft", checks: null, mergeable: null, review: { approvals: 0, changesRequested: 0 } },
-      { number: 63, title: "Alice PR 2", tags: [], author: "alice", comments: 0, age: "just now", status: "changes-requested", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 } },
+      { number: 61, title: "Alice PR", tags: [], author: "alice", comments: 0, age: "yesterday", status: "draft", checks: null, mergeable: null, review: { approvals: 0, changesRequested: 0, commented: 0 } },
+      { number: 63, title: "Alice PR 2", tags: [], author: "alice", comments: 0, age: "just now", status: "changes-requested", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 } },
     ],
     voteOn: [],
     discuss: [
@@ -256,7 +272,7 @@ describe("DRIVE sections", () => {
     reviewPRs: [],
     draftPRs: [],
     addressFeedback: [
-      { number: 60, title: "Bob PR", tags: [], author: "bob", comments: 0, age: "2 days ago", status: "changes-requested", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 } },
+      { number: 60, title: "Bob PR", tags: [], author: "bob", comments: 0, age: "2 days ago", status: "changes-requested", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 } },
     ],
     notifications: [],
     notes: [],
@@ -458,7 +474,7 @@ describe("unread notification indicator", () => {
     const unreadSummary: RepoSummary = {
       ...summary,
       reviewPRs: [
-        { number: 49, title: "Search", tags: ["feature"], author: "carol", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 }, unread: true, unreadReason: "review_requested", unreadAge: "1h ago" },
+        { number: 49, title: "Search", tags: ["feature"], author: "carol", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 }, unread: true, unreadReason: "review_requested", unreadAge: "1h ago" },
       ],
     };
     const output = formatStatus(unreadSummary);
@@ -492,7 +508,7 @@ describe("unread notification indicator", () => {
     const unreadSummary: RepoSummary = {
       ...summary,
       reviewPRs: [
-        { number: 49, title: "Search", tags: [], author: "carol", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 }, unread: true, unreadReason: "review_requested", unreadAge: "1h ago" },
+        { number: 49, title: "Search", tags: [], author: "carol", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 }, unread: true, unreadReason: "review_requested", unreadAge: "1h ago" },
       ],
     };
     const output = formatStatus(unreadSummary);

--- a/cli/src/output/formatter.ts
+++ b/cli/src/output/formatter.ts
@@ -86,6 +86,7 @@ function formatMeta(item: SummaryItem, sectionType: SectionType, currentUser: st
     if (item.review) {
       const segments = [`${item.review.approvals} approved`];
       if (item.review.changesRequested > 0) segments.push(chalk.red(`${item.review.changesRequested} changes-requested`));
+      if (item.review.commented > 0) segments.push(chalk.dim(`${item.review.commented} with feedback`));
       parts.push(kv("review", segments.join(", ")));
     }
     if (item.yourReview) {

--- a/cli/src/output/json.test.ts
+++ b/cli/src/output/json.test.ts
@@ -12,9 +12,9 @@ const summary: RepoSummary = {
   discuss: [{ number: 52, title: "API versioning", tags: ["discuss"], author: "bob", comments: 5, age: "yesterday" }],
   implement: [{ number: 45, title: "User Dashboard", tags: ["enhancement"], author: "carol", comments: 0, age: "3 days ago" }],
   unclassified: [],
-  reviewPRs: [{ number: 49, title: "Search", tags: ["feature"], author: "dave", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 } }],
-  draftPRs: [{ number: 53, title: "Design system", tags: [], author: "eve", comments: 0, age: "just now", status: "draft", checks: "failing", mergeable: null, review: { approvals: 0, changesRequested: 0 } }],
-  addressFeedback: [{ number: 54, title: "Decision explorer fixups", tags: [], author: "frank", comments: 1, age: "1h ago", status: "changes-requested", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 1 } }],
+  reviewPRs: [{ number: 49, title: "Search", tags: ["feature"], author: "dave", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 } }],
+  draftPRs: [{ number: 53, title: "Design system", tags: [], author: "eve", comments: 0, age: "just now", status: "draft", checks: "failing", mergeable: null, review: { approvals: 0, changesRequested: 0, commented: 0 } }],
+  addressFeedback: [{ number: 54, title: "Decision explorer fixups", tags: [], author: "frank", comments: 1, age: "1h ago", status: "changes-requested", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 1, commented: 0 } }],
   notifications: [],
   notes: [],
 };
@@ -95,7 +95,7 @@ describe("jsonStatus()", () => {
     expect(result.reviewPRs[0].status).toBe("pending");
     expect(result.reviewPRs[0].checks).toBe("passing");
     expect(result.reviewPRs[0].mergeable).toBe("clean");
-    expect(result.reviewPRs[0].review).toEqual({ approvals: 0, changesRequested: 0 });
+    expect(result.reviewPRs[0].review).toEqual({ approvals: 0, changesRequested: 0, commented: 0 });
     expect(result.reviewPRs[0]).not.toHaveProperty("detail");
 
     // Verify draftPRs items
@@ -104,6 +104,21 @@ describe("jsonStatus()", () => {
 
     // Verify addressFeedback items
     expect(result.addressFeedback[0].status).toBe("changes-requested");
+  });
+
+  it("preserves commented review count in JSON output", () => {
+    const withFeedback: RepoSummary = {
+      ...summary,
+      reviewPRs: [
+        {
+          ...summary.reviewPRs[0],
+          review: { approvals: 1, changesRequested: 0, commented: 2 },
+        },
+      ],
+    };
+
+    const result = JSON.parse(jsonStatus(withFeedback));
+    expect(result.reviewPRs[0].review.commented).toBe(2);
   });
 
   it("includes canonical item URLs when present", () => {
@@ -192,7 +207,7 @@ describe("unread notification fields in JSON", () => {
       { number: 45, title: "User Dashboard", tags: ["enhancement"], author: "carol", comments: 0, age: "3 days ago", unread: true, unreadReason: "comment", unreadAge: "2h ago" },
     ],
     reviewPRs: [
-      { number: 49, title: "Search", tags: ["feature"], author: "dave", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0 }, unread: true, unreadReason: "review_requested", unreadAge: "1h ago" },
+      { number: 49, title: "Search", tags: ["feature"], author: "dave", comments: 0, age: "2 days ago", status: "pending", checks: "passing", mergeable: "clean", review: { approvals: 0, changesRequested: 0, commented: 0 }, unread: true, unreadReason: "review_requested", unreadAge: "1h ago" },
     ],
   };
 

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -164,8 +164,22 @@ describe("buildSummary()", () => {
     expect(summary.addressFeedback).toHaveLength(1);
     expect(summary.addressFeedback[0].number).toBe(150);
     expect(summary.addressFeedback[0].status).toBe("changes-requested");
-    expect(summary.addressFeedback[0].review).toEqual({ approvals: 1, changesRequested: 1 });
+    expect(summary.addressFeedback[0].review).toEqual({ approvals: 1, changesRequested: 1, commented: 0 });
     expect(summary.reviewPRs).toHaveLength(0);
+  });
+
+  it("counts COMMENTED reviews in aggregate feedback summary", () => {
+    const pr = makePR({
+      number: 151,
+      reviews: [
+        { state: "COMMENTED", author: { login: "reviewer-a" } },
+        { state: "APPROVED", author: { login: "reviewer-b" } },
+      ],
+    });
+
+    const summary = buildSummary(repo, [], [pr], "testuser", now);
+    expect(summary.reviewPRs).toHaveLength(1);
+    expect(summary.reviewPRs[0].review).toEqual({ approvals: 1, changesRequested: 0, commented: 1 });
   });
 
   it("includes all labels as tags on issues", () => {
@@ -518,7 +532,7 @@ describe("buildSummary()", () => {
     expect(item.status).toBe("approved");
     expect(item.checks).toBe("passing");
     expect(item.mergeable).toBe("clean");
-    expect(item.review).toEqual({ approvals: 1, changesRequested: 0 });
+    expect(item.review).toEqual({ approvals: 1, changesRequested: 0, commented: 0 });
   });
 
   it("populates null checks when no statusCheckRollup", () => {

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -15,6 +15,7 @@ import {
   mergeStatus,
   approvalCount,
   changesRequestedCount,
+  commentCount,
   timeAgo,
   reviewContext,
   latestCommitAge,
@@ -126,7 +127,11 @@ function classifyPR(
     status: "pending",
     checks: compactChecks(checkStatus(pr)),
     mergeable: compactMergeable(mergeStatus(pr)),
-    review: { approvals: approvalCount(pr), changesRequested },
+    review: {
+      approvals: approvalCount(pr),
+      changesRequested,
+      commented: commentCount(pr),
+    },
   };
 
   if (pr.isDraft) {

--- a/cli/src/summary/utils.test.ts
+++ b/cli/src/summary/utils.test.ts
@@ -11,6 +11,7 @@ import {
   mergeStatus,
   approvalCount,
   changesRequestedCount,
+  commentCount,
   reviewContext,
   latestCommitAge,
   latestCommentAge,
@@ -471,6 +472,61 @@ describe("changesRequestedCount()", () => {
       ],
     });
     expect(changesRequestedCount(pr)).toBe(1);
+  });
+});
+
+describe("commentCount()", () => {
+  it("returns 0 for no reviews", () => {
+    const pr = makePR({ reviews: [] });
+    expect(commentCount(pr)).toBe(0);
+  });
+
+  it("counts latest COMMENTED review", () => {
+    const pr = makePR({
+      reviews: [{ state: "COMMENTED", author: { login: "alice" } }],
+    });
+    expect(commentCount(pr)).toBe(1);
+  });
+
+  it("returns 0 when COMMENTED is followed by APPROVED", () => {
+    const pr = makePR({
+      reviews: [
+        { state: "COMMENTED", author: { login: "alice" } },
+        { state: "APPROVED", author: { login: "alice" } },
+      ],
+    });
+    expect(commentCount(pr)).toBe(0);
+  });
+
+  it("counts multiple reviewers with outstanding feedback", () => {
+    const pr = makePR({
+      reviews: [
+        { state: "COMMENTED", author: { login: "alice" } },
+        { state: "COMMENTED", author: { login: "bob" } },
+      ],
+    });
+    expect(commentCount(pr)).toBe(2);
+  });
+
+  it("handles mixed states across multiple reviewers", () => {
+    const pr = makePR({
+      reviews: [
+        { state: "COMMENTED", author: { login: "alice" } },
+        { state: "APPROVED", author: { login: "bob" } },
+        { state: "CHANGES_REQUESTED", author: { login: "alice" } },
+        { state: "COMMENTED", author: { login: "bob" } },
+      ],
+    });
+    // alice: COMMENTED → CHANGES_REQUESTED (latest = CHANGES_REQUESTED, not counted)
+    // bob: APPROVED → COMMENTED (latest = COMMENTED, counted)
+    expect(commentCount(pr)).toBe(1);
+  });
+
+  it("handles null author reviews without crashing", () => {
+    const pr = makePR({
+      reviews: [{ state: "COMMENTED", author: null }],
+    });
+    expect(commentCount(pr)).toBe(1);
   });
 });
 

--- a/cli/src/summary/utils.ts
+++ b/cli/src/summary/utils.ts
@@ -183,6 +183,15 @@ export function changesRequestedCount(pr: GitHubPR): number {
   return count;
 }
 
+/** Count unique non-blocking feedback reviews (latest review per author). */
+export function commentCount(pr: GitHubPR): number {
+  let count = 0;
+  for (const state of latestReviewByAuthor(pr).values()) {
+    if (state === "COMMENTED") count++;
+  }
+  return count;
+}
+
 // ── Review context ────────────────────────────────────────────────
 
 export interface ReviewContext {


### PR DESCRIPTION
## Summary

Track and display non-blocking review feedback (`COMMENTED`) in `hivemoot buzz` PR review aggregates.

### What changed
- add `commented` to `ReviewSummary`
- add `commentCount(pr)` that counts latest `COMMENTED` state per reviewer (same latest-per-author semantics as approvals/changes-requested)
- include `commented` in summary builder review objects
- render aggregate feedback in text output as `<n> with feedback`
- extend unit coverage in summary utils, builder, formatter, and JSON output tests

### Output example

Before:
```text
review: 3 approved, 1 changes-requested
```

After:
```text
review: 3 approved, 1 changes-requested, 2 with feedback
```

`with feedback` is intentionally non-blocking wording, matching the issue discussion.

Fixes #31

## Validation
- npm test --prefix cli
- npm run lint --prefix cli
- npm run build --prefix cli
