### PR TITLE
fix(cli): harden YAML and state-file handling

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^12.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -15,6 +15,24 @@ function encode(yamlContent: string): string {
   return JSON.stringify({ content: Buffer.from(yamlContent).toString("base64") });
 }
 
+function deepNestingYaml(levels: number): string {
+  const lines = [
+    "team:",
+    "  roles:",
+    "    engineer:",
+    "      description: Engineer",
+    "      instructions: Build things.",
+    "  extra:",
+  ];
+
+  for (let i = 0; i < levels; i += 1) {
+    lines.push(`${"  ".repeat(i + 2)}layer${i}:`);
+  }
+  lines.push(`${"  ".repeat(levels + 2)}leaf: value`);
+
+  return `${lines.join("\n")}\n`;
+}
+
 const validYaml = yaml.dump({
   team: {
     roles: {
@@ -339,6 +357,48 @@ describe("loadTeamConfig", () => {
     await expect(loadTeamConfig(repo)).rejects.toThrow(CliError);
     await expect(loadTeamConfig(repo)).rejects.toMatchObject({
       code: "INVALID_CONFIG",
+    });
+  });
+
+  it("uses hardened YAML parser options", async () => {
+    mockedGh.mockResolvedValue(encode(validYaml));
+    const loadSpy = vi.spyOn(yaml, "load");
+
+    await loadTeamConfig(repo);
+
+    expect(loadSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        schema: yaml.JSON_SCHEMA,
+        listener: expect.any(Function),
+      }),
+    );
+    loadSpy.mockRestore();
+  });
+
+  it("rejects YAML aliases", async () => {
+    const aliasYaml = `
+shared: &shared
+  description: Engineer
+  instructions: Build things.
+team:
+  roles:
+    engineer: *shared
+`;
+    mockedGh.mockResolvedValue(encode(aliasYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("invalid YAML"),
+    });
+  });
+
+  it("rejects overly nested YAML", async () => {
+    mockedGh.mockResolvedValue(encode(deepNestingYaml(45)));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("invalid YAML"),
     });
   });
 

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -12,6 +12,41 @@ const ROLE_SLUG_RE = /^[a-z][a-z0-9_]{0,49}$/;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_INSTRUCTIONS_LENGTH = 10_000;
 const MAX_ONBOARDING_LENGTH = 10_000;
