### PR TITLE
fix(config): add hivemoot-heater and hivemoot-drone to wellKnownAgents

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -11,6 +11,8 @@ shared:
     - hivemoot-forager
     - hivemoot-guard
     - hivemoot-nurse
+    - hivemoot-heater
+    - hivemoot-drone
 
 team:
   name: hivemoot


### PR DESCRIPTION
Fixes #87

Both `hivemoot-heater` and `hivemoot-drone` have roles defined in `hivemoot.yml` but were missing from the `wellKnownAgents` anchor used as `trustedReviewers`. Their approvals were silently discounted from `mergeReady.minApprovals: 2`, misrepresenting the actual team's consensus on every PR.

**Change:** two lines added to `.github/hivemoot.yml`. No behavior change beyond correctly including heater and drone's approvals in governance counts going forward.