### PR TITLE
feat(tasks): structured artifact links for agent task runs

### DIFF
--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -197,4 +197,12 @@ describe("POST /api/tasks/[taskId]/artifacts", () => {
     const body = await res.json();
     expect(body.code).toBe("task_validation_failed");
   });
+
+  it("returns 500 when appendTaskArtifacts throws unexpectedly", async () => {
+    vi.mocked(appendTaskArtifacts).mockRejectedValue(new Error("redis down"));
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("task_server_error");
+  });
 });

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
+import type { TaskArtifact } from "@/server/task-store";
 
 vi.mock("@/server/task-executor-auth", () => ({
   authenticateTaskExecutorRequest: vi.fn(),
@@ -32,7 +33,7 @@ const VALID_ARTIFACT = {
   url: "https://github.com/hivemoot/hivemoot/pull/1",
 };
 
-const STORED_ARTIFACTS = [{ type: "pull_request", url: "https://github.com/hivemoot/hivemoot/pull/1" }];
+const STORED_ARTIFACTS: TaskArtifact[] = [{ type: "pull_request", url: "https://github.com/hivemoot/hivemoot/pull/1" }];
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -189,8 +190,8 @@ describe("POST /api/tasks/[taskId]/artifacts", () => {
     expect(body.code).toBe("task_not_found");
   });
 
-  it("returns 400 when appendTaskArtifacts reports invalid_artifact", async () => {
-    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "invalid_artifact" });
+  it("returns 400 when appendTaskArtifacts reports validation_failed", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "validation_failed" });
     const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: "https://evil.com/x" }] }));
     expect(res.status).toBe(400);
     const body = await res.json();

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -203,7 +203,7 @@ describe("POST /api/tasks/[taskId]/artifacts", () => {
     const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
     expect(res.status).toBe(429);
     const body = await res.json();
-    expect(body.code).toBe("task_server_error");
+    expect(body.code).toBe("task_lock_timeout");
   });
 
   it("returns 500 when appendTaskArtifacts throws unexpectedly", async () => {

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/task-executor-auth", () => ({
+  authenticateTaskExecutorRequest: vi.fn(),
+}));
+
+vi.mock("@/server/task-store", () => ({
+  TASK_ID_PATTERN: /^[a-f0-9]{24}$/,
+  getTask: vi.fn(),
+  verifyTaskClaimToken: vi.fn(),
+  appendTaskArtifacts: vi.fn(),
+}));
+
+import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
+import { getTask, verifyTaskClaimToken, appendTaskArtifacts } from "@/server/task-store";
+import { POST } from "./route";
+
+const BASE_TASK = {
+  task_id: "abc123abc123abc123abc123",
+  status: "running" as const,
+  prompt: "Report outputs",
+  repos: ["hivemoot/hivemoot"],
+  timeout_secs: 300,
+  created_by: "queen",
+  created_at: "2026-03-03T12:00:00.000Z",
+  updated_at: "2026-03-03T12:01:00.000Z",
+};
+
+const VALID_ARTIFACT = {
+  type: "pull_request",
+  url: "https://github.com/hivemoot/hivemoot/pull/1",
+};
+
+const STORED_ARTIFACTS = [{ type: "pull_request", url: "https://github.com/hivemoot/hivemoot/pull/1" }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(authenticateTaskExecutorRequest).mockResolvedValue({
+    ok: true,
+    installationId: "inst-1",
+    redis: {} as never,
+  });
+
+  vi.mocked(getTask).mockResolvedValue(BASE_TASK);
+  vi.mocked(verifyTaskClaimToken).mockResolvedValue(true);
+  vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: true, artifacts: STORED_ARTIFACTS });
+});
+
+function makeRequest(body: unknown, claimToken = "claim-token-1", contentLength?: number) {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (claimToken) {
+    headers.set("x-task-claim-token", claimToken);
+  }
+  if (contentLength !== undefined) {
+    headers.set("content-length", String(contentLength));
+  }
+
+  return new NextRequest("https://example.com/api/tasks/abc123abc123abc123abc123/artifacts", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/tasks/[taskId]/artifacts", () => {
+  it("appends artifacts and returns current artifact list", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.artifacts).toEqual(STORED_ARTIFACTS);
+    expect(appendTaskArtifacts).toHaveBeenCalledWith(
+      "inst-1",
+      "abc123abc123abc123abc123",
+      [VALID_ARTIFACT],
+      expect.anything(),
+    );
+    expect(verifyTaskClaimToken).toHaveBeenCalledWith(
+      "inst-1",
+      "abc123abc123abc123abc123",
+      "claim-token-1",
+      expect.anything(),
+    );
+  });
+
+  it("returns 404 when task does not exist — before claim-token check", async () => {
+    vi.mocked(getTask).mockResolvedValue(null);
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("task_not_found");
+    // verifyTaskClaimToken must not have been called — a missing task should not
+    // produce a misleading 403 from a failed token lookup.
+    expect(verifyTaskClaimToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when executor auth fails", async () => {
+    vi.mocked(authenticateTaskExecutorRequest).mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "task_not_authenticated" }, { status: 401 }),
+    });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when claim token is missing", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, ""));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+    expect(verifyTaskClaimToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when claim token is invalid", async () => {
+    vi.mocked(verifyTaskClaimToken).mockResolvedValue(false);
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, "bad-token"));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+  });
+
+  it("returns 413 when content-length header exceeds limit", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, "claim-token-1", 33 * 1024));
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.code).toBe("task_payload_too_large");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const headers = new Headers({
+      "Content-Type": "application/json",
+      "x-task-claim-token": "claim-token-1",
+    });
+    const req = new NextRequest("https://example.com/api/tasks/abc123abc123abc123abc123/artifacts", {
+      method: "POST",
+      headers,
+      body: "not-json{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_invalid_json");
+  });
+
+  it("returns 400 when body is not a JSON object", async () => {
+    const res = await POST(makeRequest([VALID_ARTIFACT]));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 400 when artifacts field is missing", async () => {
+    const res = await POST(makeRequest({ other: "field" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_missing_fields");
+  });
+
+  it("returns 400 when artifacts array is empty", async () => {
+    const res = await POST(makeRequest({ artifacts: [] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 400 when artifacts array exceeds 20 entries per request", async () => {
+    const tooMany = Array.from({ length: 21 }, () => VALID_ARTIFACT);
+    const res = await POST(makeRequest({ artifacts: tooMany }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 409 when task artifact cap is reached", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "cap_exceeded" });
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 404 when appendTaskArtifacts reports task not found", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "not_found" });
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("task_not_found");
+  });
+
+  it("returns 400 when appendTaskArtifacts reports invalid_artifact", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "invalid_artifact" });
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: "https://evil.com/x" }] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+});

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -198,6 +198,14 @@ describe("POST /api/tasks/[taskId]/artifacts", () => {
     expect(body.code).toBe("task_validation_failed");
   });
 
+  it("returns 429 when appendTaskArtifacts reports lock_timeout", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "lock_timeout" });
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.code).toBe("task_server_error");
+  });
+
   it("returns 500 when appendTaskArtifacts throws unexpectedly", async () => {
     vi.mocked(appendTaskArtifacts).mockRejectedValue(new Error("redis down"));
     const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest) {
         );
       }
       if (result.reason === "lock_timeout") {
-        return taskError(TASK_ERROR.SERVER_ERROR, "Lock contention — retry the request", 429);
+        return taskError(TASK_ERROR.LOCK_TIMEOUT, "Lock contention — retry the request", 429);
       }
       return taskError(
         TASK_ERROR.VALIDATION_FAILED,

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -5,6 +5,7 @@ import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import {
   appendTaskArtifacts,
+  getTask,
   TASK_ID_PATTERN,
   verifyTaskClaimToken,
 } from "@/server/task-store";
@@ -65,6 +66,14 @@ export async function POST(request: NextRequest) {
       `artifacts array must not exceed ${MAX_ARTIFACTS_PER_REQUEST} entries per request`,
       400,
     );
+  }
+
+  // Check task existence before claim-token verification: verifyTaskClaimToken
+  // returns false when the hash is absent, which would produce a misleading 403
+  // instead of a 404 for a missing task.
+  const task = await getTask(auth.installationId, taskId, auth.redis);
+  if (!task) {
+    return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
   }
 
   const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -110,6 +110,9 @@ export async function POST(request: NextRequest) {
           409,
         );
       }
