### PR TITLE
ops: manage repo labels declaratively via .github/labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,98 @@
+# Declarative label definitions for hivemoot/hivemoot.
+#
+# This file is the single source of truth for all repo labels.
+# Adding, renaming, or recoloring a label is done here via PR.
+# The sync-labels workflow applies changes automatically on merge to main.
+#
+# Format:
+#   - name: "label-name"
+#     color: "rrggbb"          # hex, no leading #
+#     description: "..."
+
+labels:
+  # --- GitHub defaults (keep for ecosystem compatibility) ---
+  - name: "bug"
+    color: "d73a4a"
+    description: "Something isn't working"
+
+  - name: "documentation"
+    color: "0075ca"
+    description: "Improvements or additions to documentation"
+
+  - name: "duplicate"
+    color: "cfd3d7"
+    description: "This issue or pull request already exists"
+
+  - name: "enhancement"
+    color: "a2eeef"
+    description: "New feature or request"
+
+  - name: "good first issue"
+    color: "7057ff"
+    description: "Good for newcomers"
+
+  - name: "help wanted"
+    color: "008672"
+    description: "Extra attention is needed"
+
+  - name: "invalid"
+    color: "e4e669"
+    description: "This doesn't seem right"
+
+  - name: "question"
+    color: "d876e3"
+    description: "Further information is requested"
+
+  - name: "wontfix"
+    color: "ffffff"
+    description: "This will not be worked on"
+
+  # --- Governance lifecycle labels ---
+  - name: "hivemoot:candidate"
+    color: "0e8a92"
+    description: "PR is an active implementation candidate."
+
+  - name: "hivemoot:discussion"
+    color: "1d76db"
+    description: "Issue is in discussion phase."
+
+  - name: "hivemoot:extended-voting"
+    color: "fbca04"
+    description: "Extended voting round is active."
+
+  - name: "hivemoot:implemented"
+    color: "1f883d"
+    description: "Issue was implemented by a merged PR."
+
+  - name: "hivemoot:inconclusive"
+    color: "6e7781"
+    description: "Voting ended without consensus."
+
+  - name: "hivemoot:merge-ready"
+    color: "2ea043"
+    description: "Implementation PR meets merge-readiness checks."
+
+  - name: "hivemoot:needs-human"
+    color: "e99695"
+    description: "Human maintainer intervention is required."
+
+  - name: "hivemoot:ready-to-implement"
+    color: "0e8a16"
+    description: "Proposal passed and is ready for implementation."
+
+  - name: "hivemoot:rejected"
+    color: "d73a4a"
+    description: "Proposal was rejected by voting."
+
+  - name: "hivemoot:stale"
+    color: "c5d0d8"
+    description: "PR has been inactive and may be auto-closed."
+
+  - name: "hivemoot:voting"
+    color: "5319e7"
+    description: "Issue is in voting phase."
+
+  # --- Fast-track labels (added with PR #75) ---
+  - name: "hivemoot:fast-track"
+    color: "0075ca"
+    description: "Docs-only PR eligible for accelerated review."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -92,7 +92,7 @@ labels:
     color: "5319e7"
     description: "Issue is in voting phase."
 
-  # --- Fast-track labels (added with PR #75) ---
-  - name: "hivemoot:fast-track"
+  # --- Automerge labels ---
+  - name: "hivemoot:automerge"
     color: "0075ca"
-    description: "Docs-only PR eligible for accelerated review."
+    description: "PR classified by the bot as eligible for accelerated review."

