### PR TITLE
feat(cli): add focus filters and section suppression

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.30",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.30",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.30",
+  "version": "0.2.1",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -1055,7 +1055,6 @@ describe("buzzCommand", () => {
       focusFilters: {
         labels: { include: ["bug"] },
         authors: { exclude: ["dependabot[bot]"] },
-        suppressSections: ["ready-to-implement"],
       },
     };
     mockedLoadTeamConfig.mockResolvedValue(teamWithFocusFilters);
@@ -1070,7 +1069,6 @@ describe("buzzCommand", () => {
     expect(focusFiltersArg).toEqual({
       labels: { include: ["bug"] },
       authors: { exclude: ["dependabot[bot]"] },
-      suppressSections: ["ready-to-implement"],
     });
   });
 

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -385,6 +385,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +409,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -430,6 +432,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -473,6 +476,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -571,6 +575,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      undefined,
     );
   });
 
@@ -665,6 +670,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       notificationMap,
+      undefined,
       undefined,
     );
   });
@@ -1042,6 +1048,32 @@ describe("buzzCommand", () => {
     expect(focusArg).toBe("Focus on PR reviews first.");
   });
 
+  it("passes focus filters from team config to buildSummary", async () => {
+    const teamWithFocusFilters = {
+      ...testTeamConfig,
+      focus: "Fix bugs first.",
+      focusFilters: {
+        labels: { include: ["bug"] },
+        authors: { exclude: ["dependabot[bot]"] },
+        suppressSections: ["ready-to-implement"],
+      },
+    };
+    mockedLoadTeamConfig.mockResolvedValue(teamWithFocusFilters);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    const focusFiltersArg = mockedBuildSummary.mock.calls[0][8];
+    expect(focusArg).toBe("Fix bugs first.");
+    expect(focusFiltersArg).toEqual({
+      labels: { include: ["bug"] },
+      authors: { exclude: ["dependabot[bot]"] },
+      suppressSections: ["ready-to-implement"],
+    });
+  });
+
   it("passes undefined focus when team config has no focus", async () => {
     mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
     mockedFormatStatus.mockReturnValue("output");
@@ -1050,6 +1082,7 @@ describe("buzzCommand", () => {
 
     const focusArg = mockedBuildSummary.mock.calls[0][7];
     expect(focusArg).toBeUndefined();
+    expect(mockedBuildSummary.mock.calls[0][8]).toBeUndefined();
   });
 
   it("passes focus to buildSummary when using --role", async () => {

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -183,6 +183,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     votes,
     notifications,
     teamConfig?.focus,
+    teamConfig?.focusFilters,
   );
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -23,7 +23,6 @@ team:
   #         include: ["bug"]
   #       authors:
   #         exclude: ["dependabot[bot]"]
-  #       suppressSections: ["ready-to-implement"]
   #
   # Legacy fallback format is still supported:
   # focus:

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -13,9 +13,20 @@ team:
   #   This project is ...
   #   Read CONTRIBUTING.md for contribution workflow and access model.
 
-  # focus: optional repo steering for buzz output
+  # Structured focus blocks are optional and let you steer buzz output:
+  # activeFocus: default
+  # focuses:
+  #   default:
+  #     objective: Focus on PR reviews first.
+  #     filters:
+  #       labels:
+  #         include: ["bug"]
+  #       authors:
+  #         exclude: ["dependabot[bot]"]
+  #       suppressSections: ["ready-to-implement"]
+  #
+  # Legacy fallback format is still supported:
   # focus:
-  #   # default is free-form focus text (does not change filters in MVP)
   #   default: Focus on PR reviews first.
 
   roles:

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -589,7 +589,6 @@ team:
               authors: {
                 exclude: ["dependabot[bot]"],
               },
-              suppressSections: ["ready-to-implement", "discussion"],
             },
           },
         },
@@ -611,11 +610,10 @@ team:
       authors: {
         exclude: ["dependabot[bot]"],
       },
-      suppressSections: ["ready-to-implement", "discussion"],
     });
   });
 
-  it("ignores malformed focus filters", async () => {
+  it("trims, dedupes, and drops empty focus filter values", async () => {
     const focusesYaml = yaml.dump({
       team: {
         activeFocus: "default",
@@ -623,11 +621,12 @@ team:
           default: {
             objective: "Review queue.",
             filters: {
-              labels: "not-an-object",
-              authors: {
-                include: ["", " worker ", 5, "worker"],
+              labels: {
+                include: ["", " bug ", "bug", "wontfix "],
               },
-              suppressSections: ["", " discussion ", 42, "discussion"],
+              authors: {
+                include: ["", " worker ", "worker"],
+              },
             },
           },
         },
@@ -642,8 +641,138 @@ team:
 
     expect(config.focus).toBe("Review queue.");
     expect(config.focusFilters).toEqual({
+      labels: { include: ["bug", "wontfix"] },
       authors: { include: ["worker"] },
-      suppressSections: ["discussion"],
+    });
+  });
+
+  it("treats empty focus filters as a no-op", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              labels: {
+                include: ["", "   "],
+              },
+              authors: {
+                exclude: [],
+              },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Review queue.");
+    expect(config.focusFilters).toBeUndefined();
+  });
+
+  it("throws INVALID_CONFIG when filters is not an object", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: "not-an-object",
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters must be an object"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a match filter is not an object", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              labels: "bug",
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters.labels must be an object"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a filter list contains non-string values", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              authors: {
+                include: ["worker", 5],
+              },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters.authors.include[1] must be a string"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when suppressSections is configured", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              suppressSections: ["ready-to-implement"],
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters.suppressSections is not supported"),
     });
   });
 

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -573,6 +573,80 @@ team:
     expect(config.focus).toBe("Clear the review queue. No new code.");
   });
 
