### PR TITLE
Add GitHub App direct install links when app slug is configured

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -8,4 +8,3 @@
 # BYOK_ACTIVE_KEY_VERSION=   # Active master key version (e.g. "v1")
 # BYOK_MASTER_KEYS=          # JSON keyring: {"v1":"<64-hex-char-key>"}
 # NEXT_PUBLIC_SITE_URL=https://hivemoot.dev
-# NEXT_PUBLIC_GITHUB_APP_SLUG=  # GitHub App slug (e.g. "hivemoot") — enables direct install links

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -243,12 +243,10 @@ const steps = [
 // Page
 // ---------------------------------------------------------------------------
 
-export default function LandingPage() {
-  const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;
-  const installUrl = appSlug
-    ? `https://github.com/apps/${appSlug}/installations/new`
-    : "/setup";
+const GITHUB_APP_INSTALL_URL =
+  "https://github.com/apps/hivemoot/installations/new";
 
+export default function LandingPage() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#0a0a0a] text-[#fafafa]">
       {/* ----------------------------------------------------------------- */}
@@ -300,7 +298,7 @@ export default function LandingPage() {
             GitHub
           </a>
           <Link
-            href={installUrl}
+            href={GITHUB_APP_INSTALL_URL}
             className="rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#0a0a0a] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
           >
             Get Started
@@ -336,7 +334,7 @@ export default function LandingPage() {
 
         <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
           <Link
-            href={installUrl}
+            href={GITHUB_APP_INSTALL_URL}
             className="group inline-flex items-center gap-2 rounded-lg bg-honey-500 px-7 py-3.5 text-base font-bold text-[#0a0a0a] transition-all hover:bg-honey-400 hover:shadow-xl hover:shadow-honey-500/25"
           >
             Get Started
@@ -473,7 +471,7 @@ export default function LandingPage() {
             governance to autonomous systems — so every decision is deliberate.
           </p>
           <Link
-            href={installUrl}
+            href={GITHUB_APP_INSTALL_URL}
             className="relative inline-flex items-center gap-2 rounded-lg bg-honey-500 px-7 py-3.5 text-base font-bold text-[#0a0a0a] transition-all hover:bg-honey-400 hover:shadow-xl hover:shadow-honey-500/25"
           >
             Start governing

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -200,10 +200,6 @@ export default async function SetupPage({
   const hasSession = !!cookieStore.get(SETUP_SESSION_COOKIE)?.value;
   const isAuthorized = auth === "ok" && hasSession;
   const STEPS = buildSteps(isAuthorized);
-  const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;
-  const githubInstallUrl = appSlug
-    ? `https://github.com/apps/${appSlug}/installations/new`
-    : null;
 
   return (
     <div className="relative min-h-screen overflow-hidden">
@@ -340,9 +336,10 @@ export default async function SetupPage({
 
                 <div className="rounded-lg bg-white/[0.02] px-4 py-3">
                   <p className="text-xs leading-relaxed text-zinc-500">
-                    {githubInstallUrl
-                      ? "You'll be redirected to GitHub to install the Hivemoot App on your account or organization. After installation, you'll return here to authorize and configure your API key."
-                      : "You'll be redirected to GitHub to authorize the Hivemoot App for your organization. It works across issues, pull requests, and discussions to help your team discuss, decide, and ship changes."}
+                    You&apos;ll be redirected to GitHub to install the Hivemoot
+                    App on your account or organization. After installation,
+                    you&apos;ll return here to authorize and configure your API
+                    key.
                   </p>
                 </div>
 
@@ -365,9 +362,9 @@ export default async function SetupPage({
                     </svg>
                     Authorize with GitHub
                   </Link>
-                ) : githubInstallUrl ? (
+                ) : (
                   <Link
-                    href={githubInstallUrl}
+                    href="https://github.com/apps/hivemoot/installations/new"
                     className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-2.5 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400"
                   >
                     <svg
@@ -384,33 +381,6 @@ export default async function SetupPage({
                     </svg>
                     Install GitHub App
                   </Link>
-                ) : (
-                  <>
-                    <button
-                      type="button"
-                      disabled
-                      className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-2.5 text-sm font-semibold text-[#0a0a0a] opacity-50 cursor-not-allowed transition-colors"
-                      aria-label="Authorize with GitHub — open via the installation redirect link"
-                    >
-                      <svg
-                        className="h-4 w-4"
-                        viewBox="0 0 16 16"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        aria-hidden="true"
-                      >
-                        <rect x="3" y="7" width="10" height="7" rx="1.5" />
-                        <path d="M5 7V5a3 3 0 0 1 6 0v2" />
-                      </svg>
-                      Authorize with GitHub
-                    </button>
-                    <p className="mt-4 text-center text-xs text-zinc-600">
-                      Open this page via the GitHub App installation link to activate setup
-                    </p>
-                  </>
                 )}
               </div>
             )}


### PR DESCRIPTION
Closes #132

## Summary

Simplifies onboarding by linking CTAs directly to the GitHub App install page. Removes the `NEXT_PUBLIC_GITHUB_APP_SLUG` env var — the slug is hardcoded since it's stable public info.

## Changes

- **Landing page:** all three CTAs ("Get Started", "Start governing") now link to `github.com/apps/hivemoot/installations/new` instead of `/setup`
- **Setup page:** when no `installation_id` is present, shows an active "Install GitHub App" button instead of a disabled lock
- **Removed** `NEXT_PUBLIC_GITHUB_APP_SLUG` env var and all conditional fallback logic

## Flow

```
Landing page  →  "Get Started"
                      │
                      ▼
    github.com/apps/hivemoot/installations/new
    (user picks org/account, installs app)
                      │
                      ▼
    /setup?installation_id=123
    (redirected back by GitHub)
                      │
                      ▼
    "Authorize with GitHub"  →  enter API key  →  done
```

If a user lands on `/setup` directly (no `installation_id`), they see the "Install GitHub App" button which takes them to the same GitHub install page.