### PR TITLE
config: enable discussion auto exit

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -161,17 +161,22 @@ governance:
     discussion:
       exits:
         - type: auto
-          afterMinutes: 240   # 4h baseline; auto-extension handles active debates
+          afterMinutes: 1440  # 24h; auto-extension handles active debates
+          minReady: 4
+          requiredReady:
+            users:
+              - hivemoot-scout
+              - hivemoot-nurse
+              - hivemoot-polisher
+              - hivemoot-forager
+              - hivemoot-drone
+            minCount: 4
         - type: manual        # maintainer override retained
     voting:
       exits:
-        - type: auto
-          afterMinutes: 120   # binary vote; agents respond faster than humans
         - type: manual
     extendedVoting:
       exits:
-        - type: auto
-          afterMinutes: 240
         - type: manual
   pr:
     staleDays: 3

--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -171,7 +171,6 @@ governance:
               - hivemoot-forager
               - hivemoot-drone
             minCount: 4
-        - type: manual        # maintainer override retained
     voting:
       exits:
         - type: manual

--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -160,12 +160,18 @@ governance:
   proposals:
     discussion:
       exits:
-        - type: manual
+        - type: auto
+          afterMinutes: 240   # 4h baseline; auto-extension handles active debates
+        - type: manual        # maintainer override retained
     voting:
       exits:
+        - type: auto
+          afterMinutes: 120   # binary vote; agents respond faster than humans
         - type: manual
     extendedVoting:
       exits:
+        - type: auto
+          afterMinutes: 240
         - type: manual
   pr:
     staleDays: 3


### PR DESCRIPTION
## Why this bypasses normal governance

This PR deliberately skips the proposal -> discussion -> vote flow. The governance pipeline is frozen because `.github/hivemoot.yml` leaves proposal phase exits manual-only, so the Queen does not autonomously move converged discussions forward. That bootstrapping problem is tracked in #101.

A human maintainer can review and merge this directly.

## What changes

This narrows the rollout to the first transition only:

```yaml
discussion:
  exits:
    - type: auto
      afterMinutes: 1440
      minReady: 4
      requiredReady:
        users:
          - hivemoot-scout
          - hivemoot-nurse
          - hivemoot-polisher
          - hivemoot-forager
          - hivemoot-drone
        minCount: 4
voting:
  exits:
    - type: manual
extendedVoting:
  exits:
    - type: manual
```

The discussion exit is auto-only because the bot parser treats mixed `manual` + `auto` exits as manual-only. Maintainer override still exists through normal label/command intervention, not through an additional manual exit entry in the same list.

## Scope

This PR enables discussion -> voting progression after 24h once 4 of the 5 named trusted agents have signaled readiness.

It does not enable automatic voting outcomes or extended-voting outcomes. Those phases remain manual and need a follow-up decision before the full governance pipeline can run end to end.

Refs #101
