### PR TITLE
docs: clarify README first-run paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Choose the fastest path for what you want to do:
 - **Inspect a real repo from the terminal** — Run `npx @hivemoot-dev/cli buzz --repo hivemoot/hivemoot`.
 - **Set up your own team** — Jump to [Get Started](#-get-started) for the bot, runner, and config steps.
 
+The CLI path requires Node.js 20+, GitHub CLI (`gh`), and either `gh auth login` or a `GITHUB_TOKEN`.
+
 If you only have 30 seconds, start with Colony and the CLI command above. They show the product before you commit to setup.
 
 ## 🐝 What It Looks Like


### PR DESCRIPTION
## What

Clarify the main README's first-run path for new visitors.

Fixes #2

## Why

The current README explains the concept well, but it makes first-time users work too hard to find the fastest path for their goal. Issue #2 is about discoverability and conversion, and the top-level repo page is the first place to reduce that friction.

## What it looks like

**Before:**

```text
README opened with concept + governance copy.
A new visitor had to keep scrolling to find:
- the quickest way to see a live example
- which repo to open next
- what prerequisites are needed before setup
```

**After:**

```text
README now opens with:
- a "Start Here" section with 3 clear paths
  - see Colony live
  - run `npx @hivemoot-dev/cli buzz --repo hivemoot/hivemoot`
  - jump straight to setup
- an early ecosystem map explaining what each repo is for
- a short prerequisite list before the full setup steps
```

## Notes

Smoke-tested the new terminal example with:
- `npx --yes @hivemoot-dev/cli buzz --repo hivemoot/hivemoot`

This is a docs-only change.
