### PR TITLE
Add Step 2 API key configuration form

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.test.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.test.ts
@@ -18,6 +18,8 @@ vi.mock("@/server/setup-session", () => ({
   validateOAuthState: vi.fn(),
   createSetupSession: vi.fn(),
   OAUTH_STATE_BINDING_COOKIE: "oauth_state_binding",
+  SETUP_SESSION_COOKIE: "setup_session",
+  SESSION_TTL_SECONDS: 1800,
 }));
 
 import { validateEnv } from "@/server/env";
@@ -34,7 +36,8 @@ import {
   createSetupSession,
   OAUTH_STATE_BINDING_COOKIE,
 } from "@/server/setup-session";
-import { GET, SETUP_SESSION_COOKIE } from "./route";
+import { SETUP_SESSION_COOKIE } from "@/server/setup-session";
+import { GET } from "./route";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -29,13 +29,9 @@ import {
   validateOAuthState,
   createSetupSession,
   OAUTH_STATE_BINDING_COOKIE,
+  SETUP_SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
 } from "@/server/setup-session";
-
-/** Cookie name for the short-lived setup session token */
-export const SETUP_SESSION_COOKIE = "setup_session";
-
-/** How long the session cookie lives in the browser (matches Redis TTL) */
-const SESSION_COOKIE_MAX_AGE = 1800; // 30 minutes
 const OAUTH_STATE_READ_FAILED_CODE = "oauth_state_read_failed";
 const SETUP_SESSION_CREATE_FAILED_CODE = "setup_session_create_failed";
 
@@ -203,7 +199,7 @@ export async function GET(request: NextRequest) {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
-    maxAge: SESSION_COOKIE_MAX_AGE,
+    maxAge: SESSION_TTL_SECONDS,
     path: "/",
   });
   clearOAuthStateBindingCookie(response);

--- a/apps/web/src/app/setup/Step2Form.tsx
+++ b/apps/web/src/app/setup/Step2Form.tsx
@@ -22,7 +22,7 @@ interface SuccessData {
 }
 
 const DEFAULT_MODELS: Record<Provider, string> = {
-  anthropic: "claude-sonnet-4-5-20250514",
+  anthropic: "claude-sonnet-4-6",
   openai: "gpt-4o",
 };
 

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
 import Step2Form from "./Step2Form";
-import { SESSION_TTL_SECONDS } from "@/server/setup-session";
+import { SESSION_TTL_SECONDS, SETUP_SESSION_COOKIE } from "@/server/setup-session";
 
 export const metadata: Metadata = {
   title: "Set up Hivemoot — Governance for Autonomous AI Agents",
@@ -197,7 +197,7 @@ export default async function SetupPage({
   const auth = params.auth;
   const reason = params.reason;
   const cookieStore = await cookies();
-  const hasSession = !!cookieStore.get("setup_session")?.value;
+  const hasSession = !!cookieStore.get(SETUP_SESSION_COOKIE)?.value;
   const isAuthorized = auth === "ok" && hasSession;
   const STEPS = buildSteps(isAuthorized);
 
@@ -345,7 +345,7 @@ export default async function SetupPage({
 
                 {installationId ? (
                   <Link
-                    href={`/api/auth/github/start?installation_id=${installationId}`}
+                    href={`/api/auth/github/start?installation_id=${encodeURIComponent(installationId)}`}
                     className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-2.5 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400"
                   >
                     <svg

--- a/apps/web/src/server/byok-auth.ts
+++ b/apps/web/src/server/byok-auth.ts
@@ -10,12 +10,10 @@ import { NextRequest, NextResponse } from "next/server";
 import type Redis from "ioredis";
 import { validateEnv } from "@/server/env";
 import { getRedisClient } from "@/server/redis";
-import { getSetupSession } from "@/server/setup-session";
+import { getSetupSession, SETUP_SESSION_COOKIE } from "@/server/setup-session";
 import { parseKeyring } from "@/server/crypto";
 import { BYOK_ERROR, byokError } from "@/server/byok-error";
 import type { SetupSessionPayload } from "@/server/setup-session";
-
-const SETUP_SESSION_COOKIE = "setup_session";
 
 type AuthSuccess = {
   ok: true;

--- a/apps/web/src/server/setup-session.ts
+++ b/apps/web/src/server/setup-session.ts
@@ -30,6 +30,9 @@ const SESSION_KEY_PREFIX = "setup-session:";
  */
 export const OAUTH_STATE_BINDING_COOKIE = "oauth_state_binding";
 
+/** Cookie name for the short-lived setup session token. */
+export const SETUP_SESSION_COOKIE = "setup_session";
+
 interface OAuthStatePayload {
   installationId: string;
   stateBinding: string;


### PR DESCRIPTION
## Summary

Resolves #115.

- Adds the Step 2 BYOK API key form to `/setup` — provider selector (Anthropic/OpenAI), model field with defaults, API key input with show/hide toggle
- When authorized, replaces the full Step 1 card with a compact "GitHub connected" pill and renders the form below
- Extends session TTL from 10 to 30 minutes (both Redis and cookie) to give users enough time to configure
- Handles session countdown (warning at 5 min, amber banner at 1 min, red banner + disabled submit at expiry)
- On success, transforms form into a green confirmation card showing provider, model, key fingerprint, and timestamp
- Error handling: client-side validation, double-submit guard, provider rejection messages, session expiry detection (both proactive via countdown and reactive via 401)

## Test plan

- [ ] Visit `/setup?auth=ok&installation_id=test` — compact Step 1 card visible, Step 2 form renders
- [ ] Submit with empty key — client-side error banner
- [ ] Switch providers — model updates, key clears, errors clear
- [ ] Submit with invalid key — provider validation error from backend
- [ ] Wait for session expiry — countdown warning appears, submit disables after expiry
- [ ] Successful save — form transforms to success card with fingerprint
- [ ] Visit `/setup` without auth — existing Step 1 card unchanged
- [ ] `npm run build` passes, `npm run lint` passes