### PR TITLE
feat(cli): enforce publish preflight in buzz

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^12.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -10,6 +10,10 @@ vi.mock("../github/repo.js", () => ({
   fetchRepoPushAccess: vi.fn(),
 }));
 
+vi.mock("../github/publish.js", () => ({
+  runPublishPreflight: vi.fn(),
+}));
+
 vi.mock("../github/issues.js", () => ({
   fetchIssues: vi.fn(),
 }));
@@ -56,6 +60,7 @@ vi.mock("../output/json.js", () => ({
 
 import { loadTeamConfig } from "../config/loader.js";
 import { fetchRepoPushAccess, resolveRepo } from "../github/repo.js";
+import { runPublishPreflight } from "../github/publish.js";
 import { fetchIssues } from "../github/issues.js";
 import { fetchPulls } from "../github/pulls.js";
 import { fetchCurrentUser } from "../github/user.js";
@@ -70,6 +75,7 @@ import { buzzCommand } from "./buzz.js";
 
 const mockedResolveRepo = vi.mocked(resolveRepo);
 const mockedFetchRepoPushAccess = vi.mocked(fetchRepoPushAccess);
+const mockedRunPublishPreflight = vi.mocked(runPublishPreflight);
 const mockedLoadTeamConfig = vi.mocked(loadTeamConfig);
 const mockedFetchIssues = vi.mocked(fetchIssues);
 const mockedFetchPulls = vi.mocked(fetchPulls);
@@ -117,6 +123,11 @@ beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => {});
   mockedResolveRepo.mockResolvedValue(testRepo);
   mockedFetchRepoPushAccess.mockResolvedValue(true);
+  mockedRunPublishPreflight.mockResolvedValue({
+    command: "git push --dry-run origin HEAD",
+    ok: true,
+    originUrl: "https://github.com/hivemoot-guard/hivemoot.git",
+  });
   mockedLoadTeamConfig.mockResolvedValue(testTeamConfig);
   mockedFetchIssues.mockResolvedValue([]);
   mockedFetchPulls.mockResolvedValue([]);
@@ -862,6 +873,42 @@ describe("buzzCommand", () => {
     await buzzCommand({});
 
     expect(mockedFetchRepoPushAccess).toHaveBeenCalledWith(testRepo);
+    expect(mockedRunPublishPreflight).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds blocking note when publish preflight fails", async () => {
+    mockedRunPublishPreflight.mockResolvedValue({
+      command: "git push --dry-run origin HEAD",
+      ok: false,
+      originUrl: "https://github.com/hivemoot/test.git",
+      error: "remote: Permission denied (403)",
+    });
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes).toContain(
+      "Publish preflight failed (git push --dry-run origin HEAD) (origin: https://github.com/hivemoot/test.git): remote: Permission denied (403).",
+    );
+    expect(summaryArg.notes).toContain(
+      "Fork-first fix: git remote rename origin upstream && git remote add origin https://github.com/testuser/test.git",
+    );
+    expect(summaryArg.notes).toContain("Rerun before implementation: git push --dry-run origin HEAD");
+  });
+
+  it("adds fallback note when publish preflight execution fails", async () => {
+    mockedRunPublishPreflight.mockRejectedValue(new Error("spawn git ENOENT"));
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes).toContain(
+      "Could not run publish preflight (spawn git ENOENT) — run git push --dry-run origin HEAD before implementation.",
+    );
   });
 
   it("adds publishing-flow guidance note when token cannot push", async () => {

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -4,10 +4,12 @@ import {
   type GitHubIssue,
   type NotificationRef,
   type RecentClosedItem,
+  type RepoRef,
   type TeamConfig,
 } from "../config/types.js";
 import { loadTeamConfig } from "../config/loader.js";
 import { fetchRepoPushAccess, resolveRepo } from "../github/repo.js";
+import { runPublishPreflight } from "../github/publish.js";
 import { fetchIssues } from "../github/issues.js";
 import { fetchPulls } from "../github/pulls.js";
 import { fetchCurrentUser } from "../github/user.js";
@@ -23,6 +25,17 @@ import { loadStateWithStatus, mergeAckJournal } from "../watch/state.js";
 
 function errorDetail(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason);
+}
+
+function normalizeRemoteUrl(remoteUrl: string): string {
+  return remoteUrl.trim().toLowerCase().replace(/\.git$/, "");
+}
+
+function originTargetsUpstream(originUrl: string, repo: RepoRef): boolean {
+  const normalized = normalizeRemoteUrl(originUrl);
+  const owner = repo.owner.toLowerCase();
+  const name = repo.repo.toLowerCase();
+  return normalized.includes(`github.com/${owner}/${name}`) || normalized.includes(`github.com:${owner}/${name}`);
 }
 
 function buildUnackedMentions(
@@ -94,12 +107,20 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
 
   // Fetch summary data in parallel with optional team config loading.
   // Focus is additive and should not delay base status data.
-  const [issuesResult, prsResult, userResult, notificationsResult, pushAccessResult] = await Promise.allSettled([
+  const [
+    issuesResult,
+    prsResult,
+    userResult,
+    notificationsResult,
+    pushAccessResult,
+    publishPreflightResult,
+  ] = await Promise.allSettled([
     fetchIssues(repo, fetchLimit),
     fetchPulls(repo, fetchLimit),
     fetchCurrentUser(),
     fetchNotifications(repo),
     fetchRepoPushAccess(repo),
+    runPublishPreflight(),
   ]);
 
   try {
@@ -217,6 +238,29 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   } else {
     summary.notes.push(
       `Could not check push permissions (${errorDetail(pushAccessResult.reason)}) — check this repository's contribution docs for publishing guidance.`,
+    );
+  }
+
+  if (publishPreflightResult.status === "fulfilled") {
+    const preflight = publishPreflightResult.value;
+    if (!preflight.ok) {
+      const originSuffix = preflight.originUrl ? ` (origin: ${preflight.originUrl})` : "";
+      summary.notes.push(
+        `Publish preflight failed (${preflight.command})${originSuffix}: ${preflight.error ?? "unknown error"}.`,
+      );
+
+      if (preflight.originUrl && originTargetsUpstream(preflight.originUrl, repo)) {
+        const forkOwner = currentUser || "<your-user>";
+        summary.notes.push(
+          `Fork-first fix: git remote rename origin upstream && git remote add origin https://github.com/${forkOwner}/${repo.repo}.git`,
+        );
+      }
+
+      summary.notes.push(`Rerun before implementation: ${preflight.command}`);
+    }
+  } else {
+    summary.notes.push(
+      `Could not run publish preflight (${errorDetail(publishPreflightResult.reason)}) — run git push --dry-run origin HEAD before implementation.`,
     );
   }
 

--- a/cli/src/github/publish.test.ts
+++ b/cli/src/github/publish.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+const { mockedExecFile } = vi.hoisted(() => ({
+  mockedExecFile: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockedExecFile,
+}));
+
+import { runPublishPreflight } from "./publish.js";
+
+function mockExecSuccess(stdout: string, stderr = ""): void {
+  mockedExecFile.mockImplementationOnce(
+    (
+      _cmd: string,
+      _args: string[],
+      _options: { encoding: string },
+      callback: ExecCallback,
+    ) => {
+      callback(null, stdout, stderr);
+    },
+  );
+}
+
+function mockExecFailure(message: string, stderr = "", stdout = ""): void {
+  mockedExecFile.mockImplementationOnce(
+    (
+      _cmd: string,
+      _args: string[],
+      _options: { encoding: string },
+      callback: ExecCallback,
+    ) => {
+      callback(new Error(message), stdout, stderr);
+    },
+  );
+}
+
+describe("runPublishPreflight()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns ok=true when origin is configured and dry-run push succeeds", async () => {
+    mockExecSuccess("https://github.com/hivemoot-guard/hivemoot.git\n");
+    mockExecSuccess("");
+
+    const result = await runPublishPreflight();
+
+    expect(result).toEqual({
+      command: "git push --dry-run origin HEAD",
+      ok: true,
+      originUrl: "https://github.com/hivemoot-guard/hivemoot.git",
+    });
+
+    expect(mockedExecFile).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["remote", "get-url", "origin"],
+      { encoding: "utf8" },
+      expect.any(Function),
+    );
+    expect(mockedExecFile).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      ["push", "--dry-run", "origin", "HEAD"],
+      { encoding: "utf8" },
+      expect.any(Function),
+    );
+  });
+
+  it("returns a structured failure when origin remote cannot be resolved", async () => {
+    mockExecFailure("fatal: not a git repository", "fatal: not a git repository");
+
+    const result = await runPublishPreflight();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("could not resolve git origin remote");
+    expect(result.error).toContain("fatal: not a git repository");
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a structured failure when dry-run push fails", async () => {
+    mockExecSuccess("https://github.com/hivemoot/hivemoot.git\n");
+    mockExecFailure(
+      "push failed",
+      "remote: Permission to hivemoot/hivemoot.git denied to hivemoot-guard.",
+    );
+
+    const result = await runPublishPreflight();
+
+    expect(result).toEqual({
+      command: "git push --dry-run origin HEAD",
+      ok: false,
+      originUrl: "https://github.com/hivemoot/hivemoot.git",
+      error: "remote: Permission to hivemoot/hivemoot.git denied to hivemoot-guard.",
+    });
+  });
+});

