### PR TITLE
refactor(web): extract shared Redis lock primitive

### DIFF
--- a/apps/web/src/server/agent-token.ts
+++ b/apps/web/src/server/agent-token.ts
@@ -13,6 +13,7 @@
 import { randomBytes, createHash } from "crypto";
 import { type Redis } from "@upstash/redis";
 import { encrypt, decrypt, type EncryptedEnvelope } from "@/server/crypto";
+import { withRedisLock, LockTimeoutError } from "@/server/redis-lock";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -21,16 +22,6 @@ import { encrypt, decrypt, type EncryptedEnvelope } from "@/server/crypto";
 const TOKEN_PREFIX = "hive:agent-token:";
 const HASH_PREFIX = "agent-token-hash:";
 const LOCK_PREFIX = "hive:agent-token-lock:";
-const LOCK_TTL_SECONDS = 5;
-const LOCK_MAX_WAIT_MS = 1000;
-const LOCK_RETRY_MIN_MS = 8;
-const LOCK_RETRY_MAX_MS = 20;
-const RELEASE_LOCK_SCRIPT = `
-if redis.call("get", KEYS[1]) == ARGV[1] then
-  return redis.call("del", KEYS[1])
-end
-return 0
-`;
 
 // Atomic rotate: DEL old hash (if any), SET envelope, SET new hash index.
 // KEYS: [oldHashKey, envelopeKey, newHashKey]
@@ -79,12 +70,8 @@ export interface AgentTokenRecord {
   createdBy: string;
 }
 
