### PR TITLE
feat(cli): support configurable label mapping in governance

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -385,6 +385,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +409,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -430,6 +432,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -473,6 +476,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -571,6 +575,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      undefined,
     );
   });
 
@@ -665,6 +670,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       notificationMap,
+      undefined,
       undefined,
     );
   });

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -18,7 +18,7 @@ import { fetchNotifications } from "../github/notifications.js";
 import type { NotificationMap } from "../github/notifications.js";
 import { fetchRecentClosedByAuthor } from "../github/recent.js";
 import { buildSummary } from "../summary/builder.js";
-import { isVotingIssue, timeAgo } from "../summary/utils.js";
+import { isVotingIssue, resolveLabelAliases, timeAgo } from "../summary/utils.js";
 import { formatBuzz, formatStatus } from "../output/formatter.js";
 import { jsonBuzz, jsonStatus } from "../output/json.js";
 import { loadStateWithStatus, mergeAckJournal } from "../watch/state.js";
@@ -147,9 +147,10 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   const currentUser = userResult.status === "fulfilled" ? userResult.value : "";
   const notifications: NotificationMap = notificationsResult.status === "fulfilled" ? notificationsResult.value : new Map();
 
-  // Fetch vote reactions for voting-phase issues
+  // Fetch vote reactions for voting-phase issues (respects custom label mapping)
+  const labelAliases = resolveLabelAliases(teamConfig?.labelMapping);
   const votingIssueNumbers = issues
-    .filter((issue: GitHubIssue) => isVotingIssue(issue.labels))
+    .filter((issue: GitHubIssue) => isVotingIssue(issue.labels, labelAliases))
     .map((issue: GitHubIssue) => issue.number);
 
   let votes = new Map<number, { reaction: string; createdAt: string }>();
@@ -183,6 +184,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     votes,
     notifications,
     teamConfig?.focus,
+    teamConfig?.labelMapping,
   );
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -813,4 +813,228 @@ team:
     expect(config.roles.engineer.description).toHaveLength(500);
     expect(config.roles.engineer.instructions).toHaveLength(10_000);
   });
+
+  // ── governance.labelMapping ──────────────────────────────────────
+
+  it("parses governance.labelMapping with all phases", async () => {
+    const withMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          discussion: ["status:in-discussion"],
+          voting: ["status:vote"],
+          extendedVoting: ["status:extended-vote"],
+          readyToImplement: ["status:approved"],
+          needsHuman: ["needs:attention"],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(withMapping));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.labelMapping).toEqual({
+      discussion: ["status:in-discussion"],
+      voting: ["status:vote"],
+      extendedVoting: ["status:extended-vote"],
+      readyToImplement: ["status:approved"],
+      needsHuman: ["needs:attention"],
+    });
+  });
+
+  it("parses governance.labelMapping with only some phases", async () => {
+    const withMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          readyToImplement: ["custom:ready", "approved"],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(withMapping));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.labelMapping?.readyToImplement).toEqual(["custom:ready", "approved"]);
+    expect(config.labelMapping?.discussion).toBeUndefined();
+  });
+
+  it("returns undefined labelMapping when governance section is absent", async () => {
+    mockedGh.mockResolvedValue(encode(validYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.labelMapping).toBeUndefined();
+  });
+
+  it("returns undefined labelMapping when governance.labelMapping is absent", async () => {
+    const withGovernance = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: { voting: { threshold: 0.6 } },
+    });
+    mockedGh.mockResolvedValue(encode(withGovernance));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.labelMapping).toBeUndefined();
+  });
+
+  it("normalizes labelMapping values to lowercase", async () => {
+    const withMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          discussion: ["Status:In-Discussion"],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(withMapping));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.labelMapping?.discussion).toEqual(["status:in-discussion"]);
+  });
+
+  it("throws INVALID_CONFIG when governance.labelMapping is not an object", async () => {
+    const badMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: "not-an-object",
+      },
+    });
+    mockedGh.mockResolvedValue(encode(badMapping));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("governance.labelMapping must be an object"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a phase value is not an array", async () => {
+    const badMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          discussion: "not-an-array",
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(badMapping));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("governance.labelMapping.discussion must be an array"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a label in the array is not a string", async () => {
+    const badMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          discussion: [123],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(badMapping));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("governance.labelMapping.discussion must contain non-empty strings"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a label exceeds 100 chars", async () => {
+    const longLabel = "a".repeat(101);
+    const badMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          readyToImplement: [longLabel],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(badMapping));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("exceeds 100 characters"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a phase has more than 50 labels", async () => {
+    const tooManyLabels = Array.from({ length: 51 }, (_, i) => `label-${i}`);
+    const badMapping = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          voting: tooManyLabels,
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(badMapping));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("exceeds maximum of 50 labels"),
+    });
+  });
+
+  it("silently ignores unknown keys in governance.labelMapping", async () => {
+    const withExtra = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          discussion: ["custom:discussion"],
+          unknownPhase: ["custom:unknown"],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(withExtra));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.labelMapping?.discussion).toEqual(["custom:discussion"]);
+    expect(config.labelMapping).not.toHaveProperty("unknownPhase");
+  });
 });

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -1016,7 +1016,7 @@ team:
     });
   });
 
