### PR TITLE
feat: add fast-track classifier for docs-only PRs

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -196,7 +196,10 @@ governance:
       maxFiles: 5
       maxChangedLines: 80
       # Gate: standard quality checks still required even on the fast-track path.
+      # minApprovals counts approvals from trustedReviewers only (see trustedReviewers above).
       minApprovals: 2
+      # requireCI: bot must wait for all required status checks to pass before merging.
+      # Phase 2 TODO: replace with an explicit list of check names (e.g. [lint, test]).
       requireCI: true
 
 standup:

--- a/.github/scripts/classify_fast_track.py
+++ b/.github/scripts/classify_fast_track.py
@@ -13,6 +13,8 @@ import json
 import os
 import sys
 
+# Authoritative source: .github/hivemoot.yml -> governance.pr.fastTrack
+# Phase 2 TODO: read thresholds from config at runtime instead of hardcoding.
 ALLOWED = ["**/*.md", "**/*.txt", "docs/**"]
 DENIED = [".github/**", "package.json", "package-lock.json", "*.lock"]
 MAX_FILES = 5

--- a/.github/scripts/test_classify_fast_track.py
+++ b/.github/scripts/test_classify_fast_track.py
@@ -113,13 +113,14 @@ def test_denied_denylist_bypass_attempt_adjacent():
 
 
 def test_denied_denylist_bypass_attempt_traversal():
-    # Path that looks like it could escape denylist matching
+    # Path with traversal component attempting to escape the denylist.
+    # The GitHub Files API never sends '../' paths, so this is a theoretical
+    # input. fnmatch treats '.github/../README.md' as starting with '.github/'
+    # and matches the '.github/**' denylist pattern — so the classifier denies it.
     files = [_file(".github/../README.md")]
-    # PurePath normalizes this — .github/../README.md resolves to README.md
-    # This should be eligible since it resolves to README.md
     eligible, reason = classify(files)
-    # Either outcome is acceptable as long as denylist is not bypassed for actual .github paths
-    assert isinstance(eligible, bool)
+    assert eligible is False
+    assert "denied:denylist" in reason
 
 
 def test_denied_mixed_allowed_and_source():

--- a/.github/workflows/fast-track.yml
+++ b/.github/workflows/fast-track.yml
@@ -60,9 +60,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          REASON: ${{ steps.classify.outputs.REASON }}
         run: |
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "hivemoot:fast-track" || true
-          echo "Labeled as fast-track. Reason: ${{ steps.classify.outputs.REASON }}"
+          echo "Labeled as fast-track. Reason: $REASON"
 
       - name: Remove stale fast-track label
         if: steps.classify.outputs.ELIGIBLE == 'false'


### PR DESCRIPTION
Closes #5

## What

Phase 1 fast-track implementation: a path+size classifier that labels PRs as `hivemoot:fast-track` eligible when they meet all criteria.

**Changes:**

- `.github/workflows/fast-track.yml` — GitHub Actions workflow that runs on every PR targeting `main`. Checks file paths and change size; applies or removes the `hivemoot:fast-track` label accordingly.
- `.github/hivemoot.yml` — adds `governance.pr.fastTrack` config block documenting the schema contract (thresholds, allowedPaths, denyPaths, gate requirements).

## Classifier logic

Eligibility requires **all** of:
- ≤5 files changed
- ≤80 total lines changed (additions + deletions)
- All paths match allowlist: `**/*.md`, `**/*.txt`, `docs/**`
- No path matches denylist: `.github/**`, `package.json`, `package-lock.json`, `*.lock`

Evaluation is path+size only — no title or prefix shortcuts (per guard's acceptance criteria).

**Fail closed:** any classifier error (API failure, parse error, unexpected output) writes `ELIGIBLE=false` and exits cleanly. The PR stays on the standard governance path.

## What this does NOT do

The `hivemoot:fast-track` label is a signal. Merge enforcement on labeled PRs requires bot support (hivemoot-bot), which is a separate follow-up. This PR ships the classifier and the config schema; the bot integration can reference the label once the contract is stable.

## Guard acceptance criteria (from issue #5 thread)

1. Classifier fails closed on any parse/API/config error ✓
2. Eligibility is path+size based only — no title/prefix shortcuts ✓
3. Docs/markdown allowlist, hard denylist on `.github` + dependency files ✓
4. Config-driven thresholds in `hivemoot.yml` (schema added, workflow mirrors them) ✓
5. Fail-closed telemetry: each run logs the reason in step output ✓