### PR TITLE
feat(web): show remembered GitHub account on landing page

### DIFF
--- a/apps/web/src/app/api/auth/github/callback/route.ts
+++ b/apps/web/src/app/api/auth/github/callback/route.ts
@@ -36,6 +36,7 @@ import {
   SETUP_SESSION_COOKIE,
   SESSION_TTL_SECONDS,
 } from "@/server/setup-session";
+import { REMEMBERED_USER_COOKIE } from "@/constants/cookies";
 const OAUTH_STATE_READ_FAILED_CODE = "oauth_state_read_failed";
 const SETUP_SESSION_CREATE_FAILED_CODE = "setup_session_create_failed";
 
@@ -224,6 +225,17 @@ export async function GET(request: NextRequest) {
     maxAge: SESSION_TTL_SECONDS,
     path: "/",
   });
+
+  // Remember the authenticated user for 30 days so the landing page can show
+  // a "Continue as @username" shortcut on return visits.
+  response.cookies.set(REMEMBERED_USER_COOKIE, user.login, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 30 * 24 * 60 * 60,
+    path: "/",
+  });
+
   clearOAuthStateBindingCookie(response);
 
   return response;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { cookies } from "next/headers";
 import LottieBee from "./LottieBee";
+import { REMEMBERED_USER_COOKIE, SETUP_SESSION_COOKIE } from "@/constants/cookies";
+
+// GitHub login: alphanumeric + hyphens, 1–39 chars. Validated before use to
+// prevent any cookie-injection attack from reaching the avatar URL or DOM.
+const GITHUB_LOGIN_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,37}[a-zA-Z0-9]$|^[a-zA-Z0-9]$/;
 
 export const metadata: Metadata = {
   title: "Hivemoot — Your Own AI Engineering Team",
@@ -246,7 +252,12 @@ const steps = [
 
 const GET_STARTED_URL = "/setup";
 
-export default function LandingPage() {
+export default async function LandingPage() {
+  const cookieStore = await cookies();
+  const rawLogin = cookieStore.get(REMEMBERED_USER_COOKIE)?.value ?? null;
+  // Validate before any use — the cookie is user-controlled data.
+  const rememberedUser = rawLogin && GITHUB_LOGIN_RE.test(rawLogin) ? rawLogin : null;
+  const hasActiveSession = !!cookieStore.get(SETUP_SESSION_COOKIE)?.value;
   return (
     <div className="relative min-h-screen overflow-hidden text-[#fafafa]">
       {/* ----------------------------------------------------------------- */}
@@ -334,6 +345,39 @@ export default function LandingPage() {
           approaches, write code, review PRs, and ship — proactively,
           professionally, around the clock.
         </p>
+
+        {rememberedUser && (
+          <div className="mb-6 flex justify-center">
+            <Link
+              href={hasActiveSession ? "/dashboard" : "/setup"}
+              className="flex items-center gap-3 rounded-xl border border-zinc-700/60 bg-zinc-900/70 px-5 py-3 text-sm font-medium text-zinc-200 transition-all hover:border-honey-500/40 hover:bg-zinc-900"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`https://github.com/${rememberedUser}.png?size=64`}
+                alt=""
+                aria-hidden="true"
+                className="h-7 w-7 rounded-full border border-zinc-700"
+              />
+              Continue as{" "}
+              <span className="text-honey-400">@{rememberedUser}</span>
+              <svg
+                className="h-4 w-4 text-zinc-500"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M6 3l5 5-5 5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </Link>
+          </div>
+        )}
 
         <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
           <Link

--- a/apps/web/src/constants/cookies.ts
+++ b/apps/web/src/constants/cookies.ts
@@ -11,3 +11,10 @@ export const SETUP_SESSION_COOKIE = "setup_session";
 
 /** Browser binding cookie for OAuth state CSRF protection. */
 export const OAUTH_STATE_BINDING_COOKIE = "oauth_state_binding";
+
+/**
+ * Long-lived cookie that remembers the last successfully authenticated
+ * GitHub username. Contains only the public login string — no credentials.
+ * Used by the landing page to show a "Continue as @username" shortcut.
+ */
+export const REMEMBERED_USER_COOKIE = "hm_remembered_user";


### PR DESCRIPTION
When a user has previously authenticated, the landing page now shows a
"Continue as @username" card in the hero — matching how Google and other
services handle returning users.

## Changes

**`apps/web/src/constants/cookies.ts`**

Added `REMEMBERED_USER_COOKIE` — a long-lived cookie constant for storing
the last signed-in GitHub login (display-only, no credentials).

**`apps/web/src/app/api/auth/github/callback/route.ts`**

After issuing the setup session token, also sets `hm_remembered_user` with
the user's GitHub login. Cookie is HttpOnly (server-read-only), 30-day TTL.

**`apps/web/src/app/page.tsx`**

Converted `LandingPage` to an async server component. Reads both cookies:
- If `hm_remembered_user` is present and passes GitHub login regex validation,
  renders a "Continue as @username" card with avatar above the CTA buttons.
- If `setup_session` is also valid, the card links directly to `/dashboard`.
- Otherwise it links to `/setup` for re-authentication.

The login value is validated against the GitHub username format
(`/^[a-zA-Z0-9][a-zA-Z0-9-]{0,37}[a-zA-Z0-9]$|^[a-zA-Z0-9]$/`) before
use in any URL or DOM output to prevent cookie-injection attacks.

## Verification

- TypeScript: clean (`tsc --noEmit`)
- Tests: 142 passed, 1 skipped — no regressions

Fixes #155