--- a/cli/src/github/publish.ts
+++ b/cli/src/github/publish.ts
@@ -1,0 +1,83 @@
+import { execFile } from "node:child_process";
+
+type ExecOutput = {
+  stdout: string;
+  stderr: string;
+};
+
+type ExecError = Error & {
+  stdout?: string;
+  stderr?: string;
+};
+
+export interface PublishPreflightResult {
+  command: "git push --dry-run origin HEAD";
+  ok: boolean;
+  originUrl?: string;
+  error?: string;
+}
+
+function trimText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function execGit(args: string[]): Promise<ExecOutput> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "git",
+      args,
+      { encoding: "utf8" },
+      (error, stdout, stderr) => {
+        if (error) {
+          const enriched = error as ExecError;
+          enriched.stdout = stdout;
+          enriched.stderr = stderr;
+          reject(enriched);
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function describeExecError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const execErr = err as ExecError;
+  return (
+    trimText(execErr.stderr)
+    ?? trimText(execErr.stdout)
+    ?? trimText(execErr.message)
+    ?? "unknown error"
+  );
+}
+
+export async function runPublishPreflight(): Promise<PublishPreflightResult> {
+  const command = "git push --dry-run origin HEAD" as const;
+
+  let originUrl: string | undefined;
+  try {
+    const { stdout } = await execGit(["remote", "get-url", "origin"]);
+    originUrl = trimText(stdout);
+  } catch (err) {
+    return {
+      command,
+      ok: false,
+      error: `could not resolve git origin remote: ${describeExecError(err)}`,
+    };
+  }
+
+  try {
+    await execGit(["push", "--dry-run", "origin", "HEAD"]);
+    return { command, ok: true, originUrl };
+  } catch (err) {
+    return {
+      command,
+      ok: false,
+      originUrl,
+      error: describeExecError(err),
+    };
+  }
+}


### PR DESCRIPTION
Fixes #43

This hardens `hivemoot buzz` so publish misconfiguration fails early and explicitly.

What changed:
- Added `runPublishPreflight()` (`cli/src/github/publish.ts`) to execute:
  - `git remote get-url origin`
  - `git push --dry-run origin HEAD`
- Wired preflight into `buzz` startup (`cli/src/commands/buzz.ts`):
  - emits a blocking note when preflight fails
  - includes origin URL in diagnostics
  - emits fork-first remediation when `origin` points at upstream
  - emits a rerun reminder before implementation
- Added tests for publish preflight helper and buzz integration notes.
- Bumped CLI version to `0.1.21` in `cli/package.json` and `cli/package-lock.json`.

Validation run:
- `cd cli && npm test`
- `cd cli && npm run typecheck`
- `cd cli && npm run build`
