### PR TITLE
fix(cli): add version, governance, and updated focus to init template

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/init.test.ts
+++ b/cli/src/commands/init.test.ts
@@ -48,4 +48,29 @@ describe("initCommand", () => {
     expect(output).toMatch(/architect:\s/);
     expect(output).toMatch(/qa:\s/);
   });
+
+  it("includes version field", async () => {
+    await initCommand();
+
+    const output = vi.mocked(console.log).mock.calls[0][0] as string;
+    expect(output).toContain("version: 1");
+  });
+
+  it("includes governance block with manual exits", async () => {
+    await initCommand();
+
+    const output = vi.mocked(console.log).mock.calls[0][0] as string;
+    expect(output).toContain("governance:");
+    expect(output).toContain("type: manual");
+    expect(output).toContain("trustedReviewers:");
+  });
+
+  it("includes focuses comment in current format", async () => {
+    await initCommand();
+
+    const output = vi.mocked(console.log).mock.calls[0][0] as string;
+    expect(output).toContain("# focuses:");
+    expect(output).toContain("activeFocus");
+    expect(output).not.toContain("focus.default");
+  });
 });

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -5,6 +5,8 @@ export async function initCommand(): Promise<void> {
 # Roles define personas (who the agent is), not workflow.
 # Workflow details belong in .agent/skills/.
 
+version: 1
+
 team:
   # onboarding: optional free-form text shown to all agents before their role
   # instructions. Use it to introduce the project, point agents to key docs
@@ -13,10 +15,11 @@ team:
   #   This project is ...
   #   Read CONTRIBUTING.md for contribution workflow and access model.
 
-  # focus: optional repo steering for buzz output
-  # focus:
-  #   # default is free-form focus text (does not change filters in MVP)
-  #   default: Focus on PR reviews first.
+  # focuses: optional named focus modes for steering agent output
+  # focuses:
+  #   default:
+  #     objective: "Work on any priority issue in the backlog."
+  # activeFocus: default
 
   roles:
     pm:
@@ -50,6 +53,30 @@ team:
         Find edge cases, race conditions, and failure modes others miss.
         Push for thorough error handling and defensive design.
         Ask "what happens when this fails?" about everything.
+
+governance:
+  proposals:
+    discussion:
+      exits:
+        - type: manual
+        # Uncomment to enable timer-based auto-exit (recommended):
+        # - type: auto
+        #   afterMinutes: 1440
+    voting:
+      exits:
+        - type: manual
+        # - type: auto
+        #   afterMinutes: 1440
+    extendedVoting:
+      exits:
+        - type: manual
+        # - type: auto
+        #   afterMinutes: 1440
+  pr:
+    staleDays: 3
+    maxPRsPerIssue: 3
+    trustedReviewers:
+      - your-agent-username  # Replace with your agent GitHub account(s)
 `;
 
   console.log(template);


### PR DESCRIPTION
Fixes #228

## Problem

`hivemoot init` generates a template missing three things every working project needs:

1. **No `version: 1`** — the bot schema requires it; first-time users hit silent failures
2. **No `governance:` block** — no phase exits, no `trustedReviewers`, no PR config; the bot has nothing to act on
3. **Stale `focus.default` comment** — the codebase moved to `focuses`/`activeFocus` blocks in PR #180; the template still shows the old format

A user following the README `Get Started` section gets a config that works. A user running `hivemoot init` gets a config that silently doesn't.

## What changed

**`cli/src/commands/init.ts`:**
- Added `version: 1` at the top
- Updated stale `focus.default` comment to current `focuses`/`activeFocus` format
- Added `governance:` block: manual exits as default, auto exits commented out as an opt-in, `trustedReviewers` placeholder

**`cli/src/commands/init.test.ts`:**
- Added assertions for `version: 1`, `governance:`, `trustedReviewers:`, updated focus comment format, and absence of the old `focus.default` string

## Verification

- 699/699 tests pass
- `tsc --noEmit` clean
- CLI bumped to 0.1.30

## Notes

Governance defaults to `type: manual` with `type: auto` commented out, matching the agreed approach from issue discussion: users see the opt-in knobs but don't get automation until they explicitly enable it.