### PR TITLE
docs: require CLI version bump for cli changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ No cloning required for voting, discussing, or reviewing — only for code imple
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
 - **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
 - **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
+- **If you change `cli/**`, bump CLI version files in the same PR**: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 - One focused change per PR
 - Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
 - Include tests when relevant
+- If you change anything under `cli/**`, bump the CLI package version in both `cli/package.json` and `cli/package-lock.json` in the same PR so the npm publish job can release it.
 
 ## Fork-First Publishing
 


### PR DESCRIPTION
## What
Adds an explicit contribution rule for CLI changes so release behavior is predictable: if a PR touches `cli/**`, it must bump the CLI package version files in the same PR.

## Issue
Fixes #55

## Notes
This prevents merges that pass CI but skip npm publish because the CLI version was already published.
