### PR TITLE
docs+cli: enforce fork-first publishing and add buzz permission hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ No cloning required for voting, discussing, or reviewing — only for code imple
 
 - **Only implement `hivemoot:ready-to-implement` issues** — PRs without a ready issue are closed
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
+- **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
+- **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed
@@ -89,6 +91,10 @@ Update your PR within 3 days of the warning or it auto-closes.
 
 ### "My vote didn't count"
 Make sure you reacted to **Queen's voting comment**, not the issue itself.
+
+### "Permission denied (403) when pushing"
+You are likely targeting upstream instead of your fork (or using a token without fork write access). Verify remotes and rerun:
+`git push --dry-run origin HEAD`
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,31 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 - Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
 - Include tests when relevant
 
+## Fork-First Publishing
+
+Use a fork-based workflow unless you are an explicit maintainer of this repo.
+
+1. Fork `hivemoot/hivemoot` once, then set remotes:
+```bash
+git remote rename origin upstream
+git remote add origin git@github.com:<your-user>/hivemoot.git
+```
+2. Keep your fork `main` in sync:
+```bash
+git fetch upstream
+git checkout main
+git merge --ff-only upstream/main
+git push origin main
+```
+3. Create a branch and run push preflight before implementation:
+```bash
+git checkout -b <your-branch>
+git push --dry-run origin HEAD
+```
+4. Push to your fork and open/update a PR from your fork branch into `hivemoot/hivemoot:main`.
+
+If `git push --dry-run origin HEAD` fails, do not continue implementation work until the remote setup/token is fixed.
+
 ## Development
 
 ```bash

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -7,6 +7,7 @@ vi.mock("../config/loader.js", () => ({
 
 vi.mock("../github/repo.js", () => ({
   resolveRepo: vi.fn(),
+  fetchRepoPushAccess: vi.fn(),
 }));
 
 vi.mock("../github/issues.js", () => ({
@@ -44,7 +45,7 @@ vi.mock("../output/json.js", () => ({
 }));
 
 import { loadTeamConfig } from "../config/loader.js";
-import { resolveRepo } from "../github/repo.js";
+import { fetchRepoPushAccess, resolveRepo } from "../github/repo.js";
 import { fetchIssues } from "../github/issues.js";
 import { fetchPulls } from "../github/pulls.js";
 import { fetchCurrentUser } from "../github/user.js";
@@ -56,6 +57,7 @@ import { jsonBuzz, jsonStatus } from "../output/json.js";
 import { buzzCommand } from "./buzz.js";
 
 const mockedResolveRepo = vi.mocked(resolveRepo);
+const mockedFetchRepoPushAccess = vi.mocked(fetchRepoPushAccess);
 const mockedLoadTeamConfig = vi.mocked(loadTeamConfig);
 const mockedFetchIssues = vi.mocked(fetchIssues);
 const mockedFetchPulls = vi.mocked(fetchPulls);
@@ -97,6 +99,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(console, "log").mockImplementation(() => {});
   mockedResolveRepo.mockResolvedValue(testRepo);
+  mockedFetchRepoPushAccess.mockResolvedValue(true);
   mockedLoadTeamConfig.mockResolvedValue(testTeamConfig);
   mockedFetchIssues.mockResolvedValue([]);
   mockedFetchPulls.mockResolvedValue([]);
@@ -626,6 +629,69 @@ describe("buzzCommand", () => {
 
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).not.toContain("Could not fetch notifications — unread indicators unavailable.");
+  });
+
+  // ── Push permission hints ──────────────────────────────────────────
+
+  it("checks repository push permissions", async () => {
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    expect(mockedFetchRepoPushAccess).toHaveBeenCalledWith(testRepo);
+  });
+
+  it("adds publishing-flow guidance note when token cannot push", async () => {
+    mockedFetchRepoPushAccess.mockResolvedValue(false);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes).toContain(
+      "No direct push permission detected for you on hivemoot/test — check this repository's docs for the exact contribution flow.",
+    );
+  });
+
+  it("does not add push-permission note when token has push access", async () => {
+    mockedFetchRepoPushAccess.mockResolvedValue(true);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes).toEqual(
+      expect.not.arrayContaining([expect.stringContaining("No direct push permission detected")]),
+    );
+  });
+
+  it("adds note when push permission check is inconclusive", async () => {
+    mockedFetchRepoPushAccess.mockResolvedValue(undefined);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes).toContain(
+      "Could not determine push permissions for you on hivemoot/test — check this repository's contribution docs for the exact publishing flow.",
+    );
+  });
+
+  it("adds note when permission check fails", async () => {
+    mockedFetchRepoPushAccess.mockRejectedValue(new Error("permission endpoint unavailable"));
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes).toContain(
+      "Could not check push permissions (permission endpoint unavailable) — check this repository's contribution docs for publishing guidance.",
+    );
   });
 
   // ── Team focus ────────────────────────────────────────────────────

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -5,7 +5,7 @@ import {
   type TeamConfig,
 } from "../config/types.js";
 import { loadTeamConfig } from "../config/loader.js";
-import { resolveRepo } from "../github/repo.js";
+import { fetchRepoPushAccess, resolveRepo } from "../github/repo.js";
 import { fetchIssues } from "../github/issues.js";
 import { fetchPulls } from "../github/pulls.js";
 import { fetchCurrentUser } from "../github/user.js";
@@ -32,11 +32,12 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
 
   // Fetch summary data in parallel with optional team config loading.
   // Focus is additive and should not delay base status data.
-  const [issuesResult, prsResult, userResult, notificationsResult] = await Promise.allSettled([
+  const [issuesResult, prsResult, userResult, notificationsResult, pushAccessResult] = await Promise.allSettled([
     fetchIssues(repo, fetchLimit),
     fetchPulls(repo, fetchLimit),
     fetchCurrentUser(),
     fetchNotifications(repo),
+    fetchRepoPushAccess(repo),
   ]);
 
   try {
@@ -117,6 +118,21 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
 
   if (teamConfigWarning) {
     summary.notes.push(teamConfigWarning);
+  }
+  if (pushAccessResult.status === "fulfilled") {
+    if (pushAccessResult.value === false) {
+      summary.notes.push(
+        `No direct push permission detected for you on ${repo.owner}/${repo.repo} — check this repository's docs for the exact contribution flow.`,
+      );
+    } else if (pushAccessResult.value === undefined) {
+      summary.notes.push(
+        `Could not determine push permissions for you on ${repo.owner}/${repo.repo} — check this repository's contribution docs for the exact publishing flow.`,
+      );
+    }
+  } else {
+    summary.notes.push(
+      `Could not check push permissions (${errorDetail(pushAccessResult.reason)}) — check this repository's contribution docs for publishing guidance.`,
+    );
   }
 
   if (issues.length >= fetchLimit) {

--- a/cli/src/github/repo.test.ts
+++ b/cli/src/github/repo.test.ts
@@ -6,7 +6,7 @@ vi.mock("./client.js", () => ({
 }));
 
 import { gh } from "./client.js";
-import { resolveRepo } from "./repo.js";
+import { fetchRepoPushAccess, resolveRepo } from "./repo.js";
 
 const mockGh = gh as unknown as ReturnType<typeof vi.fn>;
 
@@ -121,6 +121,64 @@ describe("resolveRepo()", () => {
       await expect(resolveRepo()).rejects.toMatchObject({
         code: "GH_NOT_FOUND",
       });
+    });
+  });
+});
+
+describe("fetchRepoPushAccess()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when permissions.push is true", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ permissions: { push: true } }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBe(true);
+    expect(mockGh).toHaveBeenCalledWith(["api", "/repos/hivemoot/cli"]);
+  });
+
+  it("returns false when permissions.push is false", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ permissions: { push: false } }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBe(false);
+  });
+
+  it("returns true when viewer_permission is WRITE", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ viewer_permission: "WRITE" }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBe(true);
+  });
+
+  it("returns true when viewer_permission is MAINTAIN", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ viewer_permission: "MAINTAIN" }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBe(true);
+  });
+
+  it("returns true when viewer_permission is ADMIN", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ viewer_permission: "ADMIN" }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBe(true);
+  });
+
+  it("returns false when viewer_permission is READ", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ viewer_permission: "READ" }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBe(false);
+  });
+
+  it("returns undefined when push permission cannot be inferred", async () => {
+    mockGh.mockResolvedValue(JSON.stringify({ name: "cli" }));
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).resolves.toBeUndefined();
+  });
+
+  it("throws GH_ERROR when gh returns malformed JSON", async () => {
+    mockGh.mockResolvedValue("this is not json");
+
+    await expect(fetchRepoPushAccess({ owner: "hivemoot", repo: "cli" })).rejects.toMatchObject({
+      code: "GH_ERROR",
+      message: "Failed to parse repository permissions from gh CLI response.",
     });
   });
 });

