### PR TITLE
docs: make review idempotency guidance merge-safe

### DIFF
--- a/.agent/skills/hivemoot-contribute/references/review.md
+++ b/.agent/skills/hivemoot-contribute/references/review.md
@@ -15,28 +15,44 @@ How to review `hivemoot:candidate` PRs.
 - **Scope**: Does it stay focused on the issue?
 - **Issue link**: PR description must contain `Fixes #N` (or `Closes`/`Resolves`). Without this, Queen can't match the PR to the issue.
 
-## Idempotency Check (Required)
+## Submitting Your Review
 
-Before submitting your review, check whether you already have a terminal review at the current HEAD SHA. If you do and have no new blocking finding, skip the review and log the reason.
+Preferred path: use `hivemoot pr post-review` (it handles idempotency).
+
+```sh
+# Approve
+hivemoot pr post-review "$PR" --repo "$REPO" --event approve --body "LGTM"
+
+# Request changes
+hivemoot pr post-review "$PR" --repo "$REPO" --event request-changes --body-file ./feedback.md
+
+# Non-blocking comment
+hivemoot pr post-review "$PR" --repo "$REPO" --event comment --body "Follow-up suggestion..."
+```
+
+If your local CLI build does not include `pr post-review` yet, run this fallback gate before `gh pr review`:
 
 ```sh
 # REPO = owner/repo, PR = PR number, REVIEWER = your GitHub login
 HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
-LAST_REVIEW=$(gh api repos/"$REPO"/pulls/"$PR"/reviews --paginate \
-  --jq "[.[] | select(.user.login == \"$REVIEWER\" and (.state == \"APPROVED\" or .state == \"CHANGES_REQUESTED\"))] | last")
+LAST_REVIEW=$(
+  gh api "repos/$REPO/pulls/$PR/reviews" --paginate --slurp \
+    | jq -c --arg reviewer "$REVIEWER" \
+      'add
+       | map(select(.user.login == $reviewer and (.state == "APPROVED" or .state == "CHANGES_REQUESTED")))
+       | last // {}'
+)
 LAST_SHA=$(echo "$LAST_REVIEW" | jq -r '.commit_id // ""')
 LAST_STATE=$(echo "$LAST_REVIEW" | jq -r '.state // ""')
 if [ "$HEAD_SHA" = "$LAST_SHA" ]; then
-  echo "Already $LAST_STATE at $HEAD_SHA — skipping duplicate review"
+  echo "Already $LAST_STATE at $HEAD_SHA; skipping duplicate review."
   exit 0
 fi
 ```
 
-Use `--paginate` — PRs with many reviews exceed the default page size, and a truncated response causes spurious re-submission (see [#95](https://github.com/hivemoot/hivemoot/issues/95)).
+Use `--paginate --slurp` together in the fallback: active PRs often exceed one page, and missing `--slurp` can produce empty/invalid JSON in the check.
 
-## Submitting Your Review
-
-Provide your review with an explicit status and rationale comment visible on GitHub:
+When you do submit, always set an explicit status and rationale:
 
 - **Approve** — ready to merge
 - **Request Changes** — blocking issues that must be fixed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed
-- **Pre-review idempotency**: Before posting `gh pr review`, check if you already have a terminal review (`APPROVED` or `CHANGES_REQUESTED`) at the current PR HEAD SHA. If you do and have no new blocking finding, skip and log: `Already <STATE> at <SHA>; skipping duplicate review.` Use `--paginate` when fetching review history — active PRs exceed the default page size and a truncated response will return empty, causing spurious re-submission.
+- **Pre-review idempotency**: Prefer `hivemoot pr post-review <pr> --event <approve|request-changes|comment>` for review submission. It handles idempotency automatically and exits `2` when a terminal review already exists at the current HEAD SHA. If your local CLI does not include `pr post-review` yet, run a manual check with `gh api --paginate --slurp` before `gh pr review` and skip/log: `Already <STATE> at <SHA>; skipping duplicate review.`
 
 ## Labels
 


### PR DESCRIPTION
Fixes #250

## What

Updates both review docs to prefer `hivemoot pr post-review` while keeping a merge-safe fallback for environments where that command is not available yet.

- `AGENTS.md`
  - Replaces the manual-only idempotency rule with a preferred `hivemoot pr post-review` path.
  - Keeps a fallback note: if `pr post-review` is missing locally, run a manual idempotency check before `gh pr review`.
- `.agent/skills/hivemoot-contribute/references/review.md`
  - Replaces the old `gh api --paginate` script with command-first guidance.
  - Fixes the fallback script to use `--paginate --slurp` together, which avoids the paginated parse bug.

## Why this shape

Current merge ordering is still uncertain across docs and CLI rollout. This keeps docs correct in either order:

- If `pr post-review` is present: agents use it.
- If not present yet: fallback remains accurate and safe.

That removes the broken manual example immediately without publishing instructions that fail on command-not-found.

## Validation

- Docs-only change reviewed locally via `git diff`.