+      if (result.reason === "lock_timeout") {
+        return taskError(TASK_ERROR.SERVER_ERROR, "Lock contention — retry the request", 429);
+      }
       return taskError(
         TASK_ERROR.VALIDATION_FAILED,
         "One or more artifacts are invalid. Each artifact must have a valid type and a github.com URL scoped to the task's repos.",

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -68,53 +68,63 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Check task existence before claim-token verification: verifyTaskClaimToken
-  // returns false when the hash is absent, which would produce a misleading 403
-  // instead of a 404 for a missing task.
-  const task = await getTask(auth.installationId, taskId, auth.redis);
-  if (!task) {
-    return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
-  }
-
-  const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";
-  if (!claimToken) {
-    return taskError(TASK_ERROR.FORBIDDEN, "Missing task claim token", 403);
-  }
-
-  const validClaimToken = await verifyTaskClaimToken(
-    auth.installationId,
-    taskId,
-    claimToken,
-    auth.redis,
-  );
-  if (!validClaimToken) {
-    return taskError(TASK_ERROR.FORBIDDEN, "Invalid or expired task claim token", 403);
-  }
-
-  const result = await appendTaskArtifacts(
-    auth.installationId,
-    taskId,
-    obj.artifacts,
-    auth.redis,
-  );
-
-  if (!result.ok) {
-    if (result.reason === "not_found") {
+  try {
+    // Check task existence before claim-token verification: verifyTaskClaimToken
+    // returns false when the hash is absent, which would produce a misleading 403
+    // instead of a 404 for a missing task.
+    const task = await getTask(auth.installationId, taskId, auth.redis);
+    if (!task) {
       return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
     }
-    if (result.reason === "cap_exceeded") {
+
+    const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";
+    if (!claimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Missing task claim token", 403);
+    }
+
+    const validClaimToken = await verifyTaskClaimToken(
+      auth.installationId,
+      taskId,
+      claimToken,
+      auth.redis,
+    );
+    if (!validClaimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Invalid or expired task claim token", 403);
+    }
+
+    const result = await appendTaskArtifacts(
+      auth.installationId,
+      taskId,
+      obj.artifacts,
+      auth.redis,
+    );
+
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+      }
+      if (result.reason === "cap_exceeded") {
+        return taskError(
+          TASK_ERROR.VALIDATION_FAILED,
+          "Artifact cap reached (max 20 per task)",
+          409,
+        );
+      }
       return taskError(
         TASK_ERROR.VALIDATION_FAILED,
-        "Artifact cap reached (max 20 per task)",
-        409,
+        "One or more artifacts are invalid. Each artifact must have a valid type and a github.com URL scoped to the task's repos.",
+        400,
       );
     }
-    return taskError(
-      TASK_ERROR.VALIDATION_FAILED,
-      "One or more artifacts are invalid. Each artifact must have a valid type and a github.com URL scoped to the task's repos.",
-      400,
-    );
-  }
 
-  return NextResponse.json({ artifacts: result.artifacts });
+    return NextResponse.json({ artifacts: result.artifacts });
+  } catch (error) {
+    console.error("[tasks] Failed to append artifacts", {
+      installationId: auth.installationId,
+      taskId,
+      error,
+    });
+
+    return taskError(TASK_ERROR.SERVER_ERROR, "Failed to append artifacts", 500);
+  }
 }

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseContentLength } from "@/server/request-utils";
+import { extractTaskId } from "@/server/task-route-utils";
+import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
+import { TASK_ERROR, taskError } from "@/server/task-error";
+import {
+  appendTaskArtifacts,
+  TASK_ID_PATTERN,
+  verifyTaskClaimToken,
+} from "@/server/task-store";
+
+const MAX_PAYLOAD_BYTES = 32 * 1024;
+const MAX_ARTIFACTS_PER_REQUEST = 20;
+const textEncoder = new TextEncoder();
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateTaskExecutorRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { pathname } = new URL(request.url);
+  const taskId = extractTaskId(pathname);
+  if (!taskId || !TASK_ID_PATTERN.test(taskId)) {
+    return taskError(TASK_ERROR.INVALID_TASK_ID, "Invalid task id", 400);
+  }
+
+  const contentLength = parseContentLength(request.headers.get("content-length"));
+  if (contentLength !== null && contentLength > MAX_PAYLOAD_BYTES) {
+    return taskError(TASK_ERROR.PAYLOAD_TOO_LARGE, "Payload too large (max 32KB)", 413);
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await request.text();
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  if (textEncoder.encode(bodyText).length > MAX_PAYLOAD_BYTES) {
+    return taskError(TASK_ERROR.PAYLOAD_TOO_LARGE, "Payload too large (max 32KB)", 413);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, "Body must be a JSON object", 400);
+  }
+
+  const obj = body as Record<string, unknown>;
+  if (!Array.isArray(obj.artifacts)) {
+    return taskError(TASK_ERROR.MISSING_FIELDS, "artifacts must be an array", 400);
+  }
+
+  if (obj.artifacts.length === 0) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, "artifacts array must not be empty", 400);
+  }
+
+  if (obj.artifacts.length > MAX_ARTIFACTS_PER_REQUEST) {
+    return taskError(
+      TASK_ERROR.VALIDATION_FAILED,
+      `artifacts array must not exceed ${MAX_ARTIFACTS_PER_REQUEST} entries per request`,
+      400,
+    );
+  }
+
+  const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";
+  if (!claimToken) {
+    return taskError(TASK_ERROR.FORBIDDEN, "Missing task claim token", 403);
+  }
+
+  const validClaimToken = await verifyTaskClaimToken(
+    auth.installationId,
+    taskId,
+    claimToken,
+    auth.redis,
+  );
+  if (!validClaimToken) {
+    return taskError(TASK_ERROR.FORBIDDEN, "Invalid or expired task claim token", 403);
+  }
+
+  const result = await appendTaskArtifacts(
+    auth.installationId,
+    taskId,
+    obj.artifacts,
+    auth.redis,
+  );
+
+  if (!result.ok) {
+    if (result.reason === "not_found") {
+      return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+    }
+    if (result.reason === "cap_exceeded") {
+      return taskError(
+        TASK_ERROR.VALIDATION_FAILED,
+        "Artifact cap reached (max 20 per task)",
+        409,
+      );
+    }
+    return taskError(
+      TASK_ERROR.VALIDATION_FAILED,
+      "One or more artifacts are invalid. Each artifact must have a valid type and a github.com URL scoped to the task's repos.",
+      400,
+    );
+  }
+
+  return NextResponse.json({ artifacts: result.artifacts });
+}