+const YAML_MAX_ALIAS_COUNT = 0;
+const YAML_MAX_DEPTH = 40;
+
+function createYamlSecurityGuard(
+  maxDepth: number,
+  maxAliasCount: number,
+): (eventType: "open" | "close", state: unknown) => void {
+  let depth = 0;
+  let anchorCount = 0;
+
+  return (eventType, state) => {
+    if (eventType === "open") {
+      depth += 1;
+      if (depth > maxDepth) {
+        throw new Error(`YAML nesting exceeds max depth (${maxDepth})`);
+      }
+      return;
+    }
+
+    if (eventType === "close") {
+      depth = Math.max(0, depth - 1);
+
+      const anchor = typeof state === "object" && state !== null
+        ? (state as { anchor?: unknown }).anchor
+        : undefined;
+
+      if (typeof anchor === "string" && anchor.length > 0) {
+        anchorCount += 1;
+        if (anchorCount > maxAliasCount) {
+          throw new Error(`YAML aliases and anchors exceed maxAliasCount (${maxAliasCount})`);
+        }
+      }
+    }
+  };
+}
 
 function parseTeamFocus(rawFocus: unknown): string | undefined {
   if (!rawFocus || typeof rawFocus !== "object" || Array.isArray(rawFocus)) return undefined;
@@ -164,7 +199,10 @@ export async function loadTeamConfig(repo: RepoRef): Promise<TeamConfig> {
 
   let config: HivemootConfig;
   try {
-    config = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as HivemootConfig;
+    config = yaml.load(content, {
+      schema: yaml.JSON_SCHEMA,
+      listener: createYamlSecurityGuard(YAML_MAX_DEPTH, YAML_MAX_ALIAS_COUNT),
+    }) as HivemootConfig;
   } catch (err) {
     const detail = err instanceof Error ? `: ${err.message}` : "";
     throw new CliError(

--- a/cli/src/watch/state.test.ts
+++ b/cli/src/watch/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -65,6 +65,17 @@ describe("loadState()", () => {
     const state = await loadState(stateFile);
     expect(state.processedThreadIds).toEqual(["100", "200"]);
   });
+
+  it("rejects state paths that traverse symlink directories", async () => {
+    if (process.platform === "win32") return;
+
+    const realDir = join(tmpDir, "real");
+    const linkDir = join(tmpDir, "symlink");
+    await mkdir(realDir);
+    await symlink(realDir, linkDir);
+
+    await expect(loadState(join(linkDir, "watch-state.json"))).rejects.toThrow(/symbolic links/i);
+  });
 });
 
 describe("saveState()", () => {
@@ -113,6 +124,47 @@ describe("saveState()", () => {
     const raw = await readFile(stateFile, "utf-8");
     const loaded = JSON.parse(raw) as WatchState;
     expect(loaded.processedThreadIds).toEqual(["new"]);
+  });
+
+  it("creates parent directories for nested state-file paths", async () => {
+    const nestedStateFile = join(tmpDir, "nested", "dir", "watch-state.json");
+
+    await saveState(nestedStateFile, {
+      lastChecked: "2026-01-15T12:00:00Z",
+      processedThreadIds: ["nested"],
+    });
+
+    expect(existsSync(nestedStateFile)).toBe(true);
+  });
+
+  it("rejects nested state-file paths that traverse symlink directories", async () => {
+    if (process.platform === "win32") return;
+
+    const realDir = join(tmpDir, "real-parent");
+    const linkDir = join(tmpDir, "link-parent");
+    await mkdir(realDir);
+    await symlink(realDir, linkDir);
+
+    await expect(saveState(join(linkDir, "watch-state.json"), {
+      lastChecked: "2026-01-15T12:00:00Z",
+      processedThreadIds: [],
+    })).rejects.toThrow(/symbolic links/i);
+  });
+
+  it("fails when the state-file parent directory is not writable", async () => {
+    if (process.platform === "win32") return;
+
+    const lockedDir = join(tmpDir, "locked");
+    await mkdir(lockedDir, { mode: 0o500 });
+
+    try {
+      await expect(saveState(join(lockedDir, "watch-state.json"), {
+        lastChecked: "2026-01-15T12:00:00Z",
+        processedThreadIds: [],
+      })).rejects.toThrow(/readable\/writable/i);
+    } finally {
+      await chmod(lockedDir, 0o700);
+    }
   });
 });
 
@@ -255,5 +307,26 @@ describe("appendAck()", () => {
 
     const content = await readFile(journalPath, "utf-8");
     expect(content).toBe("key-1\nkey-2\nkey-3\n");
+  });
+
+  it("creates parent directories for nested state-file paths", async () => {
+    const nestedStateFile = join(tmpDir, "nested", "ack", "watch-state.json");
+    const nestedJournalPath = `${nestedStateFile}.acks`;
+
+    await appendAck(nestedStateFile, "key-1");
+
+    const content = await readFile(nestedJournalPath, "utf-8");
+    expect(content).toBe("key-1\n");
+  });
+
+  it("rejects ack paths that traverse symlink directories", async () => {
+    if (process.platform === "win32") return;
+
+    const realDir = join(tmpDir, "ack-real");
+    const linkDir = join(tmpDir, "ack-link");
+    await mkdir(realDir);
+    await symlink(realDir, linkDir);
+
+    await expect(appendAck(join(linkDir, "watch-state.json"), "key-1")).rejects.toThrow(/symbolic links/i);
   });
 });