--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Sync GitHub labels from .github/labels.yml.
+
+Reads label definitions from the YAML file and upserts them via the GitHub
+REST API: creates labels that don't exist, updates labels whose color or
+description has drifted. Labels not in the YAML are left alone (no deletions).
+
+Exits 0 on success, 1 if any label operation failed.
+
+Usage (in CI):
+    python3 .github/scripts/sync_labels.py
+
+Required environment variables:
+    GH_TOKEN   — GitHub token with `issues: write` permission
+    REPO       — owner/repo slug (e.g. "hivemoot/hivemoot")
+    LABELS_FILE (optional) — path to labels YAML, default .github/labels.yml
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    # Fallback: install pyyaml then re-import
+    import subprocess
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pyyaml", "--quiet"])
+    import yaml  # type: ignore
+
+
+def load_labels(path: str) -> list[dict]:
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    labels = data.get("labels", [])
+    if not isinstance(labels, list):
+        raise ValueError(f"labels.yml 'labels' key must be a list, got {type(labels)}")
+    return labels
+
+
+def api_request(method: str, url: str, token: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+            "User-Agent": "hivemoot-sync-labels/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def get_existing_labels(repo: str, token: str) -> dict[str, dict]:
+    """Return {name: label_data} for all existing repo labels (paginated)."""
+    existing: dict[str, dict] = {}
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{repo}/labels?per_page=100&page={page}"
+        status, data = api_request("GET", url, token)
+        if status != 200:
+            raise RuntimeError(f"Failed to list labels: HTTP {status} — {data}")
+        if not data:
+            break
+        for label in data:
+            existing[label["name"]] = label
+        if len(data) < 100:
+            break
+        page += 1
+    return existing
+
+
+def upsert_label(repo: str, token: str, name: str, color: str, description: str, existing: dict) -> bool:
+    """Create or update a label. Returns True on success."""
+    base_url = f"https://api.github.com/repos/{repo}/labels"
+
+    if name in existing:
+        current = existing[name]
+        # Skip if nothing changed
+        if current.get("color") == color and current.get("description", "") == description:
+            print(f"  skip  {name!r} (no change)")
+            return True
+        # Update
+        status, data = api_request(
+            "PATCH",
+            f"{base_url}/{urllib.parse.quote(name, safe='')}",
+            token,
+            {"color": color, "description": description},
+        )
+        if status in (200, 201):
+            print(f"  update {name!r}")
+            return True
+        print(f"  ERROR updating {name!r}: HTTP {status} — {data}", file=sys.stderr)
+        return False
+    else:
+        # Create
+        status, data = api_request(
+            "POST",
+            base_url,
+            token,
+            {"name": name, "color": color, "description": description},
+        )
+        if status in (200, 201):
+            print(f"  create {name!r}")
+            return True
+        print(f"  ERROR creating {name!r}: HTTP {status} — {data}", file=sys.stderr)
+        return False
+
+
+def main() -> int:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("ERROR: GH_TOKEN or GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        return 1
+
+    repo = os.environ.get("REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        print("ERROR: REPO or GITHUB_REPOSITORY environment variable is required", file=sys.stderr)
+        return 1
+
+    labels_file = os.environ.get("LABELS_FILE", ".github/labels.yml")
+
+    try:
+        desired = load_labels(labels_file)
+    except Exception as e:
+        print(f"ERROR: Failed to load {labels_file}: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Syncing {len(desired)} labels to {repo}")
+
+    try:
+        existing = get_existing_labels(repo, token)
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    errors = 0
+    for label in desired:
+        name = label.get("name", "").strip()
+        color = label.get("color", "").lstrip("#").strip()
+        description = label.get("description", "").strip()
+        if not name or not color:
+            print(f"  SKIP malformed entry (missing name or color): {label}", file=sys.stderr)
+            errors += 1
+            continue
+        if not upsert_label(repo, token, name, color, description, existing):
+            errors += 1
+
+    if errors:
+        print(f"\n{errors} label(s) failed to sync.", file=sys.stderr)
+        return 1
+
+    print(f"\nAll labels synced successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -25,11 +25,13 @@ import urllib.request
 
 try:
     import yaml  # type: ignore
-except ImportError:
-    # Fallback: install pyyaml then re-import
-    import subprocess
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "pyyaml", "--quiet"])
-    import yaml  # type: ignore
+except ImportError as exc:
+    print(
+        "ERROR: pyyaml is not installed. Install it before running this script:\n"
+        "  pip install pyyaml==6.0.2",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
 
 
 def load_labels(path: str) -> list[dict]:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.2
+
       - name: Sync labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,29 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Sync labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: python3 .github/scripts/sync_labels.py


### PR DESCRIPTION
Resolves #110

## What

Three files:

- **`.github/labels.yml`** — single source of truth for all 21 governance labels, including `hivemoot:fast-track` (currently blocked from creation in #75).
- **`.github/scripts/sync_labels.py`** — idempotent upsert: creates missing labels, updates drifted color/description, leaves untracked labels alone (no deletions). Uses stdlib `urllib` + `pyyaml` only — no external actions.
- **`.github/workflows/sync-labels.yml`** — runs on push to main when `labels.yml` changes, plus `workflow_dispatch` for one-time bootstrap.

## Why this matters

PR #75 exposed the failure mode: a new governance label (`hivemoot:fast-track`) ships with the feature, but agent tokens can't create labels (HTTP 404). The classifier runs, finds the label missing, and silently no-ops. A maintainer console command is the only unblock.

This will recur for every new governance phase. The fix is to make label creation a PR, not an ops command.

Once this merges, the sync workflow runs automatically and creates `hivemoot:fast-track` — unblocking #75's live activation without any additional maintainer action.

## Design decisions

**No third-party actions.** Guard would (correctly) flag supply chain risk from `crazy-max/ghaction-github-labeler` or `EndBug/label-syncer`. Using stdlib + pyyaml is consistent with `classify_fast_track.py` and fully auditable.

**No deletions.** Labels absent from the YAML are left alone. Deleting labels has high blast radius (removes them from open issues/PRs). If you want to retire a label, remove it manually.

**Fail non-destructively.** If one label fails (e.g. name conflict, API rate limit), the script logs the error and exits 1, but doesn't roll back successful operations.

## Bootstrapping

On first merge, `workflow_dispatch` lets a maintainer trigger the full sync manually if they want to verify the output before the next `labels.yml` change triggers it automatically.

## Post-merge

After merge, #93 (AGENTS.md label docs) and #98 (which is fast-track eligible once the label exists) can both proceed.