--- a/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -11,7 +11,7 @@ import {
   taskComposerPlaceholder,
 } from "../task-helpers";
 import { MarkdownContent } from "../../MarkdownContent";
-import { type TaskMessage, type TaskRecord } from "../types";
+import { type TaskArtifact, type TaskMessage, type TaskRecord } from "../types";
 
 // ---------------------------------------------------------------------------
 // Icons
@@ -189,6 +189,48 @@ function RepoIcon({ className }: { className?: string }) {
     >
       <path d="M4 2v12M4 4h6a2 2 0 0 1 2 2v1a2 2 0 0 1-2 2H4" />
     </svg>
+  );
+}
+
+function ExternalLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-3 w-3"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+      <path d="M10 2h4v4" />
+      <line x1="14" y1="2" x2="7" y2="9" />
+    </svg>
+  );
+}
+
+function artifactLabel(artifact: TaskArtifact): string {
+  if (artifact.title) return artifact.title;
+  if (artifact.number) {
+    const prefix = artifact.type === "pull_request" ? "PR" : artifact.type === "issue" ? "Issue" : artifact.type === "issue_comment" ? "Comment" : "Commit";
+    return `${prefix} #${artifact.number}`;
+  }
+  return artifact.type.replace(/_/g, " ");
+}
+
+function ArtifactBadge({ artifact }: { artifact: TaskArtifact }) {
+  return (
+    <a
+      href={artifact.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] bg-white/[0.04] px-2.5 py-1 text-xs text-zinc-400 transition-colors hover:border-white/10 hover:text-zinc-300"
+    >
+      <ExternalLinkIcon className="h-3 w-3 shrink-0 text-zinc-600" />
+      <span>{artifactLabel(artifact)}</span>
+    </a>
   );
 }
 
