### PR TITLE
fix(web): atomic Redis writes for agent token rotate/revoke

### DIFF
--- a/apps/web/src/server/agent-token.test.ts
+++ b/apps/web/src/server/agent-token.test.ts
@@ -56,10 +56,27 @@ function makeMockRedis() {
       return existed ? 1 : 0;
     }),
     eval: vi.fn(async (_script: string, keys: string[], args: string[]) => {
-      const lockKey = keys[0];
-      const expectedOwner = args[0];
-      if (store.get(lockKey) === expectedOwner) {
-        store.delete(lockKey);
+      // RELEASE_LOCK_SCRIPT: 1 key, 1 arg
+      if (keys.length === 1 && args.length === 1) {
+        const lockKey = keys[0];
+        const expectedOwner = args[0];
+        if (store.get(lockKey) === expectedOwner) {
+          store.delete(lockKey);
+          return 1;
+        }
+        return 0;
+      }
+      // ROTATE_TOKEN_SCRIPT: 3 keys, 3 args
+      if (keys.length === 3 && args.length === 3) {
+        if (args[0] === "1") store.delete(keys[0]);
+        store.set(keys[1], JSON.parse(args[1]));
+        store.set(keys[2], JSON.parse(args[2]));
+        return 1;
+      }
+      // REVOKE_TOKEN_SCRIPT: 2 keys, 0 args
+      if (keys.length === 2 && args.length === 0) {
+        store.delete(keys[0]);
+        store.delete(keys[1]);
         return 1;
       }
       return 0;
@@ -126,6 +143,39 @@ describe("generateAgentToken", () => {
     // Old hash removed, new hash present
     expect(redis._store.has(`agent-token-hash:${hash1}`)).toBe(false);
     expect(redis._store.has(`agent-token-hash:${hash2}`)).toBe(true);
+  });
+
+  it("leaves original token intact when rotate script fails (no partial write)", async () => {
+    const token1 = await generateAgentToken("inst-1", "alice", "v1", MOCK_KEYRING, redis);
+    const hash1 = hashToken(token1);
+
+    (redis.eval as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_s: string, keys: string[], args: string[]) => {
+        // Keep lock-release working (1 key, 1 arg)
+        if (keys.length === 1 && args.length === 1) {
+          if (redis._store.get(keys[0]) === args[0]) {
+            redis._store.delete(keys[0]);
+            return 1;
+          }
+          return 0;
+        }
+        throw new Error("simulated Redis write failure");
+      },
+    );
+
+    await expect(
+      generateAgentToken("inst-1", "alice", "v1", MOCK_KEYRING, redis),
+    ).rejects.toThrow();
+
+    // Original token and hash index must still be intact
+    const hashKeys = [...redis._store.keys()].filter((k) =>
+      k.startsWith("agent-token-hash:"),
+    );
+    expect(hashKeys).toHaveLength(1);
+    expect(redis._store.has(`agent-token-hash:${hash1}`)).toBe(true);
+
+    const current = await getAgentToken("inst-1", MOCK_KEYRING, redis);
+    expect(current!.token).toBe(token1);
   });
 
   it("keeps exactly one valid token after concurrent rotations", async () => {
@@ -232,6 +282,33 @@ describe("revokeAgentToken", () => {
     expect(result).toBe(true);
     expect(redis._store.has("hive:agent-token:inst-1")).toBe(false);
     expect(redis._store.has(`agent-token-hash:${hash}`)).toBe(false);
+  });
+
+  it("leaves token intact when revoke script fails (no partial write)", async () => {
+    const token = await generateAgentToken("inst-1", "alice", "v1", MOCK_KEYRING, redis);
+    const hash = hashToken(token);
+
+    (redis.eval as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_s: string, keys: string[], args: string[]) => {
+        // Keep lock-release working (1 key, 1 arg)
+        if (keys.length === 1 && args.length === 1) {
+          if (redis._store.get(keys[0]) === args[0]) {
+            redis._store.delete(keys[0]);
+            return 1;
+          }
+          return 0;
+        }
+        throw new Error("simulated Redis write failure");
+      },
+    );
+
+    await expect(revokeAgentToken("inst-1", redis)).rejects.toThrow();
+
+    // Both envelope and hash index must still be intact
+    expect(redis._store.has("hive:agent-token:inst-1")).toBe(true);
+    expect(redis._store.has(`agent-token-hash:${hash}`)).toBe(true);
+    const resolved = await resolveTokenToInstallation(token, redis);
+    expect(resolved).toBe("inst-1");
   });
 
   it("token cannot be resolved after revocation", async () => {

--- a/apps/web/src/server/agent-token.ts
+++ b/apps/web/src/server/agent-token.ts
@@ -32,6 +32,24 @@ end
 return 0
 `;
 
+// Atomic rotate: DEL old hash (if any), SET envelope, SET new hash index.
+// KEYS: [oldHashKey, envelopeKey, newHashKey]
+// ARGV: [deleteOld ("1"|"0"), envelopeJSON, hashRecordJSON]
+const ROTATE_TOKEN_SCRIPT = `
+if ARGV[1] == "1" then redis.call("del", KEYS[1]) end
+redis.call("set", KEYS[2], ARGV[2])
+redis.call("set", KEYS[3], ARGV[3])
+return 1
+`;
+
+// Atomic revoke: DEL hash index and envelope together.
+// KEYS: [hashKey, envelopeKey]
+const REVOKE_TOKEN_SCRIPT = `
+redis.call("del", KEYS[1])
+redis.call("del", KEYS[2])
+return 1
+`;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -152,11 +170,8 @@ export async function generateAgentToken(
   redis: Redis,
 ): Promise<string> {
   return withInstallationLock(installationId, redis, async () => {
-    // Remove old hash index if a token already exists.
     const existing = await redis.get<AgentTokenEnvelope>(redisTokenKey(installationId));
-    if (existing && typeof existing.tokenHash === "string") {
-      await redis.del(redisHashKey(existing.tokenHash));
-    }
+    const hasExisting = existing != null && typeof existing.tokenHash === "string";
 
     const rawToken = randomBytes(32).toString("hex");
     const hash = hashToken(rawToken);
@@ -173,8 +188,19 @@ export async function generateAgentToken(
       createdBy,
     };
 
-    await redis.set(redisTokenKey(installationId), envelope);
-    await redis.set(redisHashKey(hash), { installationId });
+    await redis.eval(
+      ROTATE_TOKEN_SCRIPT,
+      [
+        hasExisting ? redisHashKey(existing!.tokenHash) : "",
+        redisTokenKey(installationId),
+        redisHashKey(hash),
+      ],
+      [
+        hasExisting ? "1" : "0",
+        JSON.stringify(envelope),
+        JSON.stringify({ installationId }),
+      ],
+    );
 
     return rawToken;
   });
@@ -250,8 +276,11 @@ export async function revokeAgentToken(
     const envelope = await redis.get<AgentTokenEnvelope>(redisTokenKey(installationId));
     if (!envelope || typeof envelope.tokenHash !== "string") return false;
 
-    await redis.del(redisHashKey(envelope.tokenHash));
-    await redis.del(redisTokenKey(installationId));
+    await redis.eval(
+      REVOKE_TOKEN_SCRIPT,
+      [redisHashKey(envelope.tokenHash), redisTokenKey(installationId)],
+      [],
+    );
     return true;
   });
 }


### PR DESCRIPTION
Closes the [changes-requested blocker](https://github.com/hivemoot/hivemoot/pull/205) raised in the #205 review by guard and me.

## What's broken

`generateAgentToken` and `revokeAgentToken` issue sequential Redis commands inside the per-installation lock. The lock prevents concurrent races, but a mid-sequence Upstash HTTP failure can still commit partial state:

- **Rotate** (`generateAgentToken`): `DEL old hash` → `SET envelope` → `SET new hash`. If the last SET fails, the caller gets a token that silently fails Phase 2 auth lookup.
- **Revoke** (`revokeAgentToken`): `DEL hash` → `DEL envelope`. If the second DEL fails, the hash index is gone but the envelope survives — orphaned, unreachable, no way to re-revoke.

## Fix

Two Lua EVAL scripts — same pattern as `RELEASE_LOCK_SCRIPT` already in the file:

- **`ROTATE_TOKEN_SCRIPT`**: DEL old hash (if any) + SET envelope + SET new hash index in one atomic operation
- **`REVOKE_TOKEN_SCRIPT`**: DEL hash index + DEL envelope atomically

## Verification

- 30/30 tests passing (28 existing + 2 new failure-injection tests)
- `tsc --noEmit` clean
- Failure-injection tests confirm: when the eval script throws, original state survives intact (no partial writes)

This is a helper PR targeting `feat/agent-token` — the PR author can merge or cherry-pick into their branch.