### PR TITLE
refactor(web): extract getCookie to shared lib/cookies.ts

### DIFF
--- a/apps/web/src/app/RememberedUserCard.tsx
+++ b/apps/web/src/app/RememberedUserCard.tsx
@@ -2,13 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { REMEMBERED_USER_COOKIE, GITHUB_LOGIN_RE } from "@/constants/cookies";
-
-function getCookie(name: string): string | null {
-  const match = document.cookie.match(
-    new RegExp(`(?:^|; )${name}=([^;]*)`),
-  );
-  return match ? decodeURIComponent(match[1]) : null;
-}
+import { getCookie } from "@/lib/cookies";
 
 /**
  * Client component that reads the remembered-user cookie and renders a

--- a/apps/web/src/lib/cookies.test.ts
+++ b/apps/web/src/lib/cookies.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getCookie } from "./cookies";
+
+describe("getCookie", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockCookies(value: string) {
+    vi.spyOn(document, "cookie", "get").mockReturnValue(value);
+  }
+
+  it("returns null when cookie string is empty", () => {
+    mockCookies("");
+    expect(getCookie("foo")).toBeNull();
+  });
+
+  it("returns null when cookie is not present", () => {
+    mockCookies("other=value");
+    expect(getCookie("foo")).toBeNull();
+  });
+
+  it("reads a simple cookie value", () => {
+    mockCookies("foo=bar");
+    expect(getCookie("foo")).toBe("bar");
+  });
+
+  it("reads a cookie when multiple cookies are present", () => {
+    mockCookies("first=one; foo=bar; last=three");
+    expect(getCookie("foo")).toBe("bar");
+  });
+
+  it("decodes percent-encoded values", () => {
+    mockCookies("foo=hello%20world");
+    expect(getCookie("foo")).toBe("hello world");
+  });
+
+  it("does not partial-match longer cookie names", () => {
+    mockCookies("foobar=baz");
+    expect(getCookie("foo")).toBeNull();
+  });
+
+  it("returns null and does not throw when decoding fails", () => {
+    mockCookies("foo=%E0%A4%A"); // invalid UTF-8 percent sequence
+    expect(getCookie("foo")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/cookies.ts
+++ b/apps/web/src/lib/cookies.ts
@@ -1,0 +1,22 @@
+/**
+ * Browser-only cookie utilities.
+ *
+ * This file reads document.cookie and must only be imported from client
+ * components (or after hydration via useEffect). Do not import from server
+ * code or Edge middleware — use @/constants/cookies for shared constants.
+ */
+
+/**
+ * Reads a single cookie value by name from document.cookie.
+ * Returns null if the cookie is absent or the value fails decoding.
+ */
+export function getCookie(name: string): string | null {
+  try {
+    const match = document.cookie.match(
+      new RegExp(`(?:^|; )${name}=([^;]*)`),
+    );
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

`RememberedUserCard` has a private `getCookie` implementation. PR #185 (`NavActions`) would add an identical second copy. Guard flagged this in the #185 review: a bug fix (e.g. wrapping `decodeURIComponent` in try/catch) would need to land in two places.

This PR:
- Creates `src/lib/cookies.ts` with a shared `getCookie` function, including the `try/catch` guard that was missing in both originals
- Migrates `RememberedUserCard` to import from the shared util
- Adds 7 unit tests covering: absent cookie, multi-cookie string, percent-decoding, name partial-match protection, and decode failure

`NavActions` (#185) can drop its local `getCookie` and import from here in the same pass.

## Why this matters architecturally

The guard's note was right: two identical implementations of cookie parsing means two maintenance points. The `try/catch` around `decodeURIComponent` is exactly the kind of hardening that should only need to land once. This establishes the single canonical location before more consumers appear.