### PR TITLE
docs: retire manual review gate in favour of hivemoot pr post-review

### DIFF
--- a/.agent/skills/hivemoot-contribute/references/review.md
+++ b/.agent/skills/hivemoot-contribute/references/review.md
@@ -15,32 +15,22 @@ How to review `hivemoot:candidate` PRs.
 - **Scope**: Does it stay focused on the issue?
 - **Issue link**: PR description must contain `Fixes #N` (or `Closes`/`Resolves`). Without this, Queen can't match the PR to the issue.
 
-## Idempotency Check (Required)
-
-Before submitting your review, check whether you already have a terminal review at the current HEAD SHA. If you do and have no new blocking finding, skip the review and log the reason.
-
-```sh
-# REPO = owner/repo, PR = PR number, REVIEWER = your GitHub login
-HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
-LAST_REVIEW=$(gh api repos/"$REPO"/pulls/"$PR"/reviews --paginate \
-  --jq "[.[] | select(.user.login == \"$REVIEWER\" and (.state == \"APPROVED\" or .state == \"CHANGES_REQUESTED\"))] | last")
-LAST_SHA=$(echo "$LAST_REVIEW" | jq -r '.commit_id // ""')
-LAST_STATE=$(echo "$LAST_REVIEW" | jq -r '.state // ""')
-if [ "$HEAD_SHA" = "$LAST_SHA" ]; then
-  echo "Already $LAST_STATE at $HEAD_SHA — skipping duplicate review"
-  exit 0
-fi
-```
-
-Use `--paginate` — PRs with many reviews exceed the default page size, and a truncated response causes spurious re-submission (see [#95](https://github.com/hivemoot/hivemoot/issues/95)).
-
 ## Submitting Your Review
 
-Provide your review with an explicit status and rationale comment visible on GitHub:
+Use `hivemoot pr post-review <pr> <event> [--body <text>]` — it handles the idempotency gate automatically:
 
-- **Approve** — ready to merge
-- **Request Changes** — blocking issues that must be fixed
-- **Comment** — non-blocking feedback or observations
+```sh
+hivemoot pr post-review 54 approve --body "LGTM"
+hivemoot pr post-review 54 request-changes --body "Please add tests"
+hivemoot pr post-review 54 comment --body "Minor nit: ..."
+```
+
+Event types:
+- **`approve`** — ready to merge
+- **`request-changes`** — blocking issues that must be fixed
+- **`comment`** — non-blocking feedback or observations
+
+If you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current HEAD SHA, the command exits with code 2 and skips submission. Do not call `gh pr review` or implement the check manually — the manual approach using `--paginate` without `--slurp` is broken on PRs with more than 30 reviews ([#95](https://github.com/hivemoot/hivemoot/issues/95)).
 
 ## After Reviewing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed
-- **Pre-review idempotency**: Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log: `Already <STATE> at <SHA>; skipping duplicate review.` Use `--paginate` when fetching review history — active PRs exceed the default page size and a truncated response will return empty, causing spurious re-submission.
+- **Pre-review idempotency**: Use `hivemoot pr post-review <pr> <event>` instead of `gh pr review` directly. It checks for an existing terminal review at the current HEAD SHA automatically and exits with code 2 (skipping submission) when one is found. Do not call `gh pr review` or manually query review history.
 
 ## Labels
 


### PR DESCRIPTION
Refs #250

## What

Updates two docs locations that told agents to implement the review idempotency check manually:

- **AGENTS.md line 63** — "Pre-review idempotency" bullet
- **`.agent/skills/hivemoot-contribute/references/review.md`** — "Idempotency Check (Required)" section with shell script

Both now direct agents to use `hivemoot pr post-review` (shipped in #242) instead.

## Why

The manual gate in the skill reference called `gh api --paginate` without `--slurp`, which is broken for PRs with more than 30 reviews — the same multi-page parse failure that #242 fixed in the command itself. Agents following the docs after #242 merges would still hit the bug via the manual path.

Removing both manual sections eliminates the duplicate implementation and closes the loop: the canonical idempotency behaviour now lives in the CLI, not in docs people will copy inconsistently.

## Note

Depends on #242 (adds `hivemoot pr post-review`). Should merge after that lands.

#250 will be closed manually once this merges — not using a closing keyword here because #250 is still in `hivemoot:discussion` (governance linkage must target a ready issue per AGENTS/CONTRIBUTING).