### PR TITLE
Polish task detail chat UI

### DIFF
--- a/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -52,9 +52,9 @@ function ArrowLeftIcon({ className }: { className?: string }) {
   );
 }
 
-function SpinnerIcon() {
+function SpinnerIcon({ className }: { className?: string }) {
   return (
-    <svg className="h-4 w-4 animate-spin" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg className={className ?? "h-4 w-4 animate-spin"} viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.25" />
       <path d="M8 2a6 6 0 0 1 6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
     </svg>
@@ -118,25 +118,6 @@ function BotIcon({ className }: { className?: string }) {
   );
 }
 
-function InfoIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className ?? "h-4 w-4"}
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <circle cx="8" cy="8" r="6" />
-      <line x1="8" y1="7" x2="8" y2="11" />
-      <circle cx="8" cy="5" r="0.5" fill="currentColor" />
-    </svg>
-  );
-}
-
 function RetryIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -172,6 +153,23 @@ function TrashIcon({ className }: { className?: string }) {
       <polyline points="3 4 13 4" />
       <path d="M6 4V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1" />
       <path d="M4.5 4l.7 9.1a1 1 0 0 0 1 .9h3.6a1 1 0 0 0 1-.9L11.5 4" />
+    </svg>
+  );
+}
+
+function MessageSquareIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-4 w-4"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H5l-3 3V3z" />
     </svg>
   );
 }
@@ -231,6 +229,24 @@ function statusDotColor(status: string): string {
   }
 }
 