+  it("resolves filters from the active focus block", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "bug-hunt",
+        focuses: {
+          default: { objective: "General work." },
+          "bug-hunt": {
+            objective: "Fix bugs.",
+            filters: {
+              labels: {
+                include: ["bug", "v2.0-blocker"],
+                exclude: ["wontfix"],
+              },
+              authors: {
+                exclude: ["dependabot[bot]"],
+              },
+              suppressSections: ["ready-to-implement", "discussion"],
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Fix bugs.");
+    expect(config.focusFilters).toEqual({
+      labels: {
+        include: ["bug", "v2.0-blocker"],
+        exclude: ["wontfix"],
+      },
+      authors: {
+        exclude: ["dependabot[bot]"],
+      },
+      suppressSections: ["ready-to-implement", "discussion"],
+    });
+  });
+
+  it("ignores malformed focus filters", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              labels: "not-an-object",
+              authors: {
+                include: ["", " worker ", 5, "worker"],
+              },
+              suppressSections: ["", " discussion ", 42, "discussion"],
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Review queue.");
+    expect(config.focusFilters).toEqual({
+      authors: { include: ["worker"] },
+      suppressSections: ["discussion"],
+    });
+  });
+
   it("falls back to default block when activeFocus is absent", async () => {
     const focusesYaml = yaml.dump({
       team: {

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -2,6 +2,8 @@ import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
   HivemootConfig,
+  FocusFilters,
+  FocusMatchFilter,
   TeamConfig,
   RepoRef,
   RoleConfig,
@@ -64,12 +66,78 @@ function parseLegacyFocus(rawFocus: unknown): string | undefined {
 
 const MAX_OBJECTIVE_LENGTH = 2_000;
 const MAX_FOCUS_NAME_LENGTH = 64;
+const MAX_FILTER_VALUE_LENGTH = 128;
+const MAX_FILTER_VALUES = 100;
+const MAX_SUPPRESS_SECTION_LENGTH = 64;
+
+interface ResolvedFocusBlock {
+  objective: string;
+  filters?: FocusFilters;
+}
+
+function parseStringList(
+  raw: unknown,
+  maxLength: number,
+): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+
+  const values: string[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (trimmed.length > maxLength) continue;
+
+    const dedupeKey = trimmed.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    values.push(trimmed);
+    if (values.length >= MAX_FILTER_VALUES) break;
+  }
+
+  return values.length > 0 ? values : undefined;
+}
+
+function parseMatchFilter(raw: unknown): FocusMatchFilter | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+  const filter = raw as Record<string, unknown>;
+  const include = parseStringList(filter.include, MAX_FILTER_VALUE_LENGTH);
+  const exclude = parseStringList(filter.exclude, MAX_FILTER_VALUE_LENGTH);
+
+  if (!include && !exclude) return undefined;
+
+  return {
+    ...(include ? { include } : {}),
+    ...(exclude ? { exclude } : {}),
+  };
+}
+
+function parseFocusFilters(raw: unknown): FocusFilters | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+  const filters = raw as Record<string, unknown>;
+  const labels = parseMatchFilter(filters.labels);
+  const authors = parseMatchFilter(filters.authors);
+  const suppressSections = parseStringList(filters.suppressSections, MAX_SUPPRESS_SECTION_LENGTH);
+
+  if (!labels && !authors && !suppressSections) return undefined;
+
+  return {
+    ...(labels ? { labels } : {}),
+    ...(authors ? { authors } : {}),
+    ...(suppressSections ? { suppressSections } : {}),
+  };
+}
 
 // Resolves focus from the team config. Handles two formats:
 // 1. New: team.focuses (dict of FocusBlock) + team.activeFocus (key)
 // 2. Legacy: team.focus.default (plain string)
 // The new format takes precedence when team.focuses is present.
-function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
+function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocusBlock | undefined {
   const rawFocuses = rawTeam.focuses;
 
   if (rawFocuses && typeof rawFocuses === "object" && !Array.isArray(rawFocuses)) {
@@ -101,14 +169,19 @@ function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
       // and the next candidate (or undefined) is returned.
       if (objective.length > MAX_OBJECTIVE_LENGTH) continue;
 
-      return objective;
+      return {
+        objective,
+        filters: parseFocusFilters(b.filters),
+      };
     }
 
     return undefined;
   }
 
   // Fall back to the legacy focus.default format.
-  return parseLegacyFocus(rawTeam.focus);
+  const objective = parseLegacyFocus(rawTeam.focus);
+  if (!objective) return undefined;
+  return { objective };
 }
 
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
@@ -207,13 +280,14 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
     };
   }
 
-  const focus = resolveFocus(team as unknown as Record<string, unknown>);
+  const resolvedFocus = resolveFocus(team as unknown as Record<string, unknown>);
 
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
-    focus,
+    focus: resolvedFocus?.objective,
+    focusFilters: resolvedFocus?.filters,
   };
 }
 

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -68,45 +68,72 @@ const MAX_OBJECTIVE_LENGTH = 2_000;
 const MAX_FOCUS_NAME_LENGTH = 64;
 const MAX_FILTER_VALUE_LENGTH = 128;
 const MAX_FILTER_VALUES = 100;
-const MAX_SUPPRESS_SECTION_LENGTH = 64;
 
 interface ResolvedFocusBlock {
   objective: string;
   filters?: FocusFilters;
 }
 
