### PR TITLE
fix(web): hide avatar on load failure in RememberedUserCard

### DIFF
--- a/apps/web/src/app/RememberedUserCard.tsx
+++ b/apps/web/src/app/RememberedUserCard.tsx
@@ -41,6 +41,9 @@ export default function RememberedUserCard() {
           src={`https://github.com/${user}.png?size=64`}
           alt=""
           aria-hidden="true"
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).style.display = "none";
+          }}
           className="h-7 w-7 rounded-full border border-zinc-700"
         />
         Continue as{" "}


### PR DESCRIPTION
Closes #166

## What

Adds `onError` handler to the avatar `<img>` in `RememberedUserCard`. When the GitHub avatar CDN fails to load, the browser was showing a broken image icon next to the username.

## Why

The avatar is decorative — `alt=""` and `aria-hidden="true"` — so hiding it on error is the right degradation path. The card still reads "Continue as @username" correctly for all users. No placeholder needed.

## Change

One handler on the existing `<img>`:

```tsx
onError={(e) => {
  (e.currentTarget as HTMLImageElement).style.display = "none";
}}
```

Uses `currentTarget` (not `target`) per React event handler convention — `currentTarget` is always the element the handler is attached to, regardless of bubble source.