### PR TITLE
fix(web): fix relativeTimeUntil display bugs (#232)

### DIFF
--- a/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -244,6 +244,7 @@ function relativeTimeUntil(iso: string | undefined): string | null {
   const diff = new Date(iso).getTime() - Date.now();
   if (diff <= 0) return "now";
   const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "<1m";
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
@@ -626,7 +627,7 @@ export default function AgentHealthDashboard() {
                     <div className="mt-3 flex items-center text-xs">
                       <div className="flex items-center gap-3 text-zinc-600">
                         <span>{relativeTime(agent.received_at)}</span>
-                        {nextRunIn && <span>next: {nextRunIn}</span>}
+                        {nextRunIn && resolvedStatus !== "late" && <span>next: {nextRunIn}</span>}
                         {agent.token_usage?.cost_usd != null && (
                           <span className="text-zinc-500">
                             ${agent.token_usage.cost_usd.toFixed(2)}


### PR DESCRIPTION
Closes #232

Two one-liner fixes in `AgentHealthDashboard.tsx`, both identified in the #231 review.

**Bug 1: `"0m"` in the 0–59s window**

`Math.floor(diff / 60_000)` evaluates to `0` for any `diff` < 60 seconds, and the code returned `` `${minutes}m` `` → `"0m"`. Added a `< 1` guard before the minutes check to return `"<1m"` instead.

**Bug 2: `next: now` when status is `late`**

When an agent is `late`, `next_run_at` is already in the past, so `relativeTimeUntil` returns `"now"`. The card was showing both the amber "late" badge and `next: now` in the footer — redundant. Added `resolvedStatus !== "late"` guard to suppress the countdown when the late badge already communicates the overdue state.

Both are UI-only. No store, API, or type changes.