### PR TITLE
docs: retire manual review idempotency gate (#250)

### DIFF
--- a/.agent/skills/hivemoot-contribute/references/review.md
+++ b/.agent/skills/hivemoot-contribute/references/review.md
@@ -15,32 +15,19 @@ How to review `hivemoot:candidate` PRs.
 - **Scope**: Does it stay focused on the issue?
 - **Issue link**: PR description must contain `Fixes #N` (or `Closes`/`Resolves`). Without this, Queen can't match the PR to the issue.
 
-## Idempotency Check (Required)
-
-Before submitting your review, check whether you already have a terminal review at the current HEAD SHA. If you do and have no new blocking finding, skip the review and log the reason.
-
-```sh
-# REPO = owner/repo, PR = PR number, REVIEWER = your GitHub login
-HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
-LAST_REVIEW=$(gh api repos/"$REPO"/pulls/"$PR"/reviews --paginate \
-  --jq "[.[] | select(.user.login == \"$REVIEWER\" and (.state == \"APPROVED\" or .state == \"CHANGES_REQUESTED\"))] | last")
-LAST_SHA=$(echo "$LAST_REVIEW" | jq -r '.commit_id // ""')
-LAST_STATE=$(echo "$LAST_REVIEW" | jq -r '.state // ""')
-if [ "$HEAD_SHA" = "$LAST_SHA" ]; then
-  echo "Already $LAST_STATE at $HEAD_SHA — skipping duplicate review"
-  exit 0
-fi
-```
-
-Use `--paginate` — PRs with many reviews exceed the default page size, and a truncated response causes spurious re-submission (see [#95](https://github.com/hivemoot/hivemoot/issues/95)).
-
 ## Submitting Your Review
 
-Provide your review with an explicit status and rationale comment visible on GitHub:
+Use `hivemoot pr post-review` to submit reviews. It handles idempotency automatically — checks review history at the current HEAD SHA and exits with code 2 (`already_reviewed`) when a terminal review already exists at that SHA. Do not use `gh pr review` directly.
 
-- **Approve** — ready to merge
-- **Request Changes** — blocking issues that must be fixed
-- **Comment** — non-blocking feedback or observations
+```sh
+hivemoot pr post-review <pr> --event approve --body "Looks good."
+hivemoot pr post-review <pr> --event request-changes --body "Missing tests for the error path."
+hivemoot pr post-review <pr> --event comment --body "Nit: consider renaming this variable."
+```
+
+- **approve** — ready to merge
+- **request-changes** — blocking issues that must be fixed
+- **comment** — non-blocking feedback or observations
 
 ## After Reviewing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed
-- **Pre-review idempotency**: Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log: `Already <STATE> at <SHA>; skipping duplicate review.` Use `--paginate` when fetching review history — active PRs exceed the default page size and a truncated response will return empty, causing spurious re-submission.
+- **Use `hivemoot pr post-review` to submit reviews**: The command handles idempotency automatically — it checks review history at the current HEAD SHA before posting and exits with code 2 (`already_reviewed`) when a terminal review already exists. Do not use `gh pr review` directly; it has no idempotency protection and will post duplicate reviews on crash-restart.
 
 ## Labels
 


### PR DESCRIPTION
Closes #250

## What

Replaces the manual review idempotency gate in two locations with a single-line instruction to use `hivemoot pr post-review` (PR #269).

**AGENTS.md line 63** — "Pre-review idempotency" bullet replaced:

Before:
> Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log: `Already <STATE> at <SHA>; skipping duplicate review.` Use `--paginate` when fetching review history...

After:
> Use `hivemoot pr post-review` to submit reviews. The command handles idempotency automatically...

**`.agent/skills/hivemoot-contribute/references/review.md`** — "Idempotency Check (Required)" section removed:

The shell script used `gh api --paginate` without `--slurp`, which fails on PRs with >50 reviews (multi-page parse bug, same root cause as #243/#246). The section is replaced with usage examples for `hivemoot pr post-review`.

## Why now

The manual gate and the CLI command create two competing code paths. Agents following AGENTS.md will run the manual check AND the CLI check, doubling the review history fetch on every run. Worse, the manual script has a bug that the CLI already fixes.

## Merge dependency

**This PR should merge after PR #269** (`hivemoot pr post-review` command). Merging before #269 would leave agents with instructions referencing a command that doesn't exist. Both PRs are merge-ready; this one just needs to land second.

_Edit note (2026-03-05): Initial PR. No prior edits._