-export class LockTimeoutError extends Error {
-  constructor(installationId: string) {
-    super(`Timed out acquiring agent-token lock for installation ${installationId}`);
-    this.name = "LockTimeoutError";
-  }
-}
+// Re-exported so API route consumers can import from a single location.
+export { LockTimeoutError } from "@/server/redis-lock";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -106,57 +93,18 @@ function redisLockKey(installationId: string): string {
   return `${LOCK_PREFIX}${installationId}`;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function randomRetryDelayMs(): number {
-  return LOCK_RETRY_MIN_MS + Math.floor(Math.random() * (LOCK_RETRY_MAX_MS - LOCK_RETRY_MIN_MS + 1));
-}
-
-async function releaseInstallationLock(
-  lockKey: string,
-  lockOwnerToken: string,
-  redis: Redis,
-): Promise<void> {
-  await redis.eval(RELEASE_LOCK_SCRIPT, [lockKey], [lockOwnerToken]);
-}
-
-async function withInstallationLock<T>(
+function withInstallationLock<T>(
   installationId: string,
   redis: Redis,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const lockKey = redisLockKey(installationId);
-  const lockOwnerToken = randomBytes(16).toString("hex");
-  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
-
-  while (Date.now() < deadline) {
-    const acquired = await redis.set(lockKey, lockOwnerToken, {
-      nx: true,
-      ex: LOCK_TTL_SECONDS,
-    });
-
-    if (acquired === "OK") {
-      try {
-        return await fn();
-      } finally {
-        try {
-          await releaseInstallationLock(lockKey, lockOwnerToken, redis);
-        } catch (error) {
-          // Lock cleanup is best-effort so we never hide the primary operation result.
-          console.error("[agent-token] Failed to release installation lock", {
-            installationId,
-            error,
-          });
-        }
-      }
-    }
-
-    await sleep(randomRetryDelayMs());
-  }
-
-  throw new LockTimeoutError(installationId);
+  return withRedisLock(redisLockKey(installationId), redis, fn, {
+    onReleaseError: (error) =>
+      console.error("[agent-token] Failed to release installation lock", {
+        installationId,
+        error,
+      }),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/redis-lock.test.ts
+++ b/apps/web/src/server/redis-lock.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+import { withRedisLock, LockTimeoutError, LOCK_TTL_SECONDS, LOCK_MAX_WAIT_MS } from "./redis-lock";
+
+// ---------------------------------------------------------------------------
+// Minimal Redis mock
+// ---------------------------------------------------------------------------
+
+function makeMockRedis() {
+  const store = new Map<string, unknown>();
+
+  const client = {
+    set: vi.fn(async (
+      key: string,
+      value: unknown,
+      opts?: { nx?: boolean; ex?: number },
+    ) => {
+      if (opts?.nx && store.has(key)) return null;
+      store.set(key, value);
+      return "OK";
+    }),
+    eval: vi.fn(async (_script: string, keys: string[], args: string[]) => {
+      // RELEASE_LOCK_SCRIPT: 1 key, 1 arg (CAS delete)
+      const lockKey = keys[0];
+      const expectedOwner = args[0];
+      if (store.get(lockKey) === expectedOwner) {
+        store.delete(lockKey);
+        return 1;
+      }
+      return 0;
+    }),
+    _store: store,
+  };
+
+  return client as unknown as Redis & { _store: Map<string, unknown> };
+}
+
+describe("withRedisLock()", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+    vi.clearAllMocks();
+  });
+
+  it("runs the protected function and returns its result", async () => {
+    const result = await withRedisLock("test-lock", redis, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("releases the lock after the protected function completes", async () => {
+    await withRedisLock("test-lock", redis, async () => "done");
+    expect(redis._store.has("test-lock")).toBe(false);
+  });
+
+  it("releases the lock even if the protected function throws", async () => {
+    await expect(
+      withRedisLock("test-lock", redis, async () => { throw new Error("boom"); }),
+    ).rejects.toThrow("boom");
+    expect(redis._store.has("test-lock")).toBe(false);
+  });
+
+  it("passes LOCK_TTL_SECONDS as the lock TTL", async () => {
+    await withRedisLock("test-lock", redis, async () => null);
+    expect(vi.mocked(redis.set)).toHaveBeenCalledWith(
+      "test-lock",
+      expect.any(String),
+      expect.objectContaining({ ex: LOCK_TTL_SECONDS }),
+    );
+  });
+
+  it("uses nx: true so concurrent callers cannot both acquire the lock", async () => {
+    await withRedisLock("test-lock", redis, async () => null);
+    expect(vi.mocked(redis.set)).toHaveBeenCalledWith(
+      "test-lock",
+      expect.any(String),
+      expect.objectContaining({ nx: true }),
+    );
+  });
+
+  it("throws LockTimeoutError when lock cannot be acquired within deadline", async () => {
+    // Pre-fill the lock so acquisition always fails.
+    redis._store.set("test-lock", "someone-else");
+
+    await expect(
+      withRedisLock("test-lock", redis, async () => null),
+    ).rejects.toThrow(LockTimeoutError);
+  }, LOCK_MAX_WAIT_MS + 500);
+
+  it("calls onReleaseError when lock release fails", async () => {
+    const onReleaseError = vi.fn();
+    vi.mocked(redis.eval).mockRejectedValueOnce(new Error("redis down"));
+
+    await withRedisLock("test-lock", redis, async () => "ok", { onReleaseError });
+
+    expect(onReleaseError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("does not call onReleaseError on successful release", async () => {
+    const onReleaseError = vi.fn();
+    await withRedisLock("test-lock", redis, async () => null, { onReleaseError });
+    expect(onReleaseError).not.toHaveBeenCalled();
+  });
+
+  it("returns the primary operation result even when release fails", async () => {
+    vi.mocked(redis.eval).mockRejectedValueOnce(new Error("redis down"));
+
+    const result = await withRedisLock(
+      "test-lock",
+      redis,
+      async () => "primary-result",
+      { onReleaseError: () => {} },
+    );
+
+    expect(result).toBe("primary-result");
+  });
+});
+
+describe("LockTimeoutError", () => {
+  it("is an instance of Error", () => {
+    expect(new LockTimeoutError("my-lock")).toBeInstanceOf(Error);
+  });
+
+  it("has name LockTimeoutError", () => {
+    expect(new LockTimeoutError("my-lock").name).toBe("LockTimeoutError");
+  });
+
+  it("includes the lock key in the message", () => {
+    expect(new LockTimeoutError("my-lock").message).toContain("my-lock");
+  });
+});

--- a/apps/web/src/server/redis-lock.ts
+++ b/apps/web/src/server/redis-lock.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared Redis distributed lock primitive.
+ *
+ * Provides a CAS-based spin lock with a configurable key, TTL, and retry
+ * window. Both agent-token and task-store use this primitive; callers supply
+ * the lock key and any scoped logging through an optional release-error hook.
+ */
+
+import { randomBytes } from "node:crypto";
+import { type Redis } from "@upstash/redis";
+
+// ---------------------------------------------------------------------------
+// Constants (exported so consumers can reference them in error messages)
+// ---------------------------------------------------------------------------
+
+export const LOCK_TTL_SECONDS = 5;
+export const LOCK_MAX_WAIT_MS = 1000;
+const LOCK_RETRY_MIN_MS = 8;
+const LOCK_RETRY_MAX_MS = 20;
+
+// CAS-based atomic release: only deletes the key if the caller still owns it.
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WithRedisLockOptions {
+  /**
+   * Called when the lock-release step fails after the protected operation
+   * completes. Release failures are best-effort and never hide the primary
+   * operation result — this hook is for scoped logging only.
+   */
+  onReleaseError?: (error: unknown) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class LockTimeoutError extends Error {
+  constructor(lockKey: string) {
+    super(`Timed out acquiring Redis lock for key "${lockKey}"`);
+    this.name = "LockTimeoutError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function randomRetryDelayMs(): number {
+  return LOCK_RETRY_MIN_MS + Math.floor(Math.random() * (LOCK_RETRY_MAX_MS - LOCK_RETRY_MIN_MS + 1));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Acquires an exclusive lock on `lockKey`, runs `fn`, then releases the lock.
+ *
+ * Retries acquisition until `LOCK_MAX_WAIT_MS` elapses. Throws
+ * `LockTimeoutError` when the deadline is exceeded. Lock release is
+ * best-effort: if it fails, `opts.onReleaseError` is called (if provided) and
+ * the primary operation result is returned normally.
+ */
+export async function withRedisLock<T>(
+  lockKey: string,
+  redis: Redis,
+  fn: () => Promise<T>,
+  opts?: WithRedisLockOptions,
+): Promise<T> {
+  const lockOwnerToken = randomBytes(16).toString("hex");
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    const acquired = await redis.set(lockKey, lockOwnerToken, {
+      nx: true,
+      ex: LOCK_TTL_SECONDS,
+    });
+
+    if (acquired === "OK") {
+      try {
+        return await fn();
+      } finally {
+        try {
+          await redis.eval(RELEASE_LOCK_SCRIPT, [lockKey], [lockOwnerToken]);
+        } catch (error) {
+          opts?.onReleaseError?.(error);
+        }
+      }
+    }
+
+    await sleep(randomRetryDelayMs());
+  }
+
+  throw new LockTimeoutError(lockKey);
+}

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { type Redis } from "@upstash/redis";
+import { withRedisLock, LockTimeoutError } from "@/server/redis-lock";
 
 export const MAX_CONCURRENT_TASKS = 3;
 export const DEFAULT_TASK_TIMEOUT_SECONDS = 5 * 60;
@@ -13,16 +14,6 @@ const MAX_PROGRESS_CHARS = 400;
 const MAX_RESULT_CHARS = 128_000;
 const TASK_CLAIM_TOKEN_BYTES = 32;
 const TASK_LOCK_PREFIX = "hive:task-lock:";
-const TASK_LOCK_TTL_SECONDS = 5;
-const TASK_LOCK_MAX_WAIT_MS = 1000;
-const TASK_LOCK_RETRY_MIN_MS = 8;
-const TASK_LOCK_RETRY_MAX_MS = 20;
-const RELEASE_TASK_LOCK_SCRIPT = `
-if redis.call("get", KEYS[1]) == ARGV[1] then
-  return redis.call("del", KEYS[1])
-end
-return 0
-`;
 
 const VALID_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 export const TASK_ID_PATTERN = /^[a-f0-9]{24}$/;
@@ -109,12 +100,6 @@ export interface RateLimitResult {
   retryAfterSeconds: number;
 }
 
-class TaskLockTimeoutError extends Error {
-  constructor(installationId: string) {
-    super(`Timed out acquiring task lock for installation ${installationId}`);
-    this.name = "TaskLockTimeoutError";
-  }
-}
 
 function taskKey(installationId: string, taskId: string): string {
   return `task:${installationId}:${taskId}`;
@@ -164,58 +149,18 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function randomTaskLockRetryDelayMs(): number {
-  return TASK_LOCK_RETRY_MIN_MS
-    + Math.floor(Math.random() * (TASK_LOCK_RETRY_MAX_MS - TASK_LOCK_RETRY_MIN_MS + 1));
-}
-
-async function releaseTaskLock(
-  lockKey: string,
-  lockOwnerToken: string,
-  redis: Redis,
-): Promise<void> {
-  await redis.eval(RELEASE_TASK_LOCK_SCRIPT, [lockKey], [lockOwnerToken]);
-}
-
-async function withTaskInstallationLock<T>(
+function withTaskInstallationLock<T>(
   installationId: string,
   redis: Redis,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const lockKey = taskLockKey(installationId);
-  const lockOwnerToken = randomBytes(16).toString("hex");
-  const deadline = Date.now() + TASK_LOCK_MAX_WAIT_MS;
-
-  while (Date.now() < deadline) {
-    const acquired = await redis.set(lockKey, lockOwnerToken, {
-      nx: true,
-      ex: TASK_LOCK_TTL_SECONDS,
-    });
-
-    if (acquired === "OK") {
-      try {
-        return await fn();
-      } finally {
-        try {
-          await releaseTaskLock(lockKey, lockOwnerToken, redis);
-        } catch (error) {
-          // Lock cleanup is best-effort so operation results are preserved.
-          console.error("[tasks] Failed to release task lock", {
-            installationId,
-            error,
-          });
-        }
-      }
-    }
-
-    await sleep(randomTaskLockRetryDelayMs());
-  }
-
-  throw new TaskLockTimeoutError(installationId);
+  return withRedisLock(taskLockKey(installationId), redis, fn, {
+    onReleaseError: (error) =>
+      console.error("[tasks] Failed to release task lock", {
+        installationId,
+        error,
+      }),
+  });
 }
 
 function isTerminal(status: TaskStatus): boolean {
@@ -321,7 +266,7 @@ async function withTaskTransitionLock(
   try {
     return await withTaskInstallationLock(installationId, redis, fn);
   } catch (error) {
-    if (error instanceof TaskLockTimeoutError) {
+    if (error instanceof LockTimeoutError) {
       console.warn(operation, {
         installationId,
         taskId,
@@ -593,7 +538,7 @@ export async function createTask(
       };
     });
   } catch (error) {
-    if (error instanceof TaskLockTimeoutError) {
+    if (error instanceof LockTimeoutError) {
       console.warn("[tasks] Task create lock timeout", {
         installationId,
       });
@@ -754,7 +699,7 @@ export async function markTaskRunning(
       () => markTaskRunningUnlocked(installationId, taskId, redis),
     );
   } catch (error) {
-    if (error instanceof TaskLockTimeoutError) {
+    if (error instanceof LockTimeoutError) {
       console.warn("[tasks] Task start lock timeout", {
         installationId,
         taskId,
@@ -985,7 +930,7 @@ export async function claimNextPendingTask(
       return null;
     });
   } catch (error) {
-    if (error instanceof TaskLockTimeoutError) {
+    if (error instanceof LockTimeoutError) {
       console.warn("[tasks] Task claim lock timeout", {
         installationId,
       });
@@ -1292,7 +1237,7 @@ export async function resumeTaskWithFollowUp(
       };
     });
   } catch (error) {
-    if (error instanceof TaskLockTimeoutError) {
+    if (error instanceof LockTimeoutError) {
       console.warn("[tasks] Task follow-up lock timeout", {
         installationId,
         taskId,


### PR DESCRIPTION
Closes #267

## What

Extracts the duplicated Redis distributed lock implementation from `agent-token.ts` and `task-store.ts` into a shared `server/redis-lock.ts` module.

Both files had identical:
- Lua CAS-based release script
- Lock TTL/wait/retry constants (same values across both)
- `LockTimeoutError` class
- `sleep()` and `randomRetryDelayMs()` helpers
- A `withXxxInstallationLock` wrapper function

## How

New `redis-lock.ts` exports:
- `withRedisLock<T>(lockKey, redis, fn, opts?)` — the shared lock primitive
- `LockTimeoutError` — thrown on timeout
- `LOCK_TTL_SECONDS`, `LOCK_MAX_WAIT_MS` — exported for reference in error messages

Each consumer keeps a thin wrapper that provides the scoped lock key and scoped logging via `opts.onReleaseError`. The lock key prefix (`hive:agent-token-lock:`, `hive:task-lock:`) and log prefix (`[agent-token]`, `[tasks]`) remain in each consumer as the issue specifies.

`agent-token.ts` re-exports `LockTimeoutError` for backwards compatibility with `app/api/agent-token/route.ts` which imports it from there.

## Validation

- `npm run typecheck` — clean
- `npm test` — 457 passed, 1 skipped (pre-existing), 0 failed
- New `redis-lock.test.ts`: 12 tests covering lock acquisition, release, timeout, release-error hook, and error semantics