### PR TITLE
fix(web): disable form inputs and add role=alert on session expiry

### DIFF
--- a/apps/web/src/app/setup/Step2Form.tsx
+++ b/apps/web/src/app/setup/Step2Form.tsx
@@ -629,7 +629,7 @@ export default function Step2Form({
 
   const sessionBanner =
     sessionExpired ? (
-      <div className="mb-6 flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">
+      <div role="alert" className="mb-6 flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">
         <svg
           className="h-4 w-4 shrink-0 text-red-400"
           viewBox="0 0 16 16"
@@ -873,9 +873,10 @@ export default function Step2Form({
                   key={p}
                   type="button"
                   onClick={() => switchProvider(p)}
+                  disabled={sessionExpired}
                   className={`
                     flex items-center justify-center gap-2 rounded-lg border px-3 py-2.5
-                    text-sm font-medium transition-colors
+                    text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50
                     ${
                       isActive
                         ? "border-honey-500/40 bg-honey-500/10 text-honey-400"
@@ -901,7 +902,8 @@ export default function Step2Form({
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2.5 font-mono text-sm text-[#fafafa] placeholder-zinc-600 transition-colors focus:border-honey-500/50 focus:outline-none focus:ring-1 focus:ring-honey-500/20"
+            disabled={sessionExpired}
+            className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2.5 font-mono text-sm text-[#fafafa] placeholder-zinc-600 transition-colors focus:border-honey-500/50 focus:outline-none focus:ring-1 focus:ring-honey-500/20 disabled:cursor-not-allowed disabled:opacity-50"
           />
           <p className="mt-1.5 text-xs text-zinc-500">
             The model the Queen uses for AI features.
@@ -924,7 +926,8 @@ export default function Step2Form({
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder={KEY_PLACEHOLDERS[provider]}
-              className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2.5 pr-10 font-mono text-sm text-[#fafafa] placeholder-zinc-600 transition-colors focus:border-honey-500/50 focus:outline-none focus:ring-1 focus:ring-honey-500/20"
+              disabled={sessionExpired}
+              className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2.5 pr-10 font-mono text-sm text-[#fafafa] placeholder-zinc-600 transition-colors focus:border-honey-500/50 focus:outline-none focus:ring-1 focus:ring-honey-500/20 disabled:cursor-not-allowed disabled:opacity-50"
             />
             <button
               type="button"


### PR DESCRIPTION
## Summary

When the setup session expired in Step 2, only the submit button was disabled. All other form controls — provider selector, model field, API key field — remained fully interactive. A user who missed the expiry banner (or was typing when it appeared) could keep filling in the form with no way to submit it.

On a time-pressured 30-minute session window, this is a real UX failure: effort wasted, no recovery path visible.

**Changes:**
- Provider selector buttons: `disabled={sessionExpired}`
- Model input: `disabled={sessionExpired}`
- API key input: `disabled={sessionExpired}`
- Session expiry banner: `role="alert"` so screen readers announce expiry immediately

The visual treatment (`disabled:cursor-not-allowed disabled:opacity-50`) matches the existing submit button style.

## Verification

- TypeScript: clean
- Tests: 171 passed, 1 skipped — no regressions

Fixes #154