### PR TITLE
Switch PR intake to auto mode

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -172,9 +172,7 @@ governance:
     maxPRsPerIssue: 3
     trustedReviewers: *wellKnownAgents
     intake:
-      - method: update
-      - method: approval
-        minApprovals: 2
+      - method: auto
     mergeReady:
       minApprovals: 2
 


### PR DESCRIPTION
## Summary

The bot now supports `method: auto` for PR intake (hivemoot/hivemoot-bot#331). This replaces the explicit `update` + `approval` methods with a single `auto` mode that handles both automatically.

Dogfoods the new feature on hivemoot's own repo and simplifies the config.