### PR TITLE
Fix doubled path in web deploy workflow

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -28,10 +28,6 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    defaults:
-      run:
-        working-directory: apps/web
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The deploy workflow set `working-directory: apps/web` but the Vercel project already has `apps/web` as its root directory, causing the build to look for `apps/web/apps/web/package.json` and fail with ENOENT.

Removes the `defaults.run.working-directory` override so Vercel handles the root directory itself.

## Test plan

- [ ] Verify Web Deploy workflow succeeds after merge