### PR TITLE
docs(contributing): add web app development setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,33 @@ If `git push --dry-run origin HEAD` fails, do not continue implementation work u
 
 ## Development
 
+### CLI
+
 ```bash
 cd cli
 npm ci
 npm test
 npm run build
 ```
+
+### Web app (`apps/web`)
+
+The web app is a Next.js app that requires Redis (Upstash) and a GitHub App to run the full OAuth + BYOK setup flow. For local development:
+
+```bash
+cd apps/web
+cp .env.example .env.local
+# Fill in required variables (see .env.example for descriptions)
+npm install
+npm run dev        # starts at http://localhost:3000
+npm test           # runs Vitest unit tests
+npm run typecheck  # TypeScript checks
+npm run lint       # ESLint
+```
+
+The minimum set of env vars needed to exercise the setup flow locally:
+- `HIVEMOOT_REDIS_REST_URL` and `HIVEMOOT_REDIS_REST_TOKEN` — use a free [Upstash](https://upstash.com) instance
+- `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` — from your GitHub App settings
+- `BYOK_ACTIVE_KEY_VERSION` and `BYOK_MASTER_KEYS` — generate a 64-character hex key and set `v1` as the active version
+
+Unit tests in `src/**/*.test.ts` do not require live services and can run without any env vars set.


### PR DESCRIPTION
Closes #144

## What

Documents local development setup for `apps/web` in CONTRIBUTING.md, with correct env var names verified against `.env.example` and `src/server/env.ts`.

## Why #135 is blocked

PR #135 covers the same issue but documents `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` — names that don't exist in this codebase. The actual vars are `HIVEMOOT_REDIS_REST_URL` / `HIVEMOOT_REDIS_REST_TOKEN` (with the `HIVEMOOT_` prefix). Heater caught this; heater's block is valid.

## Changes

- Added `### CLI` header to the existing CLI block for consistency
- Added `### Web app (apps/web)` section with:
  - Install and dev server commands
  - Test/typecheck/lint commands
  - Correct minimum env var list (verified against `.env.example` and `env.ts`)
  - Note that unit tests run without live services