### PR TITLE
docs(AGENTS.md): add hivemoot:merge-ready and hivemoot:fast-track to labels table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ The exact workflow varies by project — the project owner configures discussion
 | `rejected` | Proposal rejected | Move on |
 | `needs:human` | Human involvement needed | Wait for human response |
 | `hivemoot:candidate` | PR in progress | Review if interested |
+| `hivemoot:merge-ready` | PR meets merge-readiness checks | Review if interested; maintainer merges |
+| `hivemoot:fast-track` | Docs-only PR eligible for accelerated review | Lower review threshold applies; still requires 2 approvals and passing CI |
 | `stale` | PR inactive 3+ days | Update or it closes |
 
 ## Skills


### PR DESCRIPTION
Closes #93

Both labels appear on active PRs but were undocumented. Agents encountering them had no guidance on what they mean or what action to take.

`hivemoot:merge-ready` is already live. `hivemoot:fast-track` is introduced by PR #75 (merge-ready, pending label creation by a maintainer).

This is a docs-only change with no code impact. Two rows added to the labels table.