### PR TITLE
feat(cli): add ghPaginatedList helper and migrate all notification callers

### DIFF
--- a/cli/src/github/client.test.ts
+++ b/cli/src/github/client.test.ts
@@ -17,7 +17,7 @@ import { promisify } from "util";
 const execFilePromisified = promisify(execFile) as unknown as ReturnType<typeof vi.fn>;
 
 // Dynamic import so the module picks up our mock
-const { gh, setGhToken, ghWithHeaders, parseHeadersAndBody } = await import("./client.js");
+const { gh, setGhToken, ghWithHeaders, parseHeadersAndBody, ghPaginatedList } = await import("./client.js");
 
 function mockSuccess(stdout: string) {
   execFilePromisified.mockResolvedValue({ stdout, stderr: "" });
@@ -221,6 +221,7 @@ describe("parseHeadersAndBody()", () => {
 });
 
 describe("ghWithHeaders()", () => {
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -274,6 +275,64 @@ describe("ghWithHeaders()", () => {
     );
 
     await expect(ghWithHeaders(["api", "-i", "/repos/foo/bar/notifications"])).rejects.toMatchObject({
+      code: "GH_ERROR",
+    });
+  });
+});
+
+describe("ghPaginatedList()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gh with --paginate --slurp and the given api path", async () => {
+    mockSuccess(JSON.stringify([[{ id: 1 }]]));
+
+    await ghPaginatedList("/repos/foo/bar/notifications");
+
+    expect(execFilePromisified.mock.calls[0][1]).toEqual([
+      "api", "--paginate", "--slurp", "/repos/foo/bar/notifications",
+    ]);
+  });
+
+  it("returns flattened items from a single page", async () => {
+    mockSuccess(JSON.stringify([[{ id: 1 }, { id: 2 }]]));
+
+    const result = await ghPaginatedList<{ id: number }>("/repos/foo/bar/items");
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("returns flattened items from multiple pages", async () => {
+    mockSuccess(JSON.stringify([[{ id: 1 }], [{ id: 2 }, { id: 3 }]]));
+
+    const result = await ghPaginatedList<{ id: number }>("/repos/foo/bar/items");
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it("returns empty array for empty response", async () => {
+    mockSuccess(JSON.stringify([[]]));
+
+    const result = await ghPaginatedList("/repos/foo/bar/items");
+
+    expect(result).toEqual([]);
+  });
+
+  it("throws CliError on invalid JSON response", async () => {
+    mockSuccess("this is not json");
+
+    await expect(ghPaginatedList("/repos/foo/bar/items")).rejects.toThrow(CliError);
+    await expect(ghPaginatedList("/repos/foo/bar/items")).rejects.toMatchObject({
+      code: "GH_ERROR",
+    });
+  });
+
+  it("throws CliError when response is a non-array (e.g. object)", async () => {
+    mockSuccess(JSON.stringify({ unexpected: true }));
+
+    await expect(ghPaginatedList("/repos/foo/bar/items")).rejects.toThrow(CliError);
+    await expect(ghPaginatedList("/repos/foo/bar/items")).rejects.toMatchObject({
       code: "GH_ERROR",
     });
   });

--- a/cli/src/github/client.ts
+++ b/cli/src/github/client.ts
@@ -138,3 +138,35 @@ export async function ghWithHeaders(args: string[]): Promise<GhHeadersResult> {
     handleGhError(err);
   }
 }
+
+/**
+ * Fetch a paginated GitHub API endpoint and return all items as a flat array.
+ *
+ * Uses `--paginate --slurp` to collect all pages into an outer array, then
+ * flattens them. Throws a typed CliError on parse failure or unexpected shape
+ * rather than silently returning an empty list.
+ */
+export async function ghPaginatedList<T>(apiPath: string): Promise<T[]> {
+  const raw = await gh(["api", "--paginate", "--slurp", apiPath]);
+
+  let pages: unknown;
+  try {
+    pages = JSON.parse(raw);
+  } catch {
+    throw new CliError(
+      `Failed to parse paginated response for ${apiPath}`,
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  if (!Array.isArray(pages)) {
+    throw new CliError(
+      `Unexpected non-array response from GitHub API: ${apiPath}`,
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  return (pages as T[][]).flat();
+}

--- a/cli/src/github/fetch-notifications.test.ts
+++ b/cli/src/github/fetch-notifications.test.ts
@@ -3,7 +3,7 @@ import { CliError } from "../config/types.js";
 
 vi.mock("./client.js", async (importActual) => {
   const actual = await importActual<typeof import("./client.js")>();
-  return { ...actual, gh: vi.fn() };
+  return { ...actual, ghPaginatedList: vi.fn() };
 });
 
 vi.mock("../watch/state.js", () => ({
@@ -11,11 +11,11 @@ vi.mock("../watch/state.js", () => ({
   buildLatestProcessedByThread: vi.fn(),
 }));
 
-import { gh } from "./client.js";
+import { ghPaginatedList } from "./client.js";
 import { loadState, buildLatestProcessedByThread } from "../watch/state.js";
 import { fetchNotificationsPull } from "./fetch-notifications.js";
 
-const mockedGh = vi.mocked(gh);
+const mockedGhPaginatedList = vi.mocked(ghPaginatedList);
 const mockedLoadState = vi.mocked(loadState);
 const mockedBuildLatest = vi.mocked(buildLatestProcessedByThread);
 
@@ -53,20 +53,17 @@ beforeEach(() => {
 
 describe("fetchNotificationsPull()", () => {
   describe("basic fetching", () => {
-    it("calls gh with --paginate --slurp on the notifications endpoint", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[]]));
+    it("calls ghPaginatedList with the notifications endpoint path", async () => {
+      mockedGhPaginatedList.mockResolvedValue([]);
       mockedLoadState.mockResolvedValue({ lastChecked: "", processedThreadIds: [] });
       await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
-      expect(mockedGh).toHaveBeenCalledWith([
-        "api",
-        "--paginate",
-        "--slurp",
-        "/repos/hivemoot/hivemoot/notifications?all=false",
-      ]);
+      expect(mockedGhPaginatedList).toHaveBeenCalledWith(
+        "/repos/hivemoot/hivemoot/notifications?all=false"
+      );
     });
 
     it("returns schema-versioned result with kind notifications_pull", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[]]));
+      mockedGhPaginatedList.mockResolvedValue([]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.schemaVersion).toBe(1);
       expect(result.kind).toBe("notifications_pull");
@@ -74,15 +71,15 @@ describe("fetchNotificationsPull()", () => {
     });
 
     it("returns empty notifications array when no notifications", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[]]));
+      mockedGhPaginatedList.mockResolvedValue([]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.notifications).toHaveLength(0);
     });
 
-    it("handles multi-page responses (array of arrays)", async () => {
+    it("handles multi-page responses (already flattened by ghPaginatedList)", async () => {
       const page1 = [makeRawNotification({ id: "thread-1" })];
       const page2 = [makeRawNotification({ id: "thread-2", updated_at: "2026-03-03T11:00:00Z" })];
-      mockedGh.mockResolvedValue(JSON.stringify([page1, page2]));
+      mockedGhPaginatedList.mockResolvedValue([...page1, ...page2]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.notifications).toHaveLength(2);
     });
@@ -90,16 +87,16 @@ describe("fetchNotificationsPull()", () => {
 
   describe("filtering", () => {
     it("skips non-unread notifications", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[
+      mockedGhPaginatedList.mockResolvedValue([
         makeRawNotification({ unread: false }),
-      ]]));
+      ]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.notifications).toHaveLength(0);
     });
 
     it("skips non-Issue/PR notification types", async () => {
       const n = makeRawNotification({ type: "Release" });
-      mockedGh.mockResolvedValue(JSON.stringify([[n]]));
+      mockedGhPaginatedList.mockResolvedValue([n]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.notifications).toHaveLength(0);
     });
@@ -107,7 +104,7 @@ describe("fetchNotificationsPull()", () => {
     it("applies reason filter when reasons does not include *", async () => {
       const mention = makeRawNotification({ reason: "mention" });
       const author = makeRawNotification({ id: "thread-2", reason: "author" });
-      mockedGh.mockResolvedValue(JSON.stringify([[mention, author]]));
+      mockedGhPaginatedList.mockResolvedValue([mention, author]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["mention"]);
       expect(result.notifications).toHaveLength(1);
       expect(result.notifications[0]!.reason).toBe("mention");
@@ -116,19 +113,19 @@ describe("fetchNotificationsPull()", () => {
     it("returns all reasons when reasons includes *", async () => {
       const mention = makeRawNotification({ reason: "mention" });
       const author = makeRawNotification({ id: "thread-2", reason: "author" });
-      mockedGh.mockResolvedValue(JSON.stringify([[mention, author]]));
+      mockedGhPaginatedList.mockResolvedValue([mention, author]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.notifications).toHaveLength(2);
     });
 
     it("sets reasons field to [*] when unfiltered", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[]]));
+      mockedGhPaginatedList.mockResolvedValue([]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.reasons).toEqual(["*"]);
     });
 
     it("sets reasons field to applied filter when filtered", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[]]));
+      mockedGhPaginatedList.mockResolvedValue([]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["mention", "review_requested"]);
       expect(result.reasons).toEqual(["mention", "review_requested"]);
     });
@@ -142,9 +139,9 @@ describe("fetchNotificationsPull()", () => {
         lastChecked: "2026-03-03T09:00:00Z",
         processedThreadIds: ["thread-1:2026-03-03T10:00:00Z"],
       });
-      mockedGh.mockResolvedValue(JSON.stringify([[
+      mockedGhPaginatedList.mockResolvedValue([
         makeRawNotification({ id: "thread-1", updated_at: "2026-03-03T10:00:00Z" }),
-      ]]));
+      ]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"], ".hivemoot-watch.json");
       expect(result.notifications).toHaveLength(0);
     });
@@ -156,15 +153,15 @@ describe("fetchNotificationsPull()", () => {
         lastChecked: "2026-03-03T09:00:00Z",
         processedThreadIds: ["thread-1:2026-03-03T09:00:00Z"],
       });
-      mockedGh.mockResolvedValue(JSON.stringify([[
+      mockedGhPaginatedList.mockResolvedValue([
         makeRawNotification({ id: "thread-1", updated_at: "2026-03-03T10:00:00Z" }),
-      ]]));
+      ]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"], ".hivemoot-watch.json");
       expect(result.notifications).toHaveLength(1);
     });
 
     it("proceeds without cursor when stateFilePath is not provided", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[makeRawNotification()]]));
+      mockedGhPaginatedList.mockResolvedValue([makeRawNotification()]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(mockedLoadState).not.toHaveBeenCalled();
       expect(result.notifications).toHaveLength(1);
@@ -172,7 +169,7 @@ describe("fetchNotificationsPull()", () => {
 
     it("proceeds without cursor when state file load fails", async () => {
       mockedLoadState.mockRejectedValue(new Error("file not found"));
-      mockedGh.mockResolvedValue(JSON.stringify([[makeRawNotification()]]));
+      mockedGhPaginatedList.mockResolvedValue([makeRawNotification()]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"], ".hivemoot-watch.json");
       expect(result.notifications).toHaveLength(1);
     });
@@ -180,9 +177,9 @@ describe("fetchNotificationsPull()", () => {
 
   describe("notification item shape", () => {
     it("includes correct fields for Issue notification", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[
+      mockedGhPaginatedList.mockResolvedValue([
         makeRawNotification({ id: "t1", reason: "mention", type: "Issue", title: "My issue" }),
-      ]]));
+      ]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       const n = result.notifications[0]!;
       expect(n.threadId).toBe("t1");
@@ -194,9 +191,9 @@ describe("fetchNotificationsPull()", () => {
     });
 
     it("includes correct fields for PullRequest notification", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify([[
+      mockedGhPaginatedList.mockResolvedValue([
         makeRawNotification({ type: "PullRequest" }),
-      ]]));
+      ]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       const n = result.notifications[0]!;
       expect(n.itemType).toBe("PullRequest");
@@ -206,7 +203,7 @@ describe("fetchNotificationsPull()", () => {
     it("sets number to null when subject URL has no parseable number", async () => {
       const n = makeRawNotification();
       n.subject.url = "https://api.github.com/repos/hivemoot/hivemoot/issues/not-a-number";
-      mockedGh.mockResolvedValue(JSON.stringify([[n]]));
+      mockedGhPaginatedList.mockResolvedValue([n]);
       const result = await fetchNotificationsPull("hivemoot/hivemoot", ["*"]);
       expect(result.notifications[0]!.number).toBeNull();
       expect(result.notifications[0]!.url).toBeNull();
@@ -214,16 +211,20 @@ describe("fetchNotificationsPull()", () => {
   });
 
   describe("error handling", () => {
-    it("throws CliError on invalid JSON response", async () => {
-      mockedGh.mockResolvedValue("not json");
+    it("propagates CliError from ghPaginatedList (e.g. parse failure)", async () => {
+      mockedGhPaginatedList.mockRejectedValue(
+        new CliError("Failed to parse paginated response", "GH_ERROR", 1)
+      );
       await expect(fetchNotificationsPull("hivemoot/hivemoot", ["*"])).rejects.toMatchObject({
         code: "GH_ERROR",
         message: expect.stringContaining("Failed to parse"),
       });
     });
 
-    it("throws CliError when response is not an array", async () => {
-      mockedGh.mockResolvedValue(JSON.stringify({ error: "bad" }));
+    it("propagates CliError from ghPaginatedList (e.g. unexpected shape)", async () => {
+      mockedGhPaginatedList.mockRejectedValue(
+        new CliError("Unexpected paginated response shape", "GH_ERROR", 1)
+      );
       await expect(fetchNotificationsPull("hivemoot/hivemoot", ["*"])).rejects.toMatchObject({
         code: "GH_ERROR",
         message: expect.stringContaining("Unexpected"),
@@ -231,7 +232,7 @@ describe("fetchNotificationsPull()", () => {
     });
 
     it("propagates gh CliError as-is", async () => {
-      mockedGh.mockRejectedValue(new CliError("HTTP 403", "GH_ERROR", 1));
+      mockedGhPaginatedList.mockRejectedValue(new CliError("HTTP 403", "GH_ERROR", 1));
       await expect(fetchNotificationsPull("hivemoot/hivemoot", ["*"])).rejects.toMatchObject({
         code: "GH_ERROR",
         message: "HTTP 403",

--- a/cli/src/github/fetch-notifications.test.ts
+++ b/cli/src/github/fetch-notifications.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CliError } from "../config/types.js";
 
-vi.mock("./client.js", () => ({
-  gh: vi.fn(),
-}));
+vi.mock("./client.js", async (importActual) => {
+  const actual = await importActual<typeof import("./client.js")>();
+  return { ...actual, gh: vi.fn() };
+});
 
 vi.mock("../watch/state.js", () => ({
   loadState: vi.fn(),

--- a/cli/src/github/fetch-notifications.ts
+++ b/cli/src/github/fetch-notifications.ts
@@ -1,5 +1,4 @@
-import { CliError } from "../config/types.js";
-import { gh } from "./client.js";
+import { ghPaginatedList } from "./client.js";
 import { parseSubjectNumber } from "./notifications.js";
 import { buildLatestProcessedByThread, loadState } from "../watch/state.js";
 
@@ -69,33 +68,9 @@ export async function fetchNotificationsPull(
     }
   }
 
-  const raw = await gh([
-    "api",
-    "--paginate",
-    "--slurp",
+  const allNotifications = await ghPaginatedList<RawNotification>(
     `/repos/${repo}/notifications?all=false`,
-  ]);
-
-  let pages: RawNotification[][];
-  try {
-    pages = JSON.parse(raw) as RawNotification[][];
-  } catch {
-    throw new CliError(
-      "Failed to parse GitHub notifications API response",
-      "GH_ERROR",
-      1,
-    );
-  }
-
-  if (!Array.isArray(pages)) {
-    throw new CliError(
-      "Unexpected GitHub notifications API response shape",
-      "GH_ERROR",
-      1,
-    );
-  }
-
-  const allNotifications = pages.flat();
+  );
   const filterByReason = reasons.length > 0 && !reasons.includes("*");
 
   const items: NotificationItem[] = [];

--- a/cli/src/github/notifications.test.ts
+++ b/cli/src/github/notifications.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("./client.js", () => ({
   gh: vi.fn(),
   ghWithHeaders: vi.fn(),
+  ghPaginatedList: vi.fn(),
 }));
 
-import { gh, ghWithHeaders } from "./client.js";
+import { gh, ghPaginatedList, ghWithHeaders } from "./client.js";
 import {
   fetchNotifications,
   fetchMentionNotifications,
@@ -26,6 +27,7 @@ import { CliError } from "../config/types.js";
 
 const mockedGh = vi.mocked(gh);
 const mockedGhWithHeaders = vi.mocked(ghWithHeaders);
+const mockedGhPaginatedList = vi.mocked(ghPaginatedList);
 const repo = { owner: "hivemoot", repo: "colony" };
 
 beforeEach(() => {
@@ -71,9 +73,9 @@ describe("parseSubjectNumber()", () => {
 
 describe("fetchNotifications()", () => {
   it("returns map of unread notifications keyed by issue number", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ reason: "mention", updated_at: "2025-06-15T10:00:00Z" }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(1);
@@ -87,44 +89,41 @@ describe("fetchNotifications()", () => {
     });
   });
 
-  it("calls gh with --paginate --slurp and correct API path", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+  it("calls ghPaginatedList with correct API path", async () => {
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     await fetchNotifications(repo);
 
-    expect(mockedGh).toHaveBeenCalledWith([
-      "api",
-      "--paginate",
-      "--slurp",
-      "/repos/hivemoot/colony/notifications",
-    ]);
+    expect(mockedGhPaginatedList).toHaveBeenCalledWith(
+      "/repos/hivemoot/colony/notifications"
+    );
   });
 
   it("filters out read notifications", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ unread: false }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(0);
   });
 
   it("filters out non-issue/PR subject types", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ subject: { url: "https://api.github.com/repos/hivemoot/colony/releases/5", type: "Release" } }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(0);
   });
 
   it("handles PullRequest subject type", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({
         subject: { url: "https://api.github.com/repos/hivemoot/colony/pulls/99", type: "PullRequest", title: "Add search", latest_comment_url: null },
         reason: "review_requested",
       }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(1);
@@ -139,10 +138,10 @@ describe("fetchNotifications()", () => {
   });
 
   it("keeps most recent notification when duplicates exist for same item", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ reason: "comment", updated_at: "2025-06-15T08:00:00Z" }),
       makeNotification({ reason: "mention", updated_at: "2025-06-15T12:00:00Z" }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(1);
@@ -157,17 +156,17 @@ describe("fetchNotifications()", () => {
   });
 
   it("keeps earlier notification when it appears after a later one", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ reason: "mention", updated_at: "2025-06-15T12:00:00Z" }),
       makeNotification({ reason: "comment", updated_at: "2025-06-15T08:00:00Z" }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.get(42)?.reason).toBe("mention");
   });
 
   it("handles multiple different items", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({
         subject: { url: "https://api.github.com/repos/hivemoot/colony/issues/10", type: "Issue", title: "Bug report", latest_comment_url: null },
         reason: "comment",
@@ -176,7 +175,7 @@ describe("fetchNotifications()", () => {
         subject: { url: "https://api.github.com/repos/hivemoot/colony/pulls/20", type: "PullRequest", title: "Refactor", latest_comment_url: null },
         reason: "author",
       }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(2);
@@ -184,7 +183,7 @@ describe("fetchNotifications()", () => {
     expect(result.get(20)?.reason).toBe("author");
   });
 
-  it("handles multi-page responses (array of arrays)", async () => {
+  it("handles multi-page responses (already flattened by ghPaginatedList)", async () => {
     const page1 = [makeNotification({ reason: "mention" })];
     const page2 = [
       makeNotification({
@@ -192,7 +191,7 @@ describe("fetchNotifications()", () => {
         subject: { url: "https://api.github.com/repos/hivemoot/colony/issues/43", type: "Issue", title: "Another issue", latest_comment_url: null },
       }),
     ];
-    mockedGh.mockResolvedValue(JSON.stringify([page1, page2]));
+    mockedGhPaginatedList.mockResolvedValue([...page1, ...page2]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(2);
@@ -201,18 +200,18 @@ describe("fetchNotifications()", () => {
   });
 
   it("returns empty map when API returns empty array", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(0);
   });
 
   it("skips notifications with unparseable subject URLs", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({
         subject: { url: "https://api.github.com/repos/hivemoot/colony", type: "Issue" },
       }),
-    ]]));
+    ]);
 
     const result = await fetchNotifications(repo);
     expect(result.size).toBe(0);
@@ -220,71 +219,60 @@ describe("fetchNotifications()", () => {
 });
 
 describe("fetchMentionNotifications()", () => {
-  it("calls gh with --paginate --slurp and repo and all=false (no since by default)", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+  it("calls ghPaginatedList with repo and all=false (no since by default)", async () => {
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     await fetchMentionNotifications("hivemoot/colony", ["mention"]);
 
-    expect(mockedGh).toHaveBeenCalledWith([
-      "api",
-      "--paginate",
-      "--slurp",
-      "/repos/hivemoot/colony/notifications?all=false",
-    ]);
+    expect(mockedGhPaginatedList).toHaveBeenCalledWith(
+      "/repos/hivemoot/colony/notifications?all=false"
+    );
   });
 
   it("includes since param when provided", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     await fetchMentionNotifications("hivemoot/colony", ["mention"], "2026-01-15T00:00:00Z");
 
-    expect(mockedGh).toHaveBeenCalledWith([
-      "api",
-      "--paginate",
-      "--slurp",
-      "/repos/hivemoot/colony/notifications?all=false&since=2026-01-15T00%3A00%3A00Z",
-    ]);
+    expect(mockedGhPaginatedList).toHaveBeenCalledWith(
+      "/repos/hivemoot/colony/notifications?all=false&since=2026-01-15T00%3A00%3A00Z"
+    );
   });
 
-  it("embeds params as URL query string, not as -f body fields", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+  it("embeds params as URL query string in the API path", async () => {
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     await fetchMentionNotifications("hivemoot/colony", ["mention"]);
 
-    const args = mockedGh.mock.calls[0][0];
-    // Must NOT contain -f flags (which send body fields and cause 404 on GET)
-    expect(args).not.toContain("-f");
-    // URL must contain query string
-    expect(args[3]).toMatch(/\?all=false/);
+    const apiPath = mockedGhPaginatedList.mock.calls[0]![0];
+    expect(apiPath).toMatch(/\?all=false/);
   });
 
   it("URL-encodes since timestamps with colons correctly", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     await fetchMentionNotifications("hivemoot/colony", ["mention"], "2026-02-13T02:11:08.000Z");
 
-    const url = mockedGh.mock.calls[0][0][3];
-    // Colons in ISO timestamps must be percent-encoded in the query string
-    expect(url).toContain("since=2026-02-13T02%3A11%3A08.000Z");
-    expect(url).not.toContain("-f");
+    const apiPath = mockedGhPaginatedList.mock.calls[0]![0];
+    expect(apiPath).toContain("since=2026-02-13T02%3A11%3A08.000Z");
   });
 
   it("omits since param when not provided", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[]]));
+    mockedGhPaginatedList.mockResolvedValue([]);
 
     await fetchMentionNotifications("hivemoot/colony", ["mention"]);
 
-    const url = mockedGh.mock.calls[0][0][3];
-    expect(url).not.toContain("since");
-    expect(url).toBe("/repos/hivemoot/colony/notifications?all=false");
+    const apiPath = mockedGhPaginatedList.mock.calls[0]![0];
+    expect(apiPath).not.toContain("since");
+    expect(apiPath).toBe("/repos/hivemoot/colony/notifications?all=false");
   });
 
   it("filters by specified reasons", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ reason: "mention" }),
       makeNotification({ id: "1002", reason: "comment" }),
       makeNotification({ id: "1003", reason: "author" }),
-    ]]));
+    ]);
 
     const result = await fetchMentionNotifications("hivemoot/colony", ["mention"]);
     expect(result).toHaveLength(1);
@@ -292,31 +280,31 @@ describe("fetchMentionNotifications()", () => {
   });
 
   it("supports multiple reasons", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ reason: "mention" }),
       makeNotification({ id: "1002", reason: "comment" }),
-    ]]));
+    ]);
 
     const result = await fetchMentionNotifications("hivemoot/colony", ["mention", "comment"]);
     expect(result).toHaveLength(2);
   });
 
   it("filters out read notifications", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({ reason: "mention", unread: false }),
-    ]]));
+    ]);
 
     const result = await fetchMentionNotifications("hivemoot/colony", ["mention"]);
     expect(result).toHaveLength(0);
   });
 
   it("filters out non-Issue/PR types", async () => {
-    mockedGh.mockResolvedValue(JSON.stringify([[
+    mockedGhPaginatedList.mockResolvedValue([
       makeNotification({
         reason: "mention",
         subject: { url: "https://api.github.com/repos/hivemoot/colony/releases/5", type: "Release", title: "v1", latest_comment_url: null },
       }),
-    ]]));
+    ]);
 
     const result = await fetchMentionNotifications("hivemoot/colony", ["mention"]);
     expect(result).toHaveLength(0);

--- a/cli/src/github/notifications.ts
+++ b/cli/src/github/notifications.ts
@@ -1,6 +1,6 @@
 import type { RepoRef, MentionEvent } from "../config/types.js";
 import { CliError } from "../config/types.js";
-import { gh, ghWithHeaders } from "./client.js";
+import { gh, ghPaginatedList, ghWithHeaders } from "./client.js";
 
 export interface NotificationInfo {
   threadId: string;   // GitHub notification thread ID — needed for ack
@@ -85,15 +85,9 @@ function subjectHtmlUrl(
  * When multiple notifications exist for the same item, keeps the most recent.
  */
 export async function fetchNotifications(repo: RepoRef): Promise<NotificationMap> {
-  const raw = await gh([
-    "api",
-    "--paginate",
-    "--slurp",
+  const notifications = await ghPaginatedList<RawNotification>(
     `/repos/${repo.owner}/${repo.repo}/notifications`,
-  ]);
-
-  const pages: RawNotification[][] = JSON.parse(raw);
-  const notifications: RawNotification[] = pages.flat();
+  );
   const map: NotificationMap = new Map();
 
   for (const n of notifications) {
@@ -137,17 +131,9 @@ export async function fetchMentionNotifications(
     params.set("since", since);
   }
 
-  const args = [
-    "api",
-    "--paginate",
-    "--slurp",
+  const notifications = await ghPaginatedList<RawNotification>(
     `/repos/${repo}/notifications?${params}`,
-  ];
-
-  const raw = await gh(args);
-
-  const pages: RawNotification[][] = JSON.parse(raw);
-  const notifications: RawNotification[] = pages.flat();
+  );
 
   return notifications.filter((n) => {
     if (!n.unread) return false;


### PR DESCRIPTION
Closes #244

## What

Adds `ghPaginatedList<T>(apiPath: string): Promise<T[]>` to `client.ts` and migrates all three inline `--paginate --slurp` callers.

## Why this matters

The `--paginate --slurp` pattern appeared independently in three places. Each site had to correctly handle `JSON.parse` errors and non-array shapes, or silently produce bad data. This pattern already appeared four times in the codebase (#243, #245, #246, #314) before convergence — having a shared helper makes the correct behavior the default path.

## What changed

**`client.ts`** — new `ghPaginatedList<T>`:
- Calls `gh(["api", "--paginate", "--slurp", apiPath])`
- Throws `CliError("GH_ERROR")` on `JSON.parse` failure (fail-closed, not `return []`)
- Throws `CliError("GH_ERROR")` on non-array response
- Returns `(pages as T[][]).flat()`

**Migrated callers:**
- `notifications.ts`: `fetchNotifications`, `fetchMentionNotifications`
- `fetch-notifications.ts`: `fetchNotificationsPull` (already had correct inline error handling — migrated for consistency)

**Tests:**
- `client.test.ts`: 6 new tests for `ghPaginatedList` (success, multi-page, empty, parse failure, non-array, call shape)
- Both test files updated to partial mock (`{ ...actual, gh: vi.fn() }`) so `ghPaginatedList` runs as real code against the mocked `gh`. All existing `mockedGh.toHaveBeenCalledWith(["api", "--paginate", "--slurp", ...])` assertions work unchanged.

## Sequencing

PR #314 (which fixed the two inline callers in `notifications.ts`) is already merged. This PR completes the work by extracting the helper and migrating all three callers, as planned in the #244 discussion.