### PR TITLE
fix(cli): bound mention routing to notification window

### DIFF
--- a/cli/src/commands/watch.test.ts
+++ b/cli/src/commands/watch.test.ts
@@ -11,6 +11,8 @@ vi.mock("../github/user.js", () => ({
 vi.mock("../github/notifications.js", () => ({
   fetchMentionNotifications: vi.fn(),
   fetchCommentBody: vi.fn(),
+  fetchRecentSubjectComments: vi.fn(),
+  fetchSubjectBody: vi.fn(),
   buildMentionEvent: vi.fn(),
   isAgentMentioned: vi.fn(),
 }));
@@ -30,6 +32,8 @@ import { fetchCurrentUser } from "../github/user.js";
 import {
   fetchMentionNotifications,
   fetchCommentBody,
+  fetchRecentSubjectComments,
+  fetchSubjectBody,
   buildMentionEvent,
   isAgentMentioned,
 } from "../github/notifications.js";
@@ -38,6 +42,8 @@ import { loadState, saveState, mergeAckJournal } from "../watch/state.js";
 const mockedFetchUser = vi.mocked(fetchCurrentUser);
 const mockedFetchMentions = vi.mocked(fetchMentionNotifications);
 const mockedFetchComment = vi.mocked(fetchCommentBody);
+const mockedFetchRecentComments = vi.mocked(fetchRecentSubjectComments);
+const mockedFetchSubjectBody = vi.mocked(fetchSubjectBody);
 const mockedBuildEvent = vi.mocked(buildMentionEvent);
 const mockedIsAgentMentioned = vi.mocked(isAgentMentioned);
 const mockedLoadState = vi.mocked(loadState);
@@ -100,6 +106,13 @@ beforeEach(() => {
   mockedLoadState.mockResolvedValue(defaultState());
   mockedSaveState.mockResolvedValue(undefined);
   mockedFetchMentions.mockResolvedValue([]);
+  mockedFetchRecentComments.mockResolvedValue([]);
+  mockedFetchSubjectBody.mockResolvedValue({
+    body: "",
+    author: "unknown",
+    htmlUrl: "https://github.com/owner/repo/issues/42",
+    updatedAt: "2026-02-01T11:30:00.000Z",
+  });
   mockedIsAgentMentioned.mockReturnValue(true);
   // mergeAckJournal returns the state unchanged by default
   mockedMergeAckJournal.mockImplementation(async (_path, state) => state);
@@ -312,6 +325,7 @@ describe("watchCommand (--once mode)", () => {
     mockedFetchMentions.mockResolvedValue([notification]);
     mockedFetchComment.mockResolvedValue(comment);
     mockedIsAgentMentioned.mockReturnValue(false);
+    mockedFetchRecentComments.mockResolvedValue([]);
 
     await watchCommand({ repo: "owner/repo", once: true });
 
@@ -327,6 +341,64 @@ describe("watchCommand (--once mode)", () => {
       expect.any(String),
       expect.objectContaining({
         processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+      }),
+    );
+  });
+
+  it("falls back to recent notification-window comments when latest comment mismatches", async () => {
+    const notification = makeNotification({ reason: "mention" });
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchComment.mockResolvedValue({
+      body: "@other-agent please take this",
+      author: "someone",
+      htmlUrl: "https://github.com/owner/repo/issues/42#issuecomment-latest",
+      createdAt: "2026-02-01T11:30:00.000Z",
+    });
+    mockedFetchRecentComments.mockResolvedValue([
+      {
+        body: "@test-agent please handle",
+        author: "owner",
+        htmlUrl: "https://github.com/owner/repo/issues/42#issuecomment-older",
+        createdAt: "2026-02-01T11:20:00.000Z",
+      },
+    ]);
+    mockedIsAgentMentioned.mockImplementation((body) => body.includes("@test-agent"));
+    mockedBuildEvent.mockReturnValue(makeEvent());
+
+    await watchCommand({ repo: "owner/repo", once: true });
+
+    expect(mockedFetchRecentComments).toHaveBeenCalledWith(
+      notification,
+      "2026-02-01T10:00:00.000Z",
+    );
+    expect(mockedBuildEvent).toHaveBeenCalledWith(
+      notification,
+      expect.objectContaining({
+        body: "@test-agent please handle",
+      }),
+      "test-agent",
+    );
+  });
+
+  it("retries when fallback recent-comment scan fails", async () => {
+    const notification = makeNotification({ reason: "mention" });
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchComment.mockResolvedValue({
+      body: "@someone else",
+      author: "someone",
+      htmlUrl: "https://github.com/owner/repo/issues/42#issuecomment-latest",
+      createdAt: "2026-02-01T11:30:00.000Z",
+    });
+    mockedIsAgentMentioned.mockReturnValue(false);
+    mockedFetchRecentComments.mockResolvedValue(null);
+
+    await watchCommand({ repo: "owner/repo", once: true });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: [],
       }),
     );
   });
@@ -384,14 +456,83 @@ describe("watchCommand (--once mode)", () => {
     const event = makeEvent();
 
     mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchSubjectBody.mockResolvedValue({
+      body: "@test-agent please take this",
+      author: "owner",
+      htmlUrl: "https://github.com/owner/repo/issues/42",
+      updatedAt: "2026-02-01T11:30:00.000Z",
+    });
+    mockedIsAgentMentioned.mockReturnValue(true);
     mockedBuildEvent.mockReturnValue(event);
 
     await watchCommand({ repo: "owner/repo", once: true });
 
     // No comment fetch when there's no URL
     expect(mockedFetchComment).not.toHaveBeenCalled();
-    // buildMentionEvent handles null comment — event should be emitted
-    expect(mockedBuildEvent).toHaveBeenCalledWith(notification, null, "test-agent");
+    expect(mockedFetchSubjectBody).toHaveBeenCalledWith(notification.subject.url);
+    expect(mockedBuildEvent).toHaveBeenCalledWith(
+      notification,
+      expect.objectContaining({
+        body: "@test-agent please take this",
+      }),
+      "test-agent",
+    );
     expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
+  });
+
+  it("skips and marks processed when subject body does not mention agent", async () => {
+    const notification = makeNotification({
+      subject: {
+        url: "https://api.github.com/repos/owner/repo/issues/42",
+        type: "Issue",
+        title: "Test issue",
+        latest_comment_url: null,
+      },
+      reason: "mention",
+    });
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchSubjectBody.mockResolvedValue({
+      body: "@another-agent please handle",
+      author: "owner",
+      htmlUrl: "https://github.com/owner/repo/issues/42",
+      updatedAt: "2026-02-01T11:30:00.000Z",
+    });
+    mockedIsAgentMentioned.mockReturnValue(false);
+
+    await watchCommand({ repo: "owner/repo", once: true });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+      }),
+    );
+  });
+
+  it("retries when subject body fetch fails", async () => {
+    const notification = makeNotification({
+      subject: {
+        url: "https://api.github.com/repos/owner/repo/issues/42",
+        type: "Issue",
+        title: "Test issue",
+        latest_comment_url: null,
+      },
+      reason: "mention",
+    });
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchSubjectBody.mockResolvedValue(null);
+
+    await watchCommand({ repo: "owner/repo", once: true });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: [],
+      }),
+    );
   });
 });

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -4,6 +4,8 @@ import { fetchCurrentUser } from "../github/user.js";
 import {
   fetchMentionNotifications,
   fetchCommentBody,
+  fetchRecentSubjectComments,
+  fetchSubjectBody,
   buildMentionEvent,
   isAgentMentioned,
 } from "../github/notifications.js";
