### PR TITLE
Rename REDIS_URL to HIVEMOOT_REDIS_URL

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,5 @@
 # Required for production
-# REDIS_URL=redis://localhost:6379
+# HIVEMOOT_REDIS_URL=redis://localhost:6379
 # GITHUB_APP_ID=
 # GITHUB_APP_PRIVATE_KEY=
 # GITHUB_CLIENT_ID=          # GitHub App OAuth Client ID (Iv1.xxx)

--- a/apps/web/BYOK_CONTRACT.md
+++ b/apps/web/BYOK_CONTRACT.md
@@ -78,7 +78,7 @@ Required in this repo (`apps/web`):
 
 | Var | Purpose |
 |---|---|
-| `REDIS_URL` | Redis connection for BYOK envelope storage |
+| `HIVEMOOT_REDIS_URL` | Redis connection for BYOK envelope storage |
 | `BYOK_ACTIVE_KEY_VERSION` | Key version used for new encryptions |
 | `BYOK_MASTER_KEYS` | JSON keyring map (`{"version":"hexKey"}`) |
 
@@ -86,7 +86,7 @@ Required in bot runtime (`hivemoot/hivemoot-bot`):
 
 | Var | Purpose |
 |---|---|
-| `REDIS_URL` | Same Redis instance that stores BYOK envelopes |
+| `HIVEMOOT_REDIS_URL` | Same Redis instance that stores BYOK envelopes |
 | `BYOK_MASTER_KEYS_JSON` | JSON keyring map used for runtime decryption |
 
 Keyring data contract is identical between `BYOK_MASTER_KEYS` and `BYOK_MASTER_KEYS_JSON`.
@@ -135,6 +135,6 @@ Contract behavior is covered by:
 These tests cover configured resolution, absent/revoked states, tamper detection, key version failures, cross-installation isolation, and migration compatibility.
 
 Real Redis execution path:
-- Set `BYOK_ACCEPTANCE_REDIS_URL` (or `REDIS_URL`) and run:
+- Set `BYOK_ACCEPTANCE_HIVEMOOT_REDIS_URL` (or `HIVEMOOT_REDIS_URL`) and run:
   - `npm test -- src/server/byok-contract-acceptance.test.ts`
 - The live-Redis block verifies resolver behavior through actual Redis transport rather than an in-memory mock.

