### PR TITLE
fix(cli): use alias-aware checks for governance pipeline detection

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1272,7 +1272,7 @@ describe("buildSummary()", () => {
     expect(summary.prioritySignals?.[0].summary).toContain("1 waiting");
   });
 
-  it("omits issue pipeline and implementation-gap without default hivemoot phase labels", () => {
+  it("includes issue pipeline when phase:* alias labels are present", () => {
     const issues = [
       makeIssue({ number: 401, labels: [{ name: "phase:ready-to-implement" }] }),
       makeIssue({ number: 402, labels: [{ name: "phase:discussion" }] }),
@@ -1286,10 +1286,30 @@ describe("buildSummary()", () => {
     ];
 
     const summary = buildSummary(repo, issues, prs, "testuser", now);
+    expect(summary.repositoryHealth?.issuePipeline).toBeDefined();
+    expect(summary.repositoryHealth?.issuePipeline?.discussion).toBe(1);
+    expect(summary.repositoryHealth?.issuePipeline?.readyToImplement).toBe(1);
+    expect(summary.notes).not.toContain("omitted");
+  });
+
+  it("omits issue pipeline and implementation-gap when no governance phase labels are present", () => {
+    const issues = [
+      makeIssue({ number: 401, labels: [{ name: "bug" }] }),
+      makeIssue({ number: 402, labels: [{ name: "enhancement" }] }),
+    ];
+    const prs = [
+      makePR({
+        number: 501,
+        author: { login: "other" },
+        closingIssuesReferences: [{ number: 401 }],
+      }),
+    ];
+
+    const summary = buildSummary(repo, issues, prs, "testuser", now);
     expect(summary.repositoryHealth?.issuePipeline).toBeUndefined();
     expect(summary.prioritySignals?.some((signal) => signal.kind === "implementation-gap")).toBe(false);
     expect(summary.notes).toContain(
-      "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.",
+      "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.",
     );
   });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -11,7 +11,6 @@ import type {
 import type { VoteMap } from "../github/votes.js";
 import type { NotificationMap } from "../github/notifications.js";
 import {
-  GOVERNANCE_LABEL_ALIASES,
   hasLabel,
   hasCIFailure,
   checkStatus,
@@ -35,15 +34,8 @@ interface IssuePipelineCounts {
   readyToImplement: number;
 }
 
-const DEFAULT_HIVEMOOT_PHASE_LABELS = new Set<string>([
-  GOVERNANCE_LABEL_ALIASES.DISCUSSION[0],
-  GOVERNANCE_LABEL_ALIASES.VOTING[0],
-  GOVERNANCE_LABEL_ALIASES.EXTENDED_VOTING[0],
-  GOVERNANCE_LABEL_ALIASES.READY_TO_IMPLEMENT[0],
-]);
-
 const OMITTED_PIPELINE_NOTE =
-  "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.";
+  "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.";
 
 function isMergeReadyPR(pr: GitHubPR): boolean {
   if (pr.isDraft) return false;
@@ -480,10 +472,13 @@ export function buildSummary(
     return a.timestamp > b.timestamp ? -1 : 1;
   });
 
-  const hasDefaultPhaseLabels = issues.some((issue) =>
-    issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
+  const hasPhaseLabels = issues.some((issue) =>
+    hasGovernanceLabel(issue.labels, "DISCUSSION") ||
+    hasGovernanceLabel(issue.labels, "VOTING") ||
+    hasGovernanceLabel(issue.labels, "EXTENDED_VOTING") ||
+    hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")
   );
-  const issuePipeline: IssuePipelineCounts | undefined = hasDefaultPhaseLabels
+  const issuePipeline: IssuePipelineCounts | undefined = hasPhaseLabels
     ? {
         discussion: discuss.length,
         voting: voteOn.length,


### PR DESCRIPTION
Closes #47

## Problem

`buildSummary()` populated `issuePipeline` (the discussion/voting/readyToImplement counts in `RepositoryHealth`) only when it detected `DEFAULT_HIVEMOOT_PHASE_LABELS` — a hardcoded set containing only the primary aliases (`hivemoot:discussion`, `hivemoot:voting`, etc). Secondary aliases like `phase:discussion` were recognized by `classifyIssue()` and correctly placed in the `discuss` bucket, but the pipeline presence check used a separate set that missed them entirely. Result: repos using `phase:*` labels got accurate issue bucketing but empty pipeline counts and no implementation-gap signal.

## Fix

Remove `DEFAULT_HIVEMOOT_PHASE_LABELS` entirely. Replace the pipeline gate with `hasGovernanceLabel()` calls — the same alias-aware function already used by `classifyIssue()`. Pipeline detection and issue bucketing now share the same normalization path, so `issuePipeline` is populated whenever issues appear in the governance phase buckets.

```ts
// Before: only primary aliases matched
const hasDefaultPhaseLabels = issues.some((issue) =>
  issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
);

// After: all configured aliases match, consistent with classifyIssue()
const hasPhaseLabels = issues.some((issue) =>
  hasGovernanceLabel(issue.labels, "DISCUSSION") ||
  hasGovernanceLabel(issue.labels, "VOTING") ||
  hasGovernanceLabel(issue.labels, "EXTENDED_VOTING") ||
  hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")
);
```

Also removes the now-unused `GOVERNANCE_LABEL_ALIASES` import from `builder.ts` (it was only used to construct the removed set).

## Tests

Updated the existing test (which verified the pre-fix bug: `phase:*` labels were not detected) to verify the correct post-fix behavior. Added a new test for the case where no governance phase labels exist at all (pipeline correctly omitted).

697/697 tests pass, `tsc --noEmit` clean.