@@ -109,33 +111,57 @@ async function runPollLoop(
         const processedKey = `${notification.id}:${notification.updated_at}`;
         if (state.processedThreadIds.includes(processedKey)) continue;
 
-        // Fetch the comment that triggered this notification
-        const comment = notification.subject.latest_comment_url
+        let eventSourceComment = notification.subject.latest_comment_url
           ? await fetchCommentBody(notification.subject.latest_comment_url)
           : null;
 
-        // -- Null-comment gate: transient API failure --
-        // URL existed but fetch returned null → skip and retry next poll.
-        // No URL at all (e.g. issue-body mention) → fall through to
-        // buildMentionEvent which handles null comments gracefully.
-        if (comment === null && notification.subject.latest_comment_url) {
+        if (notification.subject.latest_comment_url && eventSourceComment === null) {
           log(`Skipping ${notification.id}: comment fetch failed, will retry`);
           continue;
         }
 
-        // -- Mention verification (only for reason="mention" with a comment body) --
-        // GitHub keeps reason="mention" on a thread even when the latest comment
-        // doesn't mention the agent (stale thread subscription). Verify the
-        // comment body actually contains @agent before triggering a run.
-        // When there's no comment body (no URL), skip the check — the mention
-        // may be in the issue/PR body itself, which we can't fetch here.
-        if (comment !== null && notification.reason === "mention" && !isAgentMentioned(comment.body, agent)) {
-          log(`Skipping ${notification.id}: agent not mentioned in comment body (stale thread)`);
-          state = addProcessedId(state, processedKey);
-          continue;
+        if (notification.reason === "mention") {
+          if (eventSourceComment !== null) {
+            if (!isAgentMentioned(eventSourceComment.body, agent)) {
+              const recentComments = await fetchRecentSubjectComments(notification, state.lastChecked);
+              if (recentComments === null) {
+                log(`Skipping ${notification.id}: fallback comment scan failed, will retry`);
+                continue;
+              }
+
+              const matchingComment = recentComments.find((c) => isAgentMentioned(c.body, agent));
+              if (!matchingComment) {
+                log(`Skipping ${notification.id}: agent not mentioned in notification window`);
+                state = addProcessedId(state, processedKey);
+                continue;
+              }
+
+              eventSourceComment = matchingComment;
+            }
+          } else {
+            // No latest comment URL: verify explicit mention in issue/PR body.
+            const subject = await fetchSubjectBody(notification.subject.url);
+            if (subject === null) {
+              log(`Skipping ${notification.id}: subject fetch failed, will retry`);
+              continue;
+            }
+
+            if (!isAgentMentioned(subject.body, agent)) {
+              log(`Skipping ${notification.id}: agent not mentioned in subject body`);
+              state = addProcessedId(state, processedKey);
+              continue;
+            }
+
+            eventSourceComment = {
+              body: subject.body,
+              author: subject.author,
+              htmlUrl: subject.htmlUrl,
+              createdAt: subject.updatedAt,
+            };
+          }
         }
 
-        const event = buildMentionEvent(notification, comment, agent);
+        const event = buildMentionEvent(notification, eventSourceComment, agent);
         if (!event) {
           // Can't parse — skip silently. Unparseable events reappear next poll
           // but are harmless since all=false naturally drops them once the

--- a/cli/src/github/notifications.test.ts
+++ b/cli/src/github/notifications.test.ts
@@ -10,6 +10,8 @@ import {
   fetchMentionNotifications,
   markNotificationRead,
   fetchCommentBody,
+  fetchSubjectBody,
+  fetchRecentSubjectComments,
   buildMentionEvent,
   parseSubjectNumber,
   isAgentMentioned,
@@ -334,6 +336,146 @@ describe("fetchCommentBody()", () => {
     mockedGh.mockRejectedValue(new Error("API error"));
 
     const result = await fetchCommentBody("https://api.github.com/repos/hivemoot/colony/issues/comments/999");
+    expect(result).toBeNull();
+  });
+});
+
+describe("fetchSubjectBody()", () => {
+  it("returns subject detail when fetch succeeds", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({
+      body: "@hivemoot-worker please handle",
+      author: "owner",
+      htmlUrl: "https://github.com/hivemoot/colony/issues/42",
+      updatedAt: "2026-02-12T15:30:00Z",
+    }));
+
+    const result = await fetchSubjectBody("https://api.github.com/repos/hivemoot/colony/issues/42");
+    expect(result).toEqual({
+      body: "@hivemoot-worker please handle",
+      author: "owner",
+      htmlUrl: "https://github.com/hivemoot/colony/issues/42",
+      updatedAt: "2026-02-12T15:30:00Z",
+    });
+  });
+
+  it("returns null when subject fetch fails", async () => {
+    mockedGh.mockRejectedValue(new Error("API error"));
+
+    const result = await fetchSubjectBody("https://api.github.com/repos/hivemoot/colony/issues/42");
+    expect(result).toBeNull();
+  });
+});
+
+describe("fetchRecentSubjectComments()", () => {
+  it("fetches issue comments with since window", async () => {
+    const notification = makeNotification({
+      reason: "mention",
+      subject: {
+        url: "https://api.github.com/repos/hivemoot/colony/issues/42",
+        type: "Issue",
+        title: "Fix layout",
+        latest_comment_url: "https://api.github.com/repos/hivemoot/colony/issues/comments/999",
+      },
+    }) as RawNotification;
+
+    mockedGh.mockResolvedValue(JSON.stringify([
+      {
+        body: "@hivemoot-worker ping",
+        user: { login: "owner" },
+        html_url: "https://github.com/hivemoot/colony/issues/42#issuecomment-1",
+        created_at: "2026-02-12T15:00:00Z",
+      },
+    ]));
+
+    const result = await fetchRecentSubjectComments(notification, "2026-02-12T14:00:00Z");
+
+    expect(mockedGh).toHaveBeenCalledWith([
+      "api",
+      "https://api.github.com/repos/hivemoot/colony/issues/42/comments?per_page=100&since=2026-02-12T14%3A00%3A00Z",
+    ]);
+    expect(result).toEqual([
+      {
+        body: "@hivemoot-worker ping",
+        author: "owner",
+        htmlUrl: "https://github.com/hivemoot/colony/issues/42#issuecomment-1",
+        createdAt: "2026-02-12T15:00:00Z",
+      },
+    ]);
+  });
+
+  it("fetches and merges PR issue + review comments", async () => {
+    const notification = makeNotification({
+      reason: "mention",
+      subject: {
+        url: "https://api.github.com/repos/hivemoot/colony/pulls/99",
+        type: "PullRequest",
+        title: "Fix routing",
+        latest_comment_url: "https://api.github.com/repos/hivemoot/colony/issues/comments/100",
+      },
+    }) as RawNotification;
+
+    mockedGh
+      .mockResolvedValueOnce(JSON.stringify([
+        {
+          body: "@hivemoot-worker from issue comment",
+          user: { login: "owner" },
+          html_url: "https://github.com/hivemoot/colony/pull/99#issuecomment-1",
+          created_at: "2026-02-12T15:00:00Z",
+        },
+      ]))
+      .mockResolvedValueOnce(JSON.stringify([
+        {
+          body: "@hivemoot-worker from review comment",
+          user: { login: "reviewer" },
+          html_url: "https://github.com/hivemoot/colony/pull/99#discussion_r1",
+          created_at: "2026-02-12T15:10:00Z",
+        },
+      ]));
+
+    const result = await fetchRecentSubjectComments(notification, "2026-02-12T14:00:00Z");
+
+    expect(mockedGh).toHaveBeenNthCalledWith(
+      1,
+      [
+        "api",
+        "https://api.github.com/repos/hivemoot/colony/issues/99/comments?per_page=100&since=2026-02-12T14%3A00%3A00Z",
+      ],
+    );
+    expect(mockedGh).toHaveBeenNthCalledWith(
+      2,
+      [
+        "api",
+        "https://api.github.com/repos/hivemoot/colony/pulls/99/comments?per_page=100&since=2026-02-12T14%3A00%3A00Z",
+      ],
+    );
+    expect(result).toEqual([
+      {
+        body: "@hivemoot-worker from review comment",
+        author: "reviewer",
+        htmlUrl: "https://github.com/hivemoot/colony/pull/99#discussion_r1",
+        createdAt: "2026-02-12T15:10:00Z",
+      },
+      {
+        body: "@hivemoot-worker from issue comment",
+        author: "owner",
+        htmlUrl: "https://github.com/hivemoot/colony/pull/99#issuecomment-1",
+        createdAt: "2026-02-12T15:00:00Z",
+      },
+    ]);
+  });
+
+  it("returns null when fallback fetch fails", async () => {
+    const notification = makeNotification({
+      subject: {
+        url: "https://api.github.com/repos/hivemoot/colony/issues/42",
+        type: "Issue",
+        title: "Fix layout",
+        latest_comment_url: "https://api.github.com/repos/hivemoot/colony/issues/comments/999",
+      },
+    }) as RawNotification;
+    mockedGh.mockRejectedValue(new Error("timeout"));
+
+    const result = await fetchRecentSubjectComments(notification, "2026-02-12T14:00:00Z");
     expect(result).toBeNull();
   });
 });

--- a/cli/src/github/notifications.ts
+++ b/cli/src/github/notifications.ts
@@ -32,6 +32,14 @@ export interface CommentDetail {
   body: string;
   author: string;
   htmlUrl: string;
+  createdAt?: string;
+}
+
+export interface SubjectDetail {
+  body: string;
+  author: string;
+  htmlUrl: string;
+  updatedAt?: string;
 }
 
 /** Extract issue/PR number from a GitHub API subject URL (last path segment). */
@@ -152,6 +160,102 @@ export async function fetchCommentBody(commentUrl: string): Promise<CommentDetai
       author: parsed.author,
       htmlUrl: parsed.htmlUrl,
     };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch issue/PR subject body (issue body for both Issue and PullRequest subjects).