+function invalidConfig(message: string): never {
+  throw new CliError(
+    `Config error: ${message}`,
+    "INVALID_CONFIG",
+    1,
+  );
+}
+
 function parseStringList(
   raw: unknown,
   maxLength: number,
+  path: string,
 ): string[] | undefined {
-  if (!Array.isArray(raw)) return undefined;
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    invalidConfig(`${path} must be an array of strings`);
+  }
+
+  if (raw.length > MAX_FILTER_VALUES) {
+    invalidConfig(`${path} supports at most ${MAX_FILTER_VALUES} entries`);
+  }
 
   const values: string[] = [];
   const seen = new Set<string>();
 
-  for (const entry of raw) {
-    if (typeof entry !== "string") continue;
+  for (const [index, entry] of raw.entries()) {
+    if (typeof entry !== "string") {
+      invalidConfig(`${path}[${index}] must be a string`);
+    }
+
     const trimmed = entry.trim();
     if (!trimmed) continue;
-    if (trimmed.length > maxLength) continue;
+    if (trimmed.length > maxLength) {
+      invalidConfig(`${path}[${index}] exceeds ${maxLength} characters`);
+    }
 
     const dedupeKey = trimmed.toLowerCase();
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
 
     values.push(trimmed);
-    if (values.length >= MAX_FILTER_VALUES) break;
   }
 
   return values.length > 0 ? values : undefined;
 }
 
-function parseMatchFilter(raw: unknown): FocusMatchFilter | undefined {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+function parseMatchFilter(raw: unknown, path: string): FocusMatchFilter | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    invalidConfig(`${path} must be an object`);
+  }
 
   const filter = raw as Record<string, unknown>;
-  const include = parseStringList(filter.include, MAX_FILTER_VALUE_LENGTH);
-  const exclude = parseStringList(filter.exclude, MAX_FILTER_VALUE_LENGTH);
+  const unknownKeys = Object.keys(filter).filter((key) => key !== "include" && key !== "exclude");
+  if (unknownKeys.length > 0) {
+    invalidConfig(`${path} contains unsupported key(s): ${unknownKeys.join(", ")}`);
+  }
+
+  const include = parseStringList(filter.include, MAX_FILTER_VALUE_LENGTH, `${path}.include`);
+  const exclude = parseStringList(filter.exclude, MAX_FILTER_VALUE_LENGTH, `${path}.exclude`);
 
   if (!include && !exclude) return undefined;
 
@@ -116,20 +143,30 @@ function parseMatchFilter(raw: unknown): FocusMatchFilter | undefined {
   };
 }
 
-function parseFocusFilters(raw: unknown): FocusFilters | undefined {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+function parseFocusFilters(raw: unknown, path: string): FocusFilters | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    invalidConfig(`${path} must be an object`);
+  }
 
   const filters = raw as Record<string, unknown>;
-  const labels = parseMatchFilter(filters.labels);
-  const authors = parseMatchFilter(filters.authors);
-  const suppressSections = parseStringList(filters.suppressSections, MAX_SUPPRESS_SECTION_LENGTH);
+  if (Object.hasOwn(filters, "suppressSections")) {
+    invalidConfig(`${path}.suppressSections is not supported; use ${path}.labels.exclude with governance labels instead`);
+  }
 
-  if (!labels && !authors && !suppressSections) return undefined;
+  const unknownKeys = Object.keys(filters).filter((key) => key !== "labels" && key !== "authors");
+  if (unknownKeys.length > 0) {
+    invalidConfig(`${path} contains unsupported key(s): ${unknownKeys.join(", ")}`);
+  }
+
+  const labels = parseMatchFilter(filters.labels, `${path}.labels`);
+  const authors = parseMatchFilter(filters.authors, `${path}.authors`);
+
+  if (!labels && !authors) return undefined;
 
   return {
     ...(labels ? { labels } : {}),
     ...(authors ? { authors } : {}),
-    ...(suppressSections ? { suppressSections } : {}),
   };
 }
 
@@ -171,7 +208,7 @@ function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocusBlock | un
 
       return {
         objective,
-        filters: parseFocusFilters(b.filters),
+        filters: parseFocusFilters(b.filters, `team.focuses.${candidate}.filters`),
       };
     }
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -5,8 +5,20 @@ export interface RoleConfig {
   instructions: string;
 }
 