--- a/cli/src/watch/state.ts
+++ b/cli/src/watch/state.ts
@@ -1,6 +1,6 @@
-import { readFile, writeFile, rename, unlink, open } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { access, lstat, mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { constants as fsConstants, existsSync } from "node:fs";
+import { dirname, isAbsolute, join, parse, resolve, sep } from "node:path";
 
 const MAX_PROCESSED_IDS = 200;
 
@@ -15,6 +15,51 @@ export interface LoadStateResult {
   reason?: string;
 }
 
+async function assertNoSymlinkTraversal(filePath: string): Promise<void> {
+  const absolutePath = isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath);
+  const root = parse(absolutePath).root;
+  const segments = absolutePath.slice(root.length).split(sep).filter(Boolean);
+
+  let currentPath = root;
+  for (const segment of segments) {
+    currentPath = join(currentPath, segment);
+    try {
+      const stats = await lstat(currentPath);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`State file path may not traverse symbolic links: ${currentPath}`);
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "ENOENT") continue;
+      throw err;
+    }
+  }
+}
+
+async function resolveStateFilePath(filePath: string): Promise<string> {
+  const resolvedPath = isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath);
+  await assertNoSymlinkTraversal(resolvedPath);
+  return resolvedPath;
+}
+
+async function ensureWritableParentDirectory(filePath: string): Promise<void> {
+  const parentDir = dirname(filePath);
+  await mkdir(parentDir, { recursive: true, mode: 0o700 });
+  await assertNoSymlinkTraversal(parentDir);
+
+  const parentStats = await lstat(parentDir);
+  if (parentStats.isSymbolicLink() || !parentStats.isDirectory()) {
+    throw new Error(`State file parent path is not a directory: ${parentDir}`);
+  }
+
+  try {
+    await access(parentDir, fsConstants.R_OK | fsConstants.W_OK | fsConstants.X_OK);
+  } catch (err) {
+    const detail = err instanceof Error ? `: ${err.message}` : "";
+    throw new Error(`State file parent directory is not readable/writable: ${parentDir}${detail}`);
+  }
+}
+
 /** Load state from disk, or return a default initial state (since = 1 hour ago). */
 export async function loadState(filePath: string): Promise<WatchState> {
   const result = await loadStateWithStatus(filePath);
@@ -23,12 +68,14 @@ export async function loadState(filePath: string): Promise<WatchState> {
 
 /** Load state with degradation signal for callers that need explicit warnings. */
 export async function loadStateWithStatus(filePath: string): Promise<LoadStateResult> {
-  if (!existsSync(filePath)) {
+  const resolvedPath = await resolveStateFilePath(filePath);
+
+  if (!existsSync(resolvedPath)) {
     return { state: defaultState(), degraded: false };
   }
 
   try {
-    const raw = await readFile(filePath, "utf-8");
+    const raw = await readFile(resolvedPath, "utf-8");
     let parsed: Partial<WatchState>;
 
     try {
@@ -76,7 +123,10 @@ export async function loadStateWithStatus(filePath: string): Promise<LoadStateRe
 
 /** Atomically save state to disk (write to temp, then rename). */
 export async function saveState(filePath: string, state: WatchState): Promise<void> {
-  const dir = dirname(filePath);
+  const resolvedPath = await resolveStateFilePath(filePath);
+  await ensureWritableParentDirectory(resolvedPath);
+
+  const dir = dirname(resolvedPath);
   const tmpPath = join(dir, `.${Date.now()}.tmp`);
 
   const trimmed: WatchState = {
@@ -84,8 +134,17 @@ export async function saveState(filePath: string, state: WatchState): Promise<vo
     processedThreadIds: state.processedThreadIds.slice(-MAX_PROCESSED_IDS),
   };
 
-  await writeFile(tmpPath, JSON.stringify(trimmed, null, 2) + "\n", "utf-8");
-  await rename(tmpPath, filePath);
+  try {
+    await writeFile(tmpPath, JSON.stringify(trimmed, null, 2) + "\n", "utf-8");
+    await rename(tmpPath, resolvedPath);
+  } catch (err) {
+    try {
+      await unlink(tmpPath);
+    } catch {
+      // Best effort cleanup of partial temp files.
+    }
+    throw err;
+  }
 }
 
 /** Mark a thread ID as processed, maintaining the rolling window. */
@@ -113,14 +172,19 @@ function defaultState(): WatchState {
  * lose data — they'll create a new journal file after the rename.
  */
 export async function mergeAckJournal(stateFilePath: string, state: WatchState): Promise<WatchState> {
-  const journalPath = `${stateFilePath}.acks`;
-  const processingPath = `${stateFilePath}.acks.processing`;
+  const resolvedPath = await resolveStateFilePath(stateFilePath);
+  const journalPath = `${resolvedPath}.acks`;
+  const processingPath = `${resolvedPath}.acks.processing`;
 
   try {
     await rename(journalPath, processingPath);
-  } catch {
-    // No journal file — nothing to merge
-    return state;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      // No journal file — nothing to merge
+      return state;
+    }
+    throw err;
   }
 
   try {
@@ -134,8 +198,13 @@ export async function mergeAckJournal(stateFilePath: string, state: WatchState):
 
     return merged;
   } finally {
-    // Always clean up the processing file
-    try { await unlink(processingPath); } catch { /* ignore */ }
+    // Always clean up the processing file.
+    try {
+      await unlink(processingPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "ENOENT") throw err;
+    }
   }
 }
 
@@ -144,7 +213,10 @@ export async function mergeAckJournal(stateFilePath: string, state: WatchState):
  * Uses O_APPEND for safe concurrent writes from multiple ack invocations.
  */
 export async function appendAck(stateFilePath: string, key: string): Promise<void> {
-  const journalPath = `${stateFilePath}.acks`;
+  const resolvedPath = await resolveStateFilePath(stateFilePath);
+  await ensureWritableParentDirectory(resolvedPath);
+
+  const journalPath = `${resolvedPath}.acks`;
   const fh = await open(journalPath, "a");
   try {
     await fh.write(`${key}\n`);


### PR DESCRIPTION
Fixes #26

This PR hardens two CLI attack surfaces identified in the guard audit:

- YAML config loading now enforces parser guardrails:
  - max nesting depth of 40 via parse listener
  - max alias/anchor count of 0 (anchors/aliases rejected)
- Watch state-file handling now validates paths and permissions:
  - rejects symlink traversal in any existing path component
  - creates missing parent directories for write paths
  - verifies parent directory read/write/execute permissions before writes
  - surfaces non-ENOENT journal rename/unlink failures instead of silently swallowing them
- Adds failure-mode coverage for both areas in unit tests.
- Bumps CLI version to `0.1.20` (`cli/package.json` and `cli/package-lock.json`).

Validation run:
- `cd cli && npm test`
- `cd cli && npm run lint`
