### PR TITLE
feat(web): accept markdown run summaries in agent health

### DIFF
--- a/apps/web/AGENT_HEALTH_CONTRACT.md
+++ b/apps/web/AGENT_HEALTH_CONTRACT.md
@@ -48,6 +48,7 @@ Each POST represents one run for one `agent_id` + `repo`.
 | `error` | string | 1-256 chars |
 | `exit_code` | integer | Any integer |
 | `next_run_at` | string | ISO-8601, max 64 chars, between `now-5m` and `now+48h` |
+| `run_summary` | string | Markdown, ANSI-stripped, truncated to 4096 chars; empty after stripping rejected |
 | `trigger` | string | `scheduled` \| `mention` \| `manual` |
 | `token_usage` | object or `null` | Exact nested schema below; when present as an object, required scalar fields must be present even if their value is `null` |
 
@@ -78,6 +79,7 @@ When `token_usage` is an object, these top-level fields are accepted:
 Validation behavior:
 - Maximum payload size: 10KB (checked via `Content-Length` and actual body bytes).
 - Unknown top-level fields are rejected.
+- `run_summary` is sanitized by stripping ANSI escape sequences before storage.
 - Invalid JSON returns 400.
 - Server assigns `received_at`; client value is not accepted.
 
@@ -85,7 +87,7 @@ Validation behavior:
 
 Success:
 - `200` + `{"received": true, "received_at": "<iso>"}` for new accepted reports.
-- `200` + `{"received": true, "received_at": "<iso>", "duplicate": true}` for an idempotent retry with the same dedupe identity (`agent_id`, `repo`, `run_id`, `outcome`, `duration_secs`, `consecutive_failures`, `error`, `exit_code`, `next_run_at`); metadata-only differences (`model`, `trigger`, `token_usage`) are still treated as duplicates.
+- `200` + `{"received": true, "received_at": "<iso>", "duplicate": true}` for an idempotent retry with the same dedupe identity (`agent_id`, `repo`, `run_id`, `outcome`, `duration_secs`, `consecutive_failures`, `error`, `exit_code`, `next_run_at`); metadata-only differences (`model`, `run_summary`, `trigger`, `token_usage`) are still treated as duplicates.
 
 Error:
 - `401` `agent_health_not_authenticated` for missing/invalid agent token.

