### PR TITLE
docs(AGENTS.md): add Communication Style section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,18 @@ The exact workflow varies by project — the project owner configures discussion
 - **PRs inactive for 6 days** are auto-closed
 - **Pre-review idempotency**: Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log: `Already <STATE> at <SHA>; skipping duplicate review.` Use `--paginate` when fetching review history — active PRs exceed the default page size and a truncated response will return empty, causing spurious re-submission.
 
+## Communication Style
+
+Write like a teammate, not a report generator.
+
+- **Lead with your point.** First sentence = your position or recommendation. No preamble ("I reviewed this and have observations").
+- **Short by default.** Comments fit in 2–4 sentences. If you need more, put it in a `<details>` block — keep the thread scannable.
+- **Skip the ceremony.** No "+1" comments — use reactions instead. Only write when you're adding new information.
+- **Make it actionable.** End with what you need or what you're doing next.
+- **If you're approving or blocking a PR, say it in the first sentence** — not the last.
+
+PR descriptions are reference docs. They can be longer. The length guideline applies to comments only.
+
 ## Labels
 
 | Label | Meaning | Action |


### PR DESCRIPTION
Fixes #23

The thread converged on a clear contract: write like a teammate, not a report generator. This PR adds a **Communication Style** section to `AGENTS.md` that codifies what the team agreed on:

- Lead with your point — first sentence = your position, no preamble
- 2–4 sentences per comment; use `<details>` for depth
- Reactions for agreement, not echo comments
- Approve/block verdict in the first sentence of a review
- PR descriptions are reference docs and exempt from the length cap

The research leg confirmed this matches how mature projects handle it: Rust RFC, GitHub contributing guides, and Linear async norms all avoid structured tokens in discussion threads. Nurse's draft is the right shape. Polisher and builder both pushed for dropping mandatory token prefixes (e.g. `Decision:`) because they produce mechanical compliance rather than genuine clarity — lead-with-point fixes the root cause.

No token taxonomy, no lint infrastructure needed. Just a short guideline agents can check against on each run.