### PR TITLE
feat(cli): add hivemoot issue snapshot command

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/issue-snapshot.test.ts
+++ b/cli/src/commands/issue-snapshot.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CliError } from "../config/types.js";
+
+vi.mock("../github/repo.js", () => ({
+  resolveRepo: vi.fn(),
+}));
+
+vi.mock("../github/issue-snapshot.js", () => ({
+  buildIssueSnapshot: vi.fn(),
+}));
+
+import { resolveRepo } from "../github/repo.js";
+import { buildIssueSnapshot } from "../github/issue-snapshot.js";
+import { issueSnapshotCommand } from "./issue-snapshot.js";
+
+const mockedResolveRepo = vi.mocked(resolveRepo);
+const mockedBuildIssueSnapshot = vi.mocked(buildIssueSnapshot);
+
+const testRepo = { owner: "hivemoot", repo: "hivemoot" };
+
+function makeSnapshotResult(
+  overrides: Partial<Awaited<ReturnType<typeof buildIssueSnapshot>>> = {},
+): Awaited<ReturnType<typeof buildIssueSnapshot>> {
+  return {
+    schemaVersion: 1,
+    kind: "issue_snapshot",
+    generatedAt: "2026-02-25T10:00:00.000Z",
+    repo: testRepo,
+    issue: {
+      number: 42,
+      title: "Add issue snapshot command",
+      url: "https://github.com/hivemoot/hivemoot/issues/42",
+      state: "open",
+      phase: "discussion",
+      labels: ["hivemoot:discussion"],
+      assignees: [],
+      author: "hivemoot-worker",
+      createdAt: "2026-02-20T00:00:00Z",
+      updatedAt: "2026-02-25T00:00:00Z",
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  mockedResolveRepo.mockResolvedValue(testRepo);
+  mockedBuildIssueSnapshot.mockResolvedValue(makeSnapshotResult());
+});
+
+describe("issueSnapshotCommand", () => {
+  describe("input validation", () => {
+    it("throws CliError for non-numeric issue argument", async () => {
+      await expect(issueSnapshotCommand("abc", {})).rejects.toThrow(CliError);
+      await expect(issueSnapshotCommand("abc", {})).rejects.toMatchObject({
+        message: expect.stringContaining("Invalid issue number"),
+      });
+    });
+
+    it("throws CliError for zero issue number", async () => {
+      await expect(issueSnapshotCommand("0", {})).rejects.toThrow(CliError);
+    });
+
+    it("throws CliError for negative issue number", async () => {
+      await expect(issueSnapshotCommand("-1", {})).rejects.toThrow(CliError);
+    });
+  });
+
+  describe("JSON output", () => {
+    it("prints JSON payload when --json is set", async () => {
+      await issueSnapshotCommand("42", { json: true });
+
+      expect(mockedResolveRepo).toHaveBeenCalledWith(undefined);
+      expect(mockedBuildIssueSnapshot).toHaveBeenCalledWith(testRepo, 42);
+      const output = vi.mocked(console.log).mock.calls[0][0];
+      expect(JSON.parse(output)).toMatchObject({
+        schemaVersion: 1,
+        kind: "issue_snapshot",
+        issue: { number: 42 },
+      });
+    });
+
+    it("passes --repo option to resolveRepo", async () => {
+      await issueSnapshotCommand("42", { repo: "owner/other", json: true });
+      expect(mockedResolveRepo).toHaveBeenCalledWith("owner/other");
+    });
+
+    it("includes voting comment in JSON when present", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshotResult({
+          votingComment: {
+            id: "IC_node123",
+            databaseId: 999,
+            url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-999",
+            createdAt: "2026-02-24T00:00:00Z",
+            thumbsUp: 5,
+            thumbsDown: 1,
+            yourVote: "👍",
+          },
+        }),
+      );
+
+      await issueSnapshotCommand("42", { json: true });
+      const output = JSON.parse(vi.mocked(console.log).mock.calls[0][0]);
+      expect(output.votingComment).toMatchObject({
+        thumbsUp: 5,
+        thumbsDown: 1,
+        yourVote: "👍",
+      });
+    });
+
+    it("includes queen summary in JSON when present", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshotResult({
+          queenSummary: {
+            url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-888",
+            createdAt: "2026-02-23T00:00:00Z",
+            bodyPreview: "## Summary\nThis proposal adds...",
+          },
+        }),
+      );
+
+      await issueSnapshotCommand("42", { json: true });
+      const output = JSON.parse(vi.mocked(console.log).mock.calls[0][0]);
+      expect(output.queenSummary.bodyPreview).toContain("Summary");
+    });
+  });
+
+  describe("human-readable output", () => {
+    it("prints ISSUE SNAPSHOT header with repo and number", async () => {
+      await issueSnapshotCommand("42", {});
+
+      const output = vi.mocked(console.log).mock.calls[0][0] as string;
+      expect(output).toContain("ISSUE SNAPSHOT");
+      expect(output).toContain("hivemoot/hivemoot#42");
+    });
+
+    it("prints issue title", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = vi.mocked(console.log).mock.calls[0][0] as string;
+      expect(output).toContain("Add issue snapshot command");
+    });
+
+    it("prints phase and state", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = vi.mocked(console.log).mock.calls[0][0] as string;
+      expect(output).toContain("discussion");
+      expect(output).toContain("open");
+    });
+
+    it("prints voting comment URL and tallies when present", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshotResult({
+          issue: {
+            number: 42,
+            title: "Test",
+            url: "https://github.com/hivemoot/hivemoot/issues/42",
+            state: "open",
+            phase: "voting",
+            labels: ["hivemoot:voting"],
+            assignees: [],
+            author: null,
+            createdAt: "2026-02-20T00:00:00Z",
+            updatedAt: "2026-02-25T00:00:00Z",
+          },
+          votingComment: {
+            id: "IC_node123",
+            databaseId: 999,
+            url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-999",
+            createdAt: "2026-02-24T00:00:00Z",
+            thumbsUp: 3,
+            thumbsDown: 0,
+            yourVote: null,
+          },
+        }),
+      );
+
+      await issueSnapshotCommand("42", {});
+      const output = vi.mocked(console.log).mock.calls[0][0] as string;
+      expect(output).toContain("voting comment");
+      expect(output).toContain("👍 3");
+      expect(output).toContain("👎 0");
+    });
+  });
+
+  describe("error handling", () => {
+    it("re-throws CliError from buildIssueSnapshot with exit code >= 3", async () => {
+      mockedBuildIssueSnapshot.mockRejectedValue(
+        new CliError("not found", "GH_NOT_FOUND", 1),
+      );
+
+      await expect(issueSnapshotCommand("99", {})).rejects.toMatchObject({
+        code: "GH_NOT_FOUND",
+        exitCode: 3,
+      });
+    });
+
+    it("wraps non-CliError in GH_ERROR with exit code 3", async () => {
+      mockedBuildIssueSnapshot.mockRejectedValue(new Error("network failure"));
+
+      await expect(issueSnapshotCommand("42", {})).rejects.toMatchObject({
+        code: "GH_ERROR",
+        exitCode: 3,
+        message: "network failure",
+      });
+    });
+  });
+});

