### PR TITLE
fix(web): separate lock-timeout from concurrency-limit 429

### DIFF
--- a/apps/web/src/app/api/tasks/[taskId]/execute/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/execute/route.test.ts
@@ -191,6 +191,20 @@ describe("POST /api/tasks/[taskId]/execute", () => {
     expect(res.status).toBe(429);
     const body = await res.json();
     expect(body.code).toBe("task_concurrency_limited");
+    expect(body.message).toBe("Maximum concurrent tasks reached (3)");
+  });
+
+  it("returns a distinct 429 when lock acquisition times out", async () => {
+    vi.mocked(setTaskProgress).mockResolvedValue({
+      ok: false,
+      reason: "lock_timeout",
+    });
+
+    const res = await POST(makeRequest({ action: "progress", progress: "Scanning" }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.code).toBe("task_lock_timeout");
+    expect(body.message).toBe("Task state is temporarily busy, retry shortly");
   });
 
   it("returns 403 when claim token is missing", async () => {

--- a/apps/web/src/app/api/tasks/[taskId]/execute/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/execute/route.ts
@@ -52,6 +52,14 @@ function toTransitionResponse(result: TaskTransitionResult) {
     );
   }
 
+  if (result.reason === "lock_timeout") {
+    return taskError(
+      TASK_ERROR.LOCK_TIMEOUT,
+      "Task state is temporarily busy, retry shortly",
+      429,
+    );
+  }
+
   return taskError(
     TASK_ERROR.CONCURRENCY_LIMITED,
     "Maximum concurrent tasks reached (3)",

--- a/apps/web/src/server/task-error.ts
+++ b/apps/web/src/server/task-error.ts
@@ -13,6 +13,7 @@ export const TASK_ERROR = {
   TASK_NOT_FOUND: "task_not_found",
   RATE_LIMITED: "task_rate_limited",
   CONCURRENCY_LIMITED: "task_concurrency_limited",
+  LOCK_TIMEOUT: "task_lock_timeout",
   FOLLOW_UP_NOT_ALLOWED: "task_follow_up_not_allowed",
   SERVER_ERROR: "task_server_error",
 } as const;

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -94,7 +94,7 @@ export type CreateTaskResult =
 
 export type TaskTransitionResult =
   | { ok: true; task: TaskRecord }
-  | { ok: false; reason: "not_found" | "invalid_transition" | "concurrency_limited" };
+  | { ok: false; reason: "not_found" | "invalid_transition" | "concurrency_limited" | "lock_timeout" };
 
 export type TaskDeleteResult =
   | { ok: true }
@@ -326,7 +326,7 @@ async function withTaskTransitionLock(
         installationId,
         taskId,
       });
-      return { ok: false, reason: "concurrency_limited" };
+      return { ok: false, reason: "lock_timeout" };
     }
     throw error;
   }


### PR DESCRIPTION
## Summary
- return a dedicated `lock_timeout` transition reason when execute-path task transition lock acquisition times out
- map `lock_timeout` to `task_lock_timeout` with an accurate retry-oriented 429 message in `/api/tasks/[taskId]/execute`
- keep `concurrency_limited` for real active-slot exhaustion with the existing message
- add execute route coverage that asserts distinct code/message behavior for lock timeout vs concurrency limits

## Validation
- `cd apps/web && npm test -- src/app/api/tasks/[taskId]/execute/route.test.ts`
- `cd apps/web && npm run -s typecheck`

Fixes #287