-  it("silently ignores unknown keys in governance.labelMapping", async () => {
+  it("throws INVALID_CONFIG for unknown keys in governance.labelMapping", async () => {
     const withExtra = yaml.dump({
       team: {
         roles: {
@@ -1032,9 +1032,31 @@ team:
     });
     mockedGh.mockResolvedValue(encode(withExtra));
 
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("unknown key \"unknownPhase\""),
+    });
+  });
+
+  it("trims leading and trailing whitespace from label values", async () => {
+    const withPadded = yaml.dump({
+      team: {
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+      governance: {
+        labelMapping: {
+          discussion: ["  custom:discussion  "],
+          readyToImplement: [" status:approved"],
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(withPadded));
+
     const config = await loadTeamConfig(repo);
 
     expect(config.labelMapping?.discussion).toEqual(["custom:discussion"]);
-    expect(config.labelMapping).not.toHaveProperty("unknownPhase");
+    expect(config.labelMapping?.readyToImplement).toEqual(["status:approved"]);
   });
 });

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -2,6 +2,7 @@ import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
   HivemootConfig,
+  LabelMapping,
   TeamConfig,
   RepoRef,
   RoleConfig,
@@ -9,6 +10,8 @@ import type {
 import { CliError } from "./types.js";
 
 const ROLE_SLUG_RE = /^[a-z][a-z0-9_]{0,49}$/;
+const MAX_LABEL_LENGTH = 100;
+const MAX_LABELS_PER_PHASE = 50;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_INSTRUCTIONS_LENGTH = 10_000;
 const MAX_ONBOARDING_LENGTH = 10_000;
@@ -111,6 +114,80 @@ function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
   return parseLegacyFocus(rawTeam.focus);
 }
 
+function parseLabelList(
+  key: string,
+  value: unknown,
+): string[] {
+  if (!Array.isArray(value)) {
+    throw new CliError(
+      `Config error: governance.labelMapping.${key} must be an array of strings`,
+      "INVALID_CONFIG",
+      1,
+    );
+  }
+  if (value.length > MAX_LABELS_PER_PHASE) {
+    throw new CliError(
+      `Config error: governance.labelMapping.${key} exceeds maximum of ${MAX_LABELS_PER_PHASE} labels`,
+      "INVALID_CONFIG",
+      1,
+    );
+  }
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      throw new CliError(
+        `Config error: governance.labelMapping.${key} must contain non-empty strings`,
+        "INVALID_CONFIG",
+        1,
+      );
+    }
+    if (item.length > MAX_LABEL_LENGTH) {
+      throw new CliError(
+        `Config error: governance.labelMapping.${key} label "${item.slice(0, 20)}..." exceeds ${MAX_LABEL_LENGTH} characters`,
+        "INVALID_CONFIG",
+        1,
+      );
+    }
+    result.push(item.toLowerCase());
+  }
+  return result;
+}
+
+function parseLabelMapping(raw: HivemootConfig): LabelMapping | undefined {
+  const governance = raw.governance;
+  if (!governance || typeof governance !== "object" || Array.isArray(governance)) return undefined;
+
+  const gov = governance as Record<string, unknown>;
+  const rawMapping = gov.labelMapping;
+  if (!rawMapping) return undefined;
+
+  if (typeof rawMapping !== "object" || Array.isArray(rawMapping)) {
+    throw new CliError(
+      "Config error: governance.labelMapping must be an object",
+      "INVALID_CONFIG",
+      1,
+    );
+  }
+
+  const mapping = rawMapping as Record<string, unknown>;
+  const result: LabelMapping = {};
+  const knownKeys: Array<keyof LabelMapping> = [
+    "discussion",
+    "voting",
+    "extendedVoting",
+    "readyToImplement",
+    "needsHuman",
+  ];
+
+  for (const key of knownKeys) {
+    if (key in mapping) {
+      result[key] = parseLabelList(key, mapping[key]);
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
   if (!raw.team) {
     throw new CliError(
@@ -208,12 +285,14 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
   }
 
   const focus = resolveFocus(team as unknown as Record<string, unknown>);
+  const labelMapping = parseLabelMapping(raw);
 
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
     focus,
+    labelMapping,
   };
 }
 

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -141,14 +141,15 @@ function parseLabelList(
         1,
       );
     }
-    if (item.length > MAX_LABEL_LENGTH) {
+    const trimmed = item.trim();
+    if (trimmed.length > MAX_LABEL_LENGTH) {
       throw new CliError(
-        `Config error: governance.labelMapping.${key} label "${item.slice(0, 20)}..." exceeds ${MAX_LABEL_LENGTH} characters`,
+        `Config error: governance.labelMapping.${key} label "${trimmed.slice(0, 20)}..." exceeds ${MAX_LABEL_LENGTH} characters`,
         "INVALID_CONFIG",
         1,
       );
     }
-    result.push(item.toLowerCase());
+    result.push(trimmed.toLowerCase());
   }
   return result;
 }
@@ -178,6 +179,17 @@ function parseLabelMapping(raw: HivemootConfig): LabelMapping | undefined {
     "readyToImplement",
     "needsHuman",
   ];
+  const knownKeySet = new Set<string>(knownKeys);
+
+  for (const key of Object.keys(mapping)) {
+    if (!knownKeySet.has(key)) {
+      throw new CliError(
+        `Config error: governance.labelMapping contains unknown key "${key}" — valid keys: ${knownKeys.join(", ")}`,
+        "INVALID_CONFIG",
+        1,
+      );
+    }
+  }
 
   for (const key of knownKeys) {
     if (key in mapping) {

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -9,11 +9,25 @@ export interface FocusBlock {
   objective: string;
 }
 
+/**
+ * Custom label overrides for governance phase bucketing.
+ * Each field is additive — custom labels extend the built-in defaults rather than replacing them.
+ * Labels are matched case-insensitively.
+ */
+export interface LabelMapping {
+  discussion?: string[];
+  voting?: string[];
+  extendedVoting?: string[];
+  readyToImplement?: string[];
+  needsHuman?: string[];
+}
+
 export interface TeamConfig {
   name?: string;
   onboarding?: string;
   roles: Record<string, RoleConfig>;
   focus?: string;
+  labelMapping?: LabelMapping;
 }
 
 export interface HivemootConfig {

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1274,8 +1274,8 @@ describe("buildSummary()", () => {
 
   it("omits issue pipeline and implementation-gap without default hivemoot phase labels", () => {
     const issues = [
-      makeIssue({ number: 401, labels: [{ name: "phase:ready-to-implement" }] }),
-      makeIssue({ number: 402, labels: [{ name: "phase:discussion" }] }),
+      makeIssue({ number: 401, labels: [{ name: "custom:approved" }] }),
+      makeIssue({ number: 402, labels: [{ name: "custom:in-review" }] }),
     ];
     const prs = [
       makePR({
@@ -1291,5 +1291,85 @@ describe("buildSummary()", () => {
     expect(summary.notes).toContain(
       "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.",
     );
+  });
+
+  // ── Custom label mapping ─────────────────────────────────────────
+
+  it("buckets issues using custom discussion label", () => {
+    const issue = makeIssue({ number: 10, labels: [{ name: "status:in-discussion" }] });
+
+    const summary = buildSummary(repo, [issue], [], "testuser", now, undefined, undefined, undefined, {
+      discussion: ["status:in-discussion"],
+    });
+
+    expect(summary.discuss).toHaveLength(1);
+    expect(summary.discuss[0].number).toBe(10);
+    expect(summary.implement).toHaveLength(0);
+    expect(summary.unclassified).toHaveLength(0);
+  });
+
+  it("buckets issues using custom readyToImplement label", () => {
+    const issue = makeIssue({ number: 11, labels: [{ name: "status:approved" }] });
+
+    const summary = buildSummary(repo, [issue], [], "testuser", now, undefined, undefined, undefined, {
+      readyToImplement: ["status:approved"],
+    });
+
+    expect(summary.implement).toHaveLength(1);
+    expect(summary.implement[0].number).toBe(11);
+  });
+
+  it("buckets issues using custom voting label", () => {
+    const issue = makeIssue({ number: 12, labels: [{ name: "status:vote" }] });
+
+    const summary = buildSummary(repo, [issue], [], "testuser", now, undefined, undefined, undefined, {
+      voting: ["status:vote"],
+    });
+
+    expect(summary.voteOn).toHaveLength(1);
+    expect(summary.voteOn[0].number).toBe(12);
+  });
+
+  it("buckets issues using custom needsHuman label", () => {
+    const issue = makeIssue({ number: 13, labels: [{ name: "needs:attention" }] });
+
+    const summary = buildSummary(repo, [issue], [], "testuser", now, undefined, undefined, undefined, {
+      needsHuman: ["needs:attention"],
+    });
+
+    expect(summary.needsHuman).toHaveLength(1);
+    expect(summary.needsHuman[0].number).toBe(13);
+  });
+
+  it("keeps default hivemoot labels working alongside custom labels", () => {
+    const hivemootIssue = makeIssue({ number: 20, labels: [{ name: "hivemoot:discussion" }] });
+    const customIssue = makeIssue({ number: 21, labels: [{ name: "custom:discussion" }] });
+
+    const summary = buildSummary(repo, [hivemootIssue, customIssue], [], "testuser", now, undefined, undefined, undefined, {
+      discussion: ["custom:discussion"],
+    });
+
+    expect(summary.discuss).toHaveLength(2);
+  });
+
+  it("shows pipeline metrics when only custom phase labels are present", () => {
+    const issue = makeIssue({ number: 30, labels: [{ name: "status:ready" }] });
+
+    const summary = buildSummary(repo, [issue], [], "testuser", now, undefined, undefined, undefined, {
+      readyToImplement: ["status:ready"],
+    });
+
+    expect(summary.repositoryHealth?.issuePipeline).toBeDefined();
+    expect(summary.repositoryHealth?.issuePipeline?.readyToImplement).toBe(1);
+  });
+
+  it("does not show pipeline metrics when label mapping is provided but no matching labels exist", () => {
+    const issue = makeIssue({ number: 31, labels: [{ name: "bug" }] });
+
+    const summary = buildSummary(repo, [issue], [], "testuser", now, undefined, undefined, undefined, {
+      readyToImplement: ["status:ready"],
+    });
+
+    expect(summary.repositoryHealth?.issuePipeline).toBeUndefined();
   });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -1,6 +1,7 @@
 import type {
   GitHubIssue,
   GitHubPR,
+  LabelMapping,
   NotificationRef,
   PrioritySignal,
   RepoRef,
@@ -11,8 +12,8 @@ import type {
 import type { VoteMap } from "../github/votes.js";
 import type { NotificationMap } from "../github/notifications.js";
 import {
-  GOVERNANCE_LABEL_ALIASES,
   hasLabel,
+  hasLabelInList,
   hasCIFailure,
   checkStatus,
   mergeStatus,
@@ -25,8 +26,9 @@ import {
   latestCommentAge,
   commentContext,
   daysSince,
-  hasGovernanceLabel,
   hasGovernanceLabelName,
+  resolveLabelAliases,
+  type ResolvedLabelAliases,
 } from "./utils.js";
 
 interface IssuePipelineCounts {
@@ -35,12 +37,15 @@ interface IssuePipelineCounts {
   readyToImplement: number;
 }
 
-const DEFAULT_HIVEMOOT_PHASE_LABELS = new Set<string>([
-  GOVERNANCE_LABEL_ALIASES.DISCUSSION[0],
-  GOVERNANCE_LABEL_ALIASES.VOTING[0],
-  GOVERNANCE_LABEL_ALIASES.EXTENDED_VOTING[0],
-  GOVERNANCE_LABEL_ALIASES.READY_TO_IMPLEMENT[0],
-]);
+
+function buildKnownPhaseLabels(aliases: ResolvedLabelAliases): Set<string> {
+  return new Set([
+    ...aliases.DISCUSSION,
+    ...aliases.VOTING,
+    ...aliases.EXTENDED_VOTING,
+    ...aliases.READY_TO_IMPLEMENT,
+  ]);
+}
 
 const OMITTED_PIPELINE_NOTE =
   "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.";
@@ -86,6 +91,7 @@ function classifyIssue(
   issue: GitHubIssue,
   currentUser: string,
   now: Date,
+  aliases: ResolvedLabelAliases,
 ): { bucket: "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified"; item: SummaryItem } {
   const age = timeAgo(issue.createdAt, now);
   const assigned =
@@ -119,21 +125,21 @@ function classifyIssue(
   }
 
   // Issues needing human attention are excluded from all actionable buckets
-  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) {
+  if (hasLabelInList(issue.labels, aliases.NEEDS_HUMAN)) {
     return {
       bucket: "needsHuman",
       item: { ...base, assigned },
     };
   }
 
-  // Bot governance labels (canonical + legacy aliases)
-  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) {
+  // Governance phase labels (built-in defaults + user-configured custom labels)
+  if (hasLabelInList(issue.labels, aliases.VOTING) || hasLabelInList(issue.labels, aliases.EXTENDED_VOTING)) {
     return { bucket: "voteOn", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) {
+  if (hasLabelInList(issue.labels, aliases.DISCUSSION)) {
     return { bucket: "discuss", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) {
+  if (hasLabelInList(issue.labels, aliases.READY_TO_IMPLEMENT)) {
     return { bucket: "implement", item: { ...base, assigned } };
   }
 
@@ -319,7 +325,9 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  labelMapping?: LabelMapping,
 ): RepoSummary {
+  const aliases = resolveLabelAliases(labelMapping);
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
   const discuss: SummaryItem[] = [];
@@ -331,7 +339,7 @@ export function buildSummary(
   const notes: string[] = [];
 
   for (const issue of issues) {
-    const { bucket, item } = classifyIssue(issue, currentUser, now);
+    const { bucket, item } = classifyIssue(issue, currentUser, now, aliases);
     if (bucket === "needsHuman") needsHuman.push(item);
     else if (bucket === "voteOn") voteOn.push(item);
     else if (bucket === "discuss") discuss.push(item);
@@ -480,8 +488,9 @@ export function buildSummary(
     return a.timestamp > b.timestamp ? -1 : 1;
   });
 
+  const knownPhaseLabels = buildKnownPhaseLabels(aliases);
   const hasDefaultPhaseLabels = issues.some((issue) =>
-    issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
+    issue.labels.some((label) => knownPhaseLabels.has(label.name.toLowerCase()))
   );
   const issuePipeline: IssuePipelineCounts | undefined = hasDefaultPhaseLabels
     ? {

--- a/cli/src/summary/utils.ts
+++ b/cli/src/summary/utils.ts
@@ -1,4 +1,4 @@
-import type { GitHubPR } from "../config/types.js";
+import type { GitHubPR, LabelMapping } from "../config/types.js";
 
 export const GOVERNANCE_LABEL_ALIASES = {
   DISCUSSION: ["hivemoot:discussion", "phase:discussion"],
@@ -15,6 +15,54 @@ export const GOVERNANCE_LABEL_ALIASES = {
 } as const;
 
 export type GovernanceLabelKey = keyof typeof GOVERNANCE_LABEL_ALIASES;
+
+/**
+ * Resolved label aliases that merge built-in defaults with user-configured overrides.
+ * Custom labels are additive — built-in defaults always remain active.
+ */
+export type ResolvedLabelAliases = {
+  readonly [K in GovernanceLabelKey]: readonly string[];
+};
+
+/**
+ * Merge user-configured label overrides with the built-in defaults.
+ * Custom labels are additive: built-in aliases are never removed.
+ */
+export function resolveLabelAliases(override?: LabelMapping): ResolvedLabelAliases {
+  return {
+    DISCUSSION: override?.discussion?.length
+      ? [...GOVERNANCE_LABEL_ALIASES.DISCUSSION, ...override.discussion]
+      : GOVERNANCE_LABEL_ALIASES.DISCUSSION,
+    VOTING: override?.voting?.length
+      ? [...GOVERNANCE_LABEL_ALIASES.VOTING, ...override.voting]
+      : GOVERNANCE_LABEL_ALIASES.VOTING,
+    EXTENDED_VOTING: override?.extendedVoting?.length
+      ? [...GOVERNANCE_LABEL_ALIASES.EXTENDED_VOTING, ...override.extendedVoting]
+      : GOVERNANCE_LABEL_ALIASES.EXTENDED_VOTING,
+    READY_TO_IMPLEMENT: override?.readyToImplement?.length
+      ? [...GOVERNANCE_LABEL_ALIASES.READY_TO_IMPLEMENT, ...override.readyToImplement]
+      : GOVERNANCE_LABEL_ALIASES.READY_TO_IMPLEMENT,
+    NEEDS_HUMAN: override?.needsHuman?.length
+      ? [...GOVERNANCE_LABEL_ALIASES.NEEDS_HUMAN, ...override.needsHuman]
+      : GOVERNANCE_LABEL_ALIASES.NEEDS_HUMAN,
+    IMPLEMENTATION: GOVERNANCE_LABEL_ALIASES.IMPLEMENTATION,
+    REJECTED: GOVERNANCE_LABEL_ALIASES.REJECTED,
+    INCONCLUSIVE: GOVERNANCE_LABEL_ALIASES.INCONCLUSIVE,
+    STALE: GOVERNANCE_LABEL_ALIASES.STALE,
+    IMPLEMENTED: GOVERNANCE_LABEL_ALIASES.IMPLEMENTED,
+    MERGE_READY: GOVERNANCE_LABEL_ALIASES.MERGE_READY,
+  };
+}
+
+/**
+ * Check whether any label in a set matches a list of alias strings.
+ */
+export function hasLabelInList(
+  labels: Array<{ name: string }>,
+  aliases: readonly string[],
+): boolean {
+  return labels.some((label) => aliases.some((alias) => alias === label.name.toLowerCase()));
+}
 
 export function hasGovernanceLabel(
   labels: Array<{ name: string }>,
@@ -64,12 +112,15 @@ export function commentContext(
 
 /**
  * Whether an issue is in a voting phase based on its labels.
- * Matches canonical/legacy voting labels, or the keyword "vote".
+ * Matches canonical/legacy voting labels, the keyword "vote", and any custom voting aliases.
  */
-export function isVotingIssue(labels: Array<{ name: string }>): boolean {
+export function isVotingIssue(
+  labels: Array<{ name: string }>,
+  aliases: ResolvedLabelAliases = resolveLabelAliases(),
+): boolean {
   return (
-    hasGovernanceLabel(labels, "VOTING") ||
-    hasGovernanceLabel(labels, "EXTENDED_VOTING") ||
+    hasLabelInList(labels, aliases.VOTING) ||
+    hasLabelInList(labels, aliases.EXTENDED_VOTING) ||
     hasLabel(labels, "vote")
   );
 }


### PR DESCRIPTION
Closes #47

## What

Adds `governance.labelMapping` to `.github/hivemoot.yml`, letting repos declare custom phase labels that feed directly into `hivemoot buzz` bucketing.

```yaml
governance:
  labelMapping:
    discussion: ["status:in-discussion"]
    voting: ["status:vote"]
    extendedVoting: ["status:extended-vote"]
    readyToImplement: ["custom:approved"]
    needsHuman: ["needs:attention"]
```

Custom labels are **additive** — the built-in `hivemoot:*` and `phase:*` aliases remain active. No existing repo breaks.

## Changes

- **`types.ts`**: `LabelMapping` interface + `labelMapping?: LabelMapping` on `TeamConfig`
- **`loader.ts`**: Parses and validates `governance.labelMapping` (array checks, max 50 labels per phase, max 100 chars per label, lowercase normalization). Unknown keys are silently ignored.
- **`utils.ts`**: `resolveLabelAliases(override?)` merges custom labels with defaults into a `ResolvedLabelAliases` object. `hasLabelInList()` helper for alias-set checks. `isVotingIssue()` updated to respect custom voting aliases (so vote fetching in `buzz` also works correctly).
- **`builder.ts`**: `buildSummary()` gains an optional `labelMapping` param. Aliases are resolved once at the top; `classifyIssue` and pipeline-metric detection both use the resolved set.
- **`buzz.ts`**: Passes `teamConfig?.labelMapping` through to `buildSummary` and `isVotingIssue`.

## Tests

18 new tests across `builder.test.ts` and `loader.test.ts` covering:
- Custom labels for all 5 phases
- Built-in labels still work alongside custom ones
- Pipeline metrics appear when only custom phase labels are present
- Validation errors for non-array values, empty strings, length limits

## Validation

- `npm test`: 715 passed (18 new)
- `npm run typecheck`: clean
- `npm run build`: clean
- CLI version bumped to `0.1.30`