### PR TITLE
fix(web): only cache successful runtime config, not failures

### DIFF
--- a/apps/web/src/server/byok-auth.ts
+++ b/apps/web/src/server/byok-auth.ts
@@ -111,9 +111,13 @@ function loadRuntimeConfig(): RuntimeConfig {
 }
 
 function getRuntimeConfig(): RuntimeConfig {
-  if (!cachedRuntimeConfig) {
-    // Parse env + keyring once per server process to keep request auth path lean.
-    cachedRuntimeConfig = loadRuntimeConfig();
+  if (!cachedRuntimeConfig || !cachedRuntimeConfig.ok) {
+    // Only cache successful config. Failure states are not cached so transient
+    // misconfiguration during deployment doesn't permanently break the server —
+    // each request retries until config stabilizes, then caches the success.
+    const result = loadRuntimeConfig();
+    if (result.ok) cachedRuntimeConfig = result;
+    return result;
   }
   return cachedRuntimeConfig;
 }


### PR DESCRIPTION
## Summary

`getRuntimeConfig` unconditionally caches the first result from `loadRuntimeConfig`. If that first call fails (env vars not set, keyring malformed, active key version missing), the failure is cached for the container's lifetime. All subsequent BYOK requests return 503 with no recovery path short of container recycling.

**Specific scenario:** Vercel containers can cold-start during a deploy window where new env vars are being applied. A container that hits this window gets stuck returning 503 permanently.

**Fix:** only cache when `result.ok === true`. Failed loads retry on every request until config stabilizes, then cache the success. The hot path (correctly-configured servers) is unchanged.

```ts
// Before
function getRuntimeConfig(): RuntimeConfig {
  if (!cachedRuntimeConfig) {
    cachedRuntimeConfig = loadRuntimeConfig();
  }
  return cachedRuntimeConfig;
}

// After
function getRuntimeConfig(): RuntimeConfig {
  if (!cachedRuntimeConfig || !cachedRuntimeConfig.ok) {
    const result = loadRuntimeConfig();
    if (result.ok) cachedRuntimeConfig = result;
    return result;
  }
  return cachedRuntimeConfig;
}
```

Performance cost during failure is acceptable — a misconfigured server is already broken, and re-running env validation + keyring parsing per-request until fixed is the correct recovery behavior.

## Verification

- TypeScript: clean
- Tests: 171 passed, 1 skipped — no regressions

Fixes #161