### PR TITLE
fix(cli): dedupe review_requested watch events

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.2.0",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/watch.test.ts
+++ b/cli/src/commands/watch.test.ts
@@ -865,6 +865,26 @@ describe("watchCommand (review_requested)", () => {
     expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
   });
 
+  it("logs and marks processed when the review_requested event cannot be built", async () => {
+    const notification = makePrNotification();
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedBuildEvent.mockReturnValue(null);
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining("\"trigger\":\"review_requested\""));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(
+      "Skipping 1001: could not build review_requested event, marking processed",
+    ));
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+      }),
+    );
+  });
+
   it("marks processed when the review-request fetch fails permanently", async () => {
     const notification = makePrNotification();
 

--- a/cli/src/commands/watch.test.ts
+++ b/cli/src/commands/watch.test.ts
@@ -12,9 +12,11 @@ vi.mock("../github/notifications.js", () => ({
   fetchMentionNotifications: vi.fn(),
   fetchCommentBody: vi.fn(),
   fetchRecentSubjectComments: vi.fn(),
+  fetchReviewRequestState: vi.fn(),
   fetchSubjectBodyResult: vi.fn(),
   buildMentionEvent: vi.fn(),
   isAgentMentioned: vi.fn(),
+  parseSubjectNumber: vi.fn(),
 }));
 
 vi.mock("../watch/state.js", async (importOriginal) => {
@@ -33,9 +35,11 @@ import {
   fetchMentionNotifications,
   fetchCommentBody,
   fetchRecentSubjectComments,
+  fetchReviewRequestState,
   fetchSubjectBodyResult,
   buildMentionEvent,
   isAgentMentioned,
+  parseSubjectNumber,
 } from "../github/notifications.js";
 import { loadState, saveState, mergeAckJournal } from "../watch/state.js";
 
@@ -43,9 +47,11 @@ const mockedFetchUser = vi.mocked(fetchCurrentUser);
 const mockedFetchMentions = vi.mocked(fetchMentionNotifications);
 const mockedFetchComment = vi.mocked(fetchCommentBody);
 const mockedFetchRecentComments = vi.mocked(fetchRecentSubjectComments);
+const mockedFetchReviewRequestState = vi.mocked(fetchReviewRequestState);
 const mockedFetchSubjectResult = vi.mocked(fetchSubjectBodyResult);
 const mockedBuildEvent = vi.mocked(buildMentionEvent);
 const mockedIsAgentMentioned = vi.mocked(isAgentMentioned);
+const mockedParseSubjectNumber = vi.mocked(parseSubjectNumber);
 const mockedLoadState = vi.mocked(loadState);
 const mockedSaveState = vi.mocked(saveState);
 const mockedMergeAckJournal = vi.mocked(mergeAckJournal);
@@ -111,6 +117,12 @@ beforeEach(() => {
     comments: [],
     permanentFailure: false,
   });
+  mockedFetchReviewRequestState.mockResolvedValue({
+    pending: true,
+    requestId: "9001",
+    permanentFailure: false,
+    transientFailure: false,
+  });
   mockedFetchSubjectResult.mockResolvedValue({
     detail: {
       body: "@test-agent issue body mention",
@@ -118,6 +130,10 @@ beforeEach(() => {
       htmlUrl: "https://github.com/owner/repo/issues/42",
     },
     permanentFailure: false,
+  });
+  mockedParseSubjectNumber.mockImplementation((url: string) => {
+    const match = url.match(/\/(\d+)$/);
+    return match ? Number(match[1]) : undefined;
   });
   // mergeAckJournal returns the state unchanged by default
   mockedMergeAckJournal.mockImplementation(async (_path, state) => state);
@@ -623,6 +639,197 @@ describe("watchCommand (--once mode)", () => {
 
     await watchCommand({ repo: "owner/repo", once: true });
 
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+      }),
+    );
+  });
+});
+
+describe("watchCommand (review_requested)", () => {
+  function makePrNotification(overrides: Partial<RawNotification> = {}): RawNotification {
+    return makeNotification({
+      reason: "review_requested",
+      subject: {
+        url: "https://api.github.com/repos/owner/repo/pulls/99",
+        type: "PullRequest",
+        title: "Add feature X",
+        latest_comment_url: null,
+      },
+      ...overrides,
+    });
+  }
+
+  it("emits an event when the authenticated user has a new active review request", async () => {
+    const notification = makePrNotification();
+    const event = makeEvent({
+      number: 99,
+      type: "PullRequest",
+      title: "Add feature X",
+      author: "unknown",
+      body: "",
+      url: "",
+      trigger: "review_requested",
+    });
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedBuildEvent.mockReturnValue(event);
+    mockedFetchReviewRequestState.mockResolvedValue({
+      pending: true,
+      requestId: "9001",
+      permanentFailure: false,
+      transientFailure: false,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedFetchReviewRequestState).toHaveBeenCalledWith("owner", "repo", 99, "test-agent");
+    expect(mockedBuildEvent).toHaveBeenCalledWith(notification, null, "test-agent", {
+      trigger: "review_requested",
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        reviewRequestIds: ["1001:9001"],
+      }),
+    );
+  });
+
+  it("suppresses plain PR activity when the active review-request id has not changed", async () => {
+    const notification = makePrNotification({ updated_at: "2026-02-01T12:30:00.000Z" });
+
+    mockedLoadState.mockResolvedValue(defaultState({
+      reviewRequestIds: ["1001:9001"],
+    }));
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchReviewRequestState.mockResolvedValue({
+      pending: true,
+      requestId: "9001",
+      permanentFailure: false,
+      transientFailure: false,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    const eventWrites = (stdoutSpy.mock.calls as [string][])
+      .map(([s]) => s)
+      .filter((s) => s.includes('"agent"'));
+    expect(eventWrites).toHaveLength(0);
+  });
+
+  it("re-emits when GitHub exposes a new review-request id on the same thread", async () => {
+    const notification = makePrNotification({ updated_at: "2026-02-01T12:30:00.000Z" });
+    const event = makeEvent({
+      number: 99,
+      type: "PullRequest",
+      title: "Add feature X",
+      author: "unknown",
+      body: "",
+      url: "",
+      trigger: "review_requested",
+      timestamp: "2026-02-01T12:30:00.000Z",
+    });
+
+    mockedLoadState.mockResolvedValue(defaultState({
+      reviewRequestIds: ["1001:9001"],
+      processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+    }));
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedBuildEvent.mockReturnValue(event);
+    mockedFetchReviewRequestState.mockResolvedValue({
+      pending: true,
+      requestId: "9002",
+      permanentFailure: false,
+      transientFailure: false,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        reviewRequestIds: ["1001:9002"],
+      }),
+    );
+  });
+
+  it("marks processed when the reviewer is no longer actively requested", async () => {
+    const notification = makePrNotification();
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchReviewRequestState.mockResolvedValue({
+      pending: false,
+      permanentFailure: false,
+      transientFailure: false,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+      }),
+    );
+  });
+
+  it("retries when the review-request fetch fails transiently", async () => {
+    const notification = makePrNotification();
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchReviewRequestState.mockResolvedValue({
+      pending: false,
+      permanentFailure: false,
+      transientFailure: true,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: [],
+      }),
+    );
+  });
+
+  it("marks processed when the review-request fetch fails permanently", async () => {
+    const notification = makePrNotification();
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchReviewRequestState.mockResolvedValue({
+      pending: false,
+      permanentFailure: true,
+      transientFailure: false,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: ["1001:2026-02-01T11:30:00.000Z"],
+      }),
+    );
+  });
+
+  it("marks processed when review_requested appears on a non-PR subject", async () => {
+    const notification = makeNotification({ reason: "review_requested" });
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedFetchReviewRequestState).not.toHaveBeenCalled();
     expect(mockedBuildEvent).not.toHaveBeenCalled();
     expect(mockedSaveState).toHaveBeenCalledWith(
       expect.any(String),

--- a/cli/src/commands/watch.test.ts
+++ b/cli/src/commands/watch.test.ts
@@ -12,6 +12,7 @@ vi.mock("../github/notifications.js", () => ({
   fetchMentionNotifications: vi.fn(),
   fetchCommentBody: vi.fn(),
   fetchRecentSubjectComments: vi.fn(),
+  fetchLatestReviewRequestEvent: vi.fn(),
   fetchReviewRequestState: vi.fn(),
   fetchSubjectBodyResult: vi.fn(),
   buildMentionEvent: vi.fn(),
@@ -35,6 +36,7 @@ import {
   fetchMentionNotifications,
   fetchCommentBody,
   fetchRecentSubjectComments,
+  fetchLatestReviewRequestEvent,
   fetchReviewRequestState,
   fetchSubjectBodyResult,
   buildMentionEvent,
@@ -47,6 +49,7 @@ const mockedFetchUser = vi.mocked(fetchCurrentUser);
 const mockedFetchMentions = vi.mocked(fetchMentionNotifications);
 const mockedFetchComment = vi.mocked(fetchCommentBody);
 const mockedFetchRecentComments = vi.mocked(fetchRecentSubjectComments);
+const mockedFetchLatestReviewRequestEvent = vi.mocked(fetchLatestReviewRequestEvent);
 const mockedFetchReviewRequestState = vi.mocked(fetchReviewRequestState);
 const mockedFetchSubjectResult = vi.mocked(fetchSubjectBodyResult);
 const mockedBuildEvent = vi.mocked(buildMentionEvent);
@@ -116,6 +119,13 @@ beforeEach(() => {
   mockedFetchRecentComments.mockResolvedValue({
     comments: [],
     permanentFailure: false,
+  });
+  mockedFetchLatestReviewRequestEvent.mockResolvedValue({
+    eventId: "7001",
+    requester: "maintainer",
+    reviewer: "test-agent",
+    permanentFailure: false,
+    transientFailure: false,
   });
   mockedFetchReviewRequestState.mockResolvedValue({
     pending: true,
@@ -687,8 +697,11 @@ describe("watchCommand (review_requested)", () => {
     await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
 
     expect(mockedFetchReviewRequestState).toHaveBeenCalledWith("owner", "repo", 99, "test-agent");
+    expect(mockedFetchLatestReviewRequestEvent).toHaveBeenCalledWith("owner", "repo", 99, "test-agent");
     expect(mockedBuildEvent).toHaveBeenCalledWith(notification, null, "test-agent", {
       trigger: "review_requested",
+      requester: "maintainer",
+      reviewer: "test-agent",
     });
     expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
     expect(mockedSaveState).toHaveBeenCalledWith(
@@ -716,6 +729,7 @@ describe("watchCommand (review_requested)", () => {
     await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
 
     expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedFetchLatestReviewRequestEvent).not.toHaveBeenCalled();
     const eventWrites = (stdoutSpy.mock.calls as [string][])
       .map(([s]) => s)
       .filter((s) => s.includes('"agent"'));
@@ -750,6 +764,7 @@ describe("watchCommand (review_requested)", () => {
 
     await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
 
+    expect(mockedFetchLatestReviewRequestEvent).toHaveBeenCalledWith("owner", "repo", 99, "test-agent");
     expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
     expect(mockedSaveState).toHaveBeenCalledWith(
       expect.any(String),
@@ -799,6 +814,55 @@ describe("watchCommand (review_requested)", () => {
         processedThreadIds: [],
       }),
     );
+  });
+
+  it("retries when the review-request event lookup fails transiently", async () => {
+    const notification = makePrNotification();
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedFetchLatestReviewRequestEvent.mockResolvedValue({
+      permanentFailure: false,
+      transientFailure: true,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedBuildEvent).not.toHaveBeenCalled();
+    expect(mockedSaveState).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        processedThreadIds: [],
+      }),
+    );
+  });
+
+  it("emits with reviewer metadata when no matching review_requested event is available", async () => {
+    const notification = makePrNotification();
+    const event = makeEvent({
+      number: 99,
+      type: "PullRequest",
+      title: "Add feature X",
+      author: "unknown",
+      body: "",
+      url: "",
+      trigger: "review_requested",
+      reviewer: "test-agent",
+    });
+
+    mockedFetchMentions.mockResolvedValue([notification]);
+    mockedBuildEvent.mockReturnValue(event);
+    mockedFetchLatestReviewRequestEvent.mockResolvedValue({
+      permanentFailure: false,
+      transientFailure: false,
+    });
+
+    await watchCommand({ repo: "owner/repo", once: true, reasons: "review_requested" });
+
+    expect(mockedBuildEvent).toHaveBeenCalledWith(notification, null, "test-agent", {
+      trigger: "review_requested",
+      reviewer: "test-agent",
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(JSON.stringify(event) + "\n");
   });
 
   it("marks processed when the review-request fetch fails permanently", async () => {

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -236,6 +236,7 @@ async function runPollLoop(
             ...(latestReviewEvent.requester ? { requester: latestReviewEvent.requester } : {}),
           });
           if (!reviewEvent) {
+            log(`Skipping ${notification.id}: could not build review_requested event, marking processed`);
             state = addProcessedId(state, processedKey);
             latestProcessedByThread.set(notification.id, notification.updated_at);
             continue;

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -6,11 +6,21 @@ import {
   fetchMentionNotifications,
   fetchCommentBody,
   fetchRecentSubjectComments,
+  fetchReviewRequestState,
   fetchSubjectBodyResult,
   buildMentionEvent,
   isAgentMentioned,
+  parseSubjectNumber,
 } from "../github/notifications.js";
-import { loadState, saveState, mergeAckJournal, addProcessedId, buildLatestProcessedByThread } from "../watch/state.js";
+import {
+  loadState,
+  saveState,
+  mergeAckJournal,
+  addProcessedId,
+  addReviewRequestId,
+  buildLatestProcessedByThread,
+  buildLatestReviewRequestByThread,
+} from "../watch/state.js";
 
 function log(message: string): void {
   process.stderr.write(`[watch ${new Date().toISOString()}] ${message}\n`);
@@ -156,6 +166,7 @@ async function runPollLoop(
     // Merge keys acked since last poll into processedThreadIds
     state = await mergeAckJournal(stateFile, state);
     const latestProcessedByThread = buildLatestProcessedByThread(state.processedThreadIds);
+    const latestReviewRequestByThread = buildLatestReviewRequestByThread(state.reviewRequestIds ?? []);
 
     try {
       // Capture time before fetch (informational — no longer used as fetch cursor)
@@ -169,6 +180,57 @@ async function runPollLoop(
         // is recognized as a distinct event (thread IDs are reused by GitHub)
         const processedKey = `${notification.id}:${notification.updated_at}`;
         const previousProcessedAt = latestProcessedByThread.get(notification.id);
+        if (notification.reason === "review_requested") {
+          if (notification.subject.type !== "PullRequest") {
+            log(`Skipping ${notification.id}: review_requested on non-PR subject, marking processed`);
+            state = addProcessedId(state, processedKey);
+            latestProcessedByThread.set(notification.id, notification.updated_at);
+            continue;
+          }
+
+          const pullNumber = parseSubjectNumber(notification.subject.url);
+          if (pullNumber === undefined) {
+            log(`Skipping ${notification.id}: cannot parse PR number from subject URL, marking processed`);
+            state = addProcessedId(state, processedKey);
+            latestProcessedByThread.set(notification.id, notification.updated_at);
+            continue;
+          }
+
+          const [repoOwner, repoName] = repo.split("/");
+          const reviewState = await fetchReviewRequestState(repoOwner, repoName, pullNumber, agent);
+          if (reviewState.transientFailure) {
+            log(`Skipping ${notification.id}: review request check failed transiently, will retry`);
+            continue;
+          }
+          if (!reviewState.pending || !reviewState.requestId) {
+            if (reviewState.permanentFailure) {
+              log(`Skipping ${notification.id}: review request check failed permanently, marking processed`);
+            } else {
+              log(`Skipping ${notification.id}: agent is not an active requested reviewer, marking processed`);
+            }
+            state = addProcessedId(state, processedKey);
+            latestProcessedByThread.set(notification.id, notification.updated_at);
+            continue;
+          }
+
+          if (latestReviewRequestByThread.get(notification.id) === reviewState.requestId) {
+            log(`Skipping ${notification.id}: review request ${reviewState.requestId} already emitted`);
+            continue;
+          }
+
+          const reviewEvent = buildMentionEvent(notification, null, agent, { trigger: "review_requested" });
+          if (!reviewEvent) {
+            state = addProcessedId(state, processedKey);
+            latestProcessedByThread.set(notification.id, notification.updated_at);
+            continue;
+          }
+
+          process.stdout.write(JSON.stringify(reviewEvent) + "\n");
+          state = addReviewRequestId(state, notification.id, reviewState.requestId);
+          latestReviewRequestByThread.set(notification.id, reviewState.requestId);
+          continue;
+        }
+
         if (state.processedThreadIds.includes(processedKey)) continue;
 
         // Fetch the comment that triggered this notification

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -6,6 +6,7 @@ import {
   fetchMentionNotifications,
   fetchCommentBody,
   fetchRecentSubjectComments,
+  fetchLatestReviewRequestEvent,
   fetchReviewRequestState,
   fetchSubjectBodyResult,
   buildMentionEvent,
@@ -218,7 +219,22 @@ async function runPollLoop(
             continue;
           }
 
-          const reviewEvent = buildMentionEvent(notification, null, agent, { trigger: "review_requested" });
+          const latestReviewEvent = await fetchLatestReviewRequestEvent(repoOwner, repoName, pullNumber, agent);
+          if (latestReviewEvent.transientFailure) {
+            log(`Skipping ${notification.id}: review request event lookup failed transiently, will retry`);
+            continue;
+          }
+          if (latestReviewEvent.permanentFailure) {
+            log(`Continuing ${notification.id}: review request event lookup failed permanently, emitting without requester metadata`);
+          } else if (!latestReviewEvent.eventId) {
+            log(`Continuing ${notification.id}: no matching review_requested event found, emitting without requester metadata`);
+          }
+
+          const reviewEvent = buildMentionEvent(notification, null, agent, {
+            trigger: "review_requested",
+            reviewer: latestReviewEvent.reviewer ?? agent,
+            ...(latestReviewEvent.requester ? { requester: latestReviewEvent.requester } : {}),
+          });
           if (!reviewEvent) {
             state = addProcessedId(state, processedKey);
             latestProcessedByThread.set(notification.id, notification.updated_at);

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -249,6 +249,8 @@ export interface MentionEvent {
   threadId: string;   // notification thread ID
   timestamp: string;  // ISO 8601
   trigger?: "review_requested";
+  requester?: string; // for review_requested: login that requested the review
+  reviewer?: string;  // for review_requested: login the review was requested from
 }
 
 // ── Error Types ────────────────────────────────────────────────────

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -243,11 +243,12 @@ export interface MentionEvent {
   number: number;     // issue/PR number
   type: string;       // "Issue" | "PullRequest"
   title: string;
-  author: string;     // commenter who triggered the mention
-  body: string;       // comment text
-  url: string;        // HTML URL of the comment
+  author: string;     // commenter who triggered the event, or "unknown"
+  body: string;       // comment text when applicable
+  url: string;        // HTML URL of the triggering comment when applicable
   threadId: string;   // notification thread ID
   timestamp: string;  // ISO 8601
+  trigger?: "review_requested";
 }
 
 // ── Error Types ────────────────────────────────────────────────────

--- a/cli/src/github/notifications.test.ts
+++ b/cli/src/github/notifications.test.ts
@@ -11,6 +11,7 @@ import {
   markNotificationRead,
   fetchCommentBody,
   fetchRecentSubjectComments,
+  fetchLatestReviewRequestEvent,
   fetchReviewRequestState,
   fetchSubjectBody,
   fetchSubjectBodyResult,
@@ -721,6 +722,113 @@ describe("fetchReviewRequestState()", () => {
   });
 });
 
+describe("fetchLatestReviewRequestEvent()", () => {
+  it("returns the newest matching review_requested event with requester metadata", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify([[
+      {
+        id: 7001,
+        event: "review_requested",
+        created_at: "2026-03-10T12:00:00Z",
+        review_requester: { login: "maintainer-a" },
+        requested_reviewer: { login: "hivemoot-worker" },
+      },
+      {
+        id: 7002,
+        event: "review_requested",
+        created_at: "2026-03-10T12:05:00Z",
+        review_requester: { login: "maintainer-b" },
+        requested_reviewer: { login: "hivemoot-worker" },
+      },
+      {
+        id: 7003,
+        event: "review_requested",
+        created_at: "2026-03-10T12:06:00Z",
+        review_requester: { login: "maintainer-c" },
+        requested_reviewer: { login: "someone-else" },
+      },
+    ]]));
+
+    const result = await fetchLatestReviewRequestEvent("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      eventId: "7002",
+      requester: "maintainer-b",
+      reviewer: "hivemoot-worker",
+      permanentFailure: false,
+      transientFailure: false,
+    });
+    expect(mockedGh).toHaveBeenCalledWith([
+      "api",
+      "--paginate",
+      "--slurp",
+      "/repos/hivemoot/colony/issues/42/events?per_page=100",
+    ]);
+  });
+
+  it("matches reviewer login case-insensitively and falls back to actor when review_requester is absent", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify([[
+      {
+        id: 7001,
+        event: "review_requested",
+        created_at: "2026-03-10T12:05:00Z",
+        actor: { login: "maintainer-a" },
+        requested_reviewer: { login: "Hivemoot-Worker" },
+      },
+    ]]));
+
+    const result = await fetchLatestReviewRequestEvent("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      eventId: "7001",
+      requester: "maintainer-a",
+      reviewer: "Hivemoot-Worker",
+      permanentFailure: false,
+      transientFailure: false,
+    });
+  });
+
+  it("returns empty metadata when no matching review_requested event is present", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify([[
+      {
+        id: 7001,
+        event: "review_request_removed",
+        created_at: "2026-03-10T12:05:00Z",
+        review_requester: { login: "maintainer-a" },
+        requested_reviewer: { login: "hivemoot-worker" },
+      },
+    ]]));
+
+    const result = await fetchLatestReviewRequestEvent("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      permanentFailure: false,
+      transientFailure: false,
+    });
+  });
+
+  it("classifies 404 as permanent failure", async () => {
+    mockedGh.mockRejectedValue(new CliError("gh: Not Found (HTTP 404)", "GH_ERROR", 1));
+
+    const result = await fetchLatestReviewRequestEvent("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      permanentFailure: true,
+      transientFailure: false,
+    });
+  });
+
+  it("classifies other fetch failures as transient", async () => {
+    mockedGh.mockRejectedValue(new Error("network timeout"));
+
+    const result = await fetchLatestReviewRequestEvent("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      permanentFailure: false,
+      transientFailure: true,
+    });
+  });
+});
+
 describe("buildMentionEvent()", () => {
   const baseNotification: RawNotification = {
     id: "5001",
@@ -800,9 +908,13 @@ describe("buildMentionEvent()", () => {
   it("includes trigger metadata when provided", () => {
     const event = buildMentionEvent(baseNotification, null, "hivemoot-worker", {
       trigger: "review_requested",
+      requester: "maintainer",
+      reviewer: "hivemoot-worker",
     });
 
     expect(event?.trigger).toBe("review_requested");
+    expect(event?.requester).toBe("maintainer");
+    expect(event?.reviewer).toBe("hivemoot-worker");
   });
 });
 

--- a/cli/src/github/notifications.test.ts
+++ b/cli/src/github/notifications.test.ts
@@ -11,6 +11,7 @@ import {
   markNotificationRead,
   fetchCommentBody,
   fetchRecentSubjectComments,
+  fetchReviewRequestState,
   fetchSubjectBody,
   fetchSubjectBodyResult,
   buildMentionEvent,
@@ -552,6 +553,174 @@ describe("fetchRecentSubjectComments()", () => {
   });
 });
 
+describe("fetchReviewRequestState()", () => {
+  it("returns pending with a stable request id for the matching reviewer", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewRequests: {
+              nodes: [
+                {
+                  id: "RR_node_1",
+                  databaseId: 9001,
+                  requestedReviewer: {
+                    __typename: "User",
+                    login: "hivemoot-worker",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      pending: true,
+      requestId: "9001",
+      permanentFailure: false,
+      transientFailure: false,
+    });
+    expect(mockedGh).toHaveBeenCalledWith([
+      "api",
+      "graphql",
+      "-F", "owner=hivemoot",
+      "-F", "repo=colony",
+      "-F", "pullNumber=42",
+      "-f", expect.stringContaining("reviewRequests(first: 100)"),
+    ]);
+  });
+
+  it("matches reviewer login case-insensitively", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewRequests: {
+              nodes: [
+                {
+                  id: "RR_node_1",
+                  databaseId: 9001,
+                  requestedReviewer: {
+                    __typename: "User",
+                    login: "Hivemoot-Worker",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+    expect(result.pending).toBe(true);
+    expect(result.requestId).toBe("9001");
+  });
+
+  it("falls back to the GraphQL node id when databaseId is absent", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewRequests: {
+              nodes: [
+                {
+                  id: "RR_node_1",
+                  databaseId: null,
+                  requestedReviewer: {
+                    __typename: "User",
+                    login: "hivemoot-worker",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+    expect(result.requestId).toBe("RR_node_1");
+  });
+
+  it("returns not pending when the reviewer is not currently requested", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewRequests: {
+              nodes: [
+                {
+                  id: "RR_node_1",
+                  databaseId: 9001,
+                  requestedReviewer: {
+                    __typename: "User",
+                    login: "someone-else",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      pending: false,
+      permanentFailure: false,
+      transientFailure: false,
+    });
+  });
+
+  it("returns permanent failure when the pull request cannot be resolved", async () => {
+    mockedGh.mockResolvedValue(JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: null,
+        },
+      },
+    }));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      pending: false,
+      permanentFailure: true,
+      transientFailure: false,
+    });
+  });
+
+  it("classifies 404 as permanent failure", async () => {
+    mockedGh.mockRejectedValue(new CliError("gh: Not Found (HTTP 404)", "GH_ERROR", 1));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      pending: false,
+      permanentFailure: true,
+      transientFailure: false,
+    });
+  });
+
+  it("classifies other fetch failures as transient", async () => {
+    mockedGh.mockRejectedValue(new Error("network timeout"));
+
+    const result = await fetchReviewRequestState("hivemoot", "colony", 42, "hivemoot-worker");
+
+    expect(result).toEqual({
+      pending: false,
+      permanentFailure: false,
+      transientFailure: true,
+    });
+  });
+});
+
 describe("buildMentionEvent()", () => {
   const baseNotification: RawNotification = {
     id: "5001",
@@ -626,6 +795,14 @@ describe("buildMentionEvent()", () => {
     const event = buildMentionEvent(prNotification, baseComment, "hivemoot-worker");
     expect(event!.type).toBe("PullRequest");
     expect(event!.number).toBe(99);
+  });
+
+  it("includes trigger metadata when provided", () => {
+    const event = buildMentionEvent(baseNotification, null, "hivemoot-worker", {
+      trigger: "review_requested",
+    });
+
+    expect(event?.trigger).toBe("review_requested");
   });
 });
 

--- a/cli/src/github/notifications.ts
+++ b/cli/src/github/notifications.ts
@@ -47,6 +47,13 @@ export interface FetchCommentsResult {
   permanentFailure: boolean;
 }
 
+export interface ReviewRequestState {
+  pending: boolean;
+  requestId?: string;
+  permanentFailure: boolean;
+  transientFailure: boolean;
+}
+
 /** Extract issue/PR number from a GitHub API subject URL (last path segment). */
 export function parseSubjectNumber(url: string): number | undefined {
   const match = url.match(/\/(\d+)$/);
@@ -372,6 +379,108 @@ export async function fetchSubjectBodyResult(subjectUrl: string): Promise<FetchD
   }
 }
 
+interface ReviewRequestsGraphqlResponse {
+  data?: {
+    repository?: {
+      pullRequest?: {
+        reviewRequests?: {
+          nodes?: Array<{
+            id: string;
+            databaseId?: number | null;
+            requestedReviewer?: {
+              __typename: string;
+              login?: string;
+            } | null;
+          }>;
+        };
+      } | null;
+    } | null;
+  };
+}
+
+/**
+ * Fetch the current active review-request identity for a specific user.
+ *
+ * We use the GraphQL ReviewRequest object's own identifier instead of
+ * notification.updated_at. That lets watch distinguish a real re-request
+ * from ordinary PR activity on the same thread.
+ */
+export async function fetchReviewRequestState(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  reviewer: string,
+): Promise<ReviewRequestState> {
+  const query = `
+    query($owner: String!, $repo: String!, $pullNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pullNumber) {
+          reviewRequests(first: 100) {
+            nodes {
+              id
+              databaseId
+              requestedReviewer {
+                __typename
+                ... on User {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const raw = await gh([
+      "api",
+      "graphql",
+      "-F", `owner=${owner}`,
+      "-F", `repo=${repo}`,
+      "-F", `pullNumber=${pullNumber}`,
+      "-f", `query=${query}`,
+    ]);
+    const parsed = JSON.parse(raw) as ReviewRequestsGraphqlResponse;
+    const pullRequest = parsed.data?.repository?.pullRequest;
+    if (!pullRequest?.reviewRequests?.nodes) {
+      return {
+        pending: false,
+        permanentFailure: true,
+        transientFailure: false,
+      };
+    }
+
+    const match = pullRequest.reviewRequests.nodes.find((request) => (
+      request.requestedReviewer?.__typename === "User"
+      && request.requestedReviewer.login?.toLowerCase() === reviewer.toLowerCase()
+    ));
+    if (!match) {
+      return {
+        pending: false,
+        permanentFailure: false,
+        transientFailure: false,
+      };
+    }
+
+    return {
+      pending: true,
+      requestId: match.databaseId !== null && match.databaseId !== undefined
+        ? String(match.databaseId)
+        : match.id,
+      permanentFailure: false,
+      transientFailure: false,
+    };
+  } catch (err) {
+    const permanentFailure = isPermanentFetchError(err);
+    return {
+      pending: false,
+      permanentFailure,
+      transientFailure: !permanentFailure,
+    };
+  }
+}
+
 /**
  * Check if the comment body contains an @mention of the given GitHub login.
  * Case-insensitive, boundary-safe on both sides:
@@ -391,6 +500,7 @@ export function buildMentionEvent(
   notification: RawNotification,
   comment: CommentDetail | null,
   agent: string,
+  extras?: Pick<MentionEvent, "trigger">,
 ): MentionEvent | null {
   const number = parseSubjectNumber(notification.subject.url);
   if (number === undefined) return null;
@@ -406,5 +516,6 @@ export function buildMentionEvent(
     url: comment?.htmlUrl ?? "",
     threadId: notification.id,
     timestamp: notification.updated_at,
+    ...(extras?.trigger ? { trigger: extras.trigger } : {}),
   };
 }

--- a/cli/src/github/notifications.ts
+++ b/cli/src/github/notifications.ts
@@ -54,6 +54,14 @@ export interface ReviewRequestState {
   transientFailure: boolean;
 }
 
+export interface ReviewRequestEventResult {
+  eventId?: string;
+  requester?: string;
+  reviewer?: string;
+  permanentFailure: boolean;
+  transientFailure: boolean;
+}
+
 /** Extract issue/PR number from a GitHub API subject URL (last path segment). */
 export function parseSubjectNumber(url: string): number | undefined {
   const match = url.match(/\/(\d+)$/);
@@ -398,6 +406,21 @@ interface ReviewRequestsGraphqlResponse {
   };
 }
 
+interface IssueEventResponseItem {
+  id?: number;
+  event?: string;
+  created_at?: string;
+  actor?: {
+    login?: string;
+  } | null;
+  review_requester?: {
+    login?: string;
+  } | null;
+  requested_reviewer?: {
+    login?: string;
+  } | null;
+}
+
 /**
  * Fetch the current active review-request identity for a specific user.
  *
@@ -482,6 +505,70 @@ export async function fetchReviewRequestState(
 }
 
 /**
+ * Fetch the most recent review_requested issue event for a reviewer on a PR.
+ *
+ * This gives watch the requester/reviewer metadata required by the event
+ * payload without using thread updated_at as the dedupe identity.
+ */
+export async function fetchLatestReviewRequestEvent(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  reviewer: string,
+): Promise<ReviewRequestEventResult> {
+  try {
+    const raw = await gh([
+      "api",
+      "--paginate",
+      "--slurp",
+      `/repos/${owner}/${repo}/issues/${pullNumber}/events?per_page=100`,
+    ]);
+    const pages = JSON.parse(raw) as IssueEventResponseItem[][];
+    const events = pages.flat();
+
+    let latest: IssueEventResponseItem | null = null;
+    for (const event of events) {
+      if (event.event !== "review_requested") continue;
+      if (event.requested_reviewer?.login?.toLowerCase() !== reviewer.toLowerCase()) continue;
+
+      if (!latest) {
+        latest = event;
+        continue;
+      }
+
+      const createdAt = event.created_at ?? "";
+      const latestCreatedAt = latest.created_at ?? "";
+      const eventId = event.id ?? 0;
+      const latestId = latest.id ?? 0;
+      if (createdAt > latestCreatedAt || (createdAt === latestCreatedAt && eventId > latestId)) {
+        latest = event;
+      }
+    }
+
+    if (!latest?.id) {
+      return {
+        permanentFailure: false,
+        transientFailure: false,
+      };
+    }
+
+    return {
+      eventId: String(latest.id),
+      requester: latest.review_requester?.login ?? latest.actor?.login,
+      reviewer: latest.requested_reviewer?.login ?? reviewer,
+      permanentFailure: false,
+      transientFailure: false,
+    };
+  } catch (err) {
+    const permanentFailure = isPermanentFetchError(err);
+    return {
+      permanentFailure,
+      transientFailure: !permanentFailure,
+    };
+  }
+}
+
+/**
  * Check if the comment body contains an @mention of the given GitHub login.
  * Case-insensitive, boundary-safe on both sides:
  *   Left:  rejects email local-parts (foo@agent)
@@ -500,7 +587,7 @@ export function buildMentionEvent(
   notification: RawNotification,
   comment: CommentDetail | null,
   agent: string,
-  extras?: Pick<MentionEvent, "trigger">,
+  extras?: Pick<MentionEvent, "trigger" | "requester" | "reviewer">,
 ): MentionEvent | null {
   const number = parseSubjectNumber(notification.subject.url);
   if (number === undefined) return null;
@@ -517,5 +604,7 @@ export function buildMentionEvent(
     threadId: notification.id,
     timestamp: notification.updated_at,
     ...(extras?.trigger ? { trigger: extras.trigger } : {}),
+    ...(extras?.requester ? { requester: extras.requester } : {}),
+    ...(extras?.reviewer ? { reviewer: extras.reviewer } : {}),
   };
 }

--- a/cli/src/watch/state.test.ts
+++ b/cli/src/watch/state.test.ts
@@ -4,7 +4,16 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeFileSync } from "node:fs";
-import { loadState, saveState, addProcessedId, mergeAckJournal, appendAck, type WatchState } from "./state.js";
+import {
+  loadState,
+  saveState,
+  addProcessedId,
+  addReviewRequestId,
+  buildLatestReviewRequestByThread,
+  mergeAckJournal,
+  appendAck,
+  type WatchState,
+} from "./state.js";
 
 let tmpDir: string;
 let stateFile: string;
@@ -33,12 +42,14 @@ describe("loadState()", () => {
     const saved: WatchState = {
       lastChecked: "2026-01-15T10:00:00Z",
       processedThreadIds: ["100", "200", "300"],
+      reviewRequestIds: ["500:9001"],
     };
     writeFileSync(stateFile, JSON.stringify(saved));
 
     const state = await loadState(stateFile);
     expect(state.lastChecked).toBe("2026-01-15T10:00:00Z");
     expect(state.processedThreadIds).toEqual(["100", "200", "300"]);
+    expect(state.reviewRequestIds).toEqual(["500:9001"]);
   });
 
   it("returns default state on corrupted JSON", async () => {
@@ -60,10 +71,12 @@ describe("loadState()", () => {
     writeFileSync(stateFile, JSON.stringify({
       lastChecked: "2026-01-15T10:00:00Z",
       processedThreadIds: ["100", 42, null, "200"],
+      reviewRequestIds: ["500:9001", 123, null],
     }));
 
     const state = await loadState(stateFile);
     expect(state.processedThreadIds).toEqual(["100", "200"]);
+    expect(state.reviewRequestIds).toEqual(["500:9001"]);
   });
 
   it("rejects state paths that traverse symlink directories", async () => {
@@ -83,6 +96,7 @@ describe("saveState()", () => {
     const state: WatchState = {
       lastChecked: "2026-01-15T12:00:00Z",
       processedThreadIds: ["abc", "def"],
+      reviewRequestIds: ["500:9001"],
     };
 
     await saveState(stateFile, state);
@@ -91,6 +105,7 @@ describe("saveState()", () => {
     const loaded = JSON.parse(raw);
     expect(loaded.lastChecked).toBe("2026-01-15T12:00:00Z");
     expect(loaded.processedThreadIds).toEqual(["abc", "def"]);
+    expect(loaded.reviewRequestIds).toEqual(["500:9001"]);
   });
 
   it("trims processedThreadIds to 200 entries (keeping most recent)", async () => {
@@ -98,6 +113,7 @@ describe("saveState()", () => {
     const state: WatchState = {
       lastChecked: "2026-01-15T12:00:00Z",
       processedThreadIds: ids,
+      reviewRequestIds: Array.from({ length: 300 }, (_, i) => `thread-${i}:request-${i}`),
     };
 
     await saveState(stateFile, state);
@@ -105,9 +121,12 @@ describe("saveState()", () => {
     const raw = await readFile(stateFile, "utf-8");
     const loaded = JSON.parse(raw) as WatchState;
     expect(loaded.processedThreadIds.length).toBe(200);
+    expect(loaded.reviewRequestIds?.length).toBe(200);
     // Should keep the last 200 (thread-100 through thread-299)
     expect(loaded.processedThreadIds[0]).toBe("thread-100");
     expect(loaded.processedThreadIds[199]).toBe("thread-299");
+    expect(loaded.reviewRequestIds?.[0]).toBe("thread-100:request-100");
+    expect(loaded.reviewRequestIds?.[199]).toBe("thread-299:request-299");
   });
 
   it("overwrites existing state file atomically", async () => {
@@ -211,6 +230,53 @@ describe("addProcessedId()", () => {
     const updated = addProcessedId(state, "b");
     expect(state.processedThreadIds).toEqual(["a"]);
     expect(updated.processedThreadIds).toEqual(["a", "b"]);
+  });
+});
+
+describe("addReviewRequestId()", () => {
+  it("records the latest request id for a thread", () => {
+    const state: WatchState = {
+      lastChecked: "2026-01-15T10:00:00Z",
+      processedThreadIds: [],
+    };
+
+    const updated = addReviewRequestId(state, "1001", "7001");
+    expect(updated.reviewRequestIds).toEqual(["1001:7001"]);
+  });
+
+  it("replaces the prior request id for the same thread", () => {
+    const state: WatchState = {
+      lastChecked: "2026-01-15T10:00:00Z",
+      processedThreadIds: [],
+      reviewRequestIds: ["1001:7001", "2002:8002"],
+    };
+
+    const updated = addReviewRequestId(state, "1001", "7003");
+    expect(updated.reviewRequestIds).toEqual(["2002:8002", "1001:7003"]);
+  });
+
+  it("does not duplicate an existing thread/request pair", () => {
+    const state: WatchState = {
+      lastChecked: "2026-01-15T10:00:00Z",
+      processedThreadIds: [],
+      reviewRequestIds: ["1001:7001"],
+    };
+
+    const updated = addReviewRequestId(state, "1001", "7001");
+    expect(updated.reviewRequestIds).toEqual(["1001:7001"]);
+  });
+});
+
+describe("buildLatestReviewRequestByThread()", () => {
+  it("returns the latest request id for each thread", () => {
+    const result = buildLatestReviewRequestByThread([
+      "1001:7001",
+      "2002:8002",
+      "1001:7003",
+    ]);
+
+    expect(result.get("1001")).toBe("7003");
+    expect(result.get("2002")).toBe("8002");
   });
 });
 

--- a/cli/src/watch/state.ts
+++ b/cli/src/watch/state.ts
@@ -8,6 +8,13 @@ const MAX_PROCESSED_IDS = 200;
 export interface WatchState {
   lastChecked: string;           // ISO 8601 timestamp
   processedThreadIds: string[];  // rolling window of thread IDs already handled
+  /**
+   * Latest emitted review-request identity per notification thread, stored as
+   * `${threadId}:${requestId}`. The request ID comes from GitHub's GraphQL
+   * ReviewRequest object, so watch can suppress plain PR activity while still
+   * re-emitting later real re-requests on the same thread.
+   */
+  reviewRequestIds?: string[];
 }
 
 export interface LoadStateResult {
@@ -106,10 +113,16 @@ export async function loadStateWithStatus(filePath: string): Promise<LoadStateRe
     }
 
     const processedThreadIds = parsed.processedThreadIds.filter((id): id is string => typeof id === "string");
+    const reviewRequestIds = Array.isArray(parsed.reviewRequestIds)
+      ? parsed.reviewRequestIds.filter((id): id is string => typeof id === "string")
+      : undefined;
     return {
       state: {
         lastChecked: parsed.lastChecked,
         processedThreadIds,
+        ...(reviewRequestIds && reviewRequestIds.length > 0
+          ? { reviewRequestIds }
+          : {}),
       },
       degraded: false,
     };
@@ -133,6 +146,9 @@ export async function saveState(filePath: string, state: WatchState): Promise<vo
   const trimmed: WatchState = {
     lastChecked: state.lastChecked,
     processedThreadIds: state.processedThreadIds.slice(-MAX_PROCESSED_IDS),
+    ...(state.reviewRequestIds && state.reviewRequestIds.length > 0
+      ? { reviewRequestIds: state.reviewRequestIds.slice(-MAX_PROCESSED_IDS) }
+      : {}),
   };
 
   try {
@@ -155,6 +171,27 @@ export function addProcessedId(state: WatchState, threadId: string): WatchState 
     : [...state.processedThreadIds, threadId].slice(-MAX_PROCESSED_IDS);
 
   return { ...state, processedThreadIds: ids };
+}
+
+/** Record the latest emitted review-request identity for a thread. */
+export function addReviewRequestId(
+  state: WatchState,
+  threadId: string,
+  requestId: string,
+): WatchState {
+  const key = `${threadId}:${requestId}`;
+  const existing = state.reviewRequestIds ?? [];
+  if (existing.includes(key)) return state;
+
+  const next = [
+    ...existing.filter((entry) => !entry.startsWith(`${threadId}:`)),
+    key,
+  ].slice(-MAX_PROCESSED_IDS);
+
+  return {
+    ...state,
+    reviewRequestIds: next,
+  };
 }
 
 function defaultState(): WatchState {
@@ -191,6 +228,25 @@ export function buildLatestProcessedByThread(processedKeys: string[]): Map<strin
     if (!existing || updatedAt > existing) {
       byThread.set(threadId, updatedAt);
     }
+  }
+
+  return byThread;
+}
+
+/**
+ * Build a map of threadId → latest emitted review-request ID.
+ * Keys in reviewRequestIds have the composite format `threadId:requestId`.
+ */
+export function buildLatestReviewRequestByThread(reviewRequestIds: string[]): Map<string, string> {
+  const byThread = new Map<string, string>();
+
+  for (const key of reviewRequestIds) {
+    const separatorIndex = key.indexOf(":");
+    if (separatorIndex <= 0 || separatorIndex === key.length - 1) continue;
+
+    const threadId = key.slice(0, separatorIndex);
+    const requestId = key.slice(separatorIndex + 1);
+    byThread.set(threadId, requestId);
   }
 
   return byThread;


### PR DESCRIPTION
## What

Emit `review_requested` watch events from a stable review-request identity instead of notification thread churn, and enrich those events with explicit requester/reviewer metadata.

Fixes #335

## Why

`threadId:updated_at` is too noisy for review requests because GitHub bumps the notification thread on ordinary PR activity. The watcher needs a request-specific cursor so commits/comments stay silent, while a real re-request on the same thread still emits once.

The issue also asks for requester/reviewer metadata. GitHub exposes that on PR issue events, not on the notification thread itself.

## What changed

- Keep review-request dedupe keyed to GitHub's active review-request identity, not notification `updated_at`.
- Fetch the latest matching `review_requested` issue event only when a new active request is about to emit.
- Add `trigger`, `requester`, and `reviewer` fields to `review_requested` JSON output.
- Retry transient issue-event fetch failures instead of emitting an incomplete event.
- Fall back to explicit `reviewer` metadata if GitHub exposes the active request but not the matching issue event.

## What it looks like

**Before:**

```text
$ hivemoot watch --repo owner/repo --reasons review_requested --once
{"threadId":"1001","trigger":"review_requested",...}

# same review still pending, author pushes a commit
$ hivemoot watch --repo owner/repo --reasons review_requested --once
{"threadId":"1001","trigger":"review_requested",...}
```

**After:**

```text
$ hivemoot watch --repo owner/repo --reasons review_requested --once
{"threadId":"1001","trigger":"review_requested","requester":"maintainer","reviewer":"hivemoot-worker",...}

# same review still pending, later PR activity only
$ hivemoot watch --repo owner/repo --reasons review_requested --once
# no output

# author explicitly re-requests review later on the same PR/thread
$ hivemoot watch --repo owner/repo --reasons review_requested --once
{"threadId":"1001","trigger":"review_requested","requester":"maintainer","reviewer":"hivemoot-worker",...}
```

## Notes

- Uses GraphQL `reviewRequests` for the active-request cursor and PR issue events for requester/reviewer metadata.
- Validation: `npm test`, `npm run typecheck`, `npm run build` in `cli/`.
- CLI version remains `0.2.0`.
