### PR TITLE
Remove engine field from task system

### DIFF
--- a/apps/web/src/app/api/tasks/[taskId]/execute/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/execute/route.test.ts
@@ -29,7 +29,6 @@ import { POST } from "./route";
 const BASE_TASK = {
   task_id: "abc123abc123abc123abc123",
   status: "running" as const,
-  engine: "codex",
   prompt: "Deep analysis",
   repos: ["hivemoot/hivemoot"],
   timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/[taskId]/follow-up/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/follow-up/route.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     task: {
       task_id: TASK_ID,
       status: "pending",
-      engine: "codex",
       prompt: "Task",
       repos: ["hivemoot/hivemoot"],
       timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/[taskId]/messages/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/messages/route.test.ts
@@ -31,7 +31,6 @@ beforeEach(() => {
   vi.mocked(getTask).mockResolvedValue({
     task_id: TASK_ID,
     status: "running",
-    engine: "codex",
     prompt: "Investigate",
     repos: ["hivemoot/hivemoot"],
     timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/[taskId]/retry/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/retry/route.test.ts
@@ -46,7 +46,6 @@ beforeEach(() => {
     task: {
       task_id: "fff123abc123abc123abc123",
       status: "pending",
-      engine: "codex",
       prompt: "Deep analysis",
       repos: ["hivemoot/hivemoot"],
       timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/[taskId]/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/route.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
   vi.mocked(getTask).mockResolvedValue({
     task_id: "abc123abc123abc123abc123",
     status: "pending",
-    engine: "codex",
     prompt: "Deep analysis",
     repos: ["hivemoot/hivemoot"],
     timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/[taskId]/stream/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/stream/route.test.ts
@@ -31,7 +31,6 @@ beforeEach(() => {
   vi.mocked(getTask).mockResolvedValue({
     task_id: "abc123abc123abc123abc123",
     status: "completed",
-    engine: "codex",
     prompt: "Deep analysis",
     repos: ["hivemoot/hivemoot"],
     timeout_secs: 300,
@@ -60,8 +59,7 @@ describe("GET /api/tasks/[taskId]/stream", () => {
     vi.mocked(getTask).mockResolvedValue({
       task_id: "abc123abc123abc123abc123",
       status: "needs_follow_up",
-      engine: "codex",
-      prompt: "Deep analysis",
+        prompt: "Deep analysis",
       repos: ["hivemoot/hivemoot"],
       timeout_secs: 300,
       created_by: "queen",

--- a/apps/web/src/app/api/tasks/claim/route.test.ts
+++ b/apps/web/src/app/api/tasks/claim/route.test.ts
@@ -28,7 +28,6 @@ describe("POST /api/tasks/claim", () => {
     vi.mocked(claimNextPendingTask).mockResolvedValue({
       task_id: "abc123abc123abc123abc123",
       status: "running",
-      engine: "codex",
       prompt: "Deep analysis",
       repos: ["hivemoot/hivemoot"],
       timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/create/route.test.ts
+++ b/apps/web/src/app/api/tasks/create/route.test.ts
@@ -47,7 +47,6 @@ beforeEach(() => {
     request: {
       prompt: "Deep analysis",
       repos: ["hivemoot/hivemoot"],
-      engine: "codex",
       timeout_secs: 300,
     },
   });
@@ -62,7 +61,6 @@ beforeEach(() => {
     task: {
       task_id: "abc123abc123abc123abc123",
       status: "pending",
-      engine: "codex",
       prompt: "Deep analysis",
       repos: ["hivemoot/hivemoot"],
       timeout_secs: 300,

--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     {
       task_id: "abc123abc123abc123abc123",
       status: "pending",
-      engine: "codex",
       prompt: "Deep analysis",
       repos: ["hivemoot/hivemoot"],
       timeout_secs: 300,

--- a/apps/web/src/app/dashboard/tasks/TasksDashboard.tsx
+++ b/apps/web/src/app/dashboard/tasks/TasksDashboard.tsx
@@ -10,7 +10,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 interface TaskRecord {
   task_id: string;
   status: string;
-  engine: string;
   prompt: string;
   repos: string[];
   timeout_secs: number;

--- a/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -11,7 +11,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 interface TaskRecord {
   task_id: string;
   status: string;
-  engine: string;
   prompt: string;
   repos: string[];
   timeout_secs: number;
@@ -585,7 +584,7 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
         )}
 
         {/* Metadata */}
-        <dl className="mt-4 grid grid-cols-2 gap-3 border-t border-white/[0.06] pt-4 text-xs sm:grid-cols-4">
+        <dl className="mt-4 grid grid-cols-2 gap-3 border-t border-white/[0.06] pt-4 text-xs sm:grid-cols-3">
           <div>
             <dt className="text-zinc-600">Repos</dt>
             <dd className="mt-0.5 font-mono text-zinc-400">{task.repos.join(", ")}</dd>
@@ -593,10 +592,6 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
           <div>
             <dt className="text-zinc-600">Created</dt>
             <dd className="mt-0.5 text-zinc-400">{relativeTime(task.created_at)}</dd>
-          </div>
-          <div>
-            <dt className="text-zinc-600">Engine</dt>
-            <dd className="mt-0.5 font-mono text-zinc-400">{task.engine}</dd>
           </div>
           <div>
             <dt className="text-zinc-600">Timeout</dt>

--- a/apps/web/src/server/task-store.test.ts
+++ b/apps/web/src/server/task-store.test.ts
@@ -172,7 +172,6 @@ describe("validateCreateTaskRequest", () => {
     const result = validateCreateTaskRequest({
       prompt: "Investigate auth failures",
       repos: ["hivemoot/hivemoot", "hivemoot/hivemoot-agent"],
-      engine: "codex",
       timeout_secs: 420,
     });
 
@@ -191,7 +190,6 @@ describe("validateCreateTaskRequest", () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.request.engine).toBe("codex");
       expect(result.request.timeout_secs).toBe(DEFAULT_TASK_TIMEOUT_SECONDS);
     }
   });
@@ -234,8 +232,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Deep analysis",
+          prompt: "Deep analysis",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -275,8 +272,7 @@ describe("task lifecycle", () => {
         "inst-1",
         "queen",
         {
-          engine: "codex",
-          prompt: `Task ${i}`,
+              prompt: `Task ${i}`,
           repos: ["hivemoot/hivemoot"],
           timeout_secs: 300,
         },
@@ -289,8 +285,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Overflow",
+          prompt: "Overflow",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -307,8 +302,7 @@ describe("task lifecycle", () => {
           "inst-1",
           "queen",
           {
-            engine: "codex",
-            prompt: `parallel-${index}`,
+                  prompt: `parallel-${index}`,
             repos: ["hivemoot/hivemoot"],
             timeout_secs: 300,
           },
@@ -330,8 +324,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Task",
+          prompt: "Task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -352,8 +345,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Task2",
+          prompt: "Task2",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -376,8 +368,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Task",
+          prompt: "Task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 1,
       },
@@ -409,8 +400,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "A",
+          prompt: "A",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -420,8 +410,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "B",
+          prompt: "B",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -440,8 +429,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "first",
+          prompt: "first",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -451,8 +439,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "second",
+          prompt: "second",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -474,8 +461,7 @@ describe("task lifecycle", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "single",
+          prompt: "single",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -531,8 +517,7 @@ describe("follow-up workflow", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Investigate auth flow",
+          prompt: "Investigate auth flow",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -588,8 +573,7 @@ describe("follow-up workflow", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Task",
+          prompt: "Task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -678,8 +662,7 @@ describe("follow-up workflow", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Task",
+          prompt: "Task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 1,
       },
@@ -713,8 +696,7 @@ describe("follow-up workflow", () => {
         "inst-1",
         "queen",
         {
-          engine: "codex",
-          prompt: `Task ${i}`,
+              prompt: `Task ${i}`,
           repos: ["hivemoot/hivemoot"],
           timeout_secs: 300,
         },
@@ -733,8 +715,7 @@ describe("follow-up workflow", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Extra task",
+          prompt: "Extra task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -756,8 +737,7 @@ describe("task messages", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Analyze the codebase",
+          prompt: "Analyze the codebase",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -777,8 +757,7 @@ describe("task messages", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Do work",
+          prompt: "Do work",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -802,8 +781,7 @@ describe("task messages", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Investigate",
+          prompt: "Investigate",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -850,8 +828,7 @@ describe("post-transition append failure resilience", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Investigate",
+          prompt: "Investigate",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -873,8 +850,7 @@ describe("post-transition append failure resilience", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Investigate",
+          prompt: "Investigate",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -905,8 +881,7 @@ describe("post-transition append failure resilience", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Investigate",
+          prompt: "Investigate",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -938,8 +913,7 @@ describe("post-transition append failure resilience", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Investigate",
+          prompt: "Investigate",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -978,8 +952,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Task to delete",
+          prompt: "Task to delete",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1008,8 +981,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Pending task",
+          prompt: "Pending task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1030,8 +1002,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Running task",
+          prompt: "Running task",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1055,8 +1026,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Need follow-up",
+          prompt: "Need follow-up",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1080,8 +1050,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Race candidate",
+          prompt: "Race candidate",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1174,8 +1143,7 @@ describe("deleteTask", () => {
         "inst-1",
         "queen",
         {
-          engine: "codex",
-          prompt: `Task ${i}`,
+              prompt: `Task ${i}`,
           repos: ["hivemoot/hivemoot"],
           timeout_secs: 300,
         },
@@ -1189,8 +1157,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Overflow",
+          prompt: "Overflow",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1207,8 +1174,7 @@ describe("deleteTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Now fits",
+          prompt: "Now fits",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1230,8 +1196,7 @@ describe("retryTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Retry me",
+          prompt: "Retry me",
         repos: ["hivemoot/hivemoot", "hivemoot/colony"],
         timeout_secs: 420,
       },
@@ -1248,12 +1213,11 @@ describe("retryTask", () => {
     expect(retried.ok).toBe(true);
     if (!retried.ok) return;
 
-    // New task should have a different ID but same prompt/repos/engine.
+    // New task should have a different ID but same prompt/repos/timeout.
     expect(retried.task.task_id).not.toBe(created.task.task_id);
     expect(retried.task.status).toBe("pending");
     expect(retried.task.prompt).toBe("Retry me");
     expect(retried.task.repos).toEqual(["hivemoot/hivemoot", "hivemoot/colony"]);
-    expect(retried.task.engine).toBe("codex");
     expect(retried.task.timeout_secs).toBe(420);
     expect(retried.task.created_by).toBe("queen");
   });
@@ -1263,8 +1227,7 @@ describe("retryTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Running",
+          prompt: "Running",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1287,8 +1250,7 @@ describe("retryTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Pending",
+          prompt: "Pending",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1311,8 +1273,7 @@ describe("retryTask", () => {
         "inst-1",
         "queen",
         {
-          engine: "codex",
-          prompt: `Slot ${i}`,
+              prompt: `Slot ${i}`,
           repos: ["hivemoot/hivemoot"],
           timeout_secs: 300,
         },
@@ -1331,8 +1292,7 @@ describe("retryTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Refill slot",
+          prompt: "Refill slot",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },
@@ -1353,8 +1313,7 @@ describe("retryTask", () => {
       "inst-1",
       "queen",
       {
-        engine: "codex",
-        prompt: "Original",
+          prompt: "Original",
         repos: ["hivemoot/hivemoot"],
         timeout_secs: 300,
       },

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -9,7 +9,6 @@ export const FAILED_TASK_TTL_SECONDS = 24 * 60 * 60;
 export const TASK_CREATE_RATE_LIMIT_PER_MINUTE = 10;
 const MAX_REPOS_PER_TASK = 10;
 const MAX_PROMPT_CHARS = 8000;
-const MAX_ENGINE_CHARS = 64;
 const MAX_PROGRESS_CHARS = 400;
 const MAX_RESULT_CHARS = 128_000;
 const TASK_LOCK_PREFIX = "hive:task-lock:";
@@ -25,7 +24,6 @@ return 0
 `;
 
 const VALID_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const VALID_ENGINE_PATTERN = /^[A-Za-z0-9._:-]+$/;
 export const TASK_ID_PATTERN = /^[a-f0-9]{24}$/;
 
 export type TaskStatus = "pending" | "running" | "needs_follow_up" | "completed" | "failed" | "timed_out";
@@ -47,7 +45,6 @@ const MAX_MESSAGES_PER_TASK = 200;
 export interface TaskRecord {
   task_id: string;
   status: TaskStatus;
-  engine: string;
   prompt: string;
   repos: string[];
   timeout_secs: number;
@@ -64,7 +61,6 @@ export interface TaskRecord {
 interface StoredTaskRecord {
   task_id: string;
   status: TaskStatus;
-  engine: string;
   prompt: string;
   repos: string[];
   timeout_secs: number;
@@ -77,7 +73,6 @@ interface StoredTaskRecord {
 }
 
 export interface CreateTaskRequest {
-  engine: string;
   prompt: string;
   repos: string[];
   timeout_secs: number;
@@ -238,7 +233,6 @@ function parseStoredTask(raw: unknown): StoredTaskRecord | null {
     || !TASK_ID_PATTERN.test(obj.task_id)
     || typeof obj.status !== "string"
     || !["pending", "running", "needs_follow_up", "completed", "failed", "timed_out"].includes(obj.status)
-    || typeof obj.engine !== "string"
     || typeof obj.prompt !== "string"
     || !Array.isArray(obj.repos)
     || obj.repos.some((repo) => typeof repo !== "string")
@@ -254,7 +248,6 @@ function parseStoredTask(raw: unknown): StoredTaskRecord | null {
   const parsed: StoredTaskRecord = {
     task_id: obj.task_id,
     status: obj.status as TaskStatus,
-    engine: obj.engine,
     prompt: obj.prompt,
     repos: obj.repos,
     timeout_secs: obj.timeout_secs,
@@ -376,7 +369,6 @@ async function maybeTimeoutTask(
   return {
     task_id: timedOut.task.task_id,
     status: timedOut.task.status,
-    engine: timedOut.task.engine,
     prompt: timedOut.task.prompt,
     repos: timedOut.task.repos,
     timeout_secs: timedOut.task.timeout_secs,
@@ -395,7 +387,7 @@ export function validateCreateTaskRequest(body: unknown): CreateTaskValidationRe
   }
 
   const obj = body as Record<string, unknown>;
-  const allowedFields = new Set(["prompt", "repos", "engine", "timeout_secs"]);
+  const allowedFields = new Set(["prompt", "repos", "timeout_secs"]);
   for (const key of Object.keys(obj)) {
     if (!allowedFields.has(key)) {
       return { ok: false, message: `Unknown field: ${key}` };
@@ -438,22 +430,6 @@ export function validateCreateTaskRequest(body: unknown): CreateTaskValidationRe
 
   const repos = [...dedupedRepos];
 
-  let engine = "codex";
-  if (obj.engine !== undefined) {
-    if (
-      typeof obj.engine !== "string"
-      || obj.engine.trim().length < 1
-      || obj.engine.length > MAX_ENGINE_CHARS
-      || !VALID_ENGINE_PATTERN.test(obj.engine)
-    ) {
-      return {
-        ok: false,
-        message: `engine must be 1-${MAX_ENGINE_CHARS} chars and match [A-Za-z0-9._:-]+`,
-      };
-    }
-    engine = obj.engine.trim();
-  }
-
   let timeoutSecs = DEFAULT_TASK_TIMEOUT_SECONDS;
   if (obj.timeout_secs !== undefined) {
     if (
@@ -473,7 +449,6 @@ export function validateCreateTaskRequest(body: unknown): CreateTaskValidationRe
   return {
     ok: true,
     request: {
-      engine,
       prompt,
       repos,
       timeout_secs: timeoutSecs,
@@ -521,7 +496,6 @@ export async function createTask(
       const stored: StoredTaskRecord = {
         task_id: taskId,
         status: "pending",
-        engine: request.engine,
         prompt: request.prompt,
         repos: request.repos,
         timeout_secs: request.timeout_secs,
@@ -945,12 +919,11 @@ export async function retryTask(
     return { ok: false, reason: "invalid_transition" };
   }
 
-  // Create a new task reusing the original's prompt, repos, engine, and timeout.
+  // Create a new task reusing the original's prompt, repos, and timeout.
   const result = await createTask(
     installationId,
     stored.created_by,
     {
-      engine: stored.engine,
       prompt: stored.prompt,
       repos: stored.repos,
       timeout_secs: stored.timeout_secs,


### PR DESCRIPTION
## Summary

- Removes the `engine` field from the task data model, API validation, Redis storage, and UI
- Engine/provider selection is purely an apiary fleet concern — the web app doesn't need to know about it

Closes #283

## What it looks like

| Area | Before | After |
|------|--------|-------|
| Task detail metadata | Repos, Created, **Engine**, Timeout (4 cols) | Repos, Created, Timeout (3 cols) |
| Create task API | Accepts optional `engine` field | Rejects `engine` as unknown field |
| Task record in Redis | Includes `engine: "codex"` | No `engine` field |

## Test plan
- [x] All 439 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify task creation still works on deployed dashboard
- [ ] Verify existing tasks with `engine` in Redis still load (backward compatible — `parseStoredTask` ignores extra fields)