--- a/apps/web/src/app/api/auth/github/start/route.test.ts
+++ b/apps/web/src/app/api/auth/github/start/route.test.ts
@@ -110,7 +110,7 @@ describe("GET /api/auth/github/start", () => {
   });
 
   it("returns 503 when env validation fails", async () => {
-    vi.mocked(validateEnv).mockReturnValue({ ok: false, missing: ["REDIS_URL"] });
+    vi.mocked(validateEnv).mockReturnValue({ ok: false, missing: ["HIVEMOOT_REDIS_URL"] });
     const req = makeRequest("https://example.com/api/auth/github/start?installation_id=1");
     const res = await GET(req);
     expect(res.status).toBe(503);

--- a/apps/web/src/app/api/health/route.test.ts
+++ b/apps/web/src/app/api/health/route.test.ts
@@ -39,7 +39,7 @@ describe("GET /api/health", () => {
 
   it("returns 503 with missing vars in production", () => {
     env().NODE_ENV = "production";
-    delete env().REDIS_URL;
+    delete env().HIVEMOOT_REDIS_URL;
     delete env().GITHUB_APP_ID;
     delete env().GITHUB_APP_PRIVATE_KEY;
     delete env().GITHUB_CLIENT_ID;
@@ -52,7 +52,7 @@ describe("GET /api/health", () => {
     expect(response.status).toBe(503);
     expect(response.body.status).toBe("error");
     expect(response.body.missing).toEqual([
-      "REDIS_URL",
+      "HIVEMOOT_REDIS_URL",
       "GITHUB_APP_ID",
       "GITHUB_APP_PRIVATE_KEY",
       "GITHUB_CLIENT_ID",
@@ -65,7 +65,7 @@ describe("GET /api/health", () => {
 
   it("returns 200 in production when all vars present", () => {
     env().NODE_ENV = "production";
-    env().REDIS_URL = "redis://prod:6379";
+    env().HIVEMOOT_REDIS_URL = "redis://prod:6379";
     env().GITHUB_APP_ID = "99";
     env().GITHUB_APP_PRIVATE_KEY = "key";
     env().GITHUB_CLIENT_ID = "Iv1.test";

--- a/apps/web/src/server/byok-contract-acceptance.test.ts
+++ b/apps/web/src/server/byok-contract-acceptance.test.ts
@@ -46,14 +46,14 @@ function makeMockRedis() {
   return client as unknown as Redis & { _store: Map<string, string> };
 }
 
-const LIVE_REDIS_URL = process.env.BYOK_ACCEPTANCE_REDIS_URL ?? process.env.REDIS_URL;
+const LIVE_HIVEMOOT_REDIS_URL = process.env.BYOK_ACCEPTANCE_HIVEMOOT_REDIS_URL ?? process.env.HIVEMOOT_REDIS_URL;
 
 function makeLiveRedisClient(): Redis {
-  if (!LIVE_REDIS_URL) {
-    throw new Error("LIVE_REDIS_URL is required");
+  if (!LIVE_HIVEMOOT_REDIS_URL) {
+    throw new Error("LIVE_HIVEMOOT_REDIS_URL is required");
   }
 
-  return new IORedis(LIVE_REDIS_URL, {
+  return new IORedis(LIVE_HIVEMOOT_REDIS_URL, {
     maxRetriesPerRequest: 1,
     enableOfflineQueue: false,
     lazyConnect: false,
@@ -422,7 +422,7 @@ describe("BYOK contract acceptance", () => {
   });
 });
 
-const describeLiveRedis = LIVE_REDIS_URL ? describe : describe.skip;
+const describeLiveRedis = LIVE_HIVEMOOT_REDIS_URL ? describe : describe.skip;
 
 describeLiveRedis("BYOK contract acceptance (live Redis)", () => {
   it("resolves a configured installation through a real Redis transport", async () => {

--- a/apps/web/src/server/env.test.ts
+++ b/apps/web/src/server/env.test.ts
@@ -20,7 +20,7 @@ describe("validateEnv", () => {
   describe("in development", () => {
     it("returns ok when no vars are set", () => {
       delete env().NODE_ENV;
-      delete env().REDIS_URL;
+      delete env().HIVEMOOT_REDIS_URL;
       delete env().GITHUB_APP_ID;
 
       const result = validateEnv();
@@ -51,7 +51,7 @@ describe("validateEnv", () => {
 
     it("passes through optional vars when present", () => {
       delete env().NODE_ENV;
-      env().REDIS_URL = "redis://localhost:6379";
+      env().HIVEMOOT_REDIS_URL = "redis://localhost:6379";
       env().GITHUB_APP_ID = "12345";
 
       const result = validateEnv();
@@ -69,7 +69,7 @@ describe("validateEnv", () => {
     });
 
     it("fails when all required vars are missing", () => {
-      delete env().REDIS_URL;
+      delete env().HIVEMOOT_REDIS_URL;
       delete env().GITHUB_APP_ID;
       delete env().GITHUB_APP_PRIVATE_KEY;
       delete env().GITHUB_CLIENT_ID;
@@ -82,7 +82,7 @@ describe("validateEnv", () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.missing).toEqual([
-          "REDIS_URL",
+          "HIVEMOOT_REDIS_URL",
           "GITHUB_APP_ID",
           "GITHUB_APP_PRIVATE_KEY",
           "GITHUB_CLIENT_ID",
@@ -95,7 +95,7 @@ describe("validateEnv", () => {
     });
 
     it("fails when some required vars are missing", () => {
-      env().REDIS_URL = "redis://prod:6379";
+      env().HIVEMOOT_REDIS_URL = "redis://prod:6379";
       env().GITHUB_APP_ID = "99";
       delete env().GITHUB_APP_PRIVATE_KEY;
       delete env().GITHUB_CLIENT_ID;
@@ -119,7 +119,7 @@ describe("validateEnv", () => {
     });
 
     it("fails when NEXT_PUBLIC_SITE_URL is missing in production", () => {
-      env().REDIS_URL = "redis://prod:6379";
+      env().HIVEMOOT_REDIS_URL = "redis://prod:6379";
       env().GITHUB_APP_ID = "99";
       env().GITHUB_APP_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----";
       env().GITHUB_CLIENT_ID = "Iv1.test";
@@ -137,7 +137,7 @@ describe("validateEnv", () => {
     });
 
     it("succeeds when all required vars are present", () => {
-      env().REDIS_URL = "redis://prod:6379";
+      env().HIVEMOOT_REDIS_URL = "redis://prod:6379";
       env().GITHUB_APP_ID = "99";
       env().GITHUB_APP_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----";
       env().GITHUB_CLIENT_ID = "Iv1.test";

--- a/apps/web/src/server/env.ts
+++ b/apps/web/src/server/env.ts
@@ -28,7 +28,7 @@ interface EnvConfig {
 }
 
 const REQUIRED_IN_PRODUCTION = [
-  "REDIS_URL",
+  "HIVEMOOT_REDIS_URL",
   "GITHUB_APP_ID",
   "GITHUB_APP_PRIVATE_KEY",
   "GITHUB_CLIENT_ID",
@@ -53,7 +53,7 @@ export function validateEnv(): { ok: true; config: EnvConfig } | { ok: false; mi
   return {
     ok: true,
     config: {
-      redisUrl: process.env.REDIS_URL,
+      redisUrl: process.env.HIVEMOOT_REDIS_URL,
       githubAppId: process.env.GITHUB_APP_ID,
       githubAppPrivateKey: process.env.GITHUB_APP_PRIVATE_KEY,
       githubClientId: process.env.GITHUB_CLIENT_ID,


### PR DESCRIPTION
## Summary

- Renames `REDIS_URL` → `HIVEMOOT_REDIS_URL` across env validation, tests, docs, and `.env.example`
- Prevents Probot from auto-detecting the env var for its internal bottleneck rate limiter, which causes `ECONNRESET`/`EPIPE` crashes on Vercel serverless
- Companion PR to hivemoot/hivemoot-bot#300 which migrates the bot from Upstash REST to ioredis TCP

Resolves #123

## Files changed

| File | What changed |
|------|-------------|
| `env.ts` | `REQUIRED_IN_PRODUCTION` array + `process.env` access |
| `env.test.ts` | All `REDIS_URL` references in test assertions/setup |
| `byok-contract-acceptance.test.ts` | Live Redis URL env var fallback |
| `health/route.test.ts` | Health check test env vars |
| `auth/github/start/route.test.ts` | Auth start test mock config |
| `.env.example` | Example env var name |
| `BYOK_CONTRACT.md` | Runtime environment docs |

## Test plan

- [x] All 120 web app tests pass (`npx vitest run`)
- [ ] Deploy with `HIVEMOOT_REDIS_URL` set in Vercel (copy value from current `REDIS_URL`)
- [ ] Remove old `REDIS_URL` from Vercel after confirming health check passes

## Deployment note

Set `HIVEMOOT_REDIS_URL` in Vercel project settings (same connection string as current `REDIS_URL`). After deploying, remove the old `REDIS_URL` env var.