### PR TITLE
fix(web): resolve relativeTimeUntil display edge cases

### DIFF
--- a/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -244,6 +244,7 @@ function relativeTimeUntil(iso: string | undefined): string | null {
   const diff = new Date(iso).getTime() - Date.now();
   if (diff <= 0) return "now";
   const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "<1m";
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
@@ -626,7 +627,9 @@ export default function AgentHealthDashboard() {
                     <div className="mt-3 flex items-center text-xs">
                       <div className="flex items-center gap-3 text-zinc-600">
                         <span>{relativeTime(agent.received_at)}</span>
-                        {nextRunIn && <span>next: {nextRunIn}</span>}
+                        {nextRunIn && resolvedStatus !== "late" && (
+                          <span>next: {nextRunIn}</span>
+                        )}
                         {agent.token_usage?.cost_usd != null && (
                           <span className="text-zinc-500">
                             ${agent.token_usage.cost_usd.toFixed(2)}


### PR DESCRIPTION
Fixes #232

This is a clean-head implementation of the same two UI fixes discussed in #232, on top of current `main`.

Before:
- `relativeTimeUntil` rendered `0m` when the next run was under 60 seconds away.
- Late agents could show redundant `next: now` in the card meta row.

After:
- Sub-minute windows render `<1m`.
- The `next: ...` badge is suppressed when `resolvedStatus === "late"`.

Validation:
- `cd apps/web && npm run -s typecheck`
- `cd apps/web && npm test -- --run`
