### PR TITLE
fix(cli): add --paginate --slurp to fetchNotifications

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/github/notifications.test.ts
+++ b/cli/src/github/notifications.test.ts
@@ -66,8 +66,9 @@ describe("parseSubjectNumber()", () => {
 
 describe("fetchNotifications()", () => {
   it("returns map of unread notifications keyed by issue number", async () => {
+    // --slurp wraps pages in an outer array; single page response is [[...]]
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({ reason: "mention", updated_at: "2025-06-15T10:00:00Z" }),
+      [makeNotification({ reason: "mention", updated_at: "2025-06-15T10:00:00Z" })],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -82,20 +83,22 @@ describe("fetchNotifications()", () => {
     });
   });
 
-  it("calls gh with correct API path", async () => {
-    mockedGh.mockResolvedValue("[]");
+  it("calls gh with --paginate --slurp and correct API path", async () => {
+    mockedGh.mockResolvedValue("[[]]");
 
     await fetchNotifications(repo);
 
     expect(mockedGh).toHaveBeenCalledWith([
       "api",
+      "--paginate",
+      "--slurp",
       "/repos/hivemoot/colony/notifications",
     ]);
   });
 
   it("filters out read notifications", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({ unread: false }),
+      [makeNotification({ unread: false })],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -104,7 +107,7 @@ describe("fetchNotifications()", () => {
 
   it("filters out non-issue/PR subject types", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({ subject: { url: "https://api.github.com/repos/hivemoot/colony/releases/5", type: "Release" } }),
+      [makeNotification({ subject: { url: "https://api.github.com/repos/hivemoot/colony/releases/5", type: "Release" } })],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -113,10 +116,10 @@ describe("fetchNotifications()", () => {
 
   it("handles PullRequest subject type", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({
+      [makeNotification({
         subject: { url: "https://api.github.com/repos/hivemoot/colony/pulls/99", type: "PullRequest", title: "Add search", latest_comment_url: null },
         reason: "review_requested",
-      }),
+      })],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -133,8 +136,10 @@ describe("fetchNotifications()", () => {
 
   it("keeps most recent notification when duplicates exist for same item", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({ reason: "comment", updated_at: "2025-06-15T08:00:00Z" }),
-      makeNotification({ reason: "mention", updated_at: "2025-06-15T12:00:00Z" }),
+      [
+        makeNotification({ reason: "comment", updated_at: "2025-06-15T08:00:00Z" }),
+        makeNotification({ reason: "mention", updated_at: "2025-06-15T12:00:00Z" }),
+      ],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -151,8 +156,10 @@ describe("fetchNotifications()", () => {
 
   it("keeps earlier notification when it appears after a later one", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({ reason: "mention", updated_at: "2025-06-15T12:00:00Z" }),
-      makeNotification({ reason: "comment", updated_at: "2025-06-15T08:00:00Z" }),
+      [
+        makeNotification({ reason: "mention", updated_at: "2025-06-15T12:00:00Z" }),
+        makeNotification({ reason: "comment", updated_at: "2025-06-15T08:00:00Z" }),
+      ],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -161,14 +168,16 @@ describe("fetchNotifications()", () => {
 
   it("handles multiple different items", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({
-        subject: { url: "https://api.github.com/repos/hivemoot/colony/issues/10", type: "Issue", title: "Bug report", latest_comment_url: null },
-        reason: "comment",
-      }),
-      makeNotification({
-        subject: { url: "https://api.github.com/repos/hivemoot/colony/pulls/20", type: "PullRequest", title: "Refactor", latest_comment_url: null },
-        reason: "author",
-      }),
+      [
+        makeNotification({
+          subject: { url: "https://api.github.com/repos/hivemoot/colony/issues/10", type: "Issue", title: "Bug report", latest_comment_url: null },
+          reason: "comment",
+        }),
+        makeNotification({
+          subject: { url: "https://api.github.com/repos/hivemoot/colony/pulls/20", type: "PullRequest", title: "Refactor", latest_comment_url: null },
+          reason: "author",
+        }),
+      ],
     ]));
 
     const result = await fetchNotifications(repo);
@@ -178,7 +187,7 @@ describe("fetchNotifications()", () => {
   });
 
   it("returns empty map when API returns empty array", async () => {
-    mockedGh.mockResolvedValue("[]");
+    mockedGh.mockResolvedValue("[[]]");
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(0);
@@ -186,13 +195,45 @@ describe("fetchNotifications()", () => {
 
   it("skips notifications with unparseable subject URLs", async () => {
     mockedGh.mockResolvedValue(JSON.stringify([
-      makeNotification({
+      [makeNotification({
         subject: { url: "https://api.github.com/repos/hivemoot/colony", type: "Issue" },
-      }),
+      })],
     ]));
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(0);
+  });
+
+  it("correctly flattens multi-page response", async () => {
+    const page1 = [
+      makeNotification({ id: "1001", subject: { url: "https://api.github.com/repos/hivemoot/colony/issues/10", type: "Issue", title: "Issue 10", latest_comment_url: null }, reason: "comment" }),
+    ];
+    const page2 = [
+      makeNotification({ id: "1002", subject: { url: "https://api.github.com/repos/hivemoot/colony/issues/20", type: "Issue", title: "Issue 20", latest_comment_url: null }, reason: "mention" }),
+    ];
+    // --slurp wraps all pages into [[...page1], [...page2]]
+    mockedGh.mockResolvedValue(JSON.stringify([page1, page2]));
+
+    const result = await fetchNotifications(repo);
+    expect(result.size).toBe(2);
+    expect(result.get(10)?.reason).toBe("comment");
+    expect(result.get(20)?.reason).toBe("mention");
+  });
+
+  it("throws CliError on parse failure instead of silently returning empty map", async () => {
+    mockedGh.mockResolvedValue("not-valid-json");
+
+    await expect(fetchNotifications(repo)).rejects.toMatchObject({
+      code: "GH_ERROR",
+    });
+  });
+
+  it("throws CliError when API returns non-array payload", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({ error: "unexpected" }));
+
+    await expect(fetchNotifications(repo)).rejects.toMatchObject({
+      code: "GH_ERROR",
+    });
   });
 });
 

--- a/cli/src/github/notifications.ts
+++ b/cli/src/github/notifications.ts
@@ -70,12 +70,36 @@ function subjectHtmlUrl(
  * When multiple notifications exist for the same item, keeps the most recent.
  */
 export async function fetchNotifications(repo: RepoRef): Promise<NotificationMap> {
+  // --paginate emits one JSON array per page; --slurp wraps all pages into a
+  // single outer array so JSON.parse sees one valid document.
   const raw = await gh([
     "api",
+    "--paginate",
+    "--slurp",
     `/repos/${repo.owner}/${repo.repo}/notifications`,
   ]);
 
-  const notifications: RawNotification[] = JSON.parse(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliError(
+      "Failed to parse notifications response from GitHub API.",
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new CliError(
+      "Unexpected notifications response format from GitHub API.",
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  // --slurp wraps pages as an outer array of arrays; flatten to a single list.
+  const notifications: RawNotification[] = (parsed as RawNotification[][]).flat();
   const map: NotificationMap = new Map();
 
   for (const n of notifications) {


### PR DESCRIPTION
Fixes #246

## Problem

`fetchNotifications` called `gh api /repos/.../notifications` with no `--paginate`. GitHub's default `per_page` for the notifications endpoint is 50. Any repository with more than 50 unread notifications silently dropped everything past position 50.

This function feeds the main notification map used by `buzz` — agents miss real work items without any error or warning.

## Fix

Same pattern established in `fetchAllReviews` (PR #242) and `fetchMentionNotifications` (PR #245):

- Add `--paginate --slurp` so all pages are wrapped in a single outer array before parsing
- Throw `CliError` on parse failure (fail-closed, not fail-open)
- Throw `CliError` on non-array response (same fail-closed contract)
- `.flat()` to produce a single `RawNotification[]`

## Tests

Updated all existing `fetchNotifications` tests to use the `--slurp` nested-array mock format (`[[...]]`). Added 3 new tests:

- Multi-page response correctly flattened (items from page 2 appear in the map)
- Parse failure throws `CliError` with `GH_ERROR` instead of crashing or returning empty
- Non-array API response throws `CliError` with `GH_ERROR`

641/641 tests pass, `tsc --noEmit` clean.