+ * Returns null when the fetch fails.
+ */
+export async function fetchSubjectBody(subjectUrl: string): Promise<SubjectDetail | null> {
+  if (!subjectUrl) return null;
+
+  try {
+    const raw = await gh([
+      "api",
+      subjectUrl,
+      "--jq", '{ body: (.body // ""), author: (.user.login // .author.login // "unknown"), htmlUrl: .html_url, updatedAt: .updated_at }',
+    ]);
+    const parsed = JSON.parse(raw) as SubjectDetail;
+    return {
+      body: parsed.body ?? "",
+      author: parsed.author ?? "unknown",
+      htmlUrl: parsed.htmlUrl ?? "",
+      updatedAt: parsed.updatedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function withSinceQuery(url: string, since?: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("per_page", "100");
+  if (since) {
+    parsed.searchParams.set("since", since);
+  }
+  return parsed.toString();
+}
+
+async function fetchCommentsList(url: string): Promise<CommentDetail[]> {
+  const raw = await gh([
+    "api",
+    url,
+  ]);
+
+  const parsed = JSON.parse(raw) as Array<{
+    body?: string;
+    user?: { login?: string };
+    author?: { login?: string };
+    html_url?: string;
+    created_at?: string;
+  }>;
+
+  return parsed.map((item) => ({
+    body: item.body ?? "",
+    author: item.user?.login ?? item.author?.login ?? "unknown",
+    htmlUrl: item.html_url ?? "",
+    createdAt: item.created_at,
+  }));
+}
+
+/**
+ * Fetch recent thread comments for fallback mention matching.
+ * For pull requests this includes both issue comments and review comments.
+ * Returns null when any API fetch fails.
+ */
+export async function fetchRecentSubjectComments(
+  notification: RawNotification,
+  since?: string,
+): Promise<CommentDetail[] | null> {
+  const subjectUrl = notification.subject.url;
+  if (!subjectUrl) return [];
+
+  try {
+    if (notification.subject.type === "Issue") {
+      const commentsUrl = withSinceQuery(`${subjectUrl}/comments`, since);
+      return await fetchCommentsList(commentsUrl);
+    }
+
+    if (notification.subject.type === "PullRequest") {
+      const issueUrl = subjectUrl.replace("/pulls/", "/issues/");
+      const issueCommentsUrl = withSinceQuery(`${issueUrl}/comments`, since);
+      const reviewCommentsUrl = withSinceQuery(`${subjectUrl}/comments`, since);
+      const [issueComments, reviewComments] = await Promise.all([
+        fetchCommentsList(issueCommentsUrl),
+        fetchCommentsList(reviewCommentsUrl),
+      ]);
+
+      return [...issueComments, ...reviewComments].sort((a, b) => {
+        const aTime = a.createdAt ?? "";
+        const bTime = b.createdAt ?? "";
+        return bTime.localeCompare(aTime);
+      });
+    }
+
+    return [];
   } catch {
     return null;
   }


### PR DESCRIPTION
Fixes #48

This patch tightens mention routing so an agent only runs when there is an explicit `@agent` tied to the current notification window.

What changed:
- Added subject-body verification when `latest_comment_url` is absent (`reason=mention` path).
- Added fallback scan over recent thread comments when the latest comment no longer mentions the current agent.
- Scoped fallback scanning with `since=state.lastChecked` to prevent historical mentions from re-triggering on unrelated new activity.
- Included both issue comments and PR review comments in PR fallback scans.
- Preserved retry semantics for transient fetch failures and mark-processed semantics for stale mention-thread events.

Why this fixes the guard failures:
- Prevents false positives from stale mention-thread subscriptions.
- Prevents dropping valid mentions when a later comment for a different agent becomes the thread latest.
- Avoids re-emitting old mentions after new unrelated activity.

Validation:
- `npm test --prefix cli`
- `npm run lint --prefix cli`
- `npm run build --prefix cli`
