### PR TITLE
feat(web): add health GET endpoint

### DIFF
--- a/apps/web/src/app/api/agent-health/route.test.ts
+++ b/apps/web/src/app/api/agent-health/route.test.ts
@@ -5,6 +5,9 @@ import { NextRequest, NextResponse } from "next/server";
 // Mocks
 // ---------------------------------------------------------------------------
 
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
 vi.mock("@/server/agent-health-auth", () => ({
   authenticateAgentRequest: vi.fn(),
 }));
@@ -14,8 +17,11 @@ vi.mock("@/server/agent-health-store", () => ({
   recordHealthReport: vi.fn(),
   reserveHealthReportIdempotency: vi.fn(),
   releaseHealthReportIdempotency: vi.fn(),
+  getOverview: vi.fn(),
+  getHistory: vi.fn(),
 }));
 
+import { authenticateByokRequest } from "@/server/byok-auth";
 import { authenticateAgentRequest } from "@/server/agent-health-auth";
 import {
   validateReport,
@@ -23,14 +29,24 @@ import {
   recordHealthReport,
   reserveHealthReportIdempotency,
   releaseHealthReportIdempotency,
+  getOverview,
+  getHistory,
 } from "@/server/agent-health-store";
-import { POST } from "./route";
+import { POST, GET } from "./route";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function mockAuthSuccess(installationId = "inst-1") {
+const MOCK_SESSION = {
+  installationId: "inst-1",
+  userId: 1,
+  userLogin: "alice",
+};
+
+const MOCK_KEYRING = new Map([["v1", Buffer.alloc(32)]]);
+
+function mockAgentAuthSuccess(installationId = "inst-1") {
   vi.mocked(authenticateAgentRequest).mockResolvedValue({
     ok: true,
     installationId,
@@ -38,8 +54,25 @@ function mockAuthSuccess(installationId = "inst-1") {
   });
 }
 
-function mockAuthFailure(status: number, code: string, message: string) {
+function mockAgentAuthFailure(status: number, code: string, message: string) {
   vi.mocked(authenticateAgentRequest).mockResolvedValue({
+    ok: false,
+    response: NextResponse.json({ code, message }, { status }),
+  });
+}
+
+function mockSessionAuthSuccess() {
+  vi.mocked(authenticateByokRequest).mockResolvedValue({
+    ok: true,
+    session: MOCK_SESSION,
+    keyring: MOCK_KEYRING,
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  });
+}
+
+function mockSessionAuthFailure(status: number, code: string, message: string) {
+  vi.mocked(authenticateByokRequest).mockResolvedValue({
     ok: false,
     response: NextResponse.json({ code, message }, { status }),
   });
@@ -68,6 +101,16 @@ function makeRawPostRequest(bodyText: string, extraHeaders?: Record<string, stri
   });
 }
 
+function makeGetRequest(params?: Record<string, string>) {
+  const url = new URL("https://example.com/api/agent-health");
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return new NextRequest(url.toString(), { method: "GET" });
+}
+
 const VALID_REQUEST_BODY = {
   agent_id: "bee-1",
   repo: "hivemoot/sandbox",
@@ -84,7 +127,8 @@ const VALID_REPORT = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockAuthSuccess();
+  mockAgentAuthSuccess();
+  mockSessionAuthSuccess();
   vi.mocked(validateReport).mockReturnValue({
     ok: true,
     report: VALID_REPORT,
@@ -96,6 +140,8 @@ beforeEach(() => {
   vi.mocked(checkRateLimit).mockResolvedValue(true);
   vi.mocked(recordHealthReport).mockResolvedValue(undefined);
   vi.mocked(releaseHealthReportIdempotency).mockResolvedValue(undefined);
+  vi.mocked(getOverview).mockResolvedValue([]);
+  vi.mocked(getHistory).mockResolvedValue([]);
 });
 
 // ---------------------------------------------------------------------------
@@ -123,14 +169,14 @@ describe("POST /api/agent-health", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    mockAuthFailure(401, "agent_health_not_authenticated", "Invalid token");
+    mockAgentAuthFailure(401, "agent_health_not_authenticated", "Invalid token");
 
     const res = await POST(makePostRequest(VALID_REQUEST_BODY));
     expect(res.status).toBe(401);
   });
 
   it("returns 400 when body is not valid JSON", async () => {
-    mockAuthSuccess();
+    mockAgentAuthSuccess();
 
     const req = makeRawPostRequest("not-json{{{");
 
@@ -252,5 +298,134 @@ describe("POST /api/agent-health", () => {
       VALID_REPORT,
       expect.anything(),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — GET
+// ---------------------------------------------------------------------------
+
+describe("GET /api/agent-health", () => {
+  it("returns overview when no query params are provided", async () => {
+    vi.mocked(getOverview).mockResolvedValue([
+      {
+        agent_id: "bee-1",
+        repo: "hivemoot/sandbox",
+        run_id: "20260224-100000-claude-bee-1",
+        outcome: "success",
+        duration_secs: 42,
+        consecutive_failures: 0,
+        received_at: "2026-02-24T10:00:00Z",
+        online: true,
+      },
+    ]);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].agent_id).toBe("bee-1");
+  });
+
+  it("returns history when agent_id and repo are provided", async () => {
+    vi.mocked(getHistory).mockResolvedValue([
+      {
+        agent_id: "bee-1",
+        repo: "hivemoot/sandbox",
+        run_id: "20260224-100000-claude-bee-1",
+        outcome: "success",
+        duration_secs: 42,
+        consecutive_failures: 0,
+        received_at: "2026-02-24T10:00:00Z",
+      },
+    ]);
+
+    const res = await GET(makeGetRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent_id).toBe("bee-1");
+    expect(body.repo).toBe("hivemoot/sandbox");
+    expect(body.history).toHaveLength(1);
+    expect(body.runs).toHaveLength(1);
+  });
+
+  it("returns history when history=true is provided", async () => {
+    vi.mocked(getHistory).mockResolvedValue([
+      {
+        agent_id: "bee-1",
+        repo: "hivemoot/sandbox",
+        run_id: "20260224-100000-claude-bee-1",
+        outcome: "success",
+        duration_secs: 42,
+        consecutive_failures: 0,
+        received_at: "2026-02-24T10:00:00Z",
+      },
+    ]);
+
+    const res = await GET(makeGetRequest({
+      history: "true",
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.history).toHaveLength(1);
+    expect(body.runs).toHaveLength(1);
+  });
+
+  it("returns 400 when history=true is missing agent_id", async () => {
+    const res = await GET(makeGetRequest({
+      history: "true",
+      repo: "hivemoot/sandbox",
+    }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_missing_fields");
+  });
+
+  it("returns 400 when history=true is missing repo", async () => {
+    const res = await GET(makeGetRequest({
+      history: "true",
+      agent_id: "bee-1",
+    }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_missing_fields");
+  });
+
+  it("returns 400 when only agent_id is provided", async () => {
+    const res = await GET(makeGetRequest({ agent_id: "bee-1" }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_missing_fields");
+  });
+
+  it("returns 400 when only repo is provided", async () => {
+    const res = await GET(makeGetRequest({ repo: "hivemoot/sandbox" }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_missing_fields");
+  });
+
+  it("returns auth error when session is invalid", async () => {
+    mockSessionAuthFailure(401, "byok_not_authenticated", "Not authenticated");
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("passes installationId from session to getOverview", async () => {
+    await GET(makeGetRequest());
+    expect(getOverview).toHaveBeenCalledWith("inst-1", expect.anything());
   });
 });

--- a/apps/web/src/app/api/agent-health/route.ts
+++ b/apps/web/src/app/api/agent-health/route.ts
@@ -1,14 +1,20 @@
 /**
- * POST /api/agent-health
+ * POST / GET /api/agent-health
  *
- * Accepts health reports from autonomous agents. Authenticated via Bearer
- * token (agent token, not session cookie).
+ * POST — Accepts health reports from autonomous agents. Authenticated via
+ *        Bearer token (agent token).
  *
- * Rate-limited to one report per agent per repo per 60 seconds.
- * Retries for the same run_id are idempotent.
+ * GET  — Returns health overview or per-agent history. Authenticated via
+ *        setup session cookie (for dashboard users).
+ *        Query params:
+ *          (none)                       → overview of all agents
+ *          ?agent_id=X&repo=Y           → run history for one agent+repo
+ *          ?history=true&agent_id=X&repo=Y
+ *                                       → same as above (legacy issue contract)
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
 import { authenticateAgentRequest } from "@/server/agent-health-auth";
 import {
   validateReport,
@@ -16,6 +22,8 @@ import {
   recordHealthReport,
   reserveHealthReportIdempotency,
   releaseHealthReportIdempotency,
+  getOverview,
+  getHistory,
 } from "@/server/agent-health-store";
 import { AGENT_HEALTH_ERROR, agentHealthError } from "@/server/agent-health-error";
 
@@ -136,4 +144,50 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ received: true, received_at: report.received_at });
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { searchParams } = new URL(request.url);
+  const agentId = searchParams.get("agent_id");
+  const repo = searchParams.get("repo");
+  const historyFlag = searchParams.get("history");
+  const wantsHistory = historyFlag === "true";
+
+  if (wantsHistory && (!agentId || !repo)) {
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.MISSING_FIELDS,
+      "history=true requires both agent_id and repo",
+      400,
+    );
+  }
+
+  if (agentId && repo) {
+    const history = await getHistory(
+      auth.session.installationId,
+      agentId,
+      repo,
+      auth.redis,
+    );
+
+    return NextResponse.json({
+      agent_id: agentId,
+      repo,
+      history,
+      runs: history,
+    });
+  }
+
+  if (agentId || repo) {
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.MISSING_FIELDS,
+      "Both agent_id and repo are required for history queries",
+      400,
+    );
+  }
+
+  const overview = await getOverview(auth.session.installationId, auth.redis);
+  return NextResponse.json({ agents: overview });
 }

--- a/apps/web/src/server/agent-health-store.test.ts
+++ b/apps/web/src/server/agent-health-store.test.ts
@@ -6,6 +6,8 @@ import {
   releaseHealthReportIdempotency,
   checkRateLimit,
   recordHealthReport,
+  getOverview,
+  getHistory,
   type HealthReport,
 } from "./agent-health-store";
 
@@ -18,7 +20,8 @@ function makeMockRedis() {
   const sets = new Map<string, Set<string>>();
   const sortedSets = new Map<string, Map<string, number>>(); // member -> score
 
-  let queuedOps: Array<() => Promise<unknown>> = [];
+  let queuedMultiOps: Array<() => Promise<unknown>> = [];
+  let queuedReadOps: Array<() => Promise<unknown>> = [];
 
   const client = {
     set: vi.fn(async (key: string, value: unknown, opts?: { nx?: boolean; ex?: number }) => {
@@ -32,6 +35,9 @@ function makeMockRedis() {
       store.delete(key);
       return existed ? 1 : 0;
     }),
+    ttl: vi.fn(async (key: string) => {
+      return store.has(key) ? 1800 : -2;
+    }),
     sadd: vi.fn(async (key: string, ...members: string[]) => {
       if (!sets.has(key)) sets.set(key, new Set());
       const set = sets.get(key)!;
@@ -44,10 +50,22 @@ function makeMockRedis() {
       }
       return added;
     }),
+    smembers: vi.fn(async (key: string) => {
+      const set = sets.get(key);
+      return set ? [...set] : [];
+    }),
     zadd: vi.fn(async (key: string, entry: { score: number; member: string }) => {
       if (!sortedSets.has(key)) sortedSets.set(key, new Map());
       sortedSets.get(key)!.set(entry.member, entry.score);
       return 1;
+    }),
+    zrange: vi.fn(async (key: string, start: number, stop: number, opts?: { rev?: boolean }) => {
+      const zset = sortedSets.get(key);
+      if (!zset) return [];
+      const entries = [...zset.entries()].sort((a, b) =>
+        opts?.rev ? b[1] - a[1] : a[1] - b[1],
+      );
+      return entries.slice(start, stop + 1).map(([member]) => member);
     }),
     zremrangebyscore: vi.fn(async (key: string, min: string | number, max: string | number) => {
       const zset = sortedSets.get(key);
@@ -64,34 +82,56 @@ function makeMockRedis() {
       return removed;
     }),
     multi: vi.fn(() => {
-      queuedOps = [];
-      return pipeline;
+      queuedMultiOps = [];
+      return writePipeline;
+    }),
+    pipeline: vi.fn(() => {
+      queuedReadOps = [];
+      return readPipeline;
     }),
     _store: store,
     _sets: sets,
     _sortedSets: sortedSets,
   };
 
-  const pipeline = {
+  const writePipeline = {
     set: vi.fn((...args: Parameters<typeof client.set>) => {
-      queuedOps.push(() => client.set(...args));
-      return pipeline;
+      queuedMultiOps.push(() => client.set(...args));
+      return writePipeline;
     }),
     zadd: vi.fn((...args: Parameters<typeof client.zadd>) => {
-      queuedOps.push(() => client.zadd(...args));
-      return pipeline;
+      queuedMultiOps.push(() => client.zadd(...args));
+      return writePipeline;
     }),
     sadd: vi.fn((...args: Parameters<typeof client.sadd>) => {
-      queuedOps.push(() => client.sadd(...args));
-      return pipeline;
+      queuedMultiOps.push(() => client.sadd(...args));
+      return writePipeline;
     }),
     zremrangebyscore: vi.fn((...args: Parameters<typeof client.zremrangebyscore>) => {
-      queuedOps.push(() => client.zremrangebyscore(...args));
-      return pipeline;
+      queuedMultiOps.push(() => client.zremrangebyscore(...args));
+      return writePipeline;
     }),
     exec: vi.fn(async () => {
       const results: unknown[] = [];
-      for (const op of queuedOps) {
+      for (const op of queuedMultiOps) {
+        results.push(await op());
+      }
+      return results;
+    }),
+  };
+
+  const readPipeline = {
+    get: vi.fn((...args: Parameters<typeof client.get>) => {
+      queuedReadOps.push(() => client.get(...args));
+      return readPipeline;
+    }),
+    ttl: vi.fn((...args: Parameters<typeof client.ttl>) => {
+      queuedReadOps.push(() => client.ttl(...args));
+      return readPipeline;
+    }),
+    exec: vi.fn(async () => {
+      const results: unknown[] = [];
+      for (const op of queuedReadOps) {
         results.push(await op());
       }
       return results;
@@ -103,6 +143,7 @@ function makeMockRedis() {
     _sets: Map<string, Set<string>>;
     _sortedSets: Map<string, Map<string, number>>;
     multi: ReturnType<typeof vi.fn>;
+    pipeline: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -172,6 +213,19 @@ describe("validateReport", () => {
   it("rejects invalid agent_id", () => {
     const result = validateReport({
       agent_id: "BEE#1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 1,
+      consecutive_failures: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("agent_id");
+  });
+
+  it("rejects agent_id containing colon", () => {
+    const result = validateReport({
+      agent_id: "bee:1",
       repo: "hivemoot/sandbox",
       run_id: "run-1",
       outcome: "success",
@@ -508,5 +562,154 @@ describe("recordHealthReport", () => {
       "-inf",
       cutoff,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — getOverview
+// ---------------------------------------------------------------------------
+
+describe("getOverview", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redis = makeMockRedis();
+  });
+
+  it("returns empty array when no agents are indexed", async () => {
+    const result = await getOverview("inst-1", redis);
+    expect(result).toEqual([]);
+  });
+
+  it("returns overview entries for indexed agents", async () => {
+    const report: HealthReport = {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "failure",
+      duration_secs: 33,
+      consecutive_failures: 2,
+      error: "timeout",
+      received_at: "2026-02-24T10:00:00Z",
+    };
+
+    // Simulate state after recordHealthReport
+    redis._sets.set("agent-health:index:inst-1", new Set(["bee-1:hivemoot/sandbox"]));
+    redis._store.set("agent-health:latest:inst-1:bee-1:hivemoot/sandbox", report);
+
+    const result = await getOverview("inst-1", redis);
+    expect(result).toHaveLength(1);
+    expect(result[0].agent_id).toBe("bee-1");
+    expect(result[0].repo).toBe("hivemoot/sandbox");
+    expect(result[0].outcome).toBe("failure");
+    expect(result[0].consecutive_failures).toBe(2);
+    expect(result[0].online).toBe(true);
+  });
+
+  it("uses Redis pipeline for overview reads", async () => {
+    redis._sets.set("agent-health:index:inst-1", new Set(["bee-1:hivemoot/sandbox"]));
+    redis._store.set("agent-health:latest:inst-1:bee-1:hivemoot/sandbox", {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 1,
+      consecutive_failures: 0,
+      received_at: "2026-02-24T10:00:00Z",
+    });
+
+    await getOverview("inst-1", redis);
+
+    expect(redis.pipeline).toHaveBeenCalledTimes(1);
+    expect(redis.get).toHaveBeenCalledTimes(1);
+    expect(redis.ttl).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks agents as offline when latest key has expired", async () => {
+    redis._sets.set("agent-health:index:inst-1", new Set(["bee-1:hivemoot/sandbox"]));
+    // No latest key stored → expired
+    vi.mocked(redis.ttl).mockResolvedValue(-2);
+
+    const result = await getOverview("inst-1", redis);
+    expect(result).toHaveLength(1);
+    expect(result[0].online).toBe(false);
+    expect(result[0].agent_id).toBe("bee-1");
+  });
+
+  it("sorts entries by received_at descending", async () => {
+    redis._sets.set("agent-health:index:inst-1", new Set([
+      "bee-1:hivemoot/sandbox",
+      "bee-2:hivemoot/sandbox",
+    ]));
+    redis._store.set("agent-health:latest:inst-1:bee-1:hivemoot/sandbox", {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 42,
+      consecutive_failures: 0,
+      received_at: "2026-02-24T09:00:00Z",
+    });
+    redis._store.set("agent-health:latest:inst-1:bee-2:hivemoot/sandbox", {
+      agent_id: "bee-2",
+      repo: "hivemoot/sandbox",
+      run_id: "run-2",
+      outcome: "failure",
+      duration_secs: 20,
+      consecutive_failures: 1,
+      received_at: "2026-02-24T10:00:00Z",
+    });
+
+    const result = await getOverview("inst-1", redis);
+    expect(result[0].agent_id).toBe("bee-2"); // more recent
+    expect(result[1].agent_id).toBe("bee-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — getHistory
+// ---------------------------------------------------------------------------
+
+describe("getHistory", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redis = makeMockRedis();
+  });
+
+  it("returns empty array when no history exists", async () => {
+    const result = await getHistory("inst-1", "bee-1", "repo", redis);
+    expect(result).toEqual([]);
+  });
+
+  it("returns parsed reports from sorted set", async () => {
+    const recentTimestamp = new Date(Date.now() - 60_000).toISOString(); // 1 min ago
+    const report: HealthReport = {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 9,
+      consecutive_failures: 0,
+      received_at: recentTimestamp,
+    };
+
+    // Simulate stored sorted set data
+    const key = "agent-health:runs:inst-1:bee-1:hivemoot/sandbox";
+    redis._sortedSets.set(key, new Map([
+      [JSON.stringify(report), new Date(recentTimestamp).getTime()],
+    ]));
+
+    const result = await getHistory("inst-1", "bee-1", "hivemoot/sandbox", redis);
+    expect(result).toHaveLength(1);
+    expect(result[0].agent_id).toBe("bee-1");
+    expect(result[0].outcome).toBe("success");
+  });
+
+  it("trims stale entries before returning", async () => {
+    await getHistory("inst-1", "bee-1", "repo", redis);
+    expect(redis.zremrangebyscore).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/server/agent-health-store.ts
+++ b/apps/web/src/server/agent-health-store.ts
@@ -1,5 +1,5 @@
 /**
- * Agent health report storage.
+ * Agent health report storage and retrieval.
  *
  * Redis layout per agent:
  *
@@ -30,6 +30,7 @@ import { type Redis } from "@upstash/redis";
 const LATEST_TTL_SECONDS = 30 * 60; // 30 minutes
 const RATE_LIMIT_SECONDS = 60;
 const HISTORY_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_HISTORY_ENTRIES = 1440; // 24h at 1/min
 const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
 const AGENT_ID_PATTERN = /^[a-z0-9_-]+$/;
 
@@ -47,6 +48,19 @@ export interface HealthReport {
   error?: string;
   exit_code?: number;
   received_at: string; // ISO 8601, server-assigned
+}
+
+export interface HealthOverviewEntry {
+  agent_id: string;
+  repo: string;
+  run_id?: string;
+  outcome?: HealthReport["outcome"];
+  duration_secs?: number;
+  consecutive_failures?: number;
+  error?: string;
+  exit_code?: number;
+  received_at: string;
+  online: boolean; // true if latest key still has TTL remaining
 }
 
 // ---------------------------------------------------------------------------
@@ -381,4 +395,133 @@ export async function recordHealthReport(
       cutoff,
     )
     .exec();
+}
+
+// ---------------------------------------------------------------------------
+// Read functions (used by GET endpoint)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns an overview of all agents for an installation.
+ * One entry per agent+repo combo, with online status derived from TTL.
+ */
+export async function getOverview(
+  installId: string,
+  redis: Redis,
+): Promise<HealthOverviewEntry[]> {
+  const members = await redis.smembers(indexKey(installId));
+  if (!members || members.length === 0) return [];
+
+  const indexed = members
+    .map((member) => {
+      const separatorIdx = member.indexOf(":");
+      if (separatorIdx <= 0 || separatorIdx === member.length - 1) return null;
+
+      const agentId = member.slice(0, separatorIdx);
+      const repo = member.slice(separatorIdx + 1);
+      return {
+        agentId,
+        repo,
+        key: latestKey(installId, agentId, repo),
+      };
+    })
+    .filter((entry): entry is { agentId: string; repo: string; key: string } => entry !== null);
+
+  if (indexed.length === 0) return [];
+
+  const pipeline = redis.pipeline();
+  for (const entry of indexed) {
+    pipeline.get(entry.key);
+    pipeline.ttl(entry.key);
+  }
+  const results = await pipeline.exec();
+
+  const entries: HealthOverviewEntry[] = [];
+
+  for (let i = 0; i < indexed.length; i += 1) {
+    const reportRaw = results[i * 2] ?? null;
+    const ttlRaw = results[(i * 2) + 1];
+    const ttl = typeof ttlRaw === "number" ? ttlRaw : Number(ttlRaw);
+    const online = Number.isFinite(ttl) && ttl > 0;
+
+    if (typeof reportRaw === "object" && reportRaw !== null && !Array.isArray(reportRaw)) {
+      const report = reportRaw as Partial<HealthReport>;
+
+      if (
+        typeof report.agent_id === "string"
+        && typeof report.repo === "string"
+        && typeof report.received_at === "string"
+      ) {
+        entries.push({
+          agent_id: report.agent_id,
+          repo: report.repo,
+          run_id: typeof report.run_id === "string" ? report.run_id : undefined,
+          outcome: VALID_OUTCOMES.has(report.outcome ?? "")
+            ? (report.outcome as HealthReport["outcome"])
+            : undefined,
+          duration_secs: typeof report.duration_secs === "number" ? report.duration_secs : undefined,
+          consecutive_failures: typeof report.consecutive_failures === "number"
+            ? report.consecutive_failures
+            : undefined,
+          error: typeof report.error === "string" ? report.error : undefined,
+          exit_code: typeof report.exit_code === "number" ? report.exit_code : undefined,
+          received_at: report.received_at,
+          online,
+        });
+        continue;
+      }
+    }
+
+    // Agent existed but latest key is missing/corrupt — show as offline fallback.
+    entries.push({
+      agent_id: indexed[i].agentId,
+      repo: indexed[i].repo,
+      received_at: "",
+      online: false,
+    });
+  }
+
+  // Sort by received_at descending (most recent first)
+  entries.sort((a, b) => {
+    if (!a.received_at) return 1;
+    if (!b.received_at) return -1;
+    return b.received_at.localeCompare(a.received_at);
+  });
+
+  return entries;
+}
+
+/**
+ * Returns the run history for a specific agent+repo combo.
+ * Results are sorted newest-first, limited to MAX_HISTORY_ENTRIES.
+ */
+export async function getHistory(
+  installId: string,
+  agentId: string,
+  repo: string,
+  redis: Redis,
+): Promise<HealthReport[]> {
+  const key = runsKey(installId, agentId, repo);
+
+  // Trim stale entries first
+  const now = Date.now();
+  const cutoff = now - HISTORY_RETENTION_MS;
+  await redis.zremrangebyscore(key, "-inf", cutoff);
+
+  // Fetch newest-first
+  const raw = await redis.zrange(key, 0, MAX_HISTORY_ENTRIES - 1, { rev: true });
+  if (!raw || raw.length === 0) return [];
+
+  return raw
+    .map((entry) => {
+      if (typeof entry === "string") {
+        try {
+          return JSON.parse(entry) as HealthReport;
+        } catch {
+          return null;
+        }
+      }
+      return entry as HealthReport;
+    })
+    .filter((report): report is HealthReport => report !== null);
 }


### PR DESCRIPTION
## Summary$'
'$'
'Adds read access to agent health data for the dashboard. Part 3 of the Agent Health API (#169). Builds on #206.$'
'$'
'- GET `/api/agent-health` (session cookie auth) returns all-agents overview$'
'- GET `/api/agent-health?agent_id=X__CURRENT_BODY_PLACEHOLDER__repo=Y` returns per-agent run history$'
'- `getOverview()` reads index + latest keys, derives online status from TTL$'
'- `getHistory()` reads sorted set, trims stale entries, returns newest-first$'
'- 13 new tests (6 GET endpoint + 7 read function)$'
'$'
'### What it looks like$'
'$'
'**GET /api/agent-health** (overview):$'
'```json$'
'{$'
'  "agents": [$'
'    { "agent_id": "bee-1", "repo": "hivemoot/sandbox", "status": "working", "online": true, "received_at": "2026-02-25T10:00:00Z" },$'
'    { "agent_id": "bee-2", "repo": "hivemoot/sandbox", "status": "idle", "online": false, "received_at": "" }$'
'  ]$'
'}$'
'```$'
'$'
'**GET /api/agent-health?agent_id=bee-1__CURRENT_BODY_PLACEHOLDER__repo=hivemoot/sandbox** (history):$'
'```json$'
'{$'
'  "agent_id": "bee-1",$'
'  "repo": "hivemoot/sandbox",$'
'  "history": [$'
'    { "status": "working", "current_issue": 42, "received_at": "2026-02-25T10:00:00Z" },$'
'    { "status": "idle", "received_at": "2026-02-25T09:00:00Z" }$'
'  ]$'
'}$'
'```$'
'$'
'Closes #201

## Post-review update

- Added support for `history=true` query mode on `GET /api/agent-health` (in addition to existing `agent_id+repo` behavior)
- History responses now include both `history` and `runs` arrays as aliases for contract compatibility
- Added tests for `history=true` success and missing-param validation
