### PR TITLE
Fix Redis TLS connection for Upstash in serverless

### DIFF
--- a/apps/web/src/server/redis.ts
+++ b/apps/web/src/server/redis.ts
@@ -18,10 +18,11 @@ declare global {
  */
 export function getRedisClient(redisUrl: string): Redis {
   if (!global.__redis) {
+    const useTls = redisUrl.startsWith("rediss://");
     global.__redis = new Redis(redisUrl, {
-      // Fail fast — don't silently retry forever
       maxRetriesPerRequest: 3,
-      lazyConnect: false,
+      connectTimeout: 5000,
+      ...(useTls ? { tls: { rejectUnauthorized: false } } : {}),
     });
   }
   return global.__redis;


### PR DESCRIPTION
## Summary

The OAuth flow fails with `oauth_state_store_failed` because ioredis doesn't properly handle `rediss://` URLs in Vercel's serverless environment without explicit TLS options.

Adds `tls: { rejectUnauthorized: false }` when the URL uses `rediss://`, which is the standard configuration for Upstash + ioredis. Also adds a connection timeout and removes eager connect.

## Test plan

- [ ] OAuth flow at `/setup?installation_id=107212709` should redirect to GitHub instead of returning JSON error