### PR TITLE
fix(web): resolve next-run display edge cases

### DIFF
--- a/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -9,6 +9,11 @@ import {
   type GroupMode,
   type GroupStatus,
 } from "./agent-health-grouping";
+import {
+  relativeTime,
+  relativeTimeUntil,
+  shouldShowNextRun,
+} from "./agent-health-time";
 
 // ---------------------------------------------------------------------------
 // Types (matches server-side HealthOverviewEntry and HealthReport)
@@ -227,29 +232,6 @@ function TokenSummary({ tu }: { tu: TokenUsage }) {
 }
 
 const GROUP_MODE_STORAGE_KEY = "hivemoot-dashboard-group";
-
-function relativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
-}
-
-function relativeTimeUntil(iso: string | undefined): string | null {
-  if (!iso) return null;
-  const diff = new Date(iso).getTime() - Date.now();
-  if (diff <= 0) return "now";
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  if (remainingMinutes === 0) return `${hours}h`;
-  return `${hours}h ${remainingMinutes}m`;
-}
 
 // ---------------------------------------------------------------------------
 // Refresh interval
@@ -626,7 +608,9 @@ export default function AgentHealthDashboard() {
                     <div className="mt-3 flex items-center text-xs">
                       <div className="flex items-center gap-3 text-zinc-600">
                         <span>{relativeTime(agent.received_at)}</span>
-                        {nextRunIn && <span>next: {nextRunIn}</span>}
+                        {shouldShowNextRun(resolvedStatus, nextRunIn) && (
+                          <span>next: {nextRunIn}</span>
+                        )}
                         {agent.token_usage?.cost_usd != null && (
                           <span className="text-zinc-500">
                             ${agent.token_usage.cost_usd.toFixed(2)}

--- a/apps/web/src/app/dashboard/agent-health-time.test.ts
+++ b/apps/web/src/app/dashboard/agent-health-time.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { relativeTimeUntil, shouldShowNextRun } from "./agent-health-time";
+
+const NOW = Date.UTC(2026, 2, 4, 0, 0, 0);
+
+describe("relativeTimeUntil", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when next run timestamp is missing", () => {
+    expect(relativeTimeUntil(undefined)).toBeNull();
+  });
+
+  it("returns <1m for sub-minute future windows", () => {
+    const inThirtySeconds = new Date(NOW + 30_000).toISOString();
+    expect(relativeTimeUntil(inThirtySeconds)).toBe("<1m");
+  });
+
+  it("returns minutes for 1-59 minute windows", () => {
+    const inEightMinutes = new Date(NOW + 8 * 60_000).toISOString();
+    expect(relativeTimeUntil(inEightMinutes)).toBe("8m");
+  });
+
+  it("returns now for late timestamps", () => {
+    const oneSecondAgo = new Date(NOW - 1_000).toISOString();
+    expect(relativeTimeUntil(oneSecondAgo)).toBe("now");
+  });
+});
+
+describe("shouldShowNextRun", () => {
+  it("hides next-run text for late status", () => {
+    expect(shouldShowNextRun("late", "now")).toBe(false);
+  });
+
+  it("shows next-run text for non-late status when next run exists", () => {
+    expect(shouldShowNextRun("ok", "<1m")).toBe(true);
+  });
+
+  it("hides next-run text when there is no next-run value", () => {
+    expect(shouldShowNextRun("ok", null)).toBe(false);
+  });
+});

--- a/apps/web/src/app/dashboard/agent-health-time.ts
+++ b/apps/web/src/app/dashboard/agent-health-time.ts
@@ -1,0 +1,32 @@
+import type { GroupStatus } from "./agent-health-grouping";
+
+export function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function relativeTimeUntil(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const diff = new Date(iso).getTime() - Date.now();
+  if (diff <= 0) return "now";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (remainingMinutes === 0) return `${hours}h`;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+export function shouldShowNextRun(
+  status: GroupStatus,
+  nextRunIn: string | null,
+): boolean {
+  return nextRunIn !== null && status !== "late";
+}


### PR DESCRIPTION
Fixes #232

This updates the agent health dashboard next-run text to handle two UI edge cases cleanly:

- Return `"<1m"` (instead of `"0m"`) when `next_run_at` is 1-59 seconds in the future.
- Suppress `next: now` when the resolved status is `late` (the late badge already conveys that state).

Implementation details:
- Extracted `relativeTime` / `relativeTimeUntil` into `agent-health-time.ts`.
- Added `shouldShowNextRun` helper to keep the late-state rule explicit.
- Added unit tests in `agent-health-time.test.ts` for sub-minute formatting and late-state suppression.

Validation:
- `npm test --prefix apps/web -- agent-health-time.test.ts`
- `npm run -s typecheck --prefix apps/web`