--- a/apps/web/src/app/api/agent-health/route.test.ts
+++ b/apps/web/src/app/api/agent-health/route.test.ts
@@ -373,6 +373,7 @@ describe("GET /api/agent-health", () => {
         outcome: "success",
         duration_secs: 42,
         consecutive_failures: 0,
+        run_summary: "### Done\nCommented on #325.",
         received_at: "2026-02-24T10:00:00Z",
         status: "ok",
       },
@@ -384,6 +385,7 @@ describe("GET /api/agent-health", () => {
     const body = await res.json();
     expect(body.agents).toHaveLength(1);
     expect(body.agents[0].agent_id).toBe("bee-1");
+    expect(body.agents[0].run_summary).toBe("### Done\nCommented on #325.");
   });
 
   it("returns history when agent_id and repo are provided", async () => {
@@ -395,6 +397,7 @@ describe("GET /api/agent-health", () => {
         outcome: "success",
         duration_secs: 42,
         consecutive_failures: 0,
+        run_summary: "### Done\nCommented on #325.",
         received_at: "2026-02-24T10:00:00Z",
       },
     ]);
@@ -410,6 +413,7 @@ describe("GET /api/agent-health", () => {
     expect(body.repo).toBe("hivemoot/sandbox");
     expect(body.history).toHaveLength(1);
     expect(body.runs).toHaveLength(1);
+    expect(body.history[0].run_summary).toBe("### Done\nCommented on #325.");
   });
 
   it("returns history when history=true is provided", async () => {

--- a/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -47,6 +47,7 @@ interface AgentOverviewEntry {
   online?: boolean;
   status?: "ok" | "failed" | "late" | "unknown";
   next_run_at?: string;
+  run_summary?: string;
   trigger?: TriggerType;
   token_usage?: TokenUsage | null;
 }
@@ -61,6 +62,7 @@ interface HealthHistoryEntry {
   error?: string;
   exit_code?: number;
   received_at: string;
+  run_summary?: string;
   trigger?: TriggerType;
   token_usage?: TokenUsage | null;
 }

--- a/apps/web/src/server/agent-health-store.test.ts
+++ b/apps/web/src/server/agent-health-store.test.ts
@@ -596,6 +596,52 @@ describe("validateReport", () => {
     if (result.ok) expect(result.report.token_usage).toBeNull();
   });
 
+  it("accepts run_summary, strips ANSI escapes, and trims surrounding whitespace", () => {
+    const result = validateReport({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 60,
+      consecutive_failures: 0,
+      run_summary: "\n\u001b[32m### Done\u001b[39m\nMerged docs and posted review.\n",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.run_summary).toBe("### Done\nMerged docs and posted review.");
+    }
+  });
+
+  it("rejects run_summary that is empty after ANSI stripping", () => {
+    const result = validateReport({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 60,
+      consecutive_failures: 0,
+      run_summary: "\u001b[31m\u001b[0m   ",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("run_summary");
+  });
+
+  it("caps run_summary at 4096 chars after sanitization", () => {
+    const result = validateReport({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 60,
+      consecutive_failures: 0,
+      run_summary: `${"\u001b[32m"}${"x".repeat(5000)}\u001b[0m`,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.run_summary).toHaveLength(4096);
+    }
+  });
+
   it("omits token_usage from report when not provided", () => {
     const result = validateReport({
       agent_id: "bee-1",
@@ -733,6 +779,23 @@ describe("reserveHealthReportIdempotency", () => {
     };
 
     const reservation = await reserveHealthReportIdempotency("inst-1", retryWithModel, redis);
+    expect(reservation).toStrictEqual({
+      kind: "duplicate",
+      receivedAt: "2026-02-24T10:00:00Z",
+    });
+  });
+
+  it("treats run_summary as non-identity metadata for idempotency", async () => {
+    await reserveHealthReportIdempotency("inst-1", baseReport, redis);
+    await commitHealthReportIdempotency("inst-1", baseReport, redis);
+
+    const retryWithSummary: HealthReport = {
+      ...baseReport,
+      run_summary: "### Done\nCommented on #325.",
+      received_at: "2026-02-24T10:01:00Z",
+    };
+
+    const reservation = await reserveHealthReportIdempotency("inst-1", retryWithSummary, redis);
     expect(reservation).toStrictEqual({
       kind: "duplicate",
       receivedAt: "2026-02-24T10:00:00Z",
@@ -969,6 +1032,7 @@ describe("getOverview", () => {
       consecutive_failures: 2,
       model: "openai/gpt-4o",
       error: "timeout",
+      run_summary: "### Done\nOpened a PR and replied to review.",
       received_at: "2026-02-24T10:00:00Z",
     };
 
@@ -983,6 +1047,7 @@ describe("getOverview", () => {
     expect(result[0].outcome).toBe("failure");
     expect(result[0].consecutive_failures).toBe(2);
     expect(result[0].model).toBe("openai/gpt-4o");
+    expect(result[0].run_summary).toBe("### Done\nOpened a PR and replied to review.");
     expect(result[0].status).toBe("failed");
   });
 
@@ -1160,6 +1225,7 @@ describe("getHistory", () => {
       outcome: "success",
       duration_secs: 9,
       consecutive_failures: 0,
+      run_summary: "### Done\nMerged #281.",
       received_at: recentTimestamp,
     };
 
@@ -1173,6 +1239,7 @@ describe("getHistory", () => {
     expect(result).toHaveLength(1);
     expect(result[0].agent_id).toBe("bee-1");
     expect(result[0].outcome).toBe("success");
+    expect(result[0].run_summary).toBe("### Done\nMerged #281.");
   });
 
   it("trims stale entries before returning", async () => {

--- a/apps/web/src/server/agent-health-store.ts
+++ b/apps/web/src/server/agent-health-store.ts
@@ -34,8 +34,10 @@ const RATE_LIMIT_SECONDS = 60;
 const HISTORY_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_HISTORY_ENTRIES = 1440; // read-side cap; ~24h at 1 report/min
 const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
+const MAX_RUN_SUMMARY_CHARS = 4096;
 export const AGENT_ID_PATTERN = /^[a-z0-9_-]+$/;
 const MODEL_PATTERN = /^[a-zA-Z0-9._:/-]{1,128}$/;
+const ANSI_ESCAPE_PATTERN = /[\u001B\u009B](?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,6 +74,7 @@ export interface HealthReport {
   error?: string;
   exit_code?: number;
   next_run_at?: string; // ISO 8601, optional — when the next scheduled run is expected
+  run_summary?: string;
   trigger?: TriggerType;
   token_usage?: TokenUsage | null;
   received_at: string; // ISO 8601, server-assigned
@@ -92,8 +95,15 @@ export interface HealthOverviewEntry {
   received_at: string;
   status: AgentStatus;
   next_run_at?: string;
+  run_summary?: string;
   trigger?: TriggerType;
   token_usage?: TokenUsage | null;
+}
+
+function sanitizeRunSummary(input: string): string {
+  const stripped = input.replace(ANSI_ESCAPE_PATTERN, "").trim();
+  if (stripped.length <= MAX_RUN_SUMMARY_CHARS) return stripped;
+  return stripped.slice(0, MAX_RUN_SUMMARY_CHARS);
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +231,7 @@ const ALLOWED_FIELDS = new Set([
   "error",
   "exit_code",
   "next_run_at",
+  "run_summary",
   "trigger",
   "token_usage",
 ]);
@@ -343,6 +354,23 @@ export function validateReport(body: unknown): ValidationResult {
     }
   }
 
+  if (obj.run_summary !== undefined) {
+    if (typeof obj.run_summary !== "string") {
+      return {
+        ok: false,
+        message: "run_summary must be a non-empty string after ANSI stripping if provided",
+      };
+    }
+
+    const sanitizedRunSummary = sanitizeRunSummary(obj.run_summary);
+    if (sanitizedRunSummary.length < 1) {
+      return {
+        ok: false,
+        message: "run_summary must be a non-empty string after ANSI stripping if provided",
+      };
+    }
+  }
+
   if (
     obj.trigger !== undefined
     && (typeof obj.trigger !== "string" || !VALID_TRIGGERS.has(obj.trigger as TriggerType))
@@ -439,6 +467,7 @@ export function validateReport(body: unknown): ValidationResult {
   if (typeof obj.model === "string") report.model = obj.model;
   if (typeof obj.exit_code === "number") report.exit_code = obj.exit_code;
   if (typeof obj.next_run_at === "string") report.next_run_at = obj.next_run_at;
+  if (typeof obj.run_summary === "string") report.run_summary = sanitizeRunSummary(obj.run_summary);
   if (typeof obj.trigger === "string") report.trigger = obj.trigger as TriggerType;
   if (obj.token_usage !== undefined) report.token_usage = obj.token_usage as TokenUsage | null;
 
@@ -713,6 +742,7 @@ export async function getOverview(
           received_at: report.received_at,
           status: deriveStatus(report),
           next_run_at: typeof report.next_run_at === "string" ? report.next_run_at : undefined,
+          run_summary: typeof report.run_summary === "string" ? report.run_summary : undefined,
           trigger: typeof report.trigger === "string" && VALID_TRIGGERS.has(report.trigger as TriggerType) ? report.trigger : undefined,
           token_usage: "token_usage" in report ? report.token_usage : undefined,
         });


### PR DESCRIPTION
Fixes #325

`run_summary` is the missing piece between the current agent health payload and the dashboard follow-up in #326. The owner locked the contract to an optional markdown string, so this PR adds that backend support now instead of waiting on UI work.

## What changed
- accept optional `run_summary` on `POST /api/agent-health`
- strip ANSI escapes, trim surrounding whitespace, and cap stored content at 4096 chars
- preserve `run_summary` through overview and history reads
- keep `run_summary` out of the idempotency identity, matching the existing metadata-only treatment for `model` / `trigger` / `token_usage`
- document the updated contract in `apps/web/AGENT_HEALTH_CONTRACT.md`

## Before / after
Before:
```json
{
  "agent_id": "worker",
  "repo": "hivemoot/colony",
  "run_id": "20260310-120000-worker",
  "outcome": "success",
  "duration_secs": 42,
  "consecutive_failures": 0
}
```

After:
```json
{
  "agent_id": "worker",
  "repo": "hivemoot/colony",
  "run_id": "20260310-120000-worker",
  "outcome": "success",
  "duration_secs": 42,
  "consecutive_failures": 0,
  "run_summary": "### Done\nMerged #281 and replied on #325."
}
```

## Validation
- `npm run -s typecheck --prefix apps/web`
- `npm test --prefix apps/web -- src/app/api/agent-health/route.test.ts src/server/agent-health-store.test.ts`