+function statusBgColor(status: string): string {
+  switch (status) {
+    case "completed":
+      return "bg-green-500/10";
+    case "running":
+      return "bg-blue-500/10";
+    case "pending":
+      return "bg-zinc-500/10";
+    case "needs_follow_up":
+      return "bg-amber-500/10";
+    case "failed":
+    case "timed_out":
+      return "bg-red-500/10";
+    default:
+      return "bg-zinc-500/10";
+  }
+}
+
 function statusLabel(status: string): string {
   switch (status) {
     case "completed":
@@ -277,16 +293,12 @@ function isDeletable(status: string): boolean {
 // Markdown renderer
 // ---------------------------------------------------------------------------
 
-// Context lets the pre component signal to the code component that it is
-// rendering inside a fenced code block. Without this, code blocks that have
-// no language specifier (e.g. plain ```) have no className, making them
-// indistinguishable from inline backtick code via className alone.
 const InPre = createContext(false);
 
 function MdPre({ children }: React.ComponentPropsWithoutRef<"pre"> & ExtraProps) {
   return (
     <InPre.Provider value={true}>
-      <pre className="my-2 overflow-auto rounded-lg bg-black/30 p-3 text-xs">{children}</pre>
+      <pre className="my-2.5 overflow-auto rounded-lg bg-black/40 p-3.5 text-[13px] leading-relaxed">{children}</pre>
     </InPre.Provider>
   );
 }
@@ -294,23 +306,22 @@ function MdPre({ children }: React.ComponentPropsWithoutRef<"pre"> & ExtraProps)
 function MdCode({ className, children }: React.ComponentPropsWithoutRef<"code"> & ExtraProps) {
   const inPre = useContext(InPre);
   if (inPre) {
-    // Block code: the pre container already provides background/padding.
-    return <code className={`${className ?? ""} font-mono text-xs`}>{children}</code>;
+    return <code className={`${className ?? ""} font-mono text-[13px]`}>{children}</code>;
   }
-  return <code className="rounded bg-black/40 px-1 py-0.5 font-mono text-xs">{children}</code>;
+  return <code className="rounded bg-white/[0.08] px-1.5 py-0.5 font-mono text-[13px]">{children}</code>;
 }
 
 function MarkdownContent({ children, className }: { children: string; className?: string }) {
   return (
-    <div className={`text-sm text-zinc-300 ${className ?? ""}`}>
+    <div className={`text-sm leading-relaxed text-zinc-300 ${className ?? ""}`}>
       <Markdown
         components={{
           h1: ({ children: c }) => <h1 className="mb-2 mt-4 text-base font-bold text-[#fafafa]">{c}</h1>,
           h2: ({ children: c }) => <h2 className="mb-1.5 mt-3 text-sm font-bold text-[#fafafa]">{c}</h2>,
           h3: ({ children: c }) => <h3 className="mb-1 mt-2 text-sm font-semibold text-zinc-200">{c}</h3>,
           p: ({ children: c }) => <p className="my-1.5">{c}</p>,
-          ul: ({ children: c }) => <ul className="my-1.5 ml-4 list-disc">{c}</ul>,
-          ol: ({ children: c }) => <ol className="my-1.5 ml-4 list-decimal">{c}</ol>,
+          ul: ({ children: c }) => <ul className="my-1.5 ml-5 list-disc">{c}</ul>,
+          ol: ({ children: c }) => <ol className="my-1.5 ml-5 list-decimal">{c}</ol>,
           li: ({ children: c }) => <li className="mt-0.5">{c}</li>,
           code: MdCode,
           pre: MdPre,
@@ -420,7 +431,6 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
           const data = JSON.parse(e.data);
           if (data.task) {
             setTask(data.task);
-            // Re-fetch messages when task state changes to pick up new timeline entries.
             fetch(`/api/tasks/${taskId}/messages`)
               .then((res) => (res.ok ? res.json() : null))
               .then((data) => {
@@ -443,7 +453,6 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
           // Ignore malformed SSE data.
         }
         eventSource.close();
-        // Final message refresh.
         fetch(`/api/tasks/${taskId}/messages`)
           .then((res) => (res.ok ? res.json() : null))
           .then((data) => {
@@ -456,7 +465,6 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
 
       eventSource.addEventListener("error", () => {
         eventSource.close();
-        // Reconnect after a delay unless stream was intentionally closed.
         if (!closed) {
           setTimeout(connectSSE, 3000);
         }
@@ -503,7 +511,6 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
       const data = await res.json();
       if (data.task) setTask(data.task);
       setFollowUpText("");
-      // Refresh messages to show the follow-up in the timeline.
       await fetchTask();
     } catch {
       setFollowUpError("Could not reach the server.");
@@ -563,9 +570,9 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-3 text-sm text-zinc-500">
+      <div className="flex items-center gap-3 py-16 text-sm text-zinc-500">
         <SpinnerIcon />
-        Loading task…
+        Loading task...
       </div>
     );
   }
@@ -575,9 +582,9 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
       <div>
         <Link
           href="/dashboard/tasks"
-          className="mb-6 flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-300"
+          className="group mb-8 inline-flex items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-zinc-300"
         >
-          <ArrowLeftIcon className="h-3.5 w-3.5" />
+          <ArrowLeftIcon className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-0.5" />
           Back to tasks
         </Link>
         <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-6">
@@ -596,9 +603,9 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
       {/* Back link */}
       <Link
         href="/dashboard/tasks"
-        className="mb-6 flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-300"
+        className="group mb-8 inline-flex items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-zinc-300"
       >
-        <ArrowLeftIcon className="h-3.5 w-3.5" />
+        <ArrowLeftIcon className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-0.5" />
         Back to tasks
       </Link>
 
@@ -606,16 +613,23 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
       <div className="mb-6 rounded-xl border border-white/[0.06] bg-[#141414] p-6">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
+            {/* Status pill */}
             <div className="flex items-center gap-3">
-              <span className={`inline-block h-3 w-3 rounded-full ${statusDotColor(task.status)}`} />
-              <span className={`text-sm font-semibold ${statusColor(task.status)}`}>
-                {statusLabel(task.status)}
-              </span>
+              <div className={`inline-flex items-center gap-2 rounded-full px-3 py-1 ${statusBgColor(task.status)}`}>
+                <span className={`h-2 w-2 rounded-full ${statusDotColor(task.status)} ${
+                  task.status === "running" ? "animate-pulse" : ""
+                }`} />
+                <span className={`text-xs font-semibold ${statusColor(task.status)}`}>
+                  {statusLabel(task.status)}
+                </span>
+              </div>
               {task.status === "running" && (
-                <SpinnerIcon />
+                <SpinnerIcon className="h-3.5 w-3.5 animate-spin text-blue-400" />
               )}
             </div>
-            <p className="mt-3 text-sm text-[#fafafa]">{task.prompt}</p>
+
+            {/* Prompt */}
+            <p className="mt-4 text-[15px] leading-relaxed text-zinc-200">{task.prompt}</p>
           </div>
 
           {/* Action buttons */}
@@ -627,7 +641,7 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
                 disabled={actionBusy !== null}
                 className="flex items-center gap-1.5 rounded-lg bg-honey-500 px-3 py-1.5 text-xs font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {actionBusy === "retry" ? <SpinnerIcon /> : <RetryIcon className="h-3.5 w-3.5" />}
+                {actionBusy === "retry" ? <SpinnerIcon className="h-3.5 w-3.5 animate-spin" /> : <RetryIcon className="h-3.5 w-3.5" />}
                 Retry
               </button>
             )}
@@ -638,7 +652,7 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
                 disabled={actionBusy !== null}
                 className="flex items-center gap-1.5 rounded-lg border border-red-500/20 px-3 py-1.5 text-xs font-semibold text-red-400 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {actionBusy === "delete" ? <SpinnerIcon /> : <TrashIcon className="h-3.5 w-3.5" />}
+                {actionBusy === "delete" ? <SpinnerIcon className="h-3.5 w-3.5 animate-spin" /> : <TrashIcon className="h-3.5 w-3.5" />}
                 Delete
               </button>
             )}
@@ -653,27 +667,27 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
         )}
 
         {/* Metadata */}
-        <dl className="mt-4 grid grid-cols-2 gap-3 border-t border-white/[0.06] pt-4 text-xs sm:grid-cols-3">
+        <dl className="mt-5 grid grid-cols-2 gap-4 border-t border-white/[0.06] pt-5 sm:grid-cols-3">
           <div>
-            <dt className="text-zinc-600">Repos</dt>
-            <dd className="mt-0.5 font-mono text-zinc-400">{task.repos.join(", ")}</dd>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-zinc-600">Repos</dt>
+            <dd className="mt-1 font-mono text-xs text-zinc-400">{task.repos.join(", ")}</dd>
           </div>
           <div>
-            <dt className="text-zinc-600">Created</dt>
-            <dd className="mt-0.5 text-zinc-400">{relativeTime(task.created_at)}</dd>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-zinc-600">Created</dt>
+            <dd className="mt-1 text-xs text-zinc-400" title={formatTime(task.created_at)}>
+              {relativeTime(task.created_at)}
+            </dd>
           </div>
           <div>
-            <dt className="text-zinc-600">Timeout</dt>
-            <dd className="mt-0.5 text-zinc-400">{task.timeout_secs}s</dd>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-zinc-600">Timeout</dt>
+            <dd className="mt-1 text-xs text-zinc-400">{task.timeout_secs}s</dd>
           </div>
         </dl>
 
-        {/* Progress bar for running tasks */}
+        {/* Progress */}
         {task.progress && !isTerminal(task.status) && task.status !== "needs_follow_up" && (
           <div className="mt-4 border-t border-white/[0.06] pt-4">
-            <p className="text-xs text-zinc-500">
-              {task.progress}
-            </p>
+            <p className="text-xs text-zinc-500">{task.progress}</p>
           </div>
         )}
 
@@ -683,80 +697,87 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
             <p className="text-sm text-red-400">{task.error}</p>
           </div>
         )}
-
       </div>
 
-      {/* Message timeline */}
+      {/* Messages */}
       <div className="rounded-xl border border-white/[0.06] bg-[#141414] p-6">
-        <h3 className="mb-4 text-sm font-semibold text-[#fafafa]">Timeline</h3>
-
         {messages.length === 0 ? (
-          <p className="text-sm text-zinc-500">No messages yet.</p>
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-white/[0.04]">
+              <MessageSquareIcon className="h-4 w-4 text-zinc-600" />
+            </div>
+            <p className="text-sm text-zinc-500">No messages yet</p>
+            <p className="mt-1 text-xs text-zinc-700">
+              Messages will appear here once the task starts.
+            </p>
+          </div>
         ) : (
-          <div>
+          <div className="space-y-6">
             {messages.map((msg, i) => {
               const isTermSys = isTerminalSystemMessage(msg);
               const isSuccess = isTermSys && msg.content === "Task completed.";
               const isFailure = isTermSys && !isSuccess;
-              const isLast = i === messages.length - 1;
 
-              // System messages render as compact status indicators
+              // System messages render as centered status dividers
               if (msg.role === "system") {
                 return (
-                  <div key={`${msg.created_at}-${i}`} className="flex gap-3">
-                    <div className="flex w-4 flex-col items-center">
-                      {i > 0 && <div className="w-px flex-1 bg-white/[0.06]" />}
-                      <div className={`my-1 h-2 w-2 shrink-0 rounded-full ${
-                        isSuccess ? "bg-green-400" : isFailure ? "bg-red-400" : "bg-zinc-700"
+                  <div key={`${msg.created_at}-${i}`} className="flex items-center gap-3 py-1">
+                    <div className="h-px flex-1 bg-white/[0.06]" />
+                    <div className="flex shrink-0 items-center gap-2.5">
+                      <span className={`h-2.5 w-2.5 rounded-full ${
+                        isSuccess ? "bg-green-400" : isFailure ? "bg-red-400" : "bg-zinc-600"
                       }`} />
-                      {!isLast && <div className="w-px flex-1 bg-white/[0.06]" />}
-                    </div>
-                    <div className="flex min-w-0 flex-1 items-center gap-2 py-1.5">
-                      <span className={`text-xs ${
-                        isSuccess ? "font-medium text-green-400" : isFailure ? "font-medium text-red-400" : "text-zinc-600"
+                      <span className={`text-xs font-medium ${
+                        isSuccess ? "text-green-400" : isFailure ? "text-red-400" : "text-zinc-500"
                       }`}>
                         {msg.content}
                       </span>
-                      <span className="text-xs text-zinc-800">{relativeTime(msg.created_at)}</span>
+                      <span className="text-xs text-zinc-600">{relativeTime(msg.created_at)}</span>
                     </div>
+                    <div className="h-px flex-1 bg-white/[0.06]" />
                   </div>
                 );
               }
 
-              // User and agent messages render as conversation cards
+              // User / agent messages render as chat bubbles
+              const isUser = msg.role === "user";
+
               return (
-                <div key={`${msg.created_at}-${i}`} className="flex gap-3">
-                  <div className="flex w-4 flex-col items-center">
-                    {i > 0 && <div className="w-px flex-1 bg-white/[0.06]" />}
-                    <div className="my-1.5 shrink-0">
-                      {msg.role === "user" ? (
-                        <UserIcon className="h-4 w-4 text-honey-500/70" />
-                      ) : (
-                        <BotIcon className="h-4 w-4 text-blue-400/70" />
-                      )}
-                    </div>
-                    {!isLast && <div className="w-px flex-1 bg-white/[0.06]" />}
+                <div key={`${msg.created_at}-${i}`} className="flex gap-3.5">
+                  {/* Avatar */}
+                  <div className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
+                    isUser
+                      ? "bg-honey-500/10 ring-1 ring-honey-500/20"
+                      : "bg-blue-500/10 ring-1 ring-blue-500/20"
+                  }`}>
+                    {isUser ? (
+                      <UserIcon className="h-3.5 w-3.5 text-honey-500" />
+                    ) : (
+                      <BotIcon className="h-3.5 w-3.5 text-blue-400" />
+                    )}
                   </div>
-                  <div className="min-w-0 flex-1 py-1.5">
+
+                  {/* Content */}
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-2 flex items-baseline gap-2">
+                      <span className={`text-[13px] font-semibold ${
+                        isUser ? "text-honey-500" : "text-blue-400"
+                      }`}>
+                        {isUser ? "You" : "Agent"}
+                      </span>
+                      <span className="text-xs text-zinc-600">{relativeTime(msg.created_at)}</span>
+                    </div>
                     <div className={`rounded-lg px-4 py-3 ${
-                      msg.role === "user"
-                        ? "border border-honey-500/10 bg-honey-500/5"
-                        : "border border-blue-500/10 bg-blue-500/5"
+                      isUser
+                        ? "bg-honey-500/[0.06]"
+                        : "bg-blue-500/[0.04]"
                     }`}>
-                      <div className="flex items-center gap-2">
-                        <span className={`text-xs font-medium ${
-                          msg.role === "user" ? "text-honey-500/70" : "text-blue-400/70"
-                        }`}>
-                          {msg.role === "user" ? "You" : "Agent"}
-                        </span>
-                        <span className="text-xs text-zinc-700">{relativeTime(msg.created_at)}</span>
-                      </div>
                       {msg.role === "agent" ? (
-                        <div className="mt-1 max-h-96 overflow-auto">
+                        <div className="max-h-[32rem] overflow-auto">
                           <MarkdownContent>{msg.content}</MarkdownContent>
                         </div>
                       ) : (
-                        <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-300">
+                        <p className="whitespace-pre-wrap text-sm leading-relaxed text-zinc-300">
                           {msg.content}
                         </p>
                       )}
@@ -769,36 +790,39 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
           </div>
         )}
 
-        {/* Follow-up input — shown when task needs follow-up */}
+        {/* Follow-up input */}
         {task.status === "needs_follow_up" && (
-          <div className="mt-4 border-t border-white/[0.06] pt-4">
-            <div className="mb-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3">
-              <p className="text-sm text-amber-400">
-                The agent is waiting for your input to continue working on this task.
-              </p>
+          <div className="mt-6 border-t border-white/[0.06] pt-5">
+            <div className="mb-4 flex items-center gap-2.5">
+              <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-amber-500/10">
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
+              </div>
+              <span className="text-sm text-amber-400">
+                The agent is waiting for your input to continue.
+              </span>
             </div>
 
             {followUpError && (
-              <div className="mb-3 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">
+              <div className="mb-3 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-2.5">
                 <p className="text-sm text-red-400">{followUpError}</p>
               </div>
             )}
 
-            <form onSubmit={handleFollowUp} className="flex gap-3">
+            <form onSubmit={handleFollowUp} className="flex items-end gap-3">
               <textarea
                 rows={2}
                 value={followUpText}
                 onChange={(e) => setFollowUpText(e.target.value)}
-                placeholder="Type your follow-up message…"
-                className="flex-1 resize-y rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2.5 text-sm text-[#fafafa] placeholder-zinc-600 transition-colors focus:border-honey-500/50 focus:outline-none focus:ring-1 focus:ring-honey-500/20"
+                placeholder="Type your follow-up message..."
+                className="flex-1 resize-y rounded-xl border border-white/[0.08] bg-white/[0.03] px-4 py-3 text-sm text-[#fafafa] placeholder-zinc-600 transition-all focus:border-honey-500/30 focus:outline-none focus:ring-2 focus:ring-honey-500/10"
               />
               <button
                 type="submit"
                 disabled={followUpSubmitting}
-                className="flex h-10 shrink-0 items-center gap-2 self-end rounded-lg bg-honey-500 px-4 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-xl bg-honey-500 text-[#0a0a0a] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {followUpSubmitting ? (
-                  <SpinnerIcon />
+                  <SpinnerIcon className="h-4 w-4 animate-spin" />
                 ) : (
                   <SendIcon className="h-4 w-4" />
                 )}


### PR DESCRIPTION
## Summary

The task detail timeline/chat UI was sloppy with alignment issues and weak visual hierarchy. This rewrites the message rendering with a clean, professional chat interface.

Fixes the misaligned timeline icons, near-invisible message cards, and cramped layout.

## What it looks like

### Before
- Tiny 16px icons used as avatars, floating on a thin timeline spine
- Message card backgrounds at 5% opacity — barely visible
- System status messages cramped with 8px dots
- Timestamps at `text-zinc-700`/`text-zinc-800` — nearly invisible on dark bg
- Basic dot + text status display

### After

| Element | Before | After |
|---|---|---|
| Avatars | 16px bare icons on timeline spine | 32px circles with tinted bg + ring border |
| Status | Bare dot + text | Pill badge with status-colored background |
| Messages | Barely-visible 5% bg cards | Distinct warm/cool tinted cards (6%/4%) |
| System events | Cramped dot on timeline | Centered dividers spanning full width |
| Metadata labels | `text-zinc-600` lowercase | Uppercase tracking-wider (dashboard-grade) |
| Empty state | Plain "No messages yet." text | Centered icon + helper text |
| Follow-up input | Rectangular textarea + button | Rounded composer with square send button |
| Back link | Static | Arrow slides left on hover |

## Test plan

- [ ] View a task with messages — verify user and agent messages display correctly with proper avatars
- [ ] View a completed task — verify green "Task completed." divider renders centered
- [ ] View a failed task — verify red failure divider renders correctly
- [ ] View a task with no messages — verify empty state with icon and helper text
- [ ] View a running task — verify status pill shows animated pulse dot + spinner
- [ ] View a needs_follow_up task — verify follow-up composer appears with pulsing amber dot
- [ ] Submit a follow-up message — verify it sends and appears in the timeline
- [ ] Hover the "Back to tasks" link — verify arrow slides left
- [ ] Verify TypeScript and lint pass (confirmed locally)