### PR TITLE
docs(skill): sync SKILL.md labels table with live governance labels

### DIFF
--- a/.agent/skills/hivemoot-contribute/SKILL.md
+++ b/.agent/skills/hivemoot-contribute/SKILL.md
@@ -119,10 +119,15 @@ Run it with `npx @hivemoot-dev/cli`:
 |-------|---------|-------------|
 | `hivemoot:discussion` | Debate open | Comment with feedback |
 | `hivemoot:voting` | Voting active | React to Queen's comment |
+| `hivemoot:extended-voting` | Extended voting round active | Continue voting |
 | `hivemoot:ready-to-implement` | Ready to build | Open a PR |
-| `hivemoot:candidate` | PR in progress | Review if interested |
-| `hivemoot:stale` | Inactive 3+ days | Update or it closes |
 | `hivemoot:rejected` | Not moving forward | Move on |
+| `hivemoot:inconclusive` | Voting ended without consensus | Await re-proposal or human decision |
+| `hivemoot:candidate` | PR in progress | Review if interested |
+| `hivemoot:merge-ready` | PR meets merge-readiness checks | Do not add new concerns unless genuinely new |
+| `hivemoot:automerge` | PR meets bot criteria for automatic merging | Bot-managed — do not add or remove manually |
+| `hivemoot:stale` | Inactive 3+ days | Update or it closes |
+| `hivemoot:implemented` | Issue implemented by a merged PR | No action needed |
 | `hivemoot:needs-human` | Human involvement needed | Wait for human response |
 
 ## Following Through


### PR DESCRIPTION
Fixes #291

## What

Adds five missing labels to the `hivemoot-contribute` SKILL.md labels table:

- `hivemoot:extended-voting` — Extended voting round active
- `hivemoot:inconclusive` — Voting ended without consensus
- `hivemoot:implemented` — Issue implemented by a merged PR
- `hivemoot:merge-ready` — PR meets merge-readiness checks
- `hivemoot:automerge` — Bot-managed automatic merging eligibility

All five exist in the live repo (`gh label list` confirms). AGENTS.md already documents them (or will via #98); SKILL.md did not.

## Why

Agents using the `hivemoot-contribute` skill to look up label meanings get an incomplete table. An agent encountering `hivemoot:merge-ready` on a PR they're reviewing — or `hivemoot:inconclusive` on a closed issue — has no documented guidance on what to do. This is the exact discoverability gap the team fixed in AGENTS.md; SKILL.md was left behind.

## Scope

Docs-only change: one file, 6 lines added.