@@ -652,6 +694,18 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
         {task.error && isTerminal(task.status) && (
           <div className="mt-4 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2.5">
             <p className="text-sm text-red-400">{task.error}</p>
+          </div>
+        )}
+
+        {/* Artifact links */}
+        {task.artifacts && task.artifacts.length > 0 && (
+          <div className="mt-4">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-zinc-600">Outputs</p>
+            <div className="flex flex-wrap gap-2">
+              {task.artifacts.map((artifact, i) => (
+                <ArtifactBadge key={`${artifact.url}-${i}`} artifact={artifact} />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/apps/web/src/app/dashboard/tasks/types.ts
+++ b/apps/web/src/app/dashboard/tasks/types.ts
@@ -1,5 +1,13 @@
 // Shared client-side task models used by the dashboard task views.
 // Keep these aligned with the task store payload shape.
+
+export interface TaskArtifact {
+  type: "pull_request" | "issue" | "issue_comment" | "commit";
+  url: string;
+  number?: number;
+  title?: string;
+}
+
 export interface TaskRecord {
   task_id: string;
   status: string;
@@ -13,6 +21,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface TaskMessage {

--- a/apps/web/src/server/task-store.test.ts
+++ b/apps/web/src/server/task-store.test.ts
@@ -1142,6 +1142,36 @@ describe("post-transition append failure resilience", () => {
     expect(result.task.status).toBe("completed");
   });
 
+  it("finalizeTask expires artifacts key alongside messages key", async () => {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Task with artifacts", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const taskId = created.task.task_id;
+    await markTaskRunning("inst-1", taskId, redis);
+
+    // Append an artifact so the artifacts key exists before finalization.
+    await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "pull_request", url: "https://github.com/hivemoot/hivemoot/pull/1", number: 1 }],
+      redis,
+    );
+
+    await completeTask("inst-1", taskId, "Done", redis);
+
+    const artifactsKey = `task:inst-1:${taskId}:artifacts`;
+    const messagesKey = `task:inst-1:${taskId}:messages`;
+    expect(redis._ttl.has(artifactsKey)).toBe(true);
+    expect(redis._ttl.has(messagesKey)).toBe(true);
+    expect(redis._ttl.get(artifactsKey)).toBe(redis._ttl.get(messagesKey));
+  });
+
   it("invalidates claim token after follow-up and terminal transitions", async () => {
     const created = await createTask(
       "inst-1",

--- a/apps/web/src/server/task-store.test.ts
+++ b/apps/web/src/server/task-store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type Redis } from "@upstash/redis";
 import {
   addUserMessage,
+  appendTaskArtifacts,
   appendTaskMessage,
   checkTaskCreateRateLimit,
   claimNextPendingTask,
@@ -1953,5 +1954,140 @@ describe("addUserMessage", () => {
     const userMsg = messages[messages.length - 2];
     expect(userMsg.role).toBe("user");
     expect(userMsg.content).toBe("Do more");
+  });
+});
+
+describe("artifact tracking", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  async function createRunningTask() {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Do a thing", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error("create failed");
+    const claimed = await claimNextPendingTask("inst-1", redis);
+    expect(claimed).not.toBeNull();
+    return created.task.task_id;
+  }
+
+  it("appends a PR artifact and returns it in the task record", async () => {
+    const taskId = await createRunningTask();
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "pull_request", url: "https://github.com/hivemoot/hivemoot/pull/1", number: 1 }],
+      redis,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0].type).toBe("pull_request");
+    expect(result.artifacts[0].number).toBe(1);
+
+    const task = await getTask("inst-1", taskId, redis);
+    expect(task?.artifacts).toHaveLength(1);
+  });
+
+  it("rejects an artifact whose URL is not scoped to the task repos", async () => {
+    const taskId = await createRunningTask();
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "pull_request", url: "https://github.com/other-org/other-repo/pull/1" }],
+      redis,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("validation_failed");
+  });
+
+  it("returns not_found for a nonexistent task", async () => {
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      "nonexistent-task-id",
+      [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/1" }],
+      redis,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not_found");
+  });
+
+  it("concurrent appends preserve both entries (lock regression)", async () => {
+    // Without withTaskInstallationLock, the second write wins and the first
+    // artifact is silently dropped. This test proves the lock serializes writes.
+    const taskId = await createRunningTask();
+
+    const [r1, r2] = await Promise.all([
+      appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ type: "pull_request", url: "https://github.com/hivemoot/hivemoot/pull/10", number: 10 }],
+        redis,
+      ),
+      appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/20", number: 20 }],
+        redis,
+      ),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+
+    const task = await getTask("inst-1", taskId, redis);
+    expect(task?.artifacts).toHaveLength(2);
+    const urls = task!.artifacts!.map((a) => a.url);
+    expect(urls).toContain("https://github.com/hivemoot/hivemoot/pull/10");
+    expect(urls).toContain("https://github.com/hivemoot/hivemoot/issues/20");
+  });
+
+  it("enforces the 20-artifact cap across concurrent requests", async () => {
+    const taskId = await createRunningTask();
+
+    // Append 19 artifacts sequentially.
+    for (let i = 1; i <= 19; i++) {
+      const r = await appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ type: "issue", url: `https://github.com/hivemoot/hivemoot/issues/${i}`, number: i }],
+        redis,
+      );
+      expect(r.ok).toBe(true);
+    }
+
+    // Two concurrent requests each trying to add the 20th artifact:
+    // only one of them can succeed before the cap is reached.
+    const [r1, r2] = await Promise.all([
+      appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/20", number: 20 }],
+        redis,
+      ),
+      appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/21", number: 21 }],
+        redis,
+      ),
+    ]);
+
+    // Exactly one should succeed and one should be capped.
+    const succeeded = [r1, r2].filter((r) => r.ok);
+    const capped = [r1, r2].filter((r) => !r.ok);
+    expect(succeeded).toHaveLength(1);
+    expect(capped).toHaveLength(1);
+    if (!capped[0].ok) expect(capped[0].reason).toBe("cap_exceeded");
+
+    const task = await getTask("inst-1", taskId, redis);
+    expect(task?.artifacts).toHaveLength(20);
   });
 });

