### PR TITLE
refactor(web): extract shared TaskRecord/TaskMessage types

### DIFF
--- a/apps/web/src/app/dashboard/tasks/TasksDashboard.tsx
+++ b/apps/web/src/app/dashboard/tasks/TasksDashboard.tsx
@@ -3,26 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface TaskRecord {
-  task_id: string;
-  status: string;
-  engine: string;
-  prompt: string;
-  repos: string[];
-  timeout_secs: number;
-  created_by: string;
-  created_at: string;
-  updated_at: string;
-  started_at?: string;
-  finished_at?: string;
-  error?: string;
-  progress?: string;
-  result?: string;
-}
+import type { TaskRecord } from "./types";
 
 type CreateFormStatus = "idle" | "submitting" | "success" | "error";
 

--- a/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -3,32 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface TaskRecord {
-  task_id: string;
-  status: string;
-  engine: string;
-  prompt: string;
-  repos: string[];
-  timeout_secs: number;
-  created_by: string;
-  created_at: string;
-  updated_at: string;
-  started_at?: string;
-  finished_at?: string;
-  error?: string;
-  progress?: string;
-  result?: string;
-}
-
-interface TaskMessage {
-  role: "user" | "agent" | "system";
-  content: string;
-  created_at: string;
-}
+import type { TaskMessage, TaskRecord } from "../types";
 
 // ---------------------------------------------------------------------------
 // Icons

--- a/apps/web/src/app/dashboard/tasks/types.ts
+++ b/apps/web/src/app/dashboard/tasks/types.ts
@@ -1,0 +1,22 @@
+export interface TaskRecord {
+  task_id: string;
+  status: string;
+  engine: string;
+  prompt: string;
+  repos: string[];
+  timeout_secs: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  finished_at?: string;
+  error?: string;
+  progress?: string;
+  result?: string;
+}
+
+export interface TaskMessage {
+  role: "user" | "agent" | "system";
+  content: string;
+  created_at: string;
+}


### PR DESCRIPTION
Fixes #268.

`TaskRecord` was duplicated verbatim in `TasksDashboard.tsx` and `TaskDetail.tsx`. `TaskMessage` lived only in `TaskDetail.tsx` but was always going to be needed in any component that renders messages.

A single `apps/web/src/app/dashboard/tasks/types.ts` is the right home:
- One definition to update when the task store schema evolves
- `TasksDashboard.tsx` imports `TaskRecord`
- `TaskDetail.tsx` imports both `TaskRecord` and `TaskMessage`

Pure refactor — no behavioral change.