### PR TITLE
Handle already-installed users in the onboarding flow

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.test.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.test.ts
@@ -12,11 +12,13 @@ vi.mock("@/server/github-auth", () => ({
   generateAppJwt: vi.fn(),
   getAuthenticatedUser: vi.fn(),
   getInstallation: vi.fn(),
+  getUserInstallations: vi.fn(),
   checkOrgAdmin: vi.fn(),
 }));
 vi.mock("@/server/setup-session", () => ({
   validateOAuthState: vi.fn(),
   createSetupSession: vi.fn(),
+  DISCOVER_SENTINEL: "discover",
   OAUTH_STATE_BINDING_COOKIE: "oauth_state_binding",
   SETUP_SESSION_COOKIE: "setup_session",
   SESSION_TTL_SECONDS: 1800,
@@ -29,6 +31,7 @@ import {
   generateAppJwt,
   getAuthenticatedUser,
   getInstallation,
+  getUserInstallations,
   checkOrgAdmin,
 } from "@/server/github-auth";
 import {
@@ -293,5 +296,104 @@ describe("GET /api/auth/github/callback — rejections", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/state/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Discovery flow (already-installed users)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/auth/github/callback — discovery flow", () => {
+  beforeEach(() => {
+    // State returns the discover sentinel instead of a numeric installation ID
+    vi.mocked(validateOAuthState).mockImplementation(async (_state, stateBinding) => (
+      stateBinding === "binding-cookie" ? "discover" : null
+    ));
+  });
+
+  it("discovers the installation and completes the flow for a user account", async () => {
+    vi.mocked(getUserInstallations).mockResolvedValue([
+      { id: 67890, app_id: 99, account: { login: "alice", type: "User" } },
+    ]);
+    vi.mocked(getInstallation).mockResolvedValue({
+      account: { login: "alice", type: "User" },
+    });
+
+    const req = makeRequestWithCookie(
+      { code: "gh-code", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location")!;
+    expect(location).toContain("auth=ok");
+    expect(location).toContain("installation_id=67890");
+    expect(getUserInstallations).toHaveBeenCalledWith("user-token", "99");
+    expect(getInstallation).toHaveBeenCalledWith("67890", "app-jwt");
+  });
+
+  it("redirects to not_installed when no installations are found", async () => {
+    vi.mocked(getUserInstallations).mockResolvedValue([]);
+
+    const req = makeRequestWithCookie(
+      { code: "gh-code", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location")!;
+    expect(location).toContain("auth=not_installed");
+    expect(location).not.toContain("installation_id=");
+  });
+
+  it("uses the first installation when multiple exist", async () => {
+    vi.mocked(getUserInstallations).mockResolvedValue([
+      { id: 111, app_id: 99, account: { login: "alice", type: "User" } },
+      { id: 222, app_id: 99, account: { login: "my-org", type: "Organization" } },
+    ]);
+    vi.mocked(getInstallation).mockResolvedValue({
+      account: { login: "alice", type: "User" },
+    });
+
+    const req = makeRequestWithCookie(
+      { code: "gh-code", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("installation_id=111");
+  });
+
+  it("returns 502 when installation discovery fails", async () => {
+    vi.mocked(getUserInstallations).mockRejectedValue(new Error("GitHub API error"));
+
+    const req = makeRequestWithCookie(
+      { code: "gh-code", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/discover/i);
+  });
+
+  it("does not set installation_id on denied redirect from discovery flow", async () => {
+    vi.mocked(validateOAuthState).mockImplementation(async (_state, stateBinding) => (
+      stateBinding === "binding-cookie" ? "discover" : null
+    ));
+
+    const req = makeRequestWithCookie(
+      { error: "access_denied", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location")!;
+    expect(location).toContain("auth=denied");
+    expect(location).not.toContain("installation_id=");
   });
 });

--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -6,6 +6,8 @@
  * Security sequence:
  * 1. Validate `state` against Redis — reject if unknown/expired (CSRF protection)
  * 2. Exchange `code` for a user access token
+ * 2b. If state held the "discover" sentinel (user started from the "already installed"
+ *     flow), resolve the real installationId via GET /user/installations
  * 3. Fetch authenticated user identity
  * 4. Fetch installation metadata (via App JWT)
  * 5. Authorization check:
@@ -23,11 +25,13 @@ import {
   generateAppJwt,
   getAuthenticatedUser,
   getInstallation,
+  getUserInstallations,
   checkOrgAdmin,
 } from "@/server/github-auth";
 import {
   validateOAuthState,
   createSetupSession,
+  DISCOVER_SENTINEL,
   OAUTH_STATE_BINDING_COOKIE,
   SETUP_SESSION_COOKIE,
   SESSION_TTL_SECONDS,
@@ -81,10 +85,11 @@ export async function GET(request: NextRequest) {
     deniedUrl.searchParams.set("auth", "denied");
 
     // Preserve installation context for retry CTA when state+cookie validate.
+    // Skip if the state held the discover sentinel — there's no specific installation to preserve.
     if (state) {
       try {
         const deniedInstallationId = await validateOAuthState(state, oauthStateBinding, redis);
-        if (deniedInstallationId) {
+        if (deniedInstallationId && deniedInstallationId !== DISCOVER_SENTINEL) {
           deniedUrl.searchParams.set("installation_id", deniedInstallationId);
         }
       } catch {
@@ -128,12 +133,29 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Failed to exchange authorization code" }, { status: 502 });
   }
 
+  // --- Step 2b: Discover installation if the user started from the "already installed" flow ---
+  if (installationId === DISCOVER_SENTINEL) {
+    try {
+      const installations = await getUserInstallations(userToken, githubAppId!);
+      if (installations.length === 0) {
+        const notInstalledUrl = new URL(`${siteUrl}/setup`);
+        notInstalledUrl.searchParams.set("auth", "not_installed");
+        const response = NextResponse.redirect(notInstalledUrl.toString());
+        clearOAuthStateBindingCookie(response);
+        return response;
+      }
+      installationId = String(installations[0].id);
+    } catch {
+      return NextResponse.json({ error: "Failed to discover installations" }, { status: 502 });
+    }
+  }
+
   let user: { login: string; id: number };
   let installation: { account: { login: string; type: string } };
 
   try {
     // --- Step 3 & 4: Fetch user identity and installation in parallel ---
-    const appJwt = generateAppJwt(githubAppId, githubAppPrivateKey);
+    const appJwt = generateAppJwt(githubAppId!, githubAppPrivateKey!);
     [user, installation] = await Promise.all([
       getAuthenticatedUser(userToken),
       getInstallation(installationId, appJwt),

--- a/apps/web/src/app/api/auth/github/start-discover/route.test.ts
+++ b/apps/web/src/app/api/auth/github/start-discover/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/server/env", () => ({
+  validateEnv: vi.fn(),
+}));
+
+vi.mock("@/server/redis", () => ({
+  getRedisClient: vi.fn(),
+}));
+
+vi.mock("@/server/setup-session", () => ({
+  createOAuthState: vi.fn(),
+  DISCOVER_SENTINEL: "discover",
+  OAUTH_STATE_BINDING_COOKIE: "oauth_state_binding",
+}));
+
+import { validateEnv } from "@/server/env";
+import { getRedisClient } from "@/server/redis";
+import { createOAuthState, OAUTH_STATE_BINDING_COOKIE } from "@/server/setup-session";
+import { GET } from "./route";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_CONFIG = {
+  githubClientId: "Iv1.test",
+  githubClientSecret: "secret",
+  redisRestUrl: "https://example.upstash.io",
+  redisRestToken: "test-token",
+  siteUrl: "https://example.com",
+  nodeEnv: "production",
+  githubAppId: "99",
+  githubAppPrivateKey: "-----BEGIN RSA PRIVATE KEY-----",
+  byokActiveKeyVersion: "v1",
+  byokMasterKeysJson: '{"v1":"' + "a".repeat(64) + '"}',
+};
+
+function makeRequest() {
+  return new NextRequest("https://example.com/api/auth/github/start-discover");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(validateEnv).mockReturnValue({ ok: true, config: { ...VALID_CONFIG } });
+  vi.mocked(getRedisClient).mockReturnValue({} as ReturnType<typeof getRedisClient>);
+  vi.mocked(createOAuthState).mockResolvedValue({
+    state: "deadbeef".repeat(8),
+    stateBinding: "cafebabe".repeat(8),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/auth/github/start-discover", () => {
+  it("redirects to GitHub OAuth URL with state — no installation_id required", async () => {
+    const req = makeRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location")!;
+    expect(location).toMatch(/^https:\/\/github\.com\/login\/oauth\/authorize/);
+    expect(location).toContain("client_id=Iv1.test");
+    expect(location).toContain("state=deadbeef");
+    expect(location).toContain("scope=read%3Aorg");
+
+    const setCookie = res.headers.get("set-cookie")!;
+    expect(setCookie).toContain(`${OAUTH_STATE_BINDING_COOKIE}=`);
+    expect(setCookie).toContain("HttpOnly");
+  });
+
+  it("passes the discover sentinel as installationId to createOAuthState", async () => {
+    const req = makeRequest();
+    await GET(req);
+
+    expect(createOAuthState).toHaveBeenCalledWith("discover", expect.anything());
+  });
+
+  it("returns 503 when env validation fails", async () => {
+    vi.mocked(validateEnv).mockReturnValue({ ok: false, missing: ["UPSTASH_REDIS_REST_URL"] });
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when GitHub OAuth is not configured", async () => {
+    vi.mocked(validateEnv).mockReturnValue({
+      ok: true,
+      config: { ...VALID_CONFIG, githubClientId: undefined, githubClientSecret: undefined },
+    });
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when Redis is not configured", async () => {
+    vi.mocked(validateEnv).mockReturnValue({
+      ok: true,
+      config: { ...VALID_CONFIG, redisRestUrl: undefined, redisRestToken: undefined },
+    });
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 with stable code when OAuth state storage fails", async () => {
+    vi.mocked(createOAuthState).mockRejectedValue(new Error("redis down"));
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("oauth_state_store_failed");
+  });
+
+  it("includes the callback redirect_uri scoped to siteUrl", async () => {
+    const req = makeRequest();
+    const res = await GET(req);
+    const location = res.headers.get("location")!;
+    expect(location).toContain(encodeURIComponent("https://example.com/api/auth/github/callback"));
+  });
+});

--- a/apps/web/src/app/api/auth/github/start-discover/route.ts
+++ b/apps/web/src/app/api/auth/github/start-discover/route.ts
@@ -1,0 +1,79 @@
+/**
+ * GET /api/auth/github/start-discover
+ *
+ * Initiates the GitHub OAuth flow for the "already installed" discovery path.
+ *
+ * Unlike /api/auth/github/start, this route does NOT require an installation_id.
+ * It stores a "discover" sentinel in the OAuth state. After the user authorizes,
+ * the callback detects the sentinel and resolves the real installation_id via
+ * GET /user/installations.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateEnv } from "@/server/env";
+import { getRedisClient } from "@/server/redis";
+import {
+  createOAuthState,
+  DISCOVER_SENTINEL,
+  OAUTH_STATE_BINDING_COOKIE,
+} from "@/server/setup-session";
+
+const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+const OAUTH_STATE_STORE_FAILED_CODE = "oauth_state_store_failed";
+const OAUTH_STATE_COOKIE_MAX_AGE = 600;
+
+export async function GET(request: NextRequest) {
+  const env = validateEnv();
+  if (!env.ok) {
+    return NextResponse.json({ error: "Server misconfiguration" }, { status: 503 });
+  }
+
+  const { githubClientId, githubClientSecret, redisRestUrl, redisRestToken, siteUrl } = env.config;
+
+  if (!githubClientId || !githubClientSecret) {
+    return NextResponse.json(
+      { error: "GitHub OAuth is not configured on this server" },
+      { status: 503 },
+    );
+  }
+  if (!redisRestUrl || !redisRestToken) {
+    return NextResponse.json(
+      { error: "Session storage is not configured on this server" },
+      { status: 503 },
+    );
+  }
+
+  const redis = getRedisClient(redisRestUrl, redisRestToken);
+
+  let stateRecord: { state: string; stateBinding: string };
+  try {
+    stateRecord = await createOAuthState(DISCOVER_SENTINEL, redis);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to store OAuth state", code: OAUTH_STATE_STORE_FAILED_CODE },
+      { status: 503 },
+    );
+  }
+
+  const callbackUrl = `${siteUrl}/api/auth/github/callback`;
+  const authorizeUrl = new URL(GITHUB_AUTHORIZE_URL);
+  authorizeUrl.searchParams.set("client_id", githubClientId);
+  authorizeUrl.searchParams.set("redirect_uri", callbackUrl);
+  authorizeUrl.searchParams.set("state", stateRecord.state);
+  authorizeUrl.searchParams.set("scope", "read:org");
+
+  const response = NextResponse.redirect(authorizeUrl.toString());
+  response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: OAUTH_STATE_COOKIE_MAX_AGE,
+    path: "/",
+  });
+
+  // Suppress Next.js static rendering check — request param is used
+  // only to satisfy the dynamic route handler signature.
+  void request;
+
+  return response;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -243,8 +243,7 @@ const steps = [
 // Page
 // ---------------------------------------------------------------------------
 
-const GITHUB_APP_INSTALL_URL =
-  "https://github.com/apps/hivemoot/installations/new";
+const GET_STARTED_URL = "/setup";
 
 export default function LandingPage() {
   return (
@@ -298,7 +297,7 @@ export default function LandingPage() {
             GitHub
           </a>
           <Link
-            href={GITHUB_APP_INSTALL_URL}
+            href={GET_STARTED_URL}
             className="rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#0a0a0a] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
           >
             Get Started
@@ -334,7 +333,7 @@ export default function LandingPage() {
 
         <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
           <Link
-            href={GITHUB_APP_INSTALL_URL}
+            href={GET_STARTED_URL}
             className="group inline-flex items-center gap-2 rounded-lg bg-honey-500 px-7 py-3.5 text-base font-bold text-[#0a0a0a] transition-all hover:bg-honey-400 hover:shadow-xl hover:shadow-honey-500/25"
           >
             Get Started
@@ -471,7 +470,7 @@ export default function LandingPage() {
             governance to autonomous systems — so every decision is deliberate.
           </p>
           <Link
-            href={GITHUB_APP_INSTALL_URL}
+            href={GET_STARTED_URL}
             className="relative inline-flex items-center gap-2 rounded-lg bg-honey-500 px-7 py-3.5 text-base font-bold text-[#0a0a0a] transition-all hover:bg-honey-400 hover:shadow-xl hover:shadow-honey-500/25"
           >
             Start governing

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -167,6 +167,18 @@ function AuthStatusBanner({ auth, reason }: { auth: string; reason?: string }) {
       </div>
     );
   }
+  if (auth === "not_installed") {
+    return (
+      <div className="mb-6 flex items-center gap-2 rounded-lg border border-honey-500/20 bg-honey-500/5 px-4 py-3">
+        <svg className="h-4 w-4 shrink-0 text-honey-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="8" cy="8" r="6" />
+          <line x1="8" y1="5" x2="8" y2="8.5" />
+          <circle cx="8" cy="11" r="0.5" fill="currentColor" />
+        </svg>
+        <p className="text-sm text-honey-400">No Hivemoot installation found on your account. Install the app first, then come back here.</p>
+      </div>
+    );
+  }
   if (auth === "forbidden") {
     const message =
       reason === "not_org_admin"
@@ -363,24 +375,39 @@ export default async function SetupPage({
                     Authorize with GitHub
                   </Link>
                 ) : (
-                  <Link
-                    href="https://github.com/apps/hivemoot/installations/new"
-                    className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-2.5 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400"
-                  >
-                    <svg
-                      className="h-4 w-4"
-                      viewBox="0 0 16 16"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
+                  <>
+                    <Link
+                      href="https://github.com/apps/hivemoot/installations/new"
+                      className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-2.5 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400"
                     >
-                      <path d="M8 2C4.686 2 2 4.686 2 8c0 2.651 1.719 4.9 4.105 5.693.3.056.41-.13.41-.289 0-.142-.006-.617-.006-1.12-1.503.274-1.878-.366-1.995-.701-.067-.172-.356-.701-.61-.842-.208-.112-.506-.387-.006-.394.469-.006.804.432.916.61.536.898 1.39.645 1.733.49.053-.387.21-.645.381-.794-1.328-.149-2.716-.664-2.716-2.95 0-.652.232-1.19.61-1.61-.06-.149-.266-.762.06-1.585 0 0 .498-.156 1.636.61a5.52 5.52 0 0 1 1.487-.2c.506 0 1.01.067 1.487.2 1.138-.773 1.636-.61 1.636-.61.326.823.12 1.436.06 1.585.378.42.61.951.61 1.61 0 2.294-1.395 2.801-2.723 2.95.216.187.405.547.405 1.108 0 .795-.007 1.436-.007 1.636 0 .159.11.35.41.29C12.282 12.9 14 10.644 14 8c0-3.314-2.686-6-6-6Z" />
-                    </svg>
-                    Install GitHub App
-                  </Link>
+                      <svg
+                        className="h-4 w-4"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M8 2C4.686 2 2 4.686 2 8c0 2.651 1.719 4.9 4.105 5.693.3.056.41-.13.41-.289 0-.142-.006-.617-.006-1.12-1.503.274-1.878-.366-1.995-.701-.067-.172-.356-.701-.61-.842-.208-.112-.506-.387-.006-.394.469-.006.804.432.916.61.536.898 1.39.645 1.733.49.053-.387.21-.645.381-.794-1.328-.149-2.716-.664-2.716-2.95 0-.652.232-1.19.61-1.61-.06-.149-.266-.762.06-1.585 0 0 .498-.156 1.636.61a5.52 5.52 0 0 1 1.487-.2c.506 0 1.01.067 1.487.2 1.138-.773 1.636-.61 1.636-.61.326.823.12 1.436.06 1.585.378.42.61.951.61 1.61 0 2.294-1.395 2.801-2.723 2.95.216.187.405.547.405 1.108 0 .795-.007 1.436-.007 1.636 0 .159.11.35.41.29C12.282 12.9 14 10.644 14 8c0-3.314-2.686-6-6-6Z" />
+                      </svg>
+                      Install GitHub App
+                    </Link>
+
+                    <div className="mt-4 flex items-center gap-3">
+                      <div className="h-px flex-1 bg-white/[0.06]" />
+                      <span className="text-xs text-zinc-600">or</span>
+                      <div className="h-px flex-1 bg-white/[0.06]" />
+                    </div>
+
+                    <Link
+                      href="/api/auth/github/start-discover"
+                      className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-[#fafafa]"
+                    >
+                      Already installed? Authorize to continue
+                    </Link>
+                  </>
                 )}
               </div>
             )}

--- a/apps/web/src/server/github-auth.ts
+++ b/apps/web/src/server/github-auth.ts
@@ -143,6 +143,52 @@ export async function getInstallation(
 }
 
 // ---------------------------------------------------------------------------
+// Installation discovery (for users who already have the app installed)
+// ---------------------------------------------------------------------------
+
+export interface UserInstallation {
+  id: number;
+  app_id: number;
+  account: {
+    login: string;
+    type: string;
+  };
+}
+
+/**
+ * Lists the authenticated user's installations of a specific GitHub App.
+ *
+ * Uses `GET /user/installations` which returns all app installations the user
+ * can access, then filters by app_id so we only return our own.
+ */
+export async function getUserInstallations(
+  userToken: string,
+  appId: string,
+): Promise<UserInstallation[]> {
+  const response = await fetch("https://api.github.com/user/installations", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${userToken}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub /user/installations returned ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    installations: Array<{
+      id: number;
+      app_id: number;
+      account: { login: string; type: string };
+    }>;
+  };
+
+  return data.installations.filter((i) => String(i.app_id) === appId);
+}
+
+// ---------------------------------------------------------------------------
 // Authorization checks
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/server/setup-session.ts
+++ b/apps/web/src/server/setup-session.ts
@@ -33,6 +33,13 @@ export const OAUTH_STATE_BINDING_COOKIE = "oauth_state_binding";
 /** Cookie name for the short-lived setup session token. */
 export const SETUP_SESSION_COOKIE = "setup_session";
 
+/**
+ * Sentinel value used as the installationId in OAuth state when the user
+ * starts the "already installed" discovery flow. The callback detects this
+ * and resolves the real installationId via `GET /user/installations`.
+ */
+export const DISCOVER_SENTINEL = "discover";
+
 interface OAuthStatePayload {
   installationId: string;
   stateBinding: string;


### PR DESCRIPTION
## Summary

Fixes the dead end where users who already have the Hivemoot GitHub App installed click "Get Started" and land on GitHub's installation settings page with no way back.

- Adds an installation discovery flow via a new `/api/auth/github/start-discover` route that starts OAuth without requiring an `installation_id`
- The callback detects the `"discover"` sentinel in state and resolves the real installation via `GET /user/installations` filtered by `app_id`
- Setup page now shows "Already installed? Authorize to continue" alongside the existing install button
- Landing page CTAs link to `/setup` instead of directly to `github.com/apps/hivemoot/installations/new`

Closes #133

## Test plan

- [ ] Verify new user flow: "Get Started" → `/setup` → "Install GitHub App" → install on GitHub → redirect back with `installation_id` → authorize → setup
- [ ] Verify returning user flow: "Get Started" → `/setup` → "Already installed? Authorize to continue" → OAuth → auto-discovers installation → setup
- [ ] Verify "not installed" case: clicking "Authorize to continue" when the app is not installed shows a warning banner
- [ ] Verify denied flow: cancelling OAuth from the discovery flow redirects to `/setup?auth=denied` without a stale `installation_id=discover` param
- [ ] All 34 auth route tests pass (7 new start-discover + 5 new callback discovery + 22 existing)