+export interface FocusMatchFilter {
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface FocusFilters {
+  labels?: FocusMatchFilter;
+  authors?: FocusMatchFilter;
+  suppressSections?: string[];
+}
+
 export interface FocusBlock {
   objective: string;
+  filters?: FocusFilters;
 }
 
 export interface TeamConfig {
@@ -14,6 +26,7 @@ export interface TeamConfig {
   onboarding?: string;
   roles: Record<string, RoleConfig>;
   focus?: string;
+  focusFilters?: FocusFilters;
 }
 
 export interface HivemootConfig {

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -13,7 +13,6 @@ export interface FocusMatchFilter {
 export interface FocusFilters {
   labels?: FocusMatchFilter;
   authors?: FocusMatchFilter;
-  suppressSections?: string[];
 }
 
 export interface FocusBlock {

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1292,4 +1292,137 @@ describe("buildSummary()", () => {
       "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.",
     );
   });
+
+  it("filters issues by label include rules before classification", () => {
+    const issues = [
+      makeIssue({ number: 700, labels: [{ name: "bug" }, { name: "hivemoot:ready-to-implement" }] }),
+      makeIssue({ number: 701, labels: [{ name: "enhancement" }, { name: "hivemoot:ready-to-implement" }] }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"] } },
+    );
+
+    expect(summary.implement.map((item) => item.number)).toEqual([700]);
+  });
+
+  it("uses exclude-wins precedence when include and exclude both match", () => {
+    const issues = [
+      makeIssue({
+        number: 710,
+        labels: [{ name: "bug" }, { name: "wontfix" }, { name: "hivemoot:ready-to-implement" }],
+      }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"], exclude: ["wontfix"] } },
+    );
+
+    expect(summary.implement).toHaveLength(0);
+  });
+
+  it("filters items by author include/exclude rules", () => {
+    const issues = [
+      makeIssue({ number: 720, author: { login: "dependabot[bot]" } }),
+      makeIssue({ number: 721, author: { login: "alice" } }),
+    ];
+    const prs = [
+      makePR({ number: 722, author: { login: "alice" } }),
+      makePR({ number: 723, author: { login: "bob" } }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      prs,
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { authors: { include: ["alice", "dependabot[bot]"], exclude: ["dependabot[bot]"] } },
+    );
+
+    expect(summary.implement.map((item) => item.number)).toEqual([721]);
+    expect(summary.reviewPRs.map((item) => item.number)).toEqual([722]);
+  });
+
+  it("suppresses configured sections and skips their notifications", () => {
+    const discussionIssue = makeIssue({ number: 730, labels: [{ name: "hivemoot:discussion" }] });
+    const readyIssue = makeIssue({ number: 731, labels: [{ name: "hivemoot:ready-to-implement" }] });
+    const notifications = new Map([
+      [730, { threadId: "T730", reason: "comment", updatedAt: "2025-06-15T11:00:00Z" }],
+      [999, {
+        threadId: "T999",
+        reason: "mention",
+        updatedAt: "2025-06-15T12:00:00Z",
+        title: "Still unread",
+        url: "https://github.com/hivemoot/colony/issues/999",
+        itemType: "Issue" as const,
+      }],
+    ]);
+
+    const summary = buildSummary(
+      repo,
+      [discussionIssue, readyIssue],
+      [],
+      "testuser",
+      now,
+      new Map(),
+      notifications,
+      undefined,
+      { suppressSections: ["discussion", "ready-to-implement"] },
+    );
+
+    expect(summary.discuss).toHaveLength(0);
+    expect(summary.implement).toHaveLength(0);
+    expect(summary.notifications).toEqual([
+      {
+        number: 999,
+        title: "Still unread",
+        url: "https://github.com/hivemoot/colony/issues/999",
+        itemType: "Issue",
+        threadId: "T999",
+        reason: "mention",
+        timestamp: "2025-06-15T12:00:00Z",
+        age: "just now",
+        ackKey: "T999:2025-06-15T12:00:00Z",
+        section: "other",
+      },
+    ]);
+  });
+
+  it("adds a note for unknown suppress section keys", () => {
+    const summary = buildSummary(
+      repo,
+      [],
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { suppressSections: ["discussion", "does-not-exist"] },
+    );
+
+    expect(summary.notes).toContain(
+      "Ignoring unknown focus filters.suppressSections value(s): does-not-exist. Valid values: needs-human, drive-discussion, drive-implementation, voting, discussion, ready-to-implement, unclassified, review-prs, draft-prs, address-feedback.",
+    );
+  });
 });

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1314,6 +1314,58 @@ describe("buildSummary()", () => {
     expect(summary.implement.map((item) => item.number)).toEqual([700]);
   });
 
+  it("keeps repository health and issue pipeline based on unfiltered data", () => {
+    const issues = [
+      makeIssue({ number: 705, labels: [{ name: "bug" }] }),
+      makeIssue({ number: 706, labels: [{ name: "hivemoot:discussion" }] }),
+      makeIssue({ number: 707, labels: [{ name: "hivemoot:ready-to-implement" }] }),
+    ];
+    const prs = [
+      makePR({
+        number: 708,
+        labels: [{ name: "bug" }],
+        author: { login: "alice" },
+        reviewDecision: "APPROVED",
+        mergeable: "MERGEABLE",
+      }),
+      makePR({
+        number: 709,
+        labels: [{ name: "enhancement" }],
+        author: { login: "bob" },
+        reviewDecision: "CHANGES_REQUESTED",
+      }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      prs,
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"] } },
+    );
+
+    expect(summary.unclassified.map((item) => item.number)).toEqual([705]);
+    expect(summary.reviewPRs.map((item) => item.number)).toEqual([708]);
+    expect(summary.repositoryHealth?.openPRs).toEqual({
+      total: 2,
+      mergeReady: 1,
+      changesRequested: 1,
+      draft: 0,
+    });
+    expect(summary.repositoryHealth?.issuePipeline).toEqual({
+      discussion: 1,
+      voting: 0,
+      readyToImplement: 1,
+    });
+    expect(summary.notes).not.toContain(
+      "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.",
+    );
+  });
+
   it("uses exclude-wins precedence when include and exclude both match", () => {
     const issues = [
       makeIssue({

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1393,6 +1393,7 @@ describe("buildSummary()", () => {
     const issues = [
       makeIssue({ number: 720, author: { login: "dependabot[bot]" } }),
       makeIssue({ number: 721, author: { login: "alice" } }),
+      makeIssue({ number: 724, author: null }),
     ];
     const prs = [
       makePR({ number: 722, author: { login: "alice" } }),
@@ -1415,9 +1416,36 @@ describe("buildSummary()", () => {
     expect(summary.reviewPRs.map((item) => item.number)).toEqual([722]);
   });
 
-  it("suppresses configured sections and skips their notifications", () => {
-    const discussionIssue = makeIssue({ number: 730, labels: [{ name: "hivemoot:discussion" }] });
-    const readyIssue = makeIssue({ number: 731, labels: [{ name: "hivemoot:ready-to-implement" }] });
+  it("keeps null-author items visible when only author excludes are configured", () => {
+    const issues = [
+      makeIssue({ number: 725, author: null }),
+      makeIssue({ number: 726, author: { login: "dependabot[bot]" } }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { authors: { exclude: ["dependabot[bot]"] } },
+    );
+
+    expect(summary.implement.map((item) => item.number)).toEqual([725]);
+  });
+
+  it("suppresses notifications for filtered-out open items", () => {
+    const discussionIssue = makeIssue({
+      number: 730,
+      labels: [{ name: "hivemoot:discussion" }, { name: "enhancement" }],
+    });
+    const readyIssue = makeIssue({
+      number: 731,
+      labels: [{ name: "bug" }, { name: "hivemoot:ready-to-implement" }],
+    });
     const notifications = new Map([
       [730, { threadId: "T730", reason: "comment", updatedAt: "2025-06-15T11:00:00Z" }],
       [999, {
@@ -1439,11 +1467,11 @@ describe("buildSummary()", () => {
       new Map(),
       notifications,
       undefined,
-      { suppressSections: ["discussion", "ready-to-implement"] },
+      { labels: { include: ["bug"] } },
     );
 
     expect(summary.discuss).toHaveLength(0);
-    expect(summary.implement).toHaveLength(0);
+    expect(summary.implement.map((item) => item.number)).toEqual([731]);
     expect(summary.notifications).toEqual([
       {
         number: 999,
@@ -1458,23 +1486,5 @@ describe("buildSummary()", () => {
         section: "other",
       },
     ]);
-  });
-
-  it("adds a note for unknown suppress section keys", () => {
-    const summary = buildSummary(
-      repo,
-      [],
-      [],
-      "testuser",
-      now,
-      new Map(),
-      new Map(),
-      undefined,
-      { suppressSections: ["discussion", "does-not-exist"] },
-    );
-
-    expect(summary.notes).toContain(
-      "Ignoring unknown focus filters.suppressSections value(s): does-not-exist. Valid values: needs-human, drive-discussion, drive-implementation, voting, discussion, ready-to-implement, unclassified, review-prs, draft-prs, address-feedback.",
-    );
   });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -195,6 +195,7 @@ function classifyIssue(
   currentUser: string,
   now: Date,
 ): { bucket: "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified"; item: SummaryItem } {
+  const bucket = classifyIssueBucket(issue);
   const age = timeAgo(issue.createdAt, now);
   const assigned =
     issue.assignees.length > 0
@@ -226,37 +227,57 @@ function classifyIssue(
     }
   }
 
-  // Issues needing human attention are excluded from all actionable buckets
-  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) {
+  // Issues needing human attention are excluded from all actionable buckets.
+  if (bucket === "needsHuman") {
     return {
       bucket: "needsHuman",
       item: { ...base, assigned },
     };
   }
 
-  // Bot governance labels (canonical + legacy aliases)
-  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) {
+  // Bot governance labels (canonical + legacy aliases).
+  if (bucket === "voteOn") {
     return { bucket: "voteOn", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) {
+  if (bucket === "discuss") {
     return { bucket: "discuss", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) {
+  if (bucket === "implement") {
     return { bucket: "implement", item: { ...base, assigned } };
-  }
-
-  // Keyword fallback (repos without the bot)
-  if (hasLabel(issue.labels, "vote")) {
-    return { bucket: "voteOn", item: base };
-  }
-  if (hasLabel(issue.labels, "discuss")) {
-    return { bucket: "discuss", item: base };
   }
 
   return {
     bucket: "unclassified",
     item: { ...base, assigned },
   };
+}
+
+function classifyIssueBucket(issue: GitHubIssue): "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified" {
+  // Issues needing human attention are excluded from all actionable buckets.
+  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) {
+    return "needsHuman";
+  }
+
+  // Bot governance labels (canonical + legacy aliases).
+  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) {
+    return "voteOn";
+  }
+  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) {
+    return "discuss";
+  }
+  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) {
+    return "implement";
+  }
+
+  // Keyword fallback (repos without the bot).
+  if (hasLabel(issue.labels, "vote")) {
+    return "voteOn";
+  }
+  if (hasLabel(issue.labels, "discuss")) {
+    return "discuss";
+  }
+
+  return "unclassified";
 }
 
 function classifyPR(
@@ -449,6 +470,15 @@ export function buildSummary(
     ? prs.filter((pr) =>
       matchesFocusFilters(pr.labels, pr.author?.login ?? undefined, normalizedFocusFilters))
     : prs;
+  let fullDiscussionCount = 0;
+  let fullVotingCount = 0;
+  let fullReadyToImplementCount = 0;
+  for (const issue of issues) {
+    const bucket = classifyIssueBucket(issue);
+    if (bucket === "discuss") fullDiscussionCount += 1;
+    else if (bucket === "voteOn") fullVotingCount += 1;
+    else if (bucket === "implement") fullReadyToImplementCount += 1;
+  }
 
   for (const issue of visibleIssues) {
     const { bucket, item } = classifyIssue(issue, currentUser, now);
@@ -631,18 +661,18 @@ export function buildSummary(
     return a.timestamp > b.timestamp ? -1 : 1;
   });
 
-  const hasDefaultPhaseLabels = visibleIssues.some((issue) =>
+  const hasDefaultPhaseLabels = issues.some((issue) =>
     issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
   );
   const issuePipeline: IssuePipelineCounts | undefined = hasDefaultPhaseLabels
     ? {
-        discussion: discuss.length,
-        voting: voteOn.length,
-        readyToImplement: implement.length,
+        discussion: fullDiscussionCount,
+        voting: fullVotingCount,
+        readyToImplement: fullReadyToImplementCount,
       }
     : undefined;
-  const repositoryHealth = buildRepositoryHealth(visibleIssues, visiblePRs, currentUser, now, issuePipeline);
-  const prioritySignals = buildPrioritySignals(repositoryHealth, countActiveCandidateIssues(visiblePRs));
+  const repositoryHealth = buildRepositoryHealth(issues, prs, currentUser, now, issuePipeline);
+  const prioritySignals = buildPrioritySignals(repositoryHealth, countActiveCandidateIssues(prs));
   if (!issuePipeline) notes.push(OMITTED_PIPELINE_NOTE);
 
   return {

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -46,28 +46,11 @@ const DEFAULT_HIVEMOOT_PHASE_LABELS = new Set<string>([
 const OMITTED_PIPELINE_NOTE =
   "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.";
 
-const FOCUS_SECTION_MAP = {
-  "needs-human": "needsHuman",
-  "drive-discussion": "driveDiscussion",
-  "drive-implementation": "driveImplementation",
-  "voting": "voteOn",
-  "discussion": "discuss",
-  "ready-to-implement": "implement",
-  "unclassified": "unclassified",
-  "review-prs": "reviewPRs",
-  "draft-prs": "draftPRs",
-  "address-feedback": "addressFeedback",
-} as const;
-
-type SuppressSectionKey = keyof typeof FOCUS_SECTION_MAP;
-
 interface NormalizedFocusFilters {
   labelInclude?: Set<string>;
   labelExclude?: Set<string>;
   authorInclude?: Set<string>;
   authorExclude?: Set<string>;
-  suppressSections: Set<SuppressSectionKey>;
-  unknownSuppressSections: string[];
 }
 
 function normalizeFilterValues(values?: string[]): Set<string> | undefined {
@@ -80,36 +63,11 @@ function normalizeFilterValues(values?: string[]): Set<string> | undefined {
 }
 
 function normalizeFocusFilters(focusFilters?: FocusFilters): NormalizedFocusFilters {
-  const labelInclude = normalizeFilterValues(focusFilters?.labels?.include);
-  const labelExclude = normalizeFilterValues(focusFilters?.labels?.exclude);
-  const authorInclude = normalizeFilterValues(focusFilters?.authors?.include);
-  const authorExclude = normalizeFilterValues(focusFilters?.authors?.exclude);
-
-  const suppressSections = new Set<SuppressSectionKey>();
-  const unknownSuppressSections: string[] = [];
-  const unknownSeen = new Set<string>();
-
-  for (const rawSection of focusFilters?.suppressSections ?? []) {
-    const key = rawSection.trim().toLowerCase();
-    if (!key) continue;
-    if (Object.hasOwn(FOCUS_SECTION_MAP, key)) {
-      suppressSections.add(key as SuppressSectionKey);
-      continue;
-    }
-
-    if (!unknownSeen.has(key)) {
-      unknownSeen.add(key);
-      unknownSuppressSections.push(rawSection);
-    }
-  }
-
   return {
-    labelInclude,
-    labelExclude,
-    authorInclude,
-    authorExclude,
-    suppressSections,
-    unknownSuppressSections,
+    labelInclude: normalizeFilterValues(focusFilters?.labels?.include),
+    labelExclude: normalizeFilterValues(focusFilters?.labels?.exclude),
+    authorInclude: normalizeFilterValues(focusFilters?.authors?.include),
+    authorExclude: normalizeFilterValues(focusFilters?.authors?.exclude),
   };
 }
 
@@ -558,33 +516,6 @@ export function buildSummary(
     return true;
   });
 
-  if (normalizedFocusFilters.suppressSections.size > 0) {
-    const sectionData = {
-      needsHuman,
-      driveDiscussion,
-      driveImplementation,
-      voteOn: filteredVoteOn,
-      discuss: filteredDiscuss,
-      implement,
-      unclassified,
-      reviewPRs: filteredReviewPRs,
-      draftPRs,
-      addressFeedback: filteredAddressFeedback,
-    };
-
-    for (const sectionKey of normalizedFocusFilters.suppressSections) {
-      const sectionName = FOCUS_SECTION_MAP[sectionKey];
-      sectionData[sectionName].length = 0;
-    }
-  }
-
-  if (normalizedFocusFilters.unknownSuppressSections.length > 0) {
-    const validSections = Object.keys(FOCUS_SECTION_MAP).join(", ");
-    notes.push(
-      `Ignoring unknown focus filters.suppressSections value(s): ${normalizedFocusFilters.unknownSuppressSections.join(", ")}. Valid values: ${validSections}.`,
-    );
-  }
-
   const sectionEntries: [string, SummaryItem[]][] = [
     ["needsHuman", needsHuman],
     ["driveDiscussion", driveDiscussion],
@@ -636,6 +567,8 @@ export function buildSummary(
 
   // Include unread notification threads that do not map to currently fetched
   // open items (e.g. closed threads or items beyond fetch limit).
+  // Skip items that are open but filtered out by focus — they are
+  // intentionally hidden and should not surface as "other" notifications.
   for (const [number, n] of notifications.entries()) {
     if (matchedNumbers.has(number)) continue;
     if (fetchedOpenNumbers.has(number)) continue;

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -1,4 +1,5 @@
 import type {
+  FocusFilters,
   GitHubIssue,
   GitHubPR,
   NotificationRef,
@@ -44,6 +45,113 @@ const DEFAULT_HIVEMOOT_PHASE_LABELS = new Set<string>([
 
 const OMITTED_PIPELINE_NOTE =
   "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.";
+
+const FOCUS_SECTION_MAP = {
+  "needs-human": "needsHuman",
+  "drive-discussion": "driveDiscussion",
+  "drive-implementation": "driveImplementation",
+  "voting": "voteOn",
+  "discussion": "discuss",
+  "ready-to-implement": "implement",
+  "unclassified": "unclassified",
+  "review-prs": "reviewPRs",
+  "draft-prs": "draftPRs",
+  "address-feedback": "addressFeedback",
+} as const;
+
+type SuppressSectionKey = keyof typeof FOCUS_SECTION_MAP;
+
+interface NormalizedFocusFilters {
+  labelInclude?: Set<string>;
+  labelExclude?: Set<string>;
+  authorInclude?: Set<string>;
+  authorExclude?: Set<string>;
+  suppressSections: Set<SuppressSectionKey>;
+  unknownSuppressSections: string[];
+}
+
+function normalizeFilterValues(values?: string[]): Set<string> | undefined {
+  if (!values || values.length === 0) return undefined;
+  const normalized = values
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+  if (normalized.length === 0) return undefined;
+  return new Set(normalized);
+}
+
+function normalizeFocusFilters(focusFilters?: FocusFilters): NormalizedFocusFilters {
+  const labelInclude = normalizeFilterValues(focusFilters?.labels?.include);
+  const labelExclude = normalizeFilterValues(focusFilters?.labels?.exclude);
+  const authorInclude = normalizeFilterValues(focusFilters?.authors?.include);
+  const authorExclude = normalizeFilterValues(focusFilters?.authors?.exclude);
+
+  const suppressSections = new Set<SuppressSectionKey>();
+  const unknownSuppressSections: string[] = [];
+  const unknownSeen = new Set<string>();
+
+  for (const rawSection of focusFilters?.suppressSections ?? []) {
+    const key = rawSection.trim().toLowerCase();
+    if (!key) continue;
+    if (Object.hasOwn(FOCUS_SECTION_MAP, key)) {
+      suppressSections.add(key as SuppressSectionKey);
+      continue;
+    }
+
+    if (!unknownSeen.has(key)) {
+      unknownSeen.add(key);
+      unknownSuppressSections.push(rawSection);
+    }
+  }
+
+  return {
+    labelInclude,
+    labelExclude,
+    authorInclude,
+    authorExclude,
+    suppressSections,
+    unknownSuppressSections,
+  };
+}
+
+function hasItemFilters(filters: NormalizedFocusFilters): boolean {
+  return Boolean(
+    filters.labelInclude ||
+    filters.labelExclude ||
+    filters.authorInclude ||
+    filters.authorExclude,
+  );
+}
+
+function matchesFocusFilters(
+  labels: Array<{ name: string }>,
+  authorLogin: string | undefined,
+  filters: NormalizedFocusFilters,
+): boolean {
+  if (!hasItemFilters(filters)) return true;
+
+  const normalizedLabels = labels.map((label) => label.name.toLowerCase());
+  const normalizedAuthor = authorLogin?.toLowerCase();
+
+  if (filters.labelExclude && normalizedLabels.some((label) => filters.labelExclude?.has(label))) {
+    return false;
+  }
+
+  if (filters.labelInclude && !normalizedLabels.some((label) => filters.labelInclude?.has(label))) {
+    return false;
+  }
+
+  if (filters.authorExclude && normalizedAuthor && filters.authorExclude.has(normalizedAuthor)) {
+    return false;
+  }
+
+  if (filters.authorInclude) {
+    if (!normalizedAuthor || !filters.authorInclude.has(normalizedAuthor)) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 function isMergeReadyPR(pr: GitHubPR): boolean {
   if (pr.isDraft) return false;
@@ -319,6 +427,7 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  focusFilters?: FocusFilters,
 ): RepoSummary {
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
@@ -330,7 +439,18 @@ export function buildSummary(
   const addressFeedback: SummaryItem[] = [];
   const notes: string[] = [];
 
-  for (const issue of issues) {
+  const normalizedFocusFilters = normalizeFocusFilters(focusFilters);
+  const shouldFilterItems = hasItemFilters(normalizedFocusFilters);
+  const visibleIssues = shouldFilterItems
+    ? issues.filter((issue) =>
+      matchesFocusFilters(issue.labels, issue.author?.login ?? undefined, normalizedFocusFilters))
+    : issues;
+  const visiblePRs = shouldFilterItems
+    ? prs.filter((pr) =>
+      matchesFocusFilters(pr.labels, pr.author?.login ?? undefined, normalizedFocusFilters))
+    : prs;
+
+  for (const issue of visibleIssues) {
     const { bucket, item } = classifyIssue(issue, currentUser, now);
     if (bucket === "needsHuman") needsHuman.push(item);
     else if (bucket === "voteOn") voteOn.push(item);
@@ -349,7 +469,7 @@ export function buildSummary(
   }
 
   // Annotate implement items with competing PR counts
-  const competitionMap = currentUser ? buildCompetitionMap(prs, currentUser) : new Map<number, number>();
+  const competitionMap = currentUser ? buildCompetitionMap(visiblePRs, currentUser) : new Map<number, number>();
   for (const item of implement) {
     const count = competitionMap.get(item.number) ?? 0;
     if (count > 0) {
@@ -357,7 +477,7 @@ export function buildSummary(
     }
   }
 
-  for (const pr of prs) {
+  for (const pr of visiblePRs) {
     const { bucket, item } = classifyPR(pr, now);
     const ctx = reviewContext(pr, currentUser, now);
     if (ctx) {
@@ -408,6 +528,33 @@ export function buildSummary(
     return true;
   });
 
+  if (normalizedFocusFilters.suppressSections.size > 0) {
+    const sectionData = {
+      needsHuman,
+      driveDiscussion,
+      driveImplementation,
+      voteOn: filteredVoteOn,
+      discuss: filteredDiscuss,
+      implement,
+      unclassified,
+      reviewPRs: filteredReviewPRs,
+      draftPRs,
+      addressFeedback: filteredAddressFeedback,
+    };
+
+    for (const sectionKey of normalizedFocusFilters.suppressSections) {
+      const sectionName = FOCUS_SECTION_MAP[sectionKey];
+      sectionData[sectionName].length = 0;
+    }
+  }
+
+  if (normalizedFocusFilters.unknownSuppressSections.length > 0) {
+    const validSections = Object.keys(FOCUS_SECTION_MAP).join(", ");
+    notes.push(
+      `Ignoring unknown focus filters.suppressSections value(s): ${normalizedFocusFilters.unknownSuppressSections.join(", ")}. Valid values: ${validSections}.`,
+    );
+  }
+
   const sectionEntries: [string, SummaryItem[]][] = [
     ["needsHuman", needsHuman],
     ["driveDiscussion", driveDiscussion],
@@ -424,6 +571,9 @@ export function buildSummary(
   // Annotate all items with unread notification status and collect notification refs
   const notificationRefs: NotificationRef[] = [];
   const matchedNumbers = new Set<number>();
+  const fetchedOpenNumbers = new Set<number>();
+  for (const issue of issues) fetchedOpenNumbers.add(issue.number);
+  for (const pr of prs) fetchedOpenNumbers.add(pr.number);
 
   for (const [section, items] of sectionEntries) {
     for (const item of items) {
@@ -458,6 +608,7 @@ export function buildSummary(
   // open items (e.g. closed threads or items beyond fetch limit).
   for (const [number, n] of notifications.entries()) {
     if (matchedNumbers.has(number)) continue;
+    if (fetchedOpenNumbers.has(number)) continue;
 
     const ackKey = `${n.threadId}:${n.updatedAt}`;
     notificationRefs.push({
@@ -480,7 +631,7 @@ export function buildSummary(
     return a.timestamp > b.timestamp ? -1 : 1;
   });
 
-  const hasDefaultPhaseLabels = issues.some((issue) =>
+  const hasDefaultPhaseLabels = visibleIssues.some((issue) =>
     issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
   );
   const issuePipeline: IssuePipelineCounts | undefined = hasDefaultPhaseLabels
@@ -490,8 +641,8 @@ export function buildSummary(
         readyToImplement: implement.length,
       }
     : undefined;
-  const repositoryHealth = buildRepositoryHealth(issues, prs, currentUser, now, issuePipeline);
-  const prioritySignals = buildPrioritySignals(repositoryHealth, countActiveCandidateIssues(prs));
+  const repositoryHealth = buildRepositoryHealth(visibleIssues, visiblePRs, currentUser, now, issuePipeline);
+  const prioritySignals = buildPrioritySignals(repositoryHealth, countActiveCandidateIssues(visiblePRs));
   if (!issuePipeline) notes.push(OMITTED_PIPELINE_NOTE);
 
   return {


### PR DESCRIPTION
Fixes #178.

The active implementation target is now label/author filtering only. `suppressSections` and `FOCUS_SECTION_MAP` are removed so focus config stays in GitHub-domain terms instead of depending on internal buzz bucket names.

## What changed
- keep `filters.labels.{include,exclude}` and `filters.authors.{include,exclude}`
- reject malformed filter config with `INVALID_CONFIG` instead of silently widening scope
- reject `filters.suppressSections` with an explicit error that points users to `filters.labels.exclude`
- keep repo-health and issue-pipeline metrics unfiltered while filtered-out open items stay out of the fallback notification bucket
- add direct regression coverage in `loader.test.ts` and `builder.test.ts`
- bump the CLI version to `0.2.2`

## What it looks like

```yaml
team:
  activeFocus: default
  focuses:
    default:
      objective: Focus on bug triage.
      filters:
        labels:
          include: ["bug"]
          exclude: ["hivemoot:discussion"]
        authors:
          exclude: ["dependabot[bot]"]
```

## Validation
- `npm ci --prefix cli`
- `npm test --prefix cli -- --run src/config/loader.test.ts src/summary/builder.test.ts src/commands/buzz.test.ts`
- `npm run --prefix cli typecheck`
- `npm run --prefix cli build`
- `npm view @hivemoot-dev/cli@0.2.2 version` -> 404

_Edit note (2026-03-21 09:42 UTC): narrowed the scope from the original section-suppression implementation to label/author filters only, refreshed the validation/version details, and repaired the YAML example formatting so the description matches the current branch exactly._


_Edit note (2026-03-26 23:05 UTC): refreshed the branch onto current main and bumped the CLI version from 0.2.1 to 0.2.2 after #263 merged, so publish will not be skipped on merge._