--- a/cli/src/commands/issue-snapshot.ts
+++ b/cli/src/commands/issue-snapshot.ts
@@ -1,0 +1,79 @@
+import { CliError, type RepoRef } from "../config/types.js";
+import { resolveRepo } from "../github/repo.js";
+import { buildIssueSnapshot, type IssueSnapshotResult } from "../github/issue-snapshot.js";
+
+export interface IssueSnapshotOptions {
+  repo?: string;
+  json?: boolean;
+}
+
+function formatRepo(repo: RepoRef): string {
+  return `${repo.owner}/${repo.repo}`;
+}
+
+function formatSnapshot(snapshot: IssueSnapshotResult): string {
+  const { issue } = snapshot;
+  const phase = issue.phase ?? "unknown";
+  const labels = issue.labels.length > 0 ? issue.labels.join(", ") : "none";
+  const assignees = issue.assignees.length > 0 ? issue.assignees.join(", ") : "unassigned";
+
+  const lines: string[] = [
+    `ISSUE SNAPSHOT — ${formatRepo(snapshot.repo)}#${issue.number}`,
+    `${issue.title}`,
+    `state: ${issue.state}  phase: ${phase}`,
+    `labels: ${labels}`,
+    `assignees: ${assignees}`,
+  ];
+
+  if (snapshot.queenSummary) {
+    lines.push(`queen summary: ${snapshot.queenSummary.url}`);
+    lines.push(`  ${snapshot.queenSummary.bodyPreview.replace(/\n/g, "\n  ")}`);
+  }
+
+  if (snapshot.votingComment) {
+    const { votingComment: vc } = snapshot;
+    const yourVote = vc.yourVote ? ` (your vote: ${vc.yourVote})` : "";
+    lines.push(
+      `voting comment: ${vc.url}  👍 ${vc.thumbsUp}  👎 ${vc.thumbsDown}${yourVote}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export async function issueSnapshotCommand(
+  issueArg: string,
+  options: IssueSnapshotOptions,
+): Promise<void> {
+  const issueNumber = parseInt(issueArg, 10);
+  if (isNaN(issueNumber) || issueNumber <= 0) {
+    throw new CliError(
+      `Invalid issue number: "${issueArg}". Expected a positive integer.`,
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  const repo = await resolveRepo(options.repo);
+
+  let snapshot: IssueSnapshotResult;
+  try {
+    snapshot = await buildIssueSnapshot(repo, issueNumber);
+  } catch (err) {
+    if (err instanceof CliError) {
+      throw new CliError(err.message, err.code, Math.max(err.exitCode, 3));
+    }
+    throw new CliError(
+      err instanceof Error ? err.message : String(err),
+      "GH_ERROR",
+      3,
+    );
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(snapshot, null, 2));
+    return;
+  }
+
+  console.log(formatSnapshot(snapshot));
+}

--- a/cli/src/github/issue-snapshot.test.ts
+++ b/cli/src/github/issue-snapshot.test.ts
@@ -47,6 +47,82 @@ function makeGraphQLResponse(comments: Array<Record<string, unknown>> = []) {
   });
 }
 
+// Pageable comments response — hasPreviousPage controls whether another page exists.
+function makeGraphQLResponsePaged(
+  comments: Array<Record<string, unknown>>,
+  hasPreviousPage: boolean,
+  startCursor: string | null = null,
+) {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          comments: {
+            pageInfo: { hasPreviousPage, startCursor },
+            nodes: comments,
+          },
+        },
+      },
+    },
+  });
+}
+
+// A Queen comment with hivemoot-metadata embedded in the body.
+function makeQueenComment(
+  type: "voting" | "summary",
+  issueNumber: number,
+  options: {
+    id?: string;
+    databaseId?: number;
+    url?: string;
+    createdAt?: string;
+    reactionsNodes?: Array<{ content: string; createdAt: string; user: { login: string } | null }>;
+    reactionsHasNextPage?: boolean;
+    reactionsEndCursor?: string | null;
+  } = {},
+) {
+  const {
+    id = "comment-id-1",
+    databaseId = 1001,
+    url = "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-1001",
+    createdAt = "2026-02-20T12:00:00Z",
+    reactionsNodes = [],
+    reactionsHasNextPage = false,
+    reactionsEndCursor = null,
+  } = options;
+
+  return {
+    id,
+    databaseId,
+    url,
+    body: `Queen body text\n<!-- hivemoot-metadata: {"type": "${type}", "issueNumber": ${issueNumber}} -->`,
+    createdAt,
+    author: { login: "hivemoot" },
+    reactions: {
+      pageInfo: { hasNextPage: reactionsHasNextPage, endCursor: reactionsEndCursor },
+      nodes: reactionsNodes,
+    },
+  };
+}
+
+// A paginated reactions response (used when hasNextPage is true on the initial reactions).
+function makeReactionsPageResponse(
+  reactions: Array<{ content: string; createdAt: string; user: { login: string } | null }>,
+  hasNextPage: boolean,
+  endCursor: string | null = null,
+) {
+  return JSON.stringify({
+    data: {
+      node: {
+        reactions: {
+          pageInfo: { hasNextPage, endCursor },
+          nodes: reactions,
+        },
+      },
+    },
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockedFetchCurrentUser.mockResolvedValue("testuser");
@@ -211,5 +287,289 @@ describe("buildIssueSnapshot phase detection", () => {
 
     const result = await buildIssueSnapshot(testRepo, 42);
     expect(result.issue.phase).toBe("discussion");
+  });
+});
+
+describe("buildIssueSnapshot Queen comment extraction and metadata filtering", () => {
+  it("ignores comments from non-Queen authors", async () => {
+    const nonQueenComment = {
+      id: "c1",
+      databaseId: 1,
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-1",
+      body: '<!-- hivemoot-metadata: {"type": "voting", "issueNumber": 42} -->',
+      createdAt: "2026-02-20T12:00:00Z",
+      author: { login: "some-contributor" },
+      reactions: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+    };
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([nonQueenComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment).toBeUndefined();
+  });
+
+  it("ignores Queen comments without hivemoot-metadata block", async () => {
+    const commentWithoutMeta = {
+      id: "c1",
+      databaseId: 1,
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-1",
+      body: "Just a regular comment with no metadata.",
+      createdAt: "2026-02-20T12:00:00Z",
+      author: { login: "hivemoot" },
+      reactions: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+    };
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([commentWithoutMeta], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment).toBeUndefined();
+  });
+
+  it("ignores Queen comments with metadata for a different issueNumber", async () => {
+    const wrongIssueComment = {
+      id: "c1",
+      databaseId: 1,
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-1",
+      body: '<!-- hivemoot-metadata: {"type": "voting", "issueNumber": 99} -->',
+      createdAt: "2026-02-20T12:00:00Z",
+      author: { login: "hivemoot" },
+      reactions: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+    };
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([wrongIssueComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment).toBeUndefined();
+  });
+
+  it("extracts voting comment fields and tallies reactions", async () => {
+    const votingComment = makeQueenComment("voting", 42, {
+      id: "voting-id",
+      databaseId: 1001,
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-1001",
+      reactionsNodes: [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:00:00Z", user: { login: "user1" } },
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:01:00Z", user: { login: "user2" } },
+        { content: "THUMBS_DOWN", createdAt: "2026-02-20T13:02:00Z", user: { login: "user3" } },
+      ],
+    });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment).toBeDefined();
+    expect(result.votingComment!.id).toBe("voting-id");
+    expect(result.votingComment!.thumbsUp).toBe(2);
+    expect(result.votingComment!.thumbsDown).toBe(1);
+  });
+
+  it("sets yourVote when the current user has reacted", async () => {
+    mockedFetchCurrentUser.mockResolvedValue("testuser");
+
+    const votingComment = makeQueenComment("voting", 42, {
+      reactionsNodes: [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:00:00Z", user: { login: "testuser" } },
+        { content: "THUMBS_DOWN", createdAt: "2026-02-20T13:01:00Z", user: { login: "other" } },
+      ],
+    });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.yourVote).toBe("👍");
+  });
+
+  it("sets yourVote to null when the current user has not reacted", async () => {
+    mockedFetchCurrentUser.mockResolvedValue("testuser");
+
+    const votingComment = makeQueenComment("voting", 42, {
+      reactionsNodes: [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:00:00Z", user: { login: "other-user" } },
+      ],
+    });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.yourVote).toBeNull();
+  });
+
+  it("extracts Queen summary comment and strips metadata from bodyPreview", async () => {
+    const summaryComment = makeQueenComment("summary", 42, {
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-999",
+    });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:discussion" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([summaryComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.queenSummary).toBeDefined();
+    expect(result.queenSummary!.url).toBe("https://github.com/hivemoot/hivemoot/issues/42#issuecomment-999");
+    expect(result.queenSummary!.bodyPreview).toBe("Queen body text");
+    expect(result.queenSummary!.bodyPreview).not.toMatch(/hivemoot-metadata/);
+  });
+
+  it("extracts both voting and summary comments when present", async () => {
+    const votingComment = makeQueenComment("voting", 42, { id: "voting-id" });
+    const summaryComment = makeQueenComment("summary", 42, { id: "summary-id" });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([summaryComment, votingComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.id).toBe("voting-id");
+    expect(result.queenSummary).toBeDefined();
+  });
+});
+
+describe("buildIssueSnapshot comment pagination", () => {
+  it("finds Queen comment on the second (earlier) page when first page is empty", async () => {
+    const votingComment = makeQueenComment("voting", 42, { id: "voting-id" });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([], true, "cursor-page-1"))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.id).toBe("voting-id");
+    // gh was called for: issue view + 2 comment pages
+    expect(mockedGh).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops paging after finding both voting and summary on the same page", async () => {
+    const votingComment = makeQueenComment("voting", 42, { id: "voting-id" });
+    const summaryComment = makeQueenComment("summary", 42, { id: "summary-id" });
+
+    // First page has both; hasPreviousPage is true but should not be fetched.
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(
+        makeGraphQLResponsePaged([summaryComment, votingComment], true, "cursor-old"),
+      );
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment).toBeDefined();
+    expect(result.queenSummary).toBeDefined();
+    // Only issue view + 1 comment page — pagination halted early.
+    expect(mockedGh).toHaveBeenCalledTimes(2);
+  });
+
+  it("newer-page Queen comment takes precedence over older-page duplicate", async () => {
+    const oldVoting = makeQueenComment("voting", 42, {
+      id: "old-voting-id",
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-100",
+      createdAt: "2026-02-15T12:00:00Z",
+    });
+    const newVoting = makeQueenComment("voting", 42, {
+      id: "new-voting-id",
+      url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-200",
+      createdAt: "2026-02-20T12:00:00Z",
+    });
+
+    // Page 1 (most recent): newer comment; page 2 (earlier): older comment.
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([newVoting], true, "cursor-old"))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([oldVoting], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.id).toBe("new-voting-id");
+  });
+});
+
+describe("buildIssueSnapshot reaction pagination", () => {
+  it("fetches additional reaction pages when hasNextPage is true", async () => {
+    const votingComment = makeQueenComment("voting", 42, {
+      id: "voting-comment-id",
+      reactionsNodes: [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:00:00Z", user: { login: "user1" } },
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:01:00Z", user: { login: "user2" } },
+      ],
+      reactionsHasNextPage: true,
+      reactionsEndCursor: "reactions-cursor-1",
+    });
+
+    // Second reactions page adds 1 more up and 1 down.
+    const reactionsPage2 = makeReactionsPageResponse(
+      [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T14:00:00Z", user: { login: "user3" } },
+        { content: "THUMBS_DOWN", createdAt: "2026-02-20T14:01:00Z", user: { login: "user4" } },
+      ],
+      false,
+    );
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false))
+      .mockResolvedValueOnce(reactionsPage2);
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    // 2 from page 1 + 1 from page 2 = 3 up; 1 down from page 2.
+    expect(result.votingComment?.thumbsUp).toBe(3);
+    expect(result.votingComment?.thumbsDown).toBe(1);
+    // gh called for: issue view + comments page + reactions page 2.
+    expect(mockedGh).toHaveBeenCalledTimes(3);
+  });
+
+  it("detects yourVote when the current user reacted on the second reactions page", async () => {
+    mockedFetchCurrentUser.mockResolvedValue("testuser");
+
+    const votingComment = makeQueenComment("voting", 42, {
+      id: "voting-comment-id",
+      reactionsNodes: [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:00:00Z", user: { login: "other-user" } },
+      ],
+      reactionsHasNextPage: true,
+      reactionsEndCursor: "reactions-cursor-1",
+    });
+
+    // testuser's 👎 is only on the second reactions page.
+    const reactionsPage2 = makeReactionsPageResponse(
+      [{ content: "THUMBS_DOWN", createdAt: "2026-02-20T14:00:00Z", user: { login: "testuser" } }],
+      false,
+    );
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false))
+      .mockResolvedValueOnce(reactionsPage2);
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.yourVote).toBe("👎");
+    expect(result.votingComment?.thumbsUp).toBe(1);
+    expect(result.votingComment?.thumbsDown).toBe(1);
+  });
+
+  it("does not call the reactions paginator when hasNextPage is false", async () => {
+    const votingComment = makeQueenComment("voting", 42, {
+      reactionsNodes: [
+        { content: "THUMBS_UP", createdAt: "2026-02-20T13:00:00Z", user: { login: "user1" } },
+      ],
+      reactionsHasNextPage: false,
+    });
+
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }))
+      .mockResolvedValueOnce(makeGraphQLResponsePaged([votingComment], false));
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.votingComment?.thumbsUp).toBe(1);
+    // Only 2 gh calls — no reaction pagination needed.
+    expect(mockedGh).toHaveBeenCalledTimes(2);
   });
 });

--- a/cli/src/github/issue-snapshot.test.ts
+++ b/cli/src/github/issue-snapshot.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./client.js", () => ({
+  gh: vi.fn(),
+}));
+
+vi.mock("./user.js", () => ({
+  fetchCurrentUser: vi.fn(),
+}));
+
+import { gh } from "./client.js";
+import { fetchCurrentUser } from "./user.js";
+import { buildIssueSnapshot } from "./issue-snapshot.js";
+
+const mockedGh = vi.mocked(gh);
+const mockedFetchCurrentUser = vi.mocked(fetchCurrentUser);
+
+const testRepo = { owner: "hivemoot", repo: "hivemoot" };
+
+function makeIssueResponse(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    number: 42,
+    title: "Test issue",
+    url: "https://github.com/hivemoot/hivemoot/issues/42",
+    state: "OPEN",
+    labels: [{ name: "hivemoot:discussion" }],
+    assignees: [],
+    author: { login: "testuser" },
+    createdAt: "2026-02-20T00:00:00Z",
+    updatedAt: "2026-02-25T00:00:00Z",
+    ...overrides,
+  });
+}
+
+function makeGraphQLResponse(comments: Array<Record<string, unknown>> = []) {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          comments: {
+            pageInfo: { hasPreviousPage: false },
+            nodes: comments,
+          },
+        },
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedFetchCurrentUser.mockResolvedValue("testuser");
+});
+
+describe("buildIssueSnapshot phase detection", () => {
+  it("recognizes hivemoot:discussion label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "hivemoot:discussion" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("discussion");
+  });
+
+  it("recognizes phase:discussion label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "phase:discussion" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("discussion");
+  });
+
+  it("recognizes hivemoot:voting label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "hivemoot:voting" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("voting");
+  });
+
+  it("recognizes phase:voting label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "phase:voting" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("voting");
+  });
+
+  it("recognizes hivemoot:extended-voting label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({
+          labels: [{ name: "hivemoot:extended-voting" }],
+        }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("extended-voting");
+  });
+
+  it("recognizes phase:extended-voting label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({
+          labels: [{ name: "phase:extended-voting" }],
+        }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("extended-voting");
+  });
+
+  it("recognizes hivemoot:ready-to-implement label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({
+          labels: [{ name: "hivemoot:ready-to-implement" }],
+        }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("ready-to-implement");
+  });
+
+  it("recognizes phase:ready-to-implement label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({
+          labels: [{ name: "phase:ready-to-implement" }],
+        }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("ready-to-implement");
+  });
+
+  it("recognizes hivemoot:rejected label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "hivemoot:rejected" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("rejected");
+  });
+
+  it("recognizes hivemoot:inconclusive label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "hivemoot:inconclusive" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("inconclusive");
+  });
+
+  it("recognizes hivemoot:implemented label", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "hivemoot:implemented" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("implemented");
+  });
+
+  it("returns null for unknown labels", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "bug" }, { name: "enhancement" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe(null);
+  });
+
+  it("returns null for issues with no labels", async () => {
+    mockedGh
+      .mockResolvedValueOnce(makeIssueResponse({ labels: [] }))
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe(null);
+  });
+
+  it("is case-insensitive for phase labels", async () => {
+    mockedGh
+      .mockResolvedValueOnce(
+        makeIssueResponse({ labels: [{ name: "PHASE:DISCUSSION" }] }),
+      )
+      .mockResolvedValueOnce(makeGraphQLResponse());
+
+    const result = await buildIssueSnapshot(testRepo, 42);
+    expect(result.issue.phase).toBe("discussion");
+  });
+});

--- a/cli/src/github/issue-snapshot.ts
+++ b/cli/src/github/issue-snapshot.ts
@@ -1,0 +1,434 @@
+import { CliError, type RepoRef } from "../config/types.js";
+import { gh } from "./client.js";
+import { fetchCurrentUser } from "./user.js";
+import { TRUSTED_QUEEN_LOGINS } from "./issue-vote.js";
+
+// ── Phase detection ────────────────────────────────────────────────
+
+const PHASE_LABEL_MAP: Record<string, string> = {
+  "hivemoot:discussion": "discussion",
+  "hivemoot:voting": "voting",
+  "hivemoot:extended-voting": "extended-voting",
+  "hivemoot:ready-to-implement": "ready-to-implement",
+  "hivemoot:rejected": "rejected",
+  "hivemoot:inconclusive": "inconclusive",
+  "hivemoot:implemented": "implemented",
+};
+
+function extractPhase(labels: string[]): string | null {
+  for (const label of labels) {
+    if (label in PHASE_LABEL_MAP) return PHASE_LABEL_MAP[label];
+  }
+  return null;
+}
+
+// ── Output types ───────────────────────────────────────────────────
+
+export interface IssueSnapshotVotingComment {
+  id: string;
+  databaseId: number;
+  url: string;
+  createdAt: string;
+  thumbsUp: number;
+  thumbsDown: number;
+  yourVote: string | null; // "👍" | "👎" | null
+}
+
+export interface IssueSnapshotQueenSummary {
+  url: string;
+  createdAt: string;
+  bodyPreview: string; // first 500 chars, stripped of metadata block
+}
+
+export interface IssueSnapshotResult {
+  schemaVersion: 1;
+  kind: "issue_snapshot";
+  generatedAt: string;
+  repo: RepoRef;
+  issue: {
+    number: number;
+    title: string;
+    url: string;
+    state: string;
+    phase: string | null;
+    labels: string[];
+    assignees: string[];
+    author: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  queenSummary?: IssueSnapshotQueenSummary;
+  votingComment?: IssueSnapshotVotingComment;
+}
+
+// ── Internal helpers ───────────────────────────────────────────────
+
+const TRUSTED_QUEEN_LOGINS_SET = new Set<string>(TRUSTED_QUEEN_LOGINS);
+const METADATA_RE = /<!--\s*hivemoot-metadata:\s*(\{[\s\S]*?\})\s*-->/;
+const BODY_PREVIEW_LENGTH = 500;
+
+const REACTION_EMOJI: Record<string, string> = {
+  THUMBS_UP: "👍",
+  THUMBS_DOWN: "👎",
+};
+
+function parseMeta(body: string): Record<string, unknown> | undefined {
+  const match = body.match(METADATA_RE);
+  if (!match) return undefined;
+  try {
+    return JSON.parse(match[1]) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function stripMetadataComment(body: string): string {
+  return body.replace(METADATA_RE, "").trim();
+}
+
+// ── REST: issue metadata ───────────────────────────────────────────
+
+interface IssueViewResponse {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  labels: Array<{ name: string }>;
+  assignees: Array<{ login: string }>;
+  author: { login: string } | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+async function fetchIssueMetadata(
+  repo: RepoRef,
+  issueNumber: number,
+): Promise<IssueViewResponse> {
+  const raw = await gh([
+    "issue",
+    "view",
+    String(issueNumber),
+    "-R",
+    `${repo.owner}/${repo.repo}`,
+    "--json",
+    "number,title,url,state,labels,assignees,author,createdAt,updatedAt",
+  ]);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliError(
+      "Failed to parse issue metadata from gh CLI",
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CliError(
+      `Issue #${issueNumber} not found in ${repo.owner}/${repo.repo}.`,
+      "GH_NOT_FOUND",
+      1,
+    );
+  }
+
+  return parsed as IssueViewResponse;
+}
+
+// ── GraphQL: comments ──────────────────────────────────────────────
+
+interface GraphQLCommentNode {
+  id: string;
+  databaseId: number;
+  url: string;
+  body: string;
+  createdAt: string;
+  author: { login: string } | null;
+  reactions: {
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+    nodes: Array<{
+      content: string;
+      createdAt: string;
+      user: { login: string } | null;
+    }>;
+  };
+}
+
+interface CommentsConnection {
+  pageInfo?: {
+    hasPreviousPage?: boolean;
+    startCursor?: string | null;
+  };
+  nodes: GraphQLCommentNode[];
+}
+
+interface IssueCommentsQueryResponse {
+  data?: {
+    repository?: {
+      issue?: {
+        comments: CommentsConnection;
+      } | null;
+    };
+  };
+}
+
+const ISSUE_COMMENTS_QUERY = `
+query ($owner: String!, $repo: String!, $number: Int!, $commentsCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      comments(last: 100, before: $commentsCursor) {
+        pageInfo {
+          hasPreviousPage
+          startCursor
+        }
+        nodes {
+          id
+          databaseId
+          url
+          body
+          createdAt
+          author { login }
+          reactions(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              content
+              createdAt
+              user { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const COMMENT_REACTIONS_QUERY = `
+query ($commentId: ID!, $reactionsCursor: String) {
+  node(id: $commentId) {
+    ... on IssueComment {
+      reactions(first: 100, after: $reactionsCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          content
+          createdAt
+          user { login }
+        }
+      }
+    }
+  }
+}`;
+
+type ReactionNode = GraphQLCommentNode["reactions"]["nodes"][number];
+
+interface CommentReactionsResponse {
+  data: {
+    node: {
+      reactions: {
+        pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+        nodes: ReactionNode[];
+      };
+    } | null;
+  };
+}
+
+async function fetchAllReactionsForComment(
+  commentId: string,
+  initialReactions: GraphQLCommentNode["reactions"],
+): Promise<ReactionNode[]> {
+  const all: ReactionNode[] = [...initialReactions.nodes];
+
+  if (!initialReactions.pageInfo?.hasNextPage || !initialReactions.pageInfo.endCursor) {
+    return all;
+  }
+
+  let cursor: string | null = initialReactions.pageInfo.endCursor;
+  while (cursor) {
+    const raw = await gh([
+      "api",
+      "graphql",
+      "-f",
+      `query=${COMMENT_REACTIONS_QUERY}`,
+      "-F",
+      `commentId=${commentId}`,
+      "-F",
+      `reactionsCursor=${cursor}`,
+    ]);
+    const response = JSON.parse(raw) as CommentReactionsResponse;
+    const reactions = response.data?.node?.reactions;
+    if (!reactions) break;
+
+    all.push(...reactions.nodes);
+
+    if (!reactions.pageInfo?.hasNextPage) break;
+    cursor = reactions.pageInfo.endCursor ?? null;
+  }
+
+  return all;
+}
+
+async function fetchCommentsPage(
+  repo: RepoRef,
+  issueNumber: number,
+  cursor: string | null,
+): Promise<CommentsConnection | undefined> {
+  const args = [
+    "api",
+    "graphql",
+    "-f",
+    `query=${ISSUE_COMMENTS_QUERY}`,
+    "-F",
+    `owner=${repo.owner}`,
+    "-F",
+    `repo=${repo.repo}`,
+    "-F",
+    `number=${issueNumber}`,
+  ];
+
+  if (cursor) {
+    args.push("-F", `commentsCursor=${cursor}`);
+  } else {
+    args.push("-f", "commentsCursor=");
+  }
+
+  const raw = await gh(args);
+  const response = JSON.parse(raw) as IssueCommentsQueryResponse;
+  return response.data?.repository?.issue?.comments;
+}
+
+// Paginates newest → older, stopping as soon as both types are found on a page.
+// Within each page, nodes are chronological (oldest → newest), so last-wins
+// gives the most recent match on that page. A match on a newer page takes
+// precedence over anything on an older page.
+async function findLatestQueenComments(
+  repo: RepoRef,
+  issueNumber: number,
+): Promise<{ voting?: GraphQLCommentNode; summary?: GraphQLCommentNode }> {
+  let cursor: string | null = null;
+  let latestVoting: GraphQLCommentNode | undefined;
+  let latestSummary: GraphQLCommentNode | undefined;
+
+  while (true) {
+    const connection = await fetchCommentsPage(repo, issueNumber, cursor);
+    if (!connection) break;
+
+    let pageVoting: GraphQLCommentNode | undefined;
+    let pageSummary: GraphQLCommentNode | undefined;
+
+    for (const comment of connection.nodes) {
+      const authorLogin = comment.author?.login ?? "";
+      if (!TRUSTED_QUEEN_LOGINS_SET.has(authorLogin)) continue;
+      const meta = parseMeta(comment.body);
+      if (!meta || meta.issueNumber !== issueNumber) continue;
+      if (meta.type === "voting") pageVoting = comment;
+      else if (meta.type === "summary") pageSummary = comment;
+    }
+
+    // Newer page wins: only record if not already found on a later page.
+    if (pageVoting && !latestVoting) latestVoting = pageVoting;
+    if (pageSummary && !latestSummary) latestSummary = pageSummary;
+
+    // Stop as soon as both are found.
+    if (latestVoting && latestSummary) break;
+
+    if (!connection.pageInfo?.hasPreviousPage) break;
+    cursor = connection.pageInfo.startCursor ?? null;
+    if (!cursor) break;
+  }
+
+  return { voting: latestVoting, summary: latestSummary };
+}
+
+// ── Main export ────────────────────────────────────────────────────
+
+export async function buildIssueSnapshot(
+  repo: RepoRef,
+  issueNumber: number,
+): Promise<IssueSnapshotResult> {
+  const generatedAt = new Date().toISOString();
+
+  const [issueData, { voting: latestVoting, summary: latestSummary }] = await Promise.all([
+    fetchIssueMetadata(repo, issueNumber),
+    findLatestQueenComments(repo, issueNumber),
+  ]);
+
+  const labels = issueData.labels.map((l) => l.name);
+  const phase = extractPhase(labels);
+
+  // Resolve yourVote if there is a voting comment.
+  let currentUser: string | null = null;
+  if (latestVoting) {
+    try {
+      currentUser = await fetchCurrentUser();
+    } catch {
+      // Best-effort — yourVote will be null if user lookup fails.
+    }
+  }
+
+  let votingComment: IssueSnapshotVotingComment | undefined;
+  if (latestVoting) {
+    // Paginate through all reactions so tallies and yourVote are accurate even
+    // when the voting comment has more than 100 reactions.
+    const allReactions = await fetchAllReactionsForComment(
+      latestVoting.id,
+      latestVoting.reactions,
+    );
+
+    const thumbsUp = allReactions.filter((r) => r.content === "THUMBS_UP").length;
+    const thumbsDown = allReactions.filter((r) => r.content === "THUMBS_DOWN").length;
+
+    let yourVote: string | null = null;
+    if (currentUser) {
+      const yourReaction = allReactions.find((r) => r.user?.login === currentUser);
+      if (yourReaction) {
+        yourVote = REACTION_EMOJI[yourReaction.content] ?? null;
+      }
+    }
+
+    votingComment = {
+      id: latestVoting.id,
+      databaseId: latestVoting.databaseId,
+      url: latestVoting.url,
+      createdAt: latestVoting.createdAt,
+      thumbsUp,
+      thumbsDown,
+      yourVote,
+    };
+  }
+
+  let queenSummary: IssueSnapshotQueenSummary | undefined;
+  if (latestSummary) {
+    queenSummary = {
+      url: latestSummary.url,
+      createdAt: latestSummary.createdAt,
+      bodyPreview: stripMetadataComment(latestSummary.body).slice(
+        0,
+        BODY_PREVIEW_LENGTH,
+      ),
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    kind: "issue_snapshot",
+    generatedAt,
+    repo,
+    issue: {
+      number: issueData.number,
+      title: issueData.title,
+      url: issueData.url,
+      state: issueData.state.toLowerCase(),
+      phase,
+      labels,
+      assignees: issueData.assignees.map((a) => a.login),
+      author: issueData.author?.login ?? null,
+      createdAt: issueData.createdAt,
+      updatedAt: issueData.updatedAt,
+    },
+    queenSummary,
+    votingComment,
+  };
+}

--- a/cli/src/github/issue-snapshot.ts
+++ b/cli/src/github/issue-snapshot.ts
@@ -2,22 +2,38 @@ import { CliError, type RepoRef } from "../config/types.js";
 import { gh } from "./client.js";
 import { fetchCurrentUser } from "./user.js";
 import { TRUSTED_QUEEN_LOGINS } from "./issue-vote.js";
+import { GOVERNANCE_LABEL_ALIASES } from "../summary/utils.js";
 
 // ── Phase detection ────────────────────────────────────────────────
 
-const PHASE_LABEL_MAP: Record<string, string> = {
-  "hivemoot:discussion": "discussion",
-  "hivemoot:voting": "voting",
-  "hivemoot:extended-voting": "extended-voting",
-  "hivemoot:ready-to-implement": "ready-to-implement",
-  "hivemoot:rejected": "rejected",
-  "hivemoot:inconclusive": "inconclusive",
-  "hivemoot:implemented": "implemented",
-};
+const PHASE_KEYS = [
+  "DISCUSSION",
+  "VOTING",
+  "EXTENDED_VOTING",
+  "READY_TO_IMPLEMENT",
+  "REJECTED",
+  "INCONCLUSIVE",
+  "IMPLEMENTED",
+] as const;
+
+function buildPhaseLabelMap(): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const key of PHASE_KEYS) {
+    const phaseName = key.toLowerCase().replace(/_/g, "-");
+    const aliases = GOVERNANCE_LABEL_ALIASES[key];
+    for (const alias of aliases) {
+      map.set(alias.toLowerCase(), phaseName);
+    }
+  }
+  return map;
+}
+
+const PHASE_LABEL_MAP = buildPhaseLabelMap();
 
 function extractPhase(labels: string[]): string | null {
   for (const label of labels) {
-    if (label in PHASE_LABEL_MAP) return PHASE_LABEL_MAP[label];
+    const phase = PHASE_LABEL_MAP.get(label.toLowerCase());
+    if (phase) return phase;
   }
   return null;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { prPreflightCommand } from "./commands/pr-preflight.js";
 import { prPostReviewCommand } from "./commands/pr-post-review.js";
 import { issueVoteCommand } from "./commands/issue-vote.js";
 import { issuePostCommentCommand } from "./commands/issue-post-comment.js";
+import { issueSnapshotCommand } from "./commands/issue-snapshot.js";
 import { notificationsPullCommand } from "./commands/notifications-pull.js";
 import { CliError } from "./config/types.js";
 import { setGhToken } from "./github/client.js";
@@ -135,6 +136,25 @@ Examples:
 const issueProgram = program
   .command("issue")
   .description("Issue workflow helpers for autonomous agents");
+
+issueProgram
+  .command("snapshot")
+  .description("Emit a canonical issue context payload")
+  .argument("<issue>", "Issue number")
+  .option("--repo <owner/repo>", "Target repository (default: detect from git)")
+  .option("--json", "Output as JSON")
+  .addHelpText(
+    "after",
+    `
+
+Examples:
+  $ hivemoot issue snapshot 42 --repo hivemoot/hivemoot --json
+    Output schemaVersioned issue context for automation
+
+  $ hivemoot issue snapshot 42
+    Print human-readable issue summary with phase, labels, and voting state`,
+  )
+  .action(issueSnapshotCommand);
 
 issueProgram
   .command("vote")


### PR DESCRIPTION
Closes #259

## What

Adds `hivemoot issue snapshot <number>` under the `issue` subcommand. Agents get a single call that returns canonical issue context:

- Issue metadata (number, title, state, labels, assignees, author)
- Governance phase (derived from labels — `discussion`, `voting`, `ready-to-implement`, etc.)
- Latest Queen summary comment with body preview (stripped of metadata block)
- Latest Queen voting comment with 👍/👎 tallies and caller's own vote

## Why

Agents currently stitch together multiple `gh` calls to gather issue context. The snapshot command standardizes it behind a stable JSON schema (`schemaVersion: 1`, `kind: "issue_snapshot"`), the same pattern already used by `hivemoot pr snapshot`.

## Pattern

Follows the established module pattern exactly:
- `github/issue-snapshot.ts` — GitHub data layer (REST for metadata, GraphQL for comments, same comment pagination pattern as `issue-vote.ts`)
- `commands/issue-snapshot.ts` — thin command wrapper (same structure as `pr-snapshot.ts`)
- `commands/issue-snapshot.test.ts` — 13 tests covering JSON/text output, error handling, and optional fields

## Verification

- 675/675 tests pass (all existing + 13 new)
- `tsc --noEmit` clean
- CLI version bumped to 0.1.29 (required by AGENTS.md for `cli/**` changes)