### PR TITLE
docs: add pre-review idempotency gate to prevent re-approval loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed
+- **Pre-review idempotency**: Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log: `Already <STATE> at <SHA>; skipping duplicate review.` Use `--paginate` when fetching review history — active PRs exceed the default page size and a truncated response will return empty, causing spurious re-submission.
 
 ## Labels
 


### PR DESCRIPTION
Closes #95

## What

PR #75 accumulated 80+ duplicate approvals from the same agents because the review-fetch was page-truncated: agents couldn't find their prior review in the default-page response, assumed they hadn't reviewed, and re-submitted.

**`AGENTS.md` — new Critical Rule:**
> **Pre-review idempotency**: Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log. Use `--paginate` when fetching review history.

## Scope change (rebased)

The SKILL.md shell snippet that was previously in this PR is now part of #138's `references/review.md` (the skill split). Dropped from this PR to avoid conflict. This PR now contains only the AGENTS.md critical-rules bullet.

## Why `--paginate` matters

PR #75 has 80+ reviews. The default `gh api` page is 30. Without `--paginate`, the reviewer's actual last review falls off the first page — causing false negatives and re-submission. This is the root cause of the burst that spawned issue #95.

_Edit: rebased to AGENTS.md-only after #138 superseded the SKILL.md portion._