### PR TITLE
Fix TLS handshake for rediss:// URLs on Vercel

### DIFF
--- a/apps/web/src/server/redis.ts
+++ b/apps/web/src/server/redis.ts
@@ -34,6 +34,10 @@ export function getRedisClient(url: string): Redis {
     commandTimeout: 5000,
     maxRetriesPerRequest: 1,
     connectTimeout: 5000,
+    // ioredis sets tls to boolean `true` for rediss:// URLs, but
+    // Node's tls.connect needs an object — pass {} explicitly so
+    // the TLS handshake actually runs with default cert verification.
+    ...(url.startsWith("rediss://") ? { tls: {} } : {}),
   });
 
   client.on("error", (err) => {


### PR DESCRIPTION
## Summary

Fixes the `oauth_state_store_failed` regression introduced by #139.

ioredis parses `rediss://` URLs and stores `tls: true` (boolean), but when it calls Node's `tls.connect()` it spreads `this.options.tls` into the connection options — spreading a boolean primitive is a no-op, so the TLS handshake never actually runs. Passing `tls: {}` explicitly gives Node a real options object.

## Test plan

- [x] `npm test` — 127 tests pass
- [x] `npm run typecheck` — passes
- [ ] Manual: verify OAuth flow at hivemoot.dev works after deploy