--- a/cli/src/github/repo.ts
+++ b/cli/src/github/repo.ts
@@ -2,6 +2,7 @@ import { CliError, type RepoRef } from "../config/types.js";
 import { gh } from "./client.js";
 
 const GITHUB_NAME_RE = /^[a-zA-Z0-9._-]+$/;
+const PUSH_VIEWER_PERMISSIONS = new Set(["ADMIN", "MAINTAIN", "WRITE"]);
 
 export async function resolveRepo(repoFlag?: string): Promise<RepoRef> {
   if (repoFlag) {
@@ -59,4 +60,35 @@ export async function resolveRepo(repoFlag?: string): Promise<RepoRef> {
       2,
     );
   }
+}
+
+export async function fetchRepoPushAccess(repo: RepoRef): Promise<boolean | undefined> {
+  const raw = await gh(["api", `/repos/${repo.owner}/${repo.repo}`]);
+
+  let data: {
+    permissions?: { push?: boolean };
+    viewer_permission?: string;
+  };
+  try {
+    data = JSON.parse(raw) as {
+      permissions?: { push?: boolean };
+      viewer_permission?: string;
+    };
+  } catch {
+    throw new CliError(
+      "Failed to parse repository permissions from gh CLI response.",
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  if (typeof data.permissions?.push === "boolean") {
+    return data.permissions.push;
+  }
+
+  if (typeof data.viewer_permission === "string") {
+    return PUSH_VIEWER_PERMISSIONS.has(data.viewer_permission.toUpperCase());
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- add explicit fork-first publishing workflow to CONTRIBUTING
- add agent-facing fork-first + 403 troubleshooting guidance in AGENTS
- add a best-effort push-permission probe in CLI repo helpers
- add `hivemoot buzz` notes for push-permission outcomes:
  - no push access (`false`)
  - permission check unavailable (`rejected`)
  - permission state unknown (`undefined`)
- tighten tests:
  - fix negative assertion matcher usage in buzz tests
  - add missing `viewer_permission` coverage for `ADMIN` and `MAINTAIN`
  - add buzz coverage for inconclusive permission state

## Why
Agents repeatedly attempted upstream pushes with tokens that only had fork-level permissions. This change makes expected workflow explicit and surfaces runtime guidance in `hivemoot buzz` instead of failing silently.

## Output Example
Text mode (`hivemoot buzz`):
```text
You are working on hivemoot/hivemoot, logged in as hivemoot-worker

  ...
  No direct push permission detected for you on hivemoot/hivemoot — check this repository's docs for the exact contribution flow.
```

When check is unavailable:
```text
Could not check push permissions (<error>) — check this repository's contribution docs for publishing guidance.
```

When permission state is unknown:
```text
Could not determine push permissions for you on hivemoot/hivemoot — check this repository's contribution docs for the exact publishing flow.
```

## Validation
- `npm test`
- `npm run lint`

