### PR TITLE
feat(cli): structured focus filters and action bans (#165)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -1106,4 +1106,136 @@ describe("buzzCommand", () => {
       code: "CONFIG_NOT_FOUND",
     });
   });
+
+  // ── Focus label filtering ──────────────────────────────────────────
+
+  it("filters issues by label include rules from focus config", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Fix bugs.",
+      resolvedFocus: {
+        objective: "Fix bugs.",
+        filters: { labels: { include: ["bug"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Bug A", labels: [{ name: "bug" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Feature B", labels: [{ name: "enhancement" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+      { number: 3, title: "Bug C", labels: [{ name: "bug" }, { name: "critical" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/3" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const issuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
+    expect(issuesArg.map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  it("filters issues by label exclude rules from focus config", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Skip wontfix.",
+      resolvedFocus: {
+        objective: "Skip wontfix.",
+        filters: { labels: { exclude: ["wontfix"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Active issue", labels: [{ name: "bug" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Won't fix", labels: [{ name: "wontfix" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const issuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
+    expect(issuesArg.map((i) => i.number)).toEqual([1]);
+  });
+
+  it("filters PRs by label include rules from focus config", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Blocker PRs only.",
+      resolvedFocus: {
+        objective: "Blocker PRs only.",
+        filters: { labels: { include: ["priority"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([
+      { number: 10, title: "PR A", labels: [{ name: "priority" }], state: "OPEN", author: null, assignees: [], comments: [], reviews: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/pull/10", isDraft: false, reviewDecision: "APPROVED", mergeable: "MERGEABLE", statusCheckRollup: null, closingIssuesReferences: [], commits: [] },
+      { number: 11, title: "PR B", labels: [{ name: "docs" }], state: "OPEN", author: null, assignees: [], comments: [], reviews: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/pull/11", isDraft: false, reviewDecision: "REVIEW_REQUIRED", mergeable: "MERGEABLE", statusCheckRollup: null, closingIssuesReferences: [], commits: [] },
+    ]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const prsArg = mockedBuildSummary.mock.calls[0][2] as Array<{ number: number }>;
+    expect(prsArg.map((p) => p.number)).toEqual([10]);
+  });
+
+  it("passes action bans from focus config to summary", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Review only.",
+      resolvedFocus: {
+        objective: "Review only.",
+        filters: { actions: { exclude: ["create-pr", "create-proposal"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.actionBans).toEqual(["create-pr", "create-proposal"]);
+  });
+
+  it("does not set actionBans when focus has no action filters", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Plain focus.",
+      resolvedFocus: { objective: "Plain focus." },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.actionBans).toBeUndefined();
+  });
+
+  it("applies no filter when focus config has no label filters", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Review only.",
+      resolvedFocus: {
+        objective: "Review only.",
+        filters: { actions: { exclude: ["create-pr"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Issue A", labels: [{ name: "bug" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Issue B", labels: [], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const issuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
+    expect(issuesArg.map((i) => i.number)).toEqual([1, 2]);
+  });
 });

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -1546,13 +1546,13 @@ describe("buzzCommand", () => {
 
   // ── suppressSections (canonical #178 Phase 2 schema) ─────────────
 
-  it("clears implement section when suppressSections includes ready-to-implement", async () => {
+  it("clears implement section when filters.suppressSections includes ready-to-implement", async () => {
     mockedLoadTeamConfig.mockResolvedValue({
       ...testTeamConfig,
       focus: "Review only.",
       resolvedFocus: {
         objective: "Review only.",
-        suppressSections: ["ready-to-implement"],
+        filters: { suppressSections: ["ready-to-implement"] },
       },
     });
     mockedFetchIssues.mockResolvedValue([]);
@@ -1567,13 +1567,13 @@ describe("buzzCommand", () => {
     expect(summaryArg.actionBans).toContain("ready-to-implement");
   });
 
-  it("clears discussion and voting sections when suppressSections specifies them", async () => {
+  it("clears discussion and voting sections when filters.suppressSections specifies them", async () => {
     mockedLoadTeamConfig.mockResolvedValue({
       ...testTeamConfig,
       focus: "Implementation sprint.",
       resolvedFocus: {
         objective: "Implementation sprint.",
-        suppressSections: ["discussion", "voting"],
+        filters: { suppressSections: ["discussion", "voting"] },
       },
     });
     mockedFetchIssues.mockResolvedValue([]);
@@ -1596,13 +1596,13 @@ describe("buzzCommand", () => {
     expect(summaryArg.actionBans).toEqual(["discussion", "voting"]);
   });
 
-  it("adds unknown-section warning to notes when suppressSections has unrecognized value", async () => {
+  it("adds unknown-section warning to notes when filters.suppressSections has unrecognized value", async () => {
     mockedLoadTeamConfig.mockResolvedValue({
       ...testTeamConfig,
       focus: "Typo focus.",
       resolvedFocus: {
         objective: "Typo focus.",
-        suppressSections: ["ready-to-implment"], // deliberate typo
+        filters: { suppressSections: ["ready-to-implment"] }, // deliberate typo
       },
     });
     mockedFetchIssues.mockResolvedValue([]);
@@ -1616,14 +1616,16 @@ describe("buzzCommand", () => {
     expect(summaryArg.notes.some((n: string) => n.includes("ready-to-implment"))).toBe(true);
   });
 
-  it("combines suppressSections and actions.exclude bans in actionBans output", async () => {
+  it("combines filters.suppressSections and actions.exclude bans in actionBans output", async () => {
     mockedLoadTeamConfig.mockResolvedValue({
       ...testTeamConfig,
       focus: "Strict review only.",
       resolvedFocus: {
         objective: "Strict review only.",
-        suppressSections: ["ready-to-implement"],
-        filters: { actions: { exclude: ["create-proposal"] } },
+        filters: {
+          suppressSections: ["ready-to-implement"],
+          actions: { exclude: ["create-proposal"] },
+        },
       },
     });
     mockedFetchIssues.mockResolvedValue([]);

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -385,6 +385,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +409,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -430,6 +432,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -473,6 +476,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -571,6 +575,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      undefined,
     );
   });
 
@@ -665,6 +670,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       notificationMap,
+      undefined,
       undefined,
     );
   });
@@ -1358,5 +1364,107 @@ describe("buzzCommand", () => {
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.implement).toEqual([implementItem]);   // not suppressed
     expect(summaryArg.driveDiscussion).toEqual([]);          // suppressed
+  });
+
+  // ── Notification leakage suppression ───────────────────────────────
+
+  it("excludes notifications for label-filtered-out issues from buildSummary", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Bugs only.",
+      resolvedFocus: {
+        objective: "Bugs only.",
+        filters: { labels: { include: ["bug"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Bug A", labels: [{ name: "bug" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Feature B", labels: [{ name: "enhancement" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    // Notifications for both issues — #2 should be suppressed after filtering
+    mockedFetchNotifications.mockResolvedValue(new Map([
+      [1, { threadId: "T1", reason: "mention", updatedAt: "2025-01-01T00:00:00Z", title: "Bug A", url: "https://github.com/h/r/issues/1", itemType: "Issue" as const }],
+      [2, { threadId: "T2", reason: "mention", updatedAt: "2025-01-02T00:00:00Z", title: "Feature B", url: "https://github.com/h/r/issues/2", itemType: "Issue" as const }],
+    ]));
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const notificationsArg = mockedBuildSummary.mock.calls[0][6] as Map<number, unknown>;
+    expect(notificationsArg.has(1)).toBe(true);   // in focus — kept
+    expect(notificationsArg.has(2)).toBe(false);  // filtered out — suppressed
+  });
+
+  it("suppresses mention notifications for label-filtered-out issues in unackedMentions", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Bugs only.",
+      resolvedFocus: {
+        objective: "Bugs only.",
+        filters: { labels: { include: ["bug"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Bug A", labels: [{ name: "bug" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Feature B", labels: [{ name: "enhancement" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedFetchNotifications.mockResolvedValue(new Map([
+      [1, { threadId: "T1", reason: "mention", updatedAt: "2025-01-01T00:00:00Z", title: "Bug A", url: "https://github.com/h/r/issues/1", itemType: "Issue" as const }],
+      [2, { threadId: "T2", reason: "mention", updatedAt: "2025-01-02T00:00:00Z", title: "Feature B", url: "https://github.com/h/r/issues/2", itemType: "Issue" as const }],
+    ]));
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [], unackedMentions: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    // Issue #1 (bug — in focus) should appear; issue #2 (enhancement — filtered) should not
+    const mentionNumbers = summaryArg.unackedMentions.map((m: { number: number }) => m.number);
+    expect(mentionNumbers).toContain(1);
+    expect(mentionNumbers).not.toContain(2);
+  });
+
+  it("passes unfiltered datasets as healthContext to buildSummary when focus filters are active", async () => {
+    const bugIssue = { number: 1, title: "Bug A", labels: [{ name: "bug" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" };
+    const featureIssue = { number: 2, title: "Feature B", labels: [{ name: "enhancement" }], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" };
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Bugs only.",
+      resolvedFocus: {
+        objective: "Bugs only.",
+        filters: { labels: { include: ["bug"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([bugIssue, featureIssue]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    // Arg [1] (focused issues): only bug issue passes the filter
+    const focusedIssuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
+    expect(focusedIssuesArg.map((i) => i.number)).toEqual([1]);
+
+    // Arg [8] (healthContext): both issues present for accurate repo health reporting
+    const healthContextArg = mockedBuildSummary.mock.calls[0][8] as { issues: Array<{ number: number }>; prs: unknown[] };
+    expect(healthContextArg).toBeDefined();
+    expect(healthContextArg.issues.map((i) => i.number)).toEqual([1, 2]);
+    expect(healthContextArg.prs).toEqual([]);
+  });
+
+  it("passes undefined healthContext to buildSummary when no focus filters are active", async () => {
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const healthContextArg = mockedBuildSummary.mock.calls[0][8];
+    expect(healthContextArg).toBeUndefined();
   });
 });

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -1185,6 +1185,82 @@ describe("buzzCommand", () => {
     expect(prsArg.map((p) => p.number)).toEqual([10]);
   });
 
+  it("filters issues by author exclude rules from focus config", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Skip bots.",
+      resolvedFocus: {
+        objective: "Skip bots.",
+        filters: { authors: { exclude: ["dependabot[bot]"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Human issue", labels: [], assignees: [], author: { login: "alice" }, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Dependabot issue", labels: [], assignees: [], author: { login: "dependabot[bot]" }, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+      { number: 3, title: "No author", labels: [], assignees: [], author: null, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/3" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const issuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
+    // dependabot[bot] excluded; null author passes through
+    expect(issuesArg.map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  it("filters PRs by author exclude rules from focus config", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Skip bots.",
+      resolvedFocus: {
+        objective: "Skip bots.",
+        filters: { authors: { exclude: ["renovate[bot]"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([
+      { number: 10, title: "Human PR", labels: [], state: "OPEN", author: { login: "bob" }, assignees: [], comments: [], reviews: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/pull/10", isDraft: false, reviewDecision: "REVIEW_REQUIRED", mergeable: "MERGEABLE", statusCheckRollup: null, closingIssuesReferences: [], commits: [] },
+      { number: 11, title: "Renovate PR", labels: [], state: "OPEN", author: { login: "renovate[bot]" }, assignees: [], comments: [], reviews: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/pull/11", isDraft: false, reviewDecision: "REVIEW_REQUIRED", mergeable: "MERGEABLE", statusCheckRollup: null, closingIssuesReferences: [], commits: [] },
+    ]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const prsArg = mockedBuildSummary.mock.calls[0][2] as Array<{ number: number }>;
+    expect(prsArg.map((p) => p.number)).toEqual([10]);
+  });
+
+  it("combines label and author filters (both must pass)", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Bug hunt, skip bots.",
+      resolvedFocus: {
+        objective: "Bug hunt, skip bots.",
+        filters: {
+          labels: { include: ["bug"] },
+          authors: { exclude: ["dependabot[bot]"] },
+        },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([
+      { number: 1, title: "Bug from human", labels: [{ name: "bug" }], assignees: [], author: { login: "alice" }, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/1" },
+      { number: 2, title: "Bug from bot", labels: [{ name: "bug" }], assignees: [], author: { login: "dependabot[bot]" }, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/2" },
+      { number: 3, title: "Enhancement from human", labels: [{ name: "enhancement" }], assignees: [], author: { login: "alice" }, comments: [], createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", url: "https://github.com/h/r/issues/3" },
+    ]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const issuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
+    // Only issue 1 passes: has bug label AND is not from a bot
+    expect(issuesArg.map((i) => i.number)).toEqual([1]);
+  });
+
   it("passes action bans from focus config to summary", async () => {
     mockedLoadTeamConfig.mockResolvedValue({
       ...testTeamConfig,

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -1543,4 +1543,104 @@ describe("buzzCommand", () => {
     const healthContextArg = mockedBuildSummary.mock.calls[0][8];
     expect(healthContextArg).toBeUndefined();
   });
+
+  // ── suppressSections (canonical #178 Phase 2 schema) ─────────────
+
+  it("clears implement section when suppressSections includes ready-to-implement", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Review only.",
+      resolvedFocus: {
+        objective: "Review only.",
+        suppressSections: ["ready-to-implement"],
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, implement: [implementItem], notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.implement).toEqual([]);
+    expect(summaryArg.actionBans).toContain("ready-to-implement");
+  });
+
+  it("clears discussion and voting sections when suppressSections specifies them", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Implementation sprint.",
+      resolvedFocus: {
+        objective: "Implementation sprint.",
+        suppressSections: ["discussion", "voting"],
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({
+      ...testSummary,
+      discuss: [discussItem],
+      voteOn: [{ number: 55, title: "Vote on this", tags: [], author: "user", comments: 0, age: "now" }],
+      implement: [implementItem],
+      notes: [],
+    });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.discuss).toEqual([]);
+    expect(summaryArg.voteOn).toEqual([]);
+    expect(summaryArg.implement).toEqual([implementItem]); // not suppressed
+    expect(summaryArg.actionBans).toEqual(["discussion", "voting"]);
+  });
+
+  it("adds unknown-section warning to notes when suppressSections has unrecognized value", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Typo focus.",
+      resolvedFocus: {
+        objective: "Typo focus.",
+        suppressSections: ["ready-to-implment"], // deliberate typo
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.notes.some((n: string) => n.includes("ready-to-implment"))).toBe(true);
+  });
+
+  it("combines suppressSections and actions.exclude bans in actionBans output", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Strict review only.",
+      resolvedFocus: {
+        objective: "Strict review only.",
+        suppressSections: ["ready-to-implement"],
+        filters: { actions: { exclude: ["create-proposal"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({
+      ...testSummary,
+      implement: [implementItem],
+      driveDiscussion: [driveItem],
+      notes: [],
+    });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.implement).toEqual([]);        // cleared by suppressSections
+    expect(summaryArg.driveDiscussion).toEqual([]);  // cleared by actions.exclude
+    expect(summaryArg.actionBans).toEqual(["ready-to-implement", "create-proposal"]);
+  });
 });

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -1238,4 +1238,125 @@ describe("buzzCommand", () => {
     const issuesArg = mockedBuildSummary.mock.calls[0][1] as Array<{ number: number }>;
     expect(issuesArg.map((i) => i.number)).toEqual([1, 2]);
   });
+
+  // ── Section suppression (structural action bans) ───────────────────
+
+  const implementItem = { number: 99, title: "Implement me", tags: [], author: "user", comments: 0, age: "now" };
+  const driveItem = { number: 88, title: "Drive discussion", tags: [], author: "user", comments: 0, age: "now" };
+  const discussItem = { number: 77, title: "Discuss this", tags: [], author: "user", comments: 0, age: "now" };
+
+  it("clears implement section when create-pr is banned", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Review only.",
+      resolvedFocus: {
+        objective: "Review only.",
+        filters: { actions: { exclude: ["create-pr"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, implement: [implementItem], notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.implement).toEqual([]);
+  });
+
+  it("clears driveDiscussion section when create-proposal is banned", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Implementation sprint.",
+      resolvedFocus: {
+        objective: "Implementation sprint.",
+        filters: { actions: { exclude: ["create-proposal"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, driveDiscussion: [driveItem], notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.driveDiscussion).toEqual([]);
+  });
+
+  it("clears discuss section when comment-on-issue is banned", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "No comments.",
+      resolvedFocus: {
+        objective: "No comments.",
+        filters: { actions: { exclude: ["comment-on-issue"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, discuss: [discussItem], notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.discuss).toEqual([]);
+  });
+
+  it("suppresses multiple sections and sets actionBans for combined ban list", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Review queue only.",
+      resolvedFocus: {
+        objective: "Review queue only.",
+        filters: { actions: { exclude: ["create-pr", "create-proposal", "comment-on-issue"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({
+      ...testSummary,
+      implement: [implementItem],
+      driveDiscussion: [driveItem],
+      discuss: [discussItem],
+      notes: [],
+    });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.implement).toEqual([]);
+    expect(summaryArg.driveDiscussion).toEqual([]);
+    expect(summaryArg.discuss).toEqual([]);
+    expect(summaryArg.actionBans).toEqual(["create-pr", "create-proposal", "comment-on-issue"]);
+  });
+
+  it("does not suppress unlisted sections when partial bans are active", async () => {
+    mockedLoadTeamConfig.mockResolvedValue({
+      ...testTeamConfig,
+      focus: "Bug sprint.",
+      resolvedFocus: {
+        objective: "Bug sprint.",
+        filters: { actions: { exclude: ["create-proposal"] } },
+      },
+    });
+    mockedFetchIssues.mockResolvedValue([]);
+    mockedFetchPulls.mockResolvedValue([]);
+    mockedBuildSummary.mockReturnValue({
+      ...testSummary,
+      implement: [implementItem],
+      driveDiscussion: [driveItem],
+      notes: [],
+    });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.implement).toEqual([implementItem]);   // not suppressed
+    expect(summaryArg.driveDiscussion).toEqual([]);          // suppressed
+  });
 });

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -97,12 +97,28 @@ function passesLabelFilter(
   return true;
 }
 
+function passesAuthorFilter(
+  authorLogin: string | null | undefined,
+  filters: FocusFilters,
+): boolean {
+  const { exclude } = filters.authors ?? {};
+  if (exclude && exclude.length > 0 && authorLogin) {
+    if (exclude.includes(authorLogin)) return false;
+  }
+  return true;
+}
+
 function applyFocusFilters<T extends GitHubIssue | GitHubPR>(
   items: T[],
   filters: FocusFilters,
 ): T[] {
-  if (!filters.labels?.include?.length && !filters.labels?.exclude?.length) return items;
-  return items.filter((item) => passesLabelFilter(itemLabels(item), filters));
+  const hasLabelFilter = !!(filters.labels?.include?.length || filters.labels?.exclude?.length);
+  const hasAuthorFilter = !!filters.authors?.exclude?.length;
+  if (!hasLabelFilter && !hasAuthorFilter) return items;
+  return items.filter((item) =>
+    passesLabelFilter(itemLabels(item), filters) &&
+    passesAuthorFilter(item.author?.login, filters),
+  );
 }
 
 // Maps action ban names to the summary sections they suppress.

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -142,6 +142,54 @@ function suppressBannedSections(summary: RepoSummary, bans: string[]): void {
   }
 }
 
+// Canonical section-name suppression from the #178 Phase 2 schema.
+// suppressSections entries use lowercase-kebab section identifiers.
+// Unknown section names are warned about in summary.notes.
+// Valid names: "ready-to-implement", "discussion", "drive-discussion",
+//   "voting", "review-prs", "drive-implementation", "needs-human".
+function applySuppressSections(summary: RepoSummary, sections: string[]): void {
+  const valid = new Set([
+    "ready-to-implement",
+    "discussion",
+    "drive-discussion",
+    "voting",
+    "review-prs",
+    "drive-implementation",
+    "needs-human",
+  ]);
+  for (const section of sections) {
+    switch (section) {
+      case "ready-to-implement":
+        summary.implement = [];
+        break;
+      case "discussion":
+        summary.discuss = [];
+        break;
+      case "drive-discussion":
+        summary.driveDiscussion = [];
+        break;
+      case "voting":
+        summary.voteOn = [];
+        break;
+      case "review-prs":
+        summary.reviewPRs = [];
+        break;
+      case "drive-implementation":
+        summary.driveImplementation = [];
+        break;
+      case "needs-human":
+        summary.needsHuman = [];
+        break;
+      default:
+        if (!valid.has(section)) {
+          summary.notes.push(
+            `Unknown suppressSections value: "${section}". Valid values: ${[...valid].join(", ")}.`,
+          );
+        }
+    }
+  }
+}
+
 export async function buzzCommand(options: BuzzOptions): Promise<void> {
   const repo = await resolveRepo(options.repo);
   const fetchLimit = options.fetchLimit ?? 200;
@@ -280,10 +328,25 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     focusFilters ? { issues: unfilteredIssues, prs: unfilteredPrs } : undefined,
   );
 
+  // Apply suppressSections (canonical #178 Phase 2 schema: section-name keys).
+  const suppressSections = teamConfig?.resolvedFocus?.suppressSections;
+  if (suppressSections && suppressSections.length > 0) {
+    applySuppressSections(summary, suppressSections);
+  }
+
+  // Apply actions.exclude (action-name keys; maps to the same structural suppression).
   const actionBans = teamConfig?.resolvedFocus?.filters?.actions?.exclude;
   if (actionBans && actionBans.length > 0) {
     suppressBannedSections(summary, actionBans);
-    summary.actionBans = actionBans;
+  }
+
+  // Collect all active bans for display transparency.
+  const allBans: string[] = [
+    ...(suppressSections ?? []),
+    ...(actionBans ?? []),
+  ];
+  if (allBans.length > 0) {
+    summary.actionBans = allBans;
   }
 
   const processedThreadIds = await processedThreadIdsPromise;

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -1,7 +1,9 @@
 import {
   CliError,
   type BuzzOptions,
+  type FocusFilters,
   type GitHubIssue,
+  type GitHubPR,
   type NotificationRef,
   type RecentClosedItem,
   type RepoRef,
@@ -76,6 +78,32 @@ function buildUnackedMentions(
   return mentions;
 }
 
+function itemLabels(item: GitHubIssue | GitHubPR): string[] {
+  return item.labels.map((l) => l.name);
+}
+
+function passesLabelFilter(
+  labels: string[],
+  filters: FocusFilters,
+): boolean {
+  const { include, exclude } = filters.labels ?? {};
+  if (include && include.length > 0) {
+    if (!include.some((l) => labels.includes(l))) return false;
+  }
+  if (exclude && exclude.length > 0) {
+    if (exclude.some((l) => labels.includes(l))) return false;
+  }
+  return true;
+}
+
+function applyFocusFilters<T extends GitHubIssue | GitHubPR>(
+  items: T[],
+  filters: FocusFilters,
+): T[] {
+  if (!filters.labels?.include?.length && !filters.labels?.exclude?.length) return items;
+  return items.filter((item) => passesLabelFilter(itemLabels(item), filters));
+}
+
 export async function buzzCommand(options: BuzzOptions): Promise<void> {
   const repo = await resolveRepo(options.repo);
   const fetchLimit = options.fetchLimit ?? 200;
@@ -142,10 +170,16 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     throw best ?? issuesResult.reason;
   }
 
-  const issues = issuesResult.status === "fulfilled" ? issuesResult.value : [];
-  const prs = prsResult.status === "fulfilled" ? prsResult.value : [];
+  let issues = issuesResult.status === "fulfilled" ? issuesResult.value : [];
+  let prs = prsResult.status === "fulfilled" ? prsResult.value : [];
   const currentUser = userResult.status === "fulfilled" ? userResult.value : "";
   const notifications: NotificationMap = notificationsResult.status === "fulfilled" ? notificationsResult.value : new Map();
+
+  const focusFilters = teamConfig?.resolvedFocus?.filters;
+  if (focusFilters) {
+    issues = applyFocusFilters(issues, focusFilters);
+    prs = applyFocusFilters(prs, focusFilters);
+  }
 
   // Fetch vote reactions for voting-phase issues
   const votingIssueNumbers = issues
@@ -184,6 +218,12 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     notifications,
     teamConfig?.focus,
   );
+
+  const actionBans = teamConfig?.resolvedFocus?.filters?.actions?.exclude;
+  if (actionBans && actionBans.length > 0) {
+    summary.actionBans = actionBans;
+  }
+
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());
   summary.recentlyClosedByYou = recentlyClosedByYou;

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -7,6 +7,7 @@ import {
   type NotificationRef,
   type RecentClosedItem,
   type RepoRef,
+  type RepoSummary,
   type TeamConfig,
 } from "../config/types.js";
 import { loadTeamConfig } from "../config/loader.js";
@@ -102,6 +103,27 @@ function applyFocusFilters<T extends GitHubIssue | GitHubPR>(
 ): T[] {
   if (!filters.labels?.include?.length && !filters.labels?.exclude?.length) return items;
   return items.filter((item) => passesLabelFilter(itemLabels(item), filters));
+}
+
+// Maps action ban names to the summary sections they suppress.
+// Suppression is structural: the agent never sees items it cannot act on.
+// create-pr     → READY TO IMPLEMENT ISSUES (items that would produce a new PR)
+// create-proposal → DRIVE THE DISCUSSION (items that would produce a proposal/comment)
+// comment-on-issue → DISCUSS ISSUES (items that invite open-ended comments)
+function suppressBannedSections(summary: RepoSummary, bans: string[]): void {
+  for (const ban of bans) {
+    switch (ban) {
+      case "create-pr":
+        summary.implement = [];
+        break;
+      case "create-proposal":
+        summary.driveDiscussion = [];
+        break;
+      case "comment-on-issue":
+        summary.discuss = [];
+        break;
+    }
+  }
 }
 
 export async function buzzCommand(options: BuzzOptions): Promise<void> {
@@ -221,6 +243,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
 
   const actionBans = teamConfig?.resolvedFocus?.filters?.actions?.exclude;
   if (actionBans && actionBans.length > 0) {
+    suppressBannedSections(summary, actionBans);
     summary.actionBans = actionBans;
   }
 

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -198,10 +198,32 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   const notifications: NotificationMap = notificationsResult.status === "fulfilled" ? notificationsResult.value : new Map();
 
   const focusFilters = teamConfig?.resolvedFocus?.filters;
+  const unfilteredIssues = issues;
+  const unfilteredPrs = prs;
   if (focusFilters) {
     issues = applyFocusFilters(issues, focusFilters);
     prs = applyFocusFilters(prs, focusFilters);
   }
+
+  // Suppress notifications whose item was excluded by focus filters.
+  // Items that were never in the fetched set (closed issues, items beyond
+  // fetch limit) are unaffected — we have no label data for them.
+  const focusedNotifications: NotificationMap = (() => {
+    if (!focusFilters) return notifications;
+    const focusedSet = new Set([
+      ...issues.map((i) => i.number),
+      ...prs.map((p) => p.number),
+    ]);
+    const fetchedSet = new Set([
+      ...unfilteredIssues.map((i) => i.number),
+      ...unfilteredPrs.map((p) => p.number),
+    ]);
+    const filteredOutNumbers = new Set(
+      [...fetchedSet].filter((n) => !focusedSet.has(n)),
+    );
+    if (filteredOutNumbers.size === 0) return notifications;
+    return new Map([...notifications.entries()].filter(([n]) => !filteredOutNumbers.has(n)));
+  })();
 
   // Fetch vote reactions for voting-phase issues
   const votingIssueNumbers = issues
@@ -237,8 +259,9 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     currentUser,
     new Date(),
     votes,
-    notifications,
+    focusedNotifications,
     teamConfig?.focus,
+    focusFilters ? { issues: unfilteredIssues, prs: unfilteredPrs } : undefined,
   );
 
   const actionBans = teamConfig?.resolvedFocus?.filters?.actions?.exclude;
@@ -248,7 +271,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   }
 
   const processedThreadIds = await processedThreadIdsPromise;
-  summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());
+  summary.unackedMentions = buildUnackedMentions(focusedNotifications, processedThreadIds, new Date());
   summary.recentlyClosedByYou = recentlyClosedByYou;
 
   if (issuesResult.status === "rejected" && prsResult.status === "rejected") {

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -328,8 +328,8 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     focusFilters ? { issues: unfilteredIssues, prs: unfilteredPrs } : undefined,
   );
 
-  // Apply suppressSections (canonical #178 Phase 2 schema: section-name keys).
-  const suppressSections = teamConfig?.resolvedFocus?.suppressSections;
+  // Apply suppressSections (canonical #178 Phase 2 schema: section-name keys under filters).
+  const suppressSections = teamConfig?.resolvedFocus?.filters?.suppressSections;
   if (suppressSections && suppressSections.length > 0) {
     applySuppressSections(summary, suppressSections);
   }

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -796,6 +796,177 @@ team:
     await expect(loadTeamConfig(repo)).rejects.toBe(otherError);
   });
 
+  // ── focus filters and action bans ────────────────────────────────
+
+  it("exposes resolvedFocus with label include filter", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "bug-hunt",
+        focuses: {
+          "bug-hunt": {
+            objective: "Fix bugs.",
+            filters: {
+              labels: { include: ["bug", "critical"] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Fix bugs.");
+    expect(config.resolvedFocus?.objective).toBe("Fix bugs.");
+    expect(config.resolvedFocus?.filters?.labels?.include).toEqual(["bug", "critical"]);
+    expect(config.resolvedFocus?.filters?.labels?.exclude).toBeUndefined();
+  });
+
+  it("exposes resolvedFocus with label exclude filter", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Regular work.",
+            filters: {
+              labels: { exclude: ["wontfix", "duplicate"] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.filters?.labels?.exclude).toEqual(["wontfix", "duplicate"]);
+    expect(config.resolvedFocus?.filters?.labels?.include).toBeUndefined();
+  });
+
+  it("exposes resolvedFocus with action bans", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "review-only",
+        focuses: {
+          "review-only": {
+            objective: "Clear the review queue. No new code.",
+            filters: {
+              actions: { exclude: ["create-pr", "comment-on-issue", "create-proposal"] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.filters?.actions?.exclude).toEqual([
+      "create-pr",
+      "comment-on-issue",
+      "create-proposal",
+    ]);
+  });
+
+  it("exposes resolvedFocus with both label and action filters", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "v2-bugs",
+        focuses: {
+          "v2-bugs": {
+            objective: "Fix v2 blockers.",
+            filters: {
+              labels: { include: ["bug", "v2-blocker"] },
+              actions: { exclude: ["create-proposal"] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.filters?.labels?.include).toEqual(["bug", "v2-blocker"]);
+    expect(config.resolvedFocus?.filters?.actions?.exclude).toEqual(["create-proposal"]);
+  });
+
+  it("returns undefined filters when focus block has no filters key", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: { objective: "Plain objective." },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.objective).toBe("Plain objective.");
+    expect(config.resolvedFocus?.filters).toBeUndefined();
+  });
+
+  it("ignores malformed filter arrays with non-string entries", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Work.",
+            filters: {
+              labels: { include: ["bug", 42] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    // Malformed include array is ignored; filters fall through to undefined
+    expect(config.resolvedFocus?.filters?.labels?.include).toBeUndefined();
+  });
+
+  it("sets resolvedFocus.filters undefined for legacy focus.default format", async () => {
+    const focusYaml = yaml.dump({
+      team: {
+        focus: { default: "Focus on PR reviews first." },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Focus on PR reviews first.");
+    expect(config.resolvedFocus?.objective).toBe("Focus on PR reviews first.");
+    expect(config.resolvedFocus?.filters).toBeUndefined();
+  });
+
   it("accepts description and instructions at exact max length", async () => {
     const exactLimitYaml = yaml.dump({
       team: {

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -1026,7 +1026,7 @@ team:
     expect(config.resolvedFocus?.filters?.authors).toBeUndefined();
   });
 
-  it("exposes resolvedFocus with suppressSections list", async () => {
+  it("exposes resolvedFocus with suppressSections list (under filters)", async () => {
     const configYaml = yaml.dump({
       team: {
         roles: { engineer: { description: "Eng.", instructions: "Code." } },
@@ -1034,7 +1034,7 @@ team:
         focuses: {
           "review-blitz": {
             objective: "Clear the review queue.",
-            suppressSections: ["ready-to-implement", "discussion"],
+            filters: { suppressSections: ["ready-to-implement", "discussion"] },
           },
         },
       },
@@ -1043,11 +1043,11 @@ team:
 
     const config = await loadTeamConfig(repo);
 
-    expect(config.resolvedFocus?.suppressSections).toEqual(["ready-to-implement", "discussion"]);
-    expect(config.resolvedFocus?.filters).toBeUndefined();
+    expect(config.resolvedFocus?.filters?.suppressSections).toEqual(["ready-to-implement", "discussion"]);
+    expect(config.resolvedFocus?.filters?.labels).toBeUndefined();
   });
 
-  it("exposes resolvedFocus with suppressSections and filters together", async () => {
+  it("exposes resolvedFocus with suppressSections and label filters together (both under filters)", async () => {
     const configYaml = yaml.dump({
       team: {
         roles: { engineer: { description: "Eng.", instructions: "Code." } },
@@ -1055,8 +1055,10 @@ team:
         focuses: {
           "bugs-only": {
             objective: "Squash bugs.",
-            suppressSections: ["ready-to-implement"],
-            filters: { labels: { include: ["bug"] } },
+            filters: {
+              suppressSections: ["ready-to-implement"],
+              labels: { include: ["bug"] },
+            },
           },
         },
       },
@@ -1065,7 +1067,7 @@ team:
 
     const config = await loadTeamConfig(repo);
 
-    expect(config.resolvedFocus?.suppressSections).toEqual(["ready-to-implement"]);
+    expect(config.resolvedFocus?.filters?.suppressSections).toEqual(["ready-to-implement"]);
     expect(config.resolvedFocus?.filters?.labels?.include).toEqual(["bug"]);
   });
 
@@ -1077,7 +1079,7 @@ team:
         focuses: {
           default: {
             objective: "Default objective.",
-            suppressSections: ["ready-to-implement", 42],
+            filters: { suppressSections: ["ready-to-implement", 42] },
           },
         },
       },
@@ -1087,7 +1089,7 @@ team:
     const config = await loadTeamConfig(repo);
 
     // parseStringArray rejects mixed-type arrays; suppressSections is silently dropped
-    expect(config.resolvedFocus?.suppressSections).toBeUndefined();
+    expect(config.resolvedFocus?.filters?.suppressSections).toBeUndefined();
   });
 
   it("sets resolvedFocus.filters undefined for legacy focus.default format", async () => {

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -1026,6 +1026,70 @@ team:
     expect(config.resolvedFocus?.filters?.authors).toBeUndefined();
   });
 
+  it("exposes resolvedFocus with suppressSections list", async () => {
+    const configYaml = yaml.dump({
+      team: {
+        roles: { engineer: { description: "Eng.", instructions: "Code." } },
+        activeFocus: "review-blitz",
+        focuses: {
+          "review-blitz": {
+            objective: "Clear the review queue.",
+            suppressSections: ["ready-to-implement", "discussion"],
+          },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(configYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.suppressSections).toEqual(["ready-to-implement", "discussion"]);
+    expect(config.resolvedFocus?.filters).toBeUndefined();
+  });
+
+  it("exposes resolvedFocus with suppressSections and filters together", async () => {
+    const configYaml = yaml.dump({
+      team: {
+        roles: { engineer: { description: "Eng.", instructions: "Code." } },
+        activeFocus: "bugs-only",
+        focuses: {
+          "bugs-only": {
+            objective: "Squash bugs.",
+            suppressSections: ["ready-to-implement"],
+            filters: { labels: { include: ["bug"] } },
+          },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(configYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.suppressSections).toEqual(["ready-to-implement"]);
+    expect(config.resolvedFocus?.filters?.labels?.include).toEqual(["bug"]);
+  });
+
+  it("ignores malformed suppressSections (non-string entries)", async () => {
+    const configYaml = yaml.dump({
+      team: {
+        roles: { engineer: { description: "Eng.", instructions: "Code." } },
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Default objective.",
+            suppressSections: ["ready-to-implement", 42],
+          },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(configYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    // parseStringArray rejects mixed-type arrays; suppressSections is silently dropped
+    expect(config.resolvedFocus?.suppressSections).toBeUndefined();
+  });
+
   it("sets resolvedFocus.filters undefined for legacy focus.default format", async () => {
     const focusYaml = yaml.dump({
       team: {

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -949,6 +949,83 @@ team:
     expect(config.resolvedFocus?.filters?.labels?.include).toBeUndefined();
   });
 
+  it("exposes resolvedFocus with author exclude filter", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Work on any issue.",
+            filters: {
+              authors: { exclude: ["dependabot[bot]"] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.filters?.authors?.exclude).toEqual(["dependabot[bot]"]);
+  });
+
+  it("exposes resolvedFocus with labels and author filters combined", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Work on bugs, skip bots.",
+            filters: {
+              labels: { include: ["bug"] },
+              authors: { exclude: ["dependabot[bot]", "renovate[bot]"] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.filters?.labels?.include).toEqual(["bug"]);
+    expect(config.resolvedFocus?.filters?.authors?.exclude).toEqual([
+      "dependabot[bot]",
+      "renovate[bot]",
+    ]);
+  });
+
+  it("ignores malformed authors filter (non-string entries)", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Work.",
+            filters: {
+              authors: { exclude: ["bot", 42] },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.resolvedFocus?.filters?.authors).toBeUndefined();
+  });
+
   it("sets resolvedFocus.filters undefined for legacy focus.default format", async () => {
     const focusYaml = yaml.dump({
       team: {

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -164,7 +164,11 @@ function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocus | undefin
       if (objective.length > MAX_OBJECTIVE_LENGTH) continue;
 
       const filters = parseFocusFilters(b.filters);
-      return filters ? { objective, filters } : { objective };
+      const suppressSections = parseStringArray(b.suppressSections);
+      const resolved: ResolvedFocus = { objective };
+      if (filters) resolved.filters = filters;
+      if (suppressSections && suppressSections.length > 0) resolved.suppressSections = suppressSections;
+      return resolved;
     }
 
     return undefined;

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -118,12 +118,15 @@ function parseFocusFilters(raw: unknown): FocusFilters | undefined {
     actionExclude = parseStringArray(actions.exclude);
   }
 
-  if (!labels && !authors && (!actionExclude || actionExclude.length === 0)) return undefined;
+  const suppressSections = parseStringArray(r.suppressSections);
+
+  if (!labels && !authors && (!actionExclude || actionExclude.length === 0) && (!suppressSections || suppressSections.length === 0)) return undefined;
 
   const result: FocusFilters = {};
   if (labels) result.labels = labels;
   if (authors) result.authors = authors;
   if (actionExclude && actionExclude.length > 0) result.actions = { exclude: actionExclude };
+  if (suppressSections && suppressSections.length > 0) result.suppressSections = suppressSections;
   return result;
 }
 
@@ -164,10 +167,8 @@ function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocus | undefin
       if (objective.length > MAX_OBJECTIVE_LENGTH) continue;
 
       const filters = parseFocusFilters(b.filters);
-      const suppressSections = parseStringArray(b.suppressSections);
       const resolved: ResolvedFocus = { objective };
       if (filters) resolved.filters = filters;
-      if (suppressSections && suppressSections.length > 0) resolved.suppressSections = suppressSections;
       return resolved;
     }
 

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -1,7 +1,10 @@
 import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
+  FocusFilters,
+  FocusLabelFilters,
   HivemootConfig,
+  ResolvedFocus,
   TeamConfig,
   RepoRef,
   RoleConfig,
@@ -64,12 +67,60 @@ function parseLegacyFocus(rawFocus: unknown): string | undefined {
 
 const MAX_OBJECTIVE_LENGTH = 2_000;
 const MAX_FOCUS_NAME_LENGTH = 64;
+const MAX_FILTER_STRINGS = 50;
+const MAX_FILTER_STRING_LENGTH = 200;
+
+// Validates and extracts a string array from a raw YAML value.
+// Returns an empty array (ignored) if the value is not a valid string array.
+function parseStringArray(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const result: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") return undefined;
+    if (item.length > MAX_FILTER_STRING_LENGTH) return undefined;
+    result.push(item);
+  }
+  if (result.length > MAX_FILTER_STRINGS) return undefined;
+  return result;
+}
+
+function parseLabelFilters(raw: unknown): FocusLabelFilters | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const r = raw as Record<string, unknown>;
+  const include = parseStringArray(r.include);
+  const exclude = parseStringArray(r.exclude);
+  if (include === undefined && exclude === undefined) return undefined;
+  const result: FocusLabelFilters = {};
+  if (include !== undefined && include.length > 0) result.include = include;
+  if (exclude !== undefined && exclude.length > 0) result.exclude = exclude;
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function parseFocusFilters(raw: unknown): FocusFilters | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const r = raw as Record<string, unknown>;
+
+  const labels = parseLabelFilters(r.labels);
+
+  let actionExclude: string[] | undefined;
+  if (r.actions && typeof r.actions === "object" && !Array.isArray(r.actions)) {
+    const actions = r.actions as Record<string, unknown>;
+    actionExclude = parseStringArray(actions.exclude);
+  }
+
+  if (!labels && (!actionExclude || actionExclude.length === 0)) return undefined;
+
+  const result: FocusFilters = {};
+  if (labels) result.labels = labels;
+  if (actionExclude && actionExclude.length > 0) result.actions = { exclude: actionExclude };
+  return result;
+}
 
 // Resolves focus from the team config. Handles two formats:
 // 1. New: team.focuses (dict of FocusBlock) + team.activeFocus (key)
 // 2. Legacy: team.focus.default (plain string)
 // The new format takes precedence when team.focuses is present.
-function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
+function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocus | undefined {
   const rawFocuses = rawTeam.focuses;
 
   if (rawFocuses && typeof rawFocuses === "object" && !Array.isArray(rawFocuses)) {
@@ -101,14 +152,16 @@ function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
       // and the next candidate (or undefined) is returned.
       if (objective.length > MAX_OBJECTIVE_LENGTH) continue;
 
-      return objective;
+      const filters = parseFocusFilters(b.filters);
+      return filters ? { objective, filters } : { objective };
     }
 
     return undefined;
   }
 
   // Fall back to the legacy focus.default format.
-  return parseLegacyFocus(rawTeam.focus);
+  const legacyObjective = parseLegacyFocus(rawTeam.focus);
+  return legacyObjective ? { objective: legacyObjective } : undefined;
 }
 
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
@@ -207,13 +260,14 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
     };
   }
 
-  const focus = resolveFocus(team as unknown as Record<string, unknown>);
+  const resolvedFocus = resolveFocus(team as unknown as Record<string, unknown>);
 
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
-    focus,
+    focus: resolvedFocus?.objective,
+    resolvedFocus,
   };
 }
 

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -1,6 +1,7 @@
 import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
+  FocusAuthorFilters,
   FocusFilters,
   FocusLabelFilters,
   HivemootConfig,
@@ -96,11 +97,20 @@ function parseLabelFilters(raw: unknown): FocusLabelFilters | undefined {
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function parseAuthorFilters(raw: unknown): FocusAuthorFilters | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const r = raw as Record<string, unknown>;
+  const exclude = parseStringArray(r.exclude);
+  if (!exclude || exclude.length === 0) return undefined;
+  return { exclude };
+}
+
 function parseFocusFilters(raw: unknown): FocusFilters | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const r = raw as Record<string, unknown>;
 
   const labels = parseLabelFilters(r.labels);
+  const authors = parseAuthorFilters(r.authors);
 
   let actionExclude: string[] | undefined;
   if (r.actions && typeof r.actions === "object" && !Array.isArray(r.actions)) {
@@ -108,10 +118,11 @@ function parseFocusFilters(raw: unknown): FocusFilters | undefined {
     actionExclude = parseStringArray(actions.exclude);
   }
 
-  if (!labels && (!actionExclude || actionExclude.length === 0)) return undefined;
+  if (!labels && !authors && (!actionExclude || actionExclude.length === 0)) return undefined;
 
   const result: FocusFilters = {};
   if (labels) result.labels = labels;
+  if (authors) result.authors = authors;
   if (actionExclude && actionExclude.length > 0) result.actions = { exclude: actionExclude };
   return result;
 }

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -22,16 +22,16 @@ export interface FocusFilters {
   labels?: FocusLabelFilters;
   authors?: FocusAuthorFilters;
   actions?: { exclude?: string[] };
-}
-
-export interface ResolvedFocus {
-  objective: string;
-  filters?: FocusFilters;
   // Canonical section-suppression key from the #178 Phase 2 design.
   // Valid values: "ready-to-implement", "discussion", "drive-discussion",
   // "voting", "review-prs", "drive-implementation", "needs-human".
   // Unknown values produce a warning in summary.notes.
   suppressSections?: string[];
+}
+
+export interface ResolvedFocus {
+  objective: string;
+  filters?: FocusFilters;
 }
 
 export interface TeamConfig {

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -14,8 +14,13 @@ export interface FocusLabelFilters {
   exclude?: string[];
 }
 
+export interface FocusAuthorFilters {
+  exclude?: string[];
+}
+
 export interface FocusFilters {
   labels?: FocusLabelFilters;
+  authors?: FocusAuthorFilters;
   actions?: { exclude?: string[] };
 }
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -27,6 +27,11 @@ export interface FocusFilters {
 export interface ResolvedFocus {
   objective: string;
   filters?: FocusFilters;
+  // Canonical section-suppression key from the #178 Phase 2 design.
+  // Valid values: "ready-to-implement", "discussion", "drive-discussion",
+  // "voting", "review-prs", "drive-implementation", "needs-human".
+  // Unknown values produce a warning in summary.notes.
+  suppressSections?: string[];
 }
 
 export interface TeamConfig {

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -9,11 +9,27 @@ export interface FocusBlock {
   objective: string;
 }
 
+export interface FocusLabelFilters {
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface FocusFilters {
+  labels?: FocusLabelFilters;
+  actions?: { exclude?: string[] };
+}
+
+export interface ResolvedFocus {
+  objective: string;
+  filters?: FocusFilters;
+}
+
 export interface TeamConfig {
   name?: string;
   onboarding?: string;
   roles: Record<string, RoleConfig>;
   focus?: string;
+  resolvedFocus?: ResolvedFocus;
 }
 
 export interface HivemootConfig {
@@ -196,6 +212,7 @@ export interface RepoSummary {
   prioritySignals?: PrioritySignal[];
   publishReadiness?: PublishReadiness;
   focus?: string;
+  actionBans?: string[];
   notes: string[];
 }
 

--- a/cli/src/output/formatter.ts
+++ b/cli/src/output/formatter.ts
@@ -21,6 +21,10 @@ function formatFocusLine(focus: string): string {
   return `Team focus: ${focus}`;
 }
 
+function formatActionBansLine(bans: string[]): string {
+  return `Restricted actions: ${bans.join(", ")}`;
+}
+
 function kv(key: string, value: string | number): string {
   return `${key}: ${chalk.dim(String(value))}`;
 }
@@ -284,6 +288,7 @@ export function formatBuzz(
       ? `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}, logged in as ${chalk.green(summary.currentUser)}`
       : `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}`,
     ...(summary.focus ? [formatFocusLine(summary.focus)] : []),
+    ...(summary.actionBans?.length ? [formatActionBansLine(summary.actionBans)] : []),
     "",
     formatSummaryBody(summary, limit),
   );
@@ -297,6 +302,7 @@ export function formatStatus(summary: RepoSummary, limit?: number): string {
       ? `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}, logged in as ${chalk.green(summary.currentUser)}`
       : `You are working on ${chalk.bold(`${summary.repo.owner}/${summary.repo.repo}`)}`,
     ...(summary.focus ? [formatFocusLine(summary.focus)] : []),
+    ...(summary.actionBans?.length ? [formatActionBansLine(summary.actionBans)] : []),
     "",
     formatSummaryBody(summary, limit),
   ];

--- a/cli/src/output/json.ts
+++ b/cli/src/output/json.ts
@@ -20,6 +20,7 @@ function summaryPayload(summary: RepoSummary): Record<string, unknown> {
     repositoryHealth: summary.repositoryHealth,
     prioritySignals: summary.prioritySignals ?? [],
     ...(summary.focus ? { focus: summary.focus } : {}),
+    ...(summary.actionBans?.length ? { actionBans: summary.actionBans } : {}),
     notes: summary.notes,
   };
 }

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1386,4 +1386,36 @@ describe("buildSummary()", () => {
     expect(gapA?.prsOlderThan3Days).toEqual(gapB?.prsOlderThan3Days);
     expect(gapA?.issuesStaleOver24h).toEqual(gapB?.issuesStaleOver24h);
   });
+
+  it("derives issuePipeline counts from healthContext.issues, not the filtered subset", () => {
+    // Focused subset: only the bug (no phase labels) → pipeline counts would be 0
+    const freshTime = "2025-06-15T11:00:00Z";
+    const bugIssue = makeIssue({ number: 1, labels: [{ name: "bug" }], updatedAt: freshTime });
+
+    // Full repo: includes discuss, vote, and ready-to-implement issues
+    const discussIssue = makeIssue({ number: 10, labels: [{ name: "hivemoot:discussion" }], updatedAt: freshTime });
+    const voteIssue = makeIssue({ number: 11, labels: [{ name: "hivemoot:vote" }], updatedAt: freshTime });
+    const readyIssue = makeIssue({ number: 12, labels: [{ name: "hivemoot:ready-to-implement" }], updatedAt: freshTime });
+    const readyIssue2 = makeIssue({ number: 13, labels: [{ name: "hivemoot:ready-to-implement" }], updatedAt: freshTime });
+
+    const allIssues = [bugIssue, discussIssue, voteIssue, readyIssue, readyIssue2];
+
+    const summary = buildSummary(
+      repo,
+      [bugIssue], // filtered: only bug issue visible in actionable sections
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { issues: allIssues, prs: [] }, // healthContext: full unfiltered set
+    );
+
+    // Pipeline counts must reflect the full repo, not the filtered 1-issue subset
+    expect(summary.repositoryHealth?.issuePipeline).toBeDefined();
+    expect(summary.repositoryHealth?.issuePipeline?.discussion).toBe(1);
+    expect(summary.repositoryHealth?.issuePipeline?.voting).toBe(1);
+    expect(summary.repositoryHealth?.issuePipeline?.readyToImplement).toBe(2);
+  });
 });

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1292,4 +1292,98 @@ describe("buildSummary()", () => {
       "Issue pipeline and implementation-gap metrics are omitted because default hivemoot phase labels were not detected.",
     );
   });
+
+  // ── healthContext: unfiltered data for health/pipeline metrics ──────
+
+  it("uses healthContext prs for stale-risk metric when provided", () => {
+    // Fresh issue: updatedAt < 1 day ago → does not trigger stale risk by itself
+    const freshIssue = makeIssue({
+      number: 1,
+      labels: [{ name: "hivemoot:ready-to-implement" }],
+      updatedAt: "2025-06-15T11:00:00Z",  // 1 hour before now
+    });
+    // Stale PR that would appear in health metrics but not in the focused subset
+    const stalePR = makePR({
+      number: 20,
+      author: { login: "other" },
+      updatedAt: "2025-06-10T00:00:00Z",  // >3 days before now
+      createdAt: "2025-06-10T00:00:00Z",
+    });
+
+    // No PRs in focused view → PR stale count should be 0
+    const summaryWithoutContext = buildSummary(repo, [freshIssue], [], "testuser", now);
+    // healthContext includes the stale PR → stale count reflects real repo state
+    const summaryWithContext = buildSummary(
+      repo,
+      [freshIssue],
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { issues: [freshIssue], prs: [stalePR] },
+    );
+
+    const healthA = summaryWithoutContext.repositoryHealth?.staleRisk;
+    const healthB = summaryWithContext.repositoryHealth?.staleRisk;
+    expect(healthA?.prsOlderThan3Days).toBe(0);
+    expect(healthB?.prsOlderThan3Days).toBe(1);  // healthContext stale PR counted
+  });
+
+  it("uses healthContext prs for active candidate count in implementation-gap signal", () => {
+    // Focused subset: two ready-to-implement issues, no PRs
+    // Must use hivemoot: prefix to trigger DEFAULT_HIVEMOOT_PHASE_LABELS detection
+    const freshTime = "2025-06-15T11:00:00Z";
+    const issues = [
+      makeIssue({ number: 1, labels: [{ name: "hivemoot:ready-to-implement" }], updatedAt: freshTime }),
+      makeIssue({ number: 2, labels: [{ name: "hivemoot:ready-to-implement" }], updatedAt: freshTime }),
+    ];
+    // Unfiltered PRs include one that closes issue #1 (active candidate)
+    const candidatePR = makePR({
+      number: 10,
+      author: { login: "other" },
+      closingIssuesReferences: [{ number: 1 }],
+    });
+
+    const summaryNoContext = buildSummary(repo, issues, [], "testuser", now);
+    const summaryWithContext = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { issues, prs: [candidatePR] },
+    );
+
+    // Without context: 2 ready, 0 candidates → gap of 2
+    const gapNoContext = summaryNoContext.prioritySignals?.find((s) => s.kind === "implementation-gap");
+    expect(gapNoContext?.summary).toContain("0 active candidate");
+
+    // With context providing the candidate PR: 2 ready, 1 active candidate → gap of 1
+    const gapWithContext = summaryWithContext.prioritySignals?.find((s) => s.kind === "implementation-gap");
+    expect(gapWithContext).toBeDefined();
+    expect(gapWithContext?.summary).toContain("1 active candidate");
+  });
+
+  it("falls back to input arrays for health when healthContext is undefined", () => {
+    const freshTime = "2025-06-15T11:00:00Z";
+    const issue = makeIssue({ number: 1, labels: [{ name: "hivemoot:ready-to-implement" }], updatedAt: freshTime });
+    const pr = makePR({ number: 10, author: { login: "other" }, closingIssuesReferences: [{ number: 1 }] });
+
+    const summaryNoContext = buildSummary(repo, [issue], [pr], "testuser", now);
+    const summaryUndefinedContext = buildSummary(
+      repo, [issue], [pr], "testuser", now,
+      new Map(), new Map(), undefined, undefined,
+    );
+
+    // Both should produce the same health data (PR is active candidate in both)
+    const gapA = summaryNoContext.repositoryHealth?.staleRisk;
+    const gapB = summaryUndefinedContext.repositoryHealth?.staleRisk;
+    expect(gapA?.prsOlderThan3Days).toEqual(gapB?.prsOlderThan3Days);
+    expect(gapA?.issuesStaleOver24h).toEqual(gapB?.issuesStaleOver24h);
+  });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -493,11 +493,30 @@ export function buildSummary(
   const hasDefaultPhaseLabels = healthIssues.some((issue) =>
     issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
   );
+
+  // When healthContext is present, the actionable buckets (discuss/voteOn/implement)
+  // were built from the filtered issues array, not the full repo. Compute pipeline
+  // counts from healthIssues so REPOSITORY HEALTH reflects real repo state.
+  let pipelineDiscussion = discuss.length;
+  let pipelineVoting = voteOn.length;
+  let pipelineReadyToImplement = implement.length;
+  if (healthContext) {
+    pipelineDiscussion = 0;
+    pipelineVoting = 0;
+    pipelineReadyToImplement = 0;
+    for (const issue of healthIssues) {
+      const { bucket } = classifyIssue(issue, currentUser, now);
+      if (bucket === "discuss") pipelineDiscussion++;
+      else if (bucket === "voteOn") pipelineVoting++;
+      else if (bucket === "implement") pipelineReadyToImplement++;
+    }
+  }
+
   const issuePipeline: IssuePipelineCounts | undefined = hasDefaultPhaseLabels
     ? {
-        discussion: discuss.length,
-        voting: voteOn.length,
-        readyToImplement: implement.length,
+        discussion: pipelineDiscussion,
+        voting: pipelineVoting,
+        readyToImplement: pipelineReadyToImplement,
       }
     : undefined;
   const repositoryHealth = buildRepositoryHealth(healthIssues, healthPrs, currentUser, now, issuePipeline);

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -319,6 +319,10 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  // When focus filters are active, pass the full unfiltered datasets here so
+  // that health metrics and pipeline counts reflect actual repo state rather
+  // than the focused subset. Actionable sections still use the focused arrays.
+  healthContext?: { issues: GitHubIssue[]; prs: GitHubPR[] },
 ): RepoSummary {
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
@@ -480,7 +484,13 @@ export function buildSummary(
     return a.timestamp > b.timestamp ? -1 : 1;
   });
 
-  const hasDefaultPhaseLabels = issues.some((issue) =>
+  // Health and pipeline metrics operate on the full repo state, not the focused
+  // subset. If the caller supplied healthContext (unfiltered data), use it here;
+  // otherwise fall back to the input arrays (no-filter path is unchanged).
+  const healthIssues = healthContext?.issues ?? issues;
+  const healthPrs = healthContext?.prs ?? prs;
+
+  const hasDefaultPhaseLabels = healthIssues.some((issue) =>
     issue.labels.some((label) => DEFAULT_HIVEMOOT_PHASE_LABELS.has(label.name.toLowerCase()))
   );
   const issuePipeline: IssuePipelineCounts | undefined = hasDefaultPhaseLabels
@@ -490,8 +500,8 @@ export function buildSummary(
         readyToImplement: implement.length,
       }
     : undefined;
-  const repositoryHealth = buildRepositoryHealth(issues, prs, currentUser, now, issuePipeline);
-  const prioritySignals = buildPrioritySignals(repositoryHealth, countActiveCandidateIssues(prs));
+  const repositoryHealth = buildRepositoryHealth(healthIssues, healthPrs, currentUser, now, issuePipeline);
+  const prioritySignals = buildPrioritySignals(repositoryHealth, countActiveCandidateIssues(healthPrs));
   if (!issuePipeline) notes.push(OMITTED_PIPELINE_NOTE);
 
   return {


### PR DESCRIPTION
Closes #165

## What changed

Focus blocks in `hivemoot.yml` can now declare label filters and action bans that the CLI enforces deterministically, removing reliance on the LLM to interpret focus text alone.

### New YAML schema

```yaml
team:
  activeFocus: "v2-bugs"
  focuses:
    default:
      objective: "Work on any ready-to-implement issue."
    v2-bugs:
      objective: "Squash v2 blockers."
      filters:
        labels:
          include: ["bug", "v2-blocker"]
        actions:
          exclude: ["create-proposal"]
    review-only:
      objective: "Clear the review queue. No new code."
      filters:
        actions:
          exclude: ["create-pr", "comment-on-issue", "create-proposal"]
```

### Implementation

**Types (`types.ts`)**
- `FocusLabelFilters`, `FocusFilters`, `ResolvedFocus` — new types for the structured focus data
- `TeamConfig.resolvedFocus?: ResolvedFocus` alongside the existing `focus?: string` (backward compat preserved)
- `RepoSummary.actionBans?: string[]` for formatter consumption

**Loader (`loader.ts`)**
- `resolveFocus` now extracts `filters.labels` and `filters.actions` from the active focus block
- Returns `ResolvedFocus | undefined` and stores it in `TeamConfig`
- Malformed filter values (non-string items, oversized strings) silently skipped — config parsing stays non-fatal
- Legacy `focus.default` format produces a `ResolvedFocus` with no filters (no behavior change)

**Buzz (`buzz.ts`)**
- `applyFocusFilters` applies label `include`/`exclude` rules to the raw issues and PRs arrays before `buildSummary` — filtered items are gone from all output
- Action bans are extracted from `resolvedFocus.filters.actions.exclude` and attached to `summary.actionBans`
- No filters and no action bans = no behavioral change vs. today

**Output**
- Formatter adds `Restricted actions: create-pr, create-proposal` line when bans are present
- JSON output includes `actionBans` array when bans are present

## Validation

710 tests pass, typecheck clean.

```
cd cli && npm test
```

New tests:
- `loader.test.ts`: 7 new tests covering include/exclude label filters, action bans, combined filters, no-filter path, malformed arrays, legacy format compatibility
- `buzz.test.ts`: 5 new tests covering issue/PR label filtering (include and exclude), action ban propagation, no-filter passthrough