### PR TITLE
feat(web): add agent-token infrastructure (generate, rotate, revoke)

### DIFF
--- a/apps/web/src/app/api/agent-token/route.test.ts
+++ b/apps/web/src/app/api/agent-token/route.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+vi.mock("@/server/agent-token", () => ({
+  generateAgentToken: vi.fn(),
+  getAgentToken: vi.fn(),
+  revokeAgentToken: vi.fn(),
+}));
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { generateAgentToken, getAgentToken, revokeAgentToken } from "@/server/agent-token";
+import { POST, GET, DELETE } from "./route";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MOCK_SESSION = {
+  installationId: "inst-123",
+  userId: 1,
+  userLogin: "alice",
+  expiresAt: Date.now() + 60_000,
+};
+
+const MOCK_KEYRING = new Map([["v1", Buffer.alloc(32)]]);
+
+function mockAuthSuccess() {
+  vi.mocked(authenticateByokRequest).mockResolvedValue({
+    ok: true,
+    session: MOCK_SESSION,
+    keyring: MOCK_KEYRING,
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  });
+}
+
+function mockAuthFailure(status: number, code: string, message: string) {
+  vi.mocked(authenticateByokRequest).mockResolvedValue({
+    ok: false,
+    response: NextResponse.json({ code, message }, { status }),
+  });
+}
+
+function makeRequest(method: string) {
+  return new NextRequest(`https://example.com/api/agent-token`, { method });
+}
+
+const TOKEN_RESULT = {
+  token: "a".repeat(64),
+  fingerprint: "aaaa",
+  createdAt: "2026-02-25T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthSuccess();
+});
+
+// ---------------------------------------------------------------------------
+// POST
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-token", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAuthFailure(401, "byok_not_authenticated", "Not authenticated");
+    const res = await POST(makeRequest("POST"));
+    expect(res.status).toBe(401);
+  });
+
+  it("generates new token, returns 201", async () => {
+    vi.mocked(getAgentToken).mockResolvedValue(null); // no existing token
+    vi.mocked(generateAgentToken).mockResolvedValue(TOKEN_RESULT);
+
+    const res = await POST(makeRequest("POST"));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.token).toBe(TOKEN_RESULT.token);
+    expect(body.fingerprint).toBe(TOKEN_RESULT.fingerprint);
+    expect(body.created_at).toBe(TOKEN_RESULT.createdAt);
+  });
+
+  it("rotates existing token, returns 200", async () => {
+    vi.mocked(getAgentToken).mockResolvedValue(TOKEN_RESULT); // existing token
+    vi.mocked(generateAgentToken).mockResolvedValue({
+      ...TOKEN_RESULT,
+      token: "b".repeat(64),
+      fingerprint: "bbbb",
+    });
+
+    const res = await POST(makeRequest("POST"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("b".repeat(64));
+  });
+
+  it("returns 500 when generateAgentToken throws", async () => {
+    vi.mocked(getAgentToken).mockResolvedValue(null);
+    vi.mocked(generateAgentToken).mockRejectedValue(new Error("Redis failure"));
+
+    const res = await POST(makeRequest("POST"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe("GET /api/agent-token", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAuthFailure(401, "byok_not_authenticated", "Not authenticated");
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns token when it exists", async () => {
+    vi.mocked(getAgentToken).mockResolvedValue(TOKEN_RESULT);
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe(TOKEN_RESULT.token);
+    expect(body.fingerprint).toBe(TOKEN_RESULT.fingerprint);
+    expect(body.created_at).toBe(TOKEN_RESULT.createdAt);
+  });
+
+  it("returns 404 when no token exists", async () => {
+    vi.mocked(getAgentToken).mockResolvedValue(null);
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("agent_token_not_found");
+  });
+
+  it("returns 500 when getAgentToken throws", async () => {
+    vi.mocked(getAgentToken).mockRejectedValue(new Error("Redis failure"));
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/agent-token", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockAuthFailure(401, "byok_not_authenticated", "Not authenticated");
+    const res = await DELETE(makeRequest("DELETE"));
+    expect(res.status).toBe(401);
+  });
+
+  it("revokes token, returns 200", async () => {
+    vi.mocked(revokeAgentToken).mockResolvedValue(true);
+
+    const res = await DELETE(makeRequest("DELETE"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.revoked).toBe(true);
+  });
+
+  it("returns 404 when no token exists", async () => {
+    vi.mocked(revokeAgentToken).mockResolvedValue(false);
+
+    const res = await DELETE(makeRequest("DELETE"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("agent_token_not_found");
+  });
+
+  it("returns 500 when revokeAgentToken throws", async () => {
+    vi.mocked(revokeAgentToken).mockRejectedValue(new Error("Redis failure"));
+
+    const res = await DELETE(makeRequest("DELETE"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_error");
+  });
+});

--- a/apps/web/src/app/api/agent-token/route.ts
+++ b/apps/web/src/app/api/agent-token/route.ts
@@ -1,0 +1,120 @@
+/**
+ * /api/agent-token — Agent credential management
+ *
+ * POST   — Generate or rotate the agent-token for this installation
+ * GET    — View the current agent-token (decrypted, one-time display)
+ * DELETE — Revoke the current agent-token
+ *
+ * All endpoints require a valid setup session cookie (same auth as BYOK routes).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { generateAgentToken, getAgentToken, revokeAgentToken } from "@/server/agent-token";
+import { AGENT_HEALTH_ERROR, agentHealthError } from "@/server/agent-health-error";
+
+/**
+ * POST /api/agent-token
+ *
+ * Generates a new token (201) or rotates an existing one (200).
+ * Returns the raw token — the only moment it is available in plaintext.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { installationId, userLogin } = auth.session;
+
+  // Check if a token already exists (determines 201 vs 200)
+  const existing = await getAgentToken(installationId, auth.keyring, auth.redis);
+  const isRotation = existing !== null;
+
+  let result: { token: string; fingerprint: string; createdAt: string };
+  try {
+    result = await generateAgentToken(
+      installationId,
+      userLogin,
+      auth.activeKeyVersion,
+      auth.keyring,
+      auth.redis,
+    );
+  } catch (err) {
+    console.error("[agent-token] Failed to generate token", { installationId, error: err });
+    return agentHealthError(AGENT_HEALTH_ERROR.SERVER_ERROR, "Failed to generate agent token", 500);
+  }
+
+  return NextResponse.json(
+    {
+      token: result.token,
+      fingerprint: result.fingerprint,
+      created_at: result.createdAt,
+    },
+    { status: isRotation ? 200 : 201 },
+  );
+}
+
+/**
+ * GET /api/agent-token
+ *
+ * Returns the decrypted token for the current installation.
+ * 404 if none has been generated yet.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { installationId } = auth.session;
+
+  let result: { token: string; fingerprint: string; createdAt: string } | null;
+  try {
+    result = await getAgentToken(installationId, auth.keyring, auth.redis);
+  } catch (err) {
+    console.error("[agent-token] Failed to retrieve token", { installationId, error: err });
+    return agentHealthError(AGENT_HEALTH_ERROR.SERVER_ERROR, "Failed to retrieve agent token", 500);
+  }
+
+  if (!result) {
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.NOT_FOUND,
+      "No agent token configured",
+      404,
+    );
+  }
+
+  return NextResponse.json({
+    token: result.token,
+    fingerprint: result.fingerprint,
+    created_at: result.createdAt,
+  });
+}
+
+/**
+ * DELETE /api/agent-token
+ *
+ * Revokes the current agent-token. Immediately invalidates Bearer auth.
+ * 404 if none exists.
+ */
+export async function DELETE(request: NextRequest) {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { installationId } = auth.session;
+
+  let revoked: boolean;
+  try {
+    revoked = await revokeAgentToken(installationId, auth.keyring, auth.redis);
+  } catch (err) {
+    console.error("[agent-token] Failed to revoke token", { installationId, error: err });
+    return agentHealthError(AGENT_HEALTH_ERROR.SERVER_ERROR, "Failed to revoke agent token", 500);
+  }
+
+  if (!revoked) {
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.NOT_FOUND,
+      "No agent token configured",
+      404,
+    );
+  }
+
+  return NextResponse.json({ revoked: true });
+}

--- a/apps/web/src/server/agent-health-error.ts
+++ b/apps/web/src/server/agent-health-error.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+export const AGENT_HEALTH_ERROR = {
+  UNAUTHORIZED: "agent_health_unauthorized",
+  NOT_FOUND: "agent_token_not_found",
+  INVALID_JSON: "agent_health_invalid_json",
+  SCHEMA_VIOLATION: "agent_health_schema_violation",
+  PAYLOAD_TOO_LARGE: "agent_health_payload_too_large",
+  RATE_LIMITED: "agent_health_rate_limited",
+  INVALID_PARAM: "agent_health_invalid_param",
+  SERVER_ERROR: "agent_health_server_error",
+} as const;
+
+export type AgentHealthErrorCode = (typeof AGENT_HEALTH_ERROR)[keyof typeof AGENT_HEALTH_ERROR];
+
+export function agentHealthError(
+  code: AgentHealthErrorCode,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+) {
+  return NextResponse.json(
+    {
+      code,
+      message,
+      ...(details ?? {}),
+    },
+    { status },
+  );
+}

--- a/apps/web/src/server/agent-token.test.ts
+++ b/apps/web/src/server/agent-token.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+import {
+  generateAgentToken,
+  getAgentToken,
+  revokeAgentToken,
+  lookupInstallationByToken,
+} from "./agent-token";
+import { parseKeyring } from "./crypto";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_KEYRING_JSON = JSON.stringify({
+  v1: "a".repeat(64),
+});
+
+const keyring = parseKeyring(TEST_KEYRING_JSON);
+const KEY_VERSION = "v1";
+
+// ---------------------------------------------------------------------------
+// Minimal Redis mock — same pattern as byok-store.test.ts
+// ---------------------------------------------------------------------------
+
+function makeMockRedis() {
+  const store = new Map<string, unknown>();
+
+  const client = {
+    set: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+      return "OK";
+    }),
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    del: vi.fn(async (...keys: string[]) => {
+      let deleted = 0;
+      for (const k of keys) {
+        if (store.has(k)) {
+          store.delete(k);
+          deleted++;
+        }
+      }
+      return deleted;
+    }),
+    _store: store,
+  };
+  return client as unknown as Redis & { _store: Map<string, unknown> };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("generateAgentToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns a 64-char hex token", async () => {
+    const result = await generateAgentToken("inst-1", "admin", KEY_VERSION, keyring, redis);
+    expect(result.token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("fingerprint is the last 4 chars of the token", async () => {
+    const result = await generateAgentToken("inst-1", "admin", KEY_VERSION, keyring, redis);
+    expect(result.fingerprint).toBe(result.token.slice(-4));
+    expect(result.fingerprint).toHaveLength(4);
+  });
+
+  it("stores an envelope at hive:agent-token:{installationId}", async () => {
+    await generateAgentToken("inst-1", "admin", KEY_VERSION, keyring, redis);
+    const stored = redis._store.get("hive:agent-token:inst-1") as Record<string, unknown>;
+    expect(stored).toBeDefined();
+    expect(typeof stored.ciphertext).toBe("string");
+    expect(typeof stored.iv).toBe("string");
+    expect(typeof stored.tag).toBe("string");
+    expect(stored.keyVersion).toBe(KEY_VERSION);
+    expect(stored.status).toBe("active");
+    expect(typeof stored.updatedAt).toBe("string");
+    expect(stored.updatedBy).toBe("admin");
+    expect(typeof stored.fingerprint).toBe("string");
+  });
+
+  it("stores a hash index at agent-token-hash:{sha256}", async () => {
+    const { token } = await generateAgentToken("inst-1", "admin", KEY_VERSION, keyring, redis);
+    // Find the hash key in the store
+    const hashKeys = [...redis._store.keys()].filter((k) =>
+      k.startsWith("agent-token-hash:"),
+    );
+    expect(hashKeys).toHaveLength(1);
+    const record = redis._store.get(hashKeys[0]) as { installationId: string };
+    expect(record.installationId).toBe("inst-1");
+    // Verify the hash matches
+    const { createHash } = await import("crypto");
+    const expectedHash = createHash("sha256").update(token, "utf8").digest("hex");
+    expect(hashKeys[0]).toBe(`agent-token-hash:${expectedHash}`);
+  });
+
+  it("rotation: replaces old envelope, deletes old hash index", async () => {
+    const { token: firstToken } = await generateAgentToken(
+      "inst-1",
+      "admin",
+      KEY_VERSION,
+      keyring,
+      redis,
+    );
+    const { token: secondToken } = await generateAgentToken(
+      "inst-1",
+      "admin",
+      KEY_VERSION,
+      keyring,
+      redis,
+    );
+
+    expect(firstToken).not.toBe(secondToken);
+
+    // Only one hash index should exist (the new one)
+    const hashKeys = [...redis._store.keys()].filter((k) =>
+      k.startsWith("agent-token-hash:"),
+    );
+    expect(hashKeys).toHaveLength(1);
+
+    // The new token should be resolvable
+    const installationId = await lookupInstallationByToken(secondToken, redis);
+    expect(installationId).toBe("inst-1");
+
+    // The old token should no longer be resolvable
+    const oldResult = await lookupInstallationByToken(firstToken, redis);
+    expect(oldResult).toBeNull();
+  });
+
+  it("createdAt is an ISO 8601 string", async () => {
+    const result = await generateAgentToken("inst-1", "admin", KEY_VERSION, keyring, redis);
+    expect(() => new Date(result.createdAt)).not.toThrow();
+    expect(new Date(result.createdAt).toISOString()).toBe(result.createdAt);
+  });
+});
+
+describe("getAgentToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns null when no token exists", async () => {
+    const result = await getAgentToken("inst-1", keyring, redis);
+    expect(result).toBeNull();
+  });
+
+  it("decrypts and returns the original token", async () => {
+    const { token: generated } = await generateAgentToken(
+      "inst-1",
+      "admin",
+      KEY_VERSION,
+      keyring,
+      redis,
+    );
+    const result = await getAgentToken("inst-1", keyring, redis);
+    expect(result).not.toBeNull();
+    expect(result!.token).toBe(generated);
+    expect(result!.fingerprint).toBe(generated.slice(-4));
+  });
+
+  it("returns null when envelope has invalid shape", async () => {
+    redis._store.set("hive:agent-token:inst-bad", { broken: true });
+    const result = await getAgentToken("inst-bad", keyring, redis);
+    expect(result).toBeNull();
+  });
+});
+
+describe("revokeAgentToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns false when no token exists", async () => {
+    const result = await revokeAgentToken("inst-1", keyring, redis);
+    expect(result).toBe(false);
+  });
+
+  it("deletes both envelope and hash index, returns true", async () => {
+    const { token } = await generateAgentToken("inst-1", "admin", KEY_VERSION, keyring, redis);
+    expect(redis._store.has("hive:agent-token:inst-1")).toBe(true);
+
+    const result = await revokeAgentToken("inst-1", keyring, redis);
+    expect(result).toBe(true);
+
+    expect(redis._store.has("hive:agent-token:inst-1")).toBe(false);
+    const hashKeys = [...redis._store.keys()].filter((k) =>
+      k.startsWith("agent-token-hash:"),
+    );
+    expect(hashKeys).toHaveLength(0);
+
+    // Token no longer resolvable
+    const installationId = await lookupInstallationByToken(token, redis);
+    expect(installationId).toBeNull();
+  });
+});
+
+describe("lookupInstallationByToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns null for unknown token", async () => {
+    const result = await lookupInstallationByToken("unknown-token", redis);
+    expect(result).toBeNull();
+  });
+
+  it("resolves installationId for valid token", async () => {
+    const { token } = await generateAgentToken("inst-42", "admin", KEY_VERSION, keyring, redis);
+    const result = await lookupInstallationByToken(token, redis);
+    expect(result).toBe("inst-42");
+  });
+
+  it("returns null after token is revoked", async () => {
+    const { token } = await generateAgentToken("inst-42", "admin", KEY_VERSION, keyring, redis);
+    await revokeAgentToken("inst-42", keyring, redis);
+    const result = await lookupInstallationByToken(token, redis);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/server/agent-token.ts
+++ b/apps/web/src/server/agent-token.ts
@@ -1,0 +1,189 @@
+/**
+ * Agent-token storage and lifecycle management.
+ *
+ * Each installation gets one agent-token: a 64-char hex random credential
+ * that agents use to authenticate with the hivemoot server (health API and
+ * future endpoints). The token is stored as an AES-256-GCM encrypted envelope
+ * in Redis, mirroring the BYOK envelope pattern.
+ *
+ * Two Redis keys per token:
+ *   hive:agent-token:{installationId}  — encrypted envelope + metadata
+ *   agent-token-hash:{sha256hex}       — reverse index: hash → installationId
+ *
+ * The hash index enables O(1) Bearer token auth lookup without storing the
+ * raw token in Redis.
+ */
+
+import { randomBytes, createHash } from "crypto";
+import { type Redis } from "@upstash/redis";
+import { encrypt, decrypt, type EncryptedEnvelope } from "@/server/crypto";
+
+const ENVELOPE_KEY_PREFIX = "hive:agent-token:";
+const HASH_INDEX_KEY_PREFIX = "agent-token-hash:";
+
+const TOKEN_BYTES = 32; // 64-char hex output
+
+export interface AgentTokenEnvelope {
+  ciphertext: string; // base64 — encrypted raw token
+  iv: string; // base64
+  tag: string; // base64 GCM auth tag
+  keyVersion: string;
+  status: "active" | "revoked";
+  updatedAt: string; // ISO 8601
+  updatedBy: string; // GitHub login of the admin who generated/rotated
+  fingerprint: string; // last 4 chars of raw token, for identification
+}
+
+function isAgentTokenStatus(value: unknown): value is AgentTokenEnvelope["status"] {
+  return value === "active" || value === "revoked";
+}
+
+function normalizeEnvelope(
+  installationId: string,
+  raw: Partial<AgentTokenEnvelope>,
+): AgentTokenEnvelope | null {
+  if (
+    typeof raw.ciphertext !== "string" ||
+    typeof raw.iv !== "string" ||
+    typeof raw.tag !== "string" ||
+    typeof raw.keyVersion !== "string" ||
+    !isAgentTokenStatus(raw.status) ||
+    typeof raw.updatedAt !== "string" ||
+    typeof raw.updatedBy !== "string" ||
+    typeof raw.fingerprint !== "string"
+  ) {
+    console.warn("Invalid agent-token envelope shape in Redis", { installationId });
+    return null;
+  }
+
+  return {
+    ciphertext: raw.ciphertext,
+    iv: raw.iv,
+    tag: raw.tag,
+    keyVersion: raw.keyVersion,
+    status: raw.status,
+    updatedAt: raw.updatedAt,
+    updatedBy: raw.updatedBy,
+    fingerprint: raw.fingerprint,
+  };
+}
+
+function tokenHash(rawToken: string): string {
+  return createHash("sha256").update(rawToken, "utf8").digest("hex");
+}
+
+/**
+ * Generates a new agent-token, encrypts it, and stores the envelope +
+ * hash index. If a token already exists, the old hash index is deleted
+ * before the new one is created (rotation).
+ *
+ * Returns the raw (plaintext) token — caller should present it to the user
+ * exactly once; it is not stored in plaintext anywhere.
+ */
+export async function generateAgentToken(
+  installationId: string,
+  userLogin: string,
+  keyVersion: string,
+  keyring: Map<string, Buffer>,
+  redis: Redis,
+): Promise<{ token: string; fingerprint: string; createdAt: string }> {
+  // Rotate: delete old hash index before replacing
+  const existingEnvelope = await getAgentTokenEnvelope(installationId, redis);
+  if (existingEnvelope) {
+    const oldToken = decrypt(existingEnvelope, keyring);
+    const oldHash = tokenHash(oldToken);
+    await redis.del(`${HASH_INDEX_KEY_PREFIX}${oldHash}`);
+  }
+
+  const rawToken = randomBytes(TOKEN_BYTES).toString("hex");
+  const fingerprint = rawToken.slice(-4);
+  const createdAt = new Date().toISOString();
+
+  const encrypted: EncryptedEnvelope = encrypt(rawToken, keyVersion, keyring);
+
+  const envelope: AgentTokenEnvelope = {
+    ciphertext: encrypted.ciphertext,
+    iv: encrypted.iv,
+    tag: encrypted.tag,
+    keyVersion: encrypted.keyVersion,
+    status: "active",
+    updatedAt: createdAt,
+    updatedBy: userLogin,
+    fingerprint,
+  };
+
+  const hash = tokenHash(rawToken);
+
+  // Pipeline: set envelope + hash index atomically-ish
+  // (Upstash REST does not expose MULTI/EXEC; sequential writes are acceptable
+  // here — worst case a crash between the two leaves a stale envelope with no
+  // hash index, which means the token is silently unusable until next rotation)
+  await redis.set(`${ENVELOPE_KEY_PREFIX}${installationId}`, envelope);
+  await redis.set(`${HASH_INDEX_KEY_PREFIX}${hash}`, { installationId });
+
+  return { token: rawToken, fingerprint, createdAt };
+}
+
+/**
+ * Returns the decrypted raw token for an installation, or null if none exists.
+ */
+export async function getAgentToken(
+  installationId: string,
+  keyring: Map<string, Buffer>,
+  redis: Redis,
+): Promise<{ token: string; fingerprint: string; createdAt: string } | null> {
+  const envelope = await getAgentTokenEnvelope(installationId, redis);
+  if (!envelope) return null;
+
+  const token = decrypt(envelope, keyring);
+  return { token, fingerprint: envelope.fingerprint, createdAt: envelope.updatedAt };
+}
+
+/**
+ * Revokes the agent-token for an installation by deleting both the envelope
+ * and the hash index. Returns true if a token existed and was deleted,
+ * false if none existed.
+ */
+export async function revokeAgentToken(
+  installationId: string,
+  keyring: Map<string, Buffer>,
+  redis: Redis,
+): Promise<boolean> {
+  const envelope = await getAgentTokenEnvelope(installationId, redis);
+  if (!envelope) return false;
+
+  const token = decrypt(envelope, keyring);
+  const hash = tokenHash(token);
+
+  await redis.del(`${HASH_INDEX_KEY_PREFIX}${hash}`);
+  await redis.del(`${ENVELOPE_KEY_PREFIX}${installationId}`);
+
+  return true;
+}
+
+/**
+ * Looks up an installationId by Bearer token hash.
+ * Used by the health POST endpoint to authenticate incoming agent requests.
+ * Returns null if the token is unknown or revoked.
+ */
+export async function lookupInstallationByToken(
+  rawToken: string,
+  redis: Redis,
+): Promise<string | null> {
+  const hash = tokenHash(rawToken);
+  const record = await redis.get<{ installationId: string }>(`${HASH_INDEX_KEY_PREFIX}${hash}`);
+  if (!record || typeof record.installationId !== "string") return null;
+  return record.installationId;
+}
+
+// Internal helper — reads and normalizes the envelope from Redis
+async function getAgentTokenEnvelope(
+  installationId: string,
+  redis: Redis,
+): Promise<AgentTokenEnvelope | null> {
+  const raw = await redis.get<Partial<AgentTokenEnvelope>>(
+    `${ENVELOPE_KEY_PREFIX}${installationId}`,
+  );
+  if (!raw) return null;
+  return normalizeEnvelope(installationId, raw);
+}


### PR DESCRIPTION
Fixes #199

Phase 1 of 3 for the agent health API.

## What

Adds the credential foundation agents need to authenticate with the hivemoot server. Follows the established BYOK envelope pattern — AES-256-GCM with a versioned keyring. Two Redis keys per token:

- `hive:agent-token:{installationId}` — encrypted envelope + metadata
- `agent-token-hash:{sha256hex}` — reverse index for O(1) Bearer auth lookup

**New files:**

| File | Purpose |
|------|---------|
| `server/agent-health-error.ts` | Error constants for all three health phases (shared by #200, #201) |
| `server/agent-token.ts` | `generateAgentToken`, `getAgentToken`, `revokeAgentToken`, `lookupInstallationByToken` |
| `server/agent-token.test.ts` | 14 unit tests — CRUD lifecycle, rotation, idempotency, hash index |
| `app/api/agent-token/route.ts` | POST (generate/rotate → 201/200), GET (view → 200/404), DELETE (revoke → 200/404) |
| `app/api/agent-token/route.test.ts` | 12 endpoint tests — auth, success, 404, 500 paths |

**Existing code reused, not modified:** `crypto.ts` (encrypt/decrypt), `byok-auth.ts` (session auth), `redis.ts` (client).

## Validation

- `npm test`: 204 passed, 1 skipped (baseline was 179, new: 26 agent-token tests)
- `tsc --noEmit`: clean
- `npm run lint`: clean

## Downstream

Phase 2 (#200) will use `lookupInstallationByToken` from `agent-token.ts` to authenticate the POST `/api/agent-health` endpoint.