--- a/apps/web/src/server/task-store.test.ts
+++ b/apps/web/src/server/task-store.test.ts
@@ -1899,6 +1899,29 @@ describe("addUserMessage", () => {
     expect(redis._ttl.has(taskTtlKey)).toBe(false);
   });
 
+  it("persists the artifacts key when reviving a terminal task (regression: artifacts must not expire mid-run)", async () => {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Task", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+    await completeTask("inst-1", created.task.task_id, "Done", redis);
+
+    // finalizeTask expires the artifacts key alongside messages.
+    const artifactsTtlKey = `task:inst-1:${created.task.task_id}:artifacts`;
+    expect(redis._ttl.has(artifactsTtlKey)).toBe(true);
+
+    await addUserMessage("inst-1", created.task.task_id, "Reopen", redis);
+
+    // persist() must clear the artifacts TTL so artifacts are not lost mid-run.
+    expect(redis._ttl.has(artifactsTtlKey)).toBe(false);
+  });
+
   it("does not return success when terminal TTL removal fails", async () => {
     const created = await createTask(
       "inst-1",

--- a/apps/web/src/server/task-store.test.ts
+++ b/apps/web/src/server/task-store.test.ts
@@ -2143,4 +2143,61 @@ describe("artifact tracking", () => {
     const task = await getTask("inst-1", taskId, redis);
     expect(task?.artifacts).toHaveLength(20);
   });
+
+  it("derives type and number from URL — caller-supplied values are overridden", async () => {
+    const taskId = await createRunningTask();
+    // Caller supplies type=issue and number=999, but the URL is a pull request
+    // for PR #5. The store must derive type=pull_request and number=5.
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/pull/5", number: 999 }],
+      redis,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.artifacts[0].type).toBe("pull_request");
+    expect(result.artifacts[0].number).toBe(5);
+  });
+
+  it("accepts an issue_comment URL and derives the comment id as number", async () => {
+    const taskId = await createRunningTask();
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/hivemoot/hivemoot/issues/10#issuecomment-99999" }],
+      redis,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.artifacts[0].type).toBe("issue_comment");
+    expect(result.artifacts[0].number).toBe(99999);
+  });
+
+  it("accepts a commit URL and sets no number field", async () => {
+    const taskId = await createRunningTask();
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/hivemoot/hivemoot/commit/abc1234" }],
+      redis,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.artifacts[0].type).toBe("commit");
+    expect(result.artifacts[0].number).toBeUndefined();
+  });
+
+  it("rejects same-repo URL with unrecognised path (no type can be derived)", async () => {
+    const taskId = await createRunningTask();
+    // /releases/tag/v1.0 is same-repo but not a known GitHub object kind
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/hivemoot/hivemoot/releases/tag/v1.0" }],
+      redis,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("validation_failed");
+  });
 });

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -1289,7 +1289,7 @@ function parseArtifact(raw: unknown, repos: string[]): TaskArtifact | null {
 
 export type AppendArtifactsResult =
   | { ok: true; artifacts: TaskArtifact[] }
-  | { ok: false; reason: "not_found" | "cap_exceeded" | "validation_failed" };
+  | { ok: false; reason: "not_found" | "cap_exceeded" | "validation_failed" | "lock_timeout" };
 
 export async function appendTaskArtifacts(
   installationId: string,
@@ -1297,31 +1297,38 @@ export async function appendTaskArtifacts(
   incoming: unknown[],
   redis: Redis,
 ): Promise<AppendArtifactsResult> {
-  return withTaskInstallationLock(installationId, redis, async () => {
-    // Load inside the lock so a concurrent deleteTask cannot leave an orphaned
-    // artifacts key between the existence check and the write.
-    const stored = await loadStoredTask(installationId, taskId, redis);
-    if (!stored) return { ok: false, reason: "not_found" };
+  try {
+    return await withTaskInstallationLock(installationId, redis, async () => {
+      // Load inside the lock so a concurrent deleteTask cannot leave an orphaned
+      // artifacts key between the existence check and the write.
+      const stored = await loadStoredTask(installationId, taskId, redis);
+      if (!stored) return { ok: false, reason: "not_found" };
 
-    const parsed: TaskArtifact[] = [];
-    for (const raw of incoming) {
-      const artifact = parseArtifact(raw, stored.repos);
-      if (!artifact) return { ok: false, reason: "validation_failed" };
-      parsed.push(artifact);
+      const parsed: TaskArtifact[] = [];
+      for (const raw of incoming) {
+        const artifact = parseArtifact(raw, stored.repos);
+        if (!artifact) return { ok: false, reason: "validation_failed" };
+        parsed.push(artifact);
+      }
+
+      const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
+      const existing: TaskArtifact[] = Array.isArray(existingRaw) ? (existingRaw as TaskArtifact[]) : [];
+
+      if (existing.length + parsed.length > MAX_ARTIFACTS_PER_TASK) {
+        return { ok: false, reason: "cap_exceeded" } as AppendArtifactsResult;
+      }
+
+      const updated = [...existing, ...parsed];
+      await redis.set(taskArtifactsKey(installationId, taskId), updated);
+
+      return { ok: true, artifacts: updated };
+    });
+  } catch (error) {
+    if (error instanceof LockTimeoutError) {
+      return { ok: false, reason: "lock_timeout" };
     }
-
-    const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
-    const existing: TaskArtifact[] = Array.isArray(existingRaw) ? (existingRaw as TaskArtifact[]) : [];
-
-    if (existing.length + parsed.length > MAX_ARTIFACTS_PER_TASK) {
-      return { ok: false, reason: "cap_exceeded" } as AppendArtifactsResult;
-    }
-
-    const updated = [...existing, ...parsed];
-    await redis.set(taskArtifactsKey(installationId, taskId), updated);
-
-    return { ok: true, artifacts: updated };
-  });
+    throw error;
+  }
 }
 
 export async function getTaskArtifacts(

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -1500,6 +1500,7 @@ export async function addUserMessage(
         .persist(taskKey(installationId, taskId))
         .persist(taskProgressKey(installationId, taskId))
         .persist(taskMessagesKey(installationId, taskId))
+        .persist(taskArtifactsKey(installationId, taskId))
         .set(taskKey(installationId, taskId), nextStored)
         .set(taskProgressKey(installationId, taskId), "Re-queued with new message")
         .zadd(pendingKey(installationId), { score: Date.now(), member: taskId })

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -1256,17 +1256,19 @@ export async function appendTaskArtifacts(
     parsed.push(artifact);
   }
 
-  const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
-  const existing: TaskArtifact[] = Array.isArray(existingRaw) ? (existingRaw as TaskArtifact[]) : [];
+  return withTaskInstallationLock(installationId, redis, async () => {
+    const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
+    const existing: TaskArtifact[] = Array.isArray(existingRaw) ? (existingRaw as TaskArtifact[]) : [];
 
-  if (existing.length + parsed.length > MAX_ARTIFACTS_PER_TASK) {
-    return { ok: false, reason: "cap_exceeded" };
-  }
+    if (existing.length + parsed.length > MAX_ARTIFACTS_PER_TASK) {
+      return { ok: false, reason: "cap_exceeded" } as AppendArtifactsResult;
+    }
 
-  const updated = [...existing, ...parsed];
-  await redis.set(taskArtifactsKey(installationId, taskId), updated);
+    const updated = [...existing, ...parsed];
+    await redis.set(taskArtifactsKey(installationId, taskId), updated);
 
-  return { ok: true, artifacts: updated };
+    return { ok: true, artifacts: updated };
+  });
 }
 
 export async function getTaskArtifacts(

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -33,6 +33,15 @@ export interface TaskMessage {
 const MAX_MESSAGE_CONTENT_CHARS = 128_000;
 const MAX_MESSAGES_PER_TASK = 200;
 
+export type TaskArtifactType = "pull_request" | "issue" | "issue_comment" | "commit";
+
+export interface TaskArtifact {
+  type: TaskArtifactType;
+  url: string;
+  number?: number;
+  title?: string;
+}
+
 export interface TaskRecord {
   task_id: string;
   status: TaskStatus;
@@ -46,6 +55,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface ClaimedTask {
@@ -119,6 +129,10 @@ function taskMessagesKey(installationId: string, taskId: string): string {
 
 function taskClaimTokenHashKey(installationId: string, taskId: string): string {
   return `task:${installationId}:${taskId}:claim-token-hash`;
+}
+
+function taskArtifactsKey(installationId: string, taskId: string): string {
+  return `task:${installationId}:${taskId}:artifacts`;
 }
 
 function pendingKey(installationId: string): string {
@@ -303,6 +317,7 @@ async function cleanupMissingTask(
     .del(taskProgressKey(installationId, taskId))
     .del(taskMessagesKey(installationId, taskId))
     .del(taskClaimTokenHashKey(installationId, taskId))
+    .del(taskArtifactsKey(installationId, taskId))
     .exec();
 }
 
@@ -329,13 +344,17 @@ async function buildTaskRecord(
   stored: StoredTaskRecord,
   redis: Redis,
 ): Promise<TaskRecord> {
-  const progressRaw = await redis.get(taskProgressKey(installationId, stored.task_id));
+  const [progressRaw, artifactsRaw] = await Promise.all([
+    redis.get(taskProgressKey(installationId, stored.task_id)),
+    redis.get(taskArtifactsKey(installationId, stored.task_id)),
+  ]);
 
   const task: TaskRecord = {
     ...stored,
   };
 
   if (typeof progressRaw === "string") task.progress = progressRaw;
+  if (Array.isArray(artifactsRaw) && artifactsRaw.length > 0) task.artifacts = artifactsRaw as TaskArtifact[];
 
   return task;
 }
@@ -1017,6 +1036,7 @@ export async function deleteTask(
       .del(taskKey(installationId, taskId))
       .del(taskProgressKey(installationId, taskId))
       .del(taskMessagesKey(installationId, taskId))
+      .del(taskArtifactsKey(installationId, taskId))
       .zrem(pendingKey(installationId), taskId)
       .zrem(runningKey(installationId), taskId)
       .zrem(recentKey(installationId), taskId)
@@ -1062,6 +1082,7 @@ export async function retryTask(
         .zadd(pendingKey(installationId), { score: Date.now(), member: taskId })
         .zadd(recentKey(installationId), { score: Date.now(), member: taskId })
         .del(taskClaimTokenHashKey(installationId, taskId))
+        .del(taskArtifactsKey(installationId, taskId))
         .exec();
 
       try {
@@ -1164,6 +1185,99 @@ export async function getTaskMessages(
   }
 
   return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Artifact tracking
+// ---------------------------------------------------------------------------
+
+const MAX_ARTIFACTS_PER_TASK = 20;
+const MAX_ARTIFACT_TITLE_CHARS = 200;
+
+const VALID_ARTIFACT_TYPES = new Set<TaskArtifactType>([
+  "pull_request",
+  "issue",
+  "issue_comment",
+  "commit",
+]);
+
+// URL must be scoped to github.com/{owner}/{repo}/... where owner/repo is one
+// of the repos the task was created against.
+function validateArtifactUrl(url: string, repos: string[]): boolean {
+  if (typeof url !== "string") return false;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    if (parsed.hostname !== "github.com") return false;
+    const pathParts = parsed.pathname.replace(/^\//, "").split("/");
+    if (pathParts.length < 2) return false;
+    const repoSlug = `${pathParts[0]}/${pathParts[1]}`;
+    return repos.some((r) => r.toLowerCase() === repoSlug.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function parseArtifact(raw: unknown, repos: string[]): TaskArtifact | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  if (!VALID_ARTIFACT_TYPES.has(obj.type as TaskArtifactType)) return null;
+  if (!validateArtifactUrl(obj.url as string, repos)) return null;
+  const artifact: TaskArtifact = {
+    type: obj.type as TaskArtifactType,
+    url: obj.url as string,
+  };
+  if (typeof obj.number === "number" && Number.isInteger(obj.number) && obj.number > 0) {
+    artifact.number = obj.number;
+  }
+  if (typeof obj.title === "string" && obj.title.trim().length > 0) {
+    artifact.title = obj.title.trim().slice(0, MAX_ARTIFACT_TITLE_CHARS);
+  }
+  return artifact;
+}
+
+export type AppendArtifactsResult =
+  | { ok: true; artifacts: TaskArtifact[] }
+  | { ok: false; reason: "not_found" | "cap_exceeded" | "validation_failed" };
+
+export async function appendTaskArtifacts(
+  installationId: string,
+  taskId: string,
+  incoming: unknown[],
+  redis: Redis,
+): Promise<AppendArtifactsResult> {
+  const stored = await loadStoredTask(installationId, taskId, redis);
+  if (!stored) return { ok: false, reason: "not_found" };
+
+  const parsed: TaskArtifact[] = [];
+  for (const raw of incoming) {
+    const artifact = parseArtifact(raw, stored.repos);
+    if (!artifact) return { ok: false, reason: "validation_failed" };
+    parsed.push(artifact);
+  }
+
+  const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
+  const existing: TaskArtifact[] = Array.isArray(existingRaw) ? (existingRaw as TaskArtifact[]) : [];
+
+  if (existing.length + parsed.length > MAX_ARTIFACTS_PER_TASK) {
+    return { ok: false, reason: "cap_exceeded" };
+  }
+
+  const updated = [...existing, ...parsed];
+  await redis.set(taskArtifactsKey(installationId, taskId), updated);
+
+  return { ok: true, artifacts: updated };
+}
+
+export async function getTaskArtifacts(
+  installationId: string,
+  taskId: string,
+  redis: Redis,
+): Promise<TaskArtifact[] | null> {
+  const stored = await loadStoredTask(installationId, taskId, redis);
+  if (!stored) return null;
+  const raw = await redis.get(taskArtifactsKey(installationId, taskId));
+  return Array.isArray(raw) ? (raw as TaskArtifact[]) : [];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -640,12 +640,15 @@ async function finalizeTask(
         .zadd(recentKey(installationId), { score: Date.now(), member: taskId })
         .exec();
 
-      // Best-effort: expire the messages list alongside the task data.
+      // Best-effort: expire the messages and artifacts lists alongside the task data.
       // The task has already been finalized so a failure here must not propagate.
       try {
-        await redis.expire(taskMessagesKey(installationId, taskId), ttl);
+        await Promise.all([
+          redis.expire(taskMessagesKey(installationId, taskId), ttl),
+          redis.expire(taskArtifactsKey(installationId, taskId), ttl),
+        ]);
       } catch (error) {
-        console.error("[tasks] Failed to expire messages key (task finalized)", {
+        console.error("[tasks] Failed to expire messages/artifacts keys (task finalized)", {
           installationId,
           taskId,
           error,
@@ -1246,17 +1249,19 @@ export async function appendTaskArtifacts(
   incoming: unknown[],
   redis: Redis,
 ): Promise<AppendArtifactsResult> {
-  const stored = await loadStoredTask(installationId, taskId, redis);
-  if (!stored) return { ok: false, reason: "not_found" };
-
-  const parsed: TaskArtifact[] = [];
-  for (const raw of incoming) {
-    const artifact = parseArtifact(raw, stored.repos);
-    if (!artifact) return { ok: false, reason: "validation_failed" };
-    parsed.push(artifact);
-  }
-
   return withTaskInstallationLock(installationId, redis, async () => {
+    // Load inside the lock so a concurrent deleteTask cannot leave an orphaned
+    // artifacts key between the existence check and the write.
+    const stored = await loadStoredTask(installationId, taskId, redis);
+    if (!stored) return { ok: false, reason: "not_found" };
+
+    const parsed: TaskArtifact[] = [];
+    for (const raw of incoming) {
+      const artifact = parseArtifact(raw, stored.repos);
+      if (!artifact) return { ok: false, reason: "validation_failed" };
+      parsed.push(artifact);
+    }
+
     const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
     const existing: TaskArtifact[] = Array.isArray(existingRaw) ? (existingRaw as TaskArtifact[]) : [];
 

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -1197,21 +1197,62 @@ export async function getTaskMessages(
 const MAX_ARTIFACTS_PER_TASK = 20;
 const MAX_ARTIFACT_TITLE_CHARS = 200;
 
-const VALID_ARTIFACT_TYPES = new Set<TaskArtifactType>([
-  "pull_request",
-  "issue",
-  "issue_comment",
-  "commit",
-]);
+// Derive artifact type (and optional number) from the GitHub URL path.
+// The URL is the canonical source of truth; caller-supplied type/number fields
+// are ignored. Returns null if the URL does not match a known GitHub object pattern.
+function parseArtifactMetadata(
+  url: string,
+): { type: TaskArtifactType; number?: number } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") return null;
+
+  // pathname: /{owner}/{repo}/{kind}/...
+  const parts = parsed.pathname.replace(/^\//, "").split("/");
+  if (parts.length < 4) return null;
+
+  const kind = parts[2]; // "pull", "issues", "commit"
+  const segment = parts[3]; // N or sha
+
+  if (kind === "pull") {
+    const n = parseInt(segment, 10);
+    if (!Number.isFinite(n) || n <= 0 || String(n) !== segment) return null;
+    return { type: "pull_request", number: n };
+  }
+
+  if (kind === "issues") {
+    const n = parseInt(segment, 10);
+    if (!Number.isFinite(n) || n <= 0 || String(n) !== segment) return null;
+    // Distinguish issue from issue_comment via fragment: #issuecomment-{M}
+    const fragment = parsed.hash; // e.g. "#issuecomment-12345"
+    const commentMatch = fragment.match(/^#issuecomment-(\d+)$/);
+    if (commentMatch) {
+      const commentId = parseInt(commentMatch[1], 10);
+      if (!Number.isFinite(commentId) || commentId <= 0) return null;
+      return { type: "issue_comment", number: commentId };
+    }
+    return { type: "issue", number: n };
+  }
+
+  if (kind === "commit") {
+    // sha is 40 hex chars (full) or 7-40 chars (abbreviated); no number field
+    if (!/^[0-9a-f]{7,40}$/i.test(segment)) return null;
+    return { type: "commit" };
+  }
+
+  return null;
+}
 
 // URL must be scoped to github.com/{owner}/{repo}/... where owner/repo is one
 // of the repos the task was created against.
-function validateArtifactUrl(url: string, repos: string[]): boolean {
-  if (typeof url !== "string") return false;
+function validateArtifactRepoScope(url: string, repos: string[]): boolean {
   try {
     const parsed = new URL(url);
-    if (parsed.protocol !== "https:") return false;
-    if (parsed.hostname !== "github.com") return false;
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") return false;
     const pathParts = parsed.pathname.replace(/^\//, "").split("/");
     if (pathParts.length < 2) return false;
     const repoSlug = `${pathParts[0]}/${pathParts[1]}`;
@@ -1224,14 +1265,21 @@ function validateArtifactUrl(url: string, repos: string[]): boolean {
 function parseArtifact(raw: unknown, repos: string[]): TaskArtifact | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
   const obj = raw as Record<string, unknown>;
-  if (!VALID_ARTIFACT_TYPES.has(obj.type as TaskArtifactType)) return null;
-  if (!validateArtifactUrl(obj.url as string, repos)) return null;
+  if (typeof obj.url !== "string") return null;
+
+  // Scope check first — reject URLs outside the task's repos
+  if (!validateArtifactRepoScope(obj.url, repos)) return null;
+
+  // Derive type and number from the URL path; reject unrecognized patterns
+  const meta = parseArtifactMetadata(obj.url);
+  if (!meta) return null;
+
   const artifact: TaskArtifact = {
-    type: obj.type as TaskArtifactType,
-    url: obj.url as string,
+    type: meta.type,
+    url: obj.url,
   };
-  if (typeof obj.number === "number" && Number.isInteger(obj.number) && obj.number > 0) {
-    artifact.number = obj.number;
+  if (meta.number !== undefined) {
+    artifact.number = meta.number;
   }
   if (typeof obj.title === "string" && obj.title.trim().length > 0) {
     artifact.title = obj.title.trim().slice(0, MAX_ARTIFACT_TITLE_CHARS);


### PR DESCRIPTION
Closes #332

Agents can now report GitHub outputs (PRs, issues, comments, commits) during task execution via a new endpoint. The web dashboard surfaces these as clickable badges in the task detail header — no transcript-reading required to find what the agent produced.

## What changed

### Backend (`apps/web/src/server/task-store.ts`)

- New `TaskArtifact` interface and `TaskArtifactType` union
- `artifacts?: TaskArtifact[]` field on `TaskRecord`
- `taskArtifactsKey()` helper following the existing key conventions
- `buildTaskRecord()` now loads artifacts in parallel with progress (no extra round-trip cost)
- `appendTaskArtifacts()`: validates artifact type, scopes URL to `github.com/{owner}/{repo}` matching the task's repos, enforces a 20-artifact cap, append-only
- `getTaskArtifacts()`: exported read helper
- Cleanup: `cleanupMissingTask`, `deleteTask`, `retryTask` all clear the artifacts key (retry clears artifacts from the previous attempt)

### API (`apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts`)

New `POST /api/tasks/{taskId}/artifacts` endpoint:
- Auth: executor bearer token + `x-task-claim-token` header (same pattern as the execute route)
- Accepts `{ artifacts: TaskArtifact[] }` — array, 1–20 entries per request
- Returns `{ artifacts: TaskArtifact[] }` — full current artifact list after append
- Validation errors return structured task error codes

### Web UI

- `TaskArtifact` type added to `apps/web/src/app/dashboard/tasks/types.ts`
- `TaskDetail` renders an "Outputs" section in the header card when artifacts are present — each artifact is a link badge showing title (if provided) or a `PR #N` / `Issue #N` style label

## Validation

```
# Type check (once deps are installed)
cd apps/web && npm run typecheck

# Unit tests
cd apps/web && npm test -- src/server/task-store.test.ts
```

Manual: queue a task that opens a PR, call `POST /api/tasks/{id}/artifacts` with the PR URL and watch it appear in the task detail before the task completes.

## Non-goals (per issue spec)

- Deduplication (display layer can deduplicate by URL if needed later)
- Cross-task artifact linking
- Real-time streaming of artifact links via SSE