### PR TITLE
refactor(web): extract shared TaskRecord/TaskMessage types

### DIFF
--- a/apps/web/src/app/dashboard/tasks/TasksDashboard.tsx
+++ b/apps/web/src/app/dashboard/tasks/TasksDashboard.tsx
@@ -2,25 +2,11 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { type TaskRecord } from "./types";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface TaskRecord {
-  task_id: string;
-  status: string;
-  prompt: string;
-  repos: string[];
-  timeout_secs: number;
-  created_by: string;
-  created_at: string;
-  updated_at: string;
-  started_at?: string;
-  finished_at?: string;
-  error?: string;
-  progress?: string;
-}
 
 type CreateFormStatus = "idle" | "submitting" | "success" | "error";
 

--- a/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -4,31 +4,7 @@ import Link from "next/link";
 import Markdown, { type ExtraProps } from "react-markdown";
 import { useRouter } from "next/navigation";
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface TaskRecord {
-  task_id: string;
-  status: string;
-  prompt: string;
-  repos: string[];
-  timeout_secs: number;
-  created_by: string;
-  created_at: string;
-  updated_at: string;
-  started_at?: string;
-  finished_at?: string;
-  error?: string;
-  progress?: string;
-}
-
-interface TaskMessage {
-  role: "user" | "agent" | "system";
-  content: string;
-  created_at: string;
-}
+import { type TaskRecord, type TaskMessage } from "../types";
 
 // ---------------------------------------------------------------------------
 // Icons

--- a/apps/web/src/app/dashboard/tasks/types.ts
+++ b/apps/web/src/app/dashboard/tasks/types.ts
@@ -1,0 +1,20 @@
+export interface TaskRecord {
+  task_id: string;
+  status: string;
+  prompt: string;
+  repos: string[];
+  timeout_secs: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  finished_at?: string;
+  error?: string;
+  progress?: string;
+}
+
+export interface TaskMessage {
+  role: "user" | "agent" | "system";
+  content: string;
+  created_at: string;
+}


### PR DESCRIPTION
Closes #268

## What

Creates `apps/web/src/app/dashboard/tasks/types.ts` to hold the shared `TaskRecord` and `TaskMessage` interfaces that were duplicated between `TasksDashboard.tsx` and `TaskDetail.tsx`.

Both components now import from the shared types file, eliminating the maintenance burden of keeping two identical interface definitions in sync as the task schema evolves.

Follows the pattern established in #265 and prevents drift risk flagged in issue #268.

## Why

`TaskRecord` and `TaskMessage` were defined independently in both `TasksDashboard.tsx` and `TaskDetail.tsx`. They share the same route tree under `apps/web/src/app/dashboard/tasks/` and the interfaces are identical.

If fields change in the task store (e.g., new status added, field renamed), both files need updating separately. A single `types.ts` in `tasks/` eliminates that drift risk.

## Validation

- `npm run typecheck` — clean
- `npm test` — all tests pass
- No behavioral changes — pure refactor