### PR TITLE
feat(cli): add hivemoot issue snapshot command

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/issue-snapshot.test.ts
+++ b/cli/src/commands/issue-snapshot.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CliError } from "../config/types.js";
+
+vi.mock("../github/repo.js", () => ({
+  resolveRepo: vi.fn(),
+}));
+
+vi.mock("../github/issue-snapshot.js", () => ({
+  buildIssueSnapshot: vi.fn(),
+}));
+
+import { resolveRepo } from "../github/repo.js";
+import { buildIssueSnapshot } from "../github/issue-snapshot.js";
+import { issueSnapshotCommand } from "./issue-snapshot.js";
+
+const mockedResolveRepo = vi.mocked(resolveRepo);
+const mockedBuildIssueSnapshot = vi.mocked(buildIssueSnapshot);
+
+const testRepo = { owner: "hivemoot", repo: "hivemoot" };
+
+function makeSnapshot(
+  overrides: Partial<Awaited<ReturnType<typeof buildIssueSnapshot>>> = {},
+): Awaited<ReturnType<typeof buildIssueSnapshot>> {
+  return {
+    schemaVersion: 1,
+    kind: "issue_snapshot",
+    generatedAt: "2026-03-12T10:00:00.000Z",
+    repo: testRepo,
+    issue: {
+      number: 42,
+      title: "feat(web): add role-targeted task delegation",
+      state: "OPEN",
+      labels: ["hivemoot:discussion"],
+      assignees: [],
+      author: "hivemoot-builder",
+      url: "https://github.com/hivemoot/hivemoot/issues/42",
+      createdAt: "2026-03-10T10:00:00Z",
+      updatedAt: "2026-03-12T09:00:00Z",
+      governance: { phase: "discussion" },
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  mockedResolveRepo.mockResolvedValue(testRepo);
+  mockedBuildIssueSnapshot.mockResolvedValue(makeSnapshot());
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe("issueSnapshotCommand", () => {
+  describe("input validation", () => {
+    it("throws CliError for non-numeric issue argument", async () => {
+      await expect(issueSnapshotCommand("abc", {})).rejects.toThrow(CliError);
+    });
+
+    it("throws CliError for zero issue number", async () => {
+      await expect(issueSnapshotCommand("0", {})).rejects.toThrow(CliError);
+    });
+
+    it("throws CliError for negative issue number", async () => {
+      await expect(issueSnapshotCommand("-1", {})).rejects.toThrow(CliError);
+    });
+
+    it("exits with code 1 for invalid issue number", async () => {
+      const err = await issueSnapshotCommand("abc", {}).catch((e) => e as CliError);
+      expect(err.exitCode).toBe(1);
+    });
+  });
+
+  describe("text output", () => {
+    it("outputs snapshot header", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("ISSUE SNAPSHOT — hivemoot/hivemoot#42");
+    });
+
+    it("outputs issue title", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("feat(web): add role-targeted task delegation");
+    });
+
+    it("outputs governance phase", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("governance: discussion");
+    });
+
+    it("outputs state", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("state: OPEN");
+    });
+
+    it("outputs queen summary when present", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshot({
+          issue: {
+            ...makeSnapshot().issue,
+            governance: { phase: "voting" },
+            queenSummary: {
+              body: "The team discussed adding role-targeted task delegation.",
+              commentId: "IC_node123",
+              url: "https://github.com/hivemoot/hivemoot/issues/42#issuecomment-100",
+            },
+          },
+        }),
+      );
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("queen summary:");
+      expect(output).toContain("role-targeted task delegation");
+    });
+
+    it("outputs queen voting tallies when present", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshot({
+          issue: {
+            ...makeSnapshot().issue,
+            governance: { phase: "voting" },
+            queenVoting: { thumbsUp: 7, thumbsDown: 1, yourVote: "thumbsUp" },
+          },
+        }),
+      );
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("👍 7");
+      expect(output).toContain("👎 1");
+      expect(output).toContain("your vote: 👍");
+    });
+
+    it("shows not voted when yourVote is null", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshot({
+          issue: {
+            ...makeSnapshot().issue,
+            queenVoting: { thumbsUp: 3, thumbsDown: 0, yourVote: null },
+          },
+        }),
+      );
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).toContain("your vote: not voted");
+    });
+
+    it("omits queen fields when absent", async () => {
+      await issueSnapshotCommand("42", {});
+      const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(output).not.toContain("queen summary:");
+      expect(output).not.toContain("queen voting:");
+    });
+  });
+
+  describe("JSON output", () => {
+    it("outputs valid JSON with --json flag", async () => {
+      await issueSnapshotCommand("42", { json: true });
+      const raw = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      const parsed = JSON.parse(raw) as Awaited<ReturnType<typeof buildIssueSnapshot>>;
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.kind).toBe("issue_snapshot");
+      expect(parsed.issue.number).toBe(42);
+    });
+
+    it("JSON includes governance phase", async () => {
+      await issueSnapshotCommand("42", { json: true });
+      const raw = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      const parsed = JSON.parse(raw) as Awaited<ReturnType<typeof buildIssueSnapshot>>;
+      expect(parsed.issue.governance.phase).toBe("discussion");
+    });
+
+    it("JSON includes optional queenVoting when present", async () => {
+      mockedBuildIssueSnapshot.mockResolvedValue(
+        makeSnapshot({
+          issue: {
+            ...makeSnapshot().issue,
+            queenVoting: { thumbsUp: 5, thumbsDown: 2, yourVote: "thumbsDown" },
+          },
+        }),
+      );
+      await issueSnapshotCommand("42", { json: true });
+      const raw = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      const parsed = JSON.parse(raw) as Awaited<ReturnType<typeof buildIssueSnapshot>>;
+      expect(parsed.issue.queenVoting?.thumbsUp).toBe(5);
+      expect(parsed.issue.queenVoting?.yourVote).toBe("thumbsDown");
+    });
+  });
+
+  describe("error handling", () => {
+    it("re-throws CliError with exitCode >= 3", async () => {
+      mockedBuildIssueSnapshot.mockRejectedValue(
+        new CliError("Issue not found", "GH_NOT_FOUND", 1),
+      );
+      const err = await issueSnapshotCommand("42", {}).catch((e) => e as CliError);
+      expect(err).toBeInstanceOf(CliError);
+      expect(err.exitCode).toBeGreaterThanOrEqual(3);
+    });
+
+    it("wraps non-CliError in a CliError with exitCode 3", async () => {
+      mockedBuildIssueSnapshot.mockRejectedValue(new Error("network timeout"));
+      const err = await issueSnapshotCommand("42", {}).catch((e) => e as CliError);
+      expect(err).toBeInstanceOf(CliError);
+      expect(err.exitCode).toBe(3);
+      expect(err.message).toBe("network timeout");
+    });
+
+    it("passes --repo option to resolveRepo", async () => {
+      await issueSnapshotCommand("42", { repo: "other/project" });
+      expect(mockedResolveRepo).toHaveBeenCalledWith("other/project");
+    });
+  });
+});

--- a/cli/src/commands/issue-snapshot.ts
+++ b/cli/src/commands/issue-snapshot.ts
@@ -1,0 +1,83 @@
+import { CliError, type RepoRef } from "../config/types.js";
+import { resolveRepo } from "../github/repo.js";
+import { buildIssueSnapshot, type IssueSnapshotResult } from "../github/issue-snapshot.js";
+
+export interface IssueSnapshotOptions {
+  repo?: string;
+  json?: boolean;
+}
+
+function formatRepo(repo: RepoRef): string {
+  return `${repo.owner}/${repo.repo}`;
+}
+
+function formatSnapshot(snapshot: IssueSnapshotResult): string {
+  const { issue } = snapshot;
+
+  const lines = [
+    `ISSUE SNAPSHOT — ${formatRepo(snapshot.repo)}#${issue.number}`,
+    issue.title,
+    `state: ${issue.state}`,
+    `labels: ${issue.labels.length > 0 ? issue.labels.join(", ") : "none"}`,
+    `governance: ${issue.governance.phase}`,
+  ];
+
+  if (issue.author) {
+    lines.push(`author: ${issue.author}`);
+  }
+
+  if (issue.assignees.length > 0) {
+    lines.push(`assignees: ${issue.assignees.join(", ")}`);
+  }
+
+  if (issue.queenSummary) {
+    const preview = issue.queenSummary.body.slice(0, 200);
+    const suffix = issue.queenSummary.body.length > 200 ? "…" : "";
+    lines.push(`queen summary: ${preview}${suffix}`);
+  }
+
+  if (issue.queenVoting) {
+    const { thumbsUp, thumbsDown, yourVote } = issue.queenVoting;
+    const voteStr = yourVote === "thumbsUp" ? "👍" : yourVote === "thumbsDown" ? "👎" : "not voted";
+    lines.push(`queen voting: 👍 ${thumbsUp}  👎 ${thumbsDown}  your vote: ${voteStr}`);
+  }
+
+  return lines.join("\n");
+}
+
+export async function issueSnapshotCommand(
+  issueArg: string,
+  options: IssueSnapshotOptions,
+): Promise<void> {
+  const issueNumber = parseInt(issueArg, 10);
+  if (isNaN(issueNumber) || issueNumber <= 0) {
+    throw new CliError(
+      `Invalid issue number: "${issueArg}". Expected a positive integer.`,
+      "GH_ERROR",
+      1,
+    );
+  }
+
+  const repo = await resolveRepo(options.repo);
+
+  let snapshot: IssueSnapshotResult;
+  try {
+    snapshot = await buildIssueSnapshot(repo, issueNumber);
+  } catch (err) {
+    if (err instanceof CliError) {
+      throw new CliError(err.message, err.code, Math.max(err.exitCode, 3));
+    }
+    throw new CliError(
+      err instanceof Error ? err.message : String(err),
+      "GH_ERROR",
+      3,
+    );
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(snapshot, null, 2));
+    return;
+  }
+
+  console.log(formatSnapshot(snapshot));
+}

--- a/cli/src/github/issue-snapshot.ts
+++ b/cli/src/github/issue-snapshot.ts
@@ -1,0 +1,354 @@
+import type { RepoRef } from "../config/types.js";
+import { CliError } from "../config/types.js";
+import { gh } from "./client.js";
+import { fetchCurrentUser } from "./user.js";
+import {
+  GOVERNANCE_LABEL_ALIASES,
+  hasGovernanceLabelName,
+  type GovernanceLabelKey,
+} from "../summary/utils.js";
+
+// === Public result types ===
+
+export interface IssueSnapshotGovernance {
+  phase: string;
+}
+
+export interface IssueSnapshotQueenSummary {
+  body: string;
+  commentId: string;
+  url: string;
+}
+
+export interface IssueSnapshotQueenVoting {
+  thumbsUp: number;
+  thumbsDown: number;
+  yourVote: "thumbsUp" | "thumbsDown" | null;
+}
+
+export interface IssueSnapshotIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: string[];
+  assignees: string[];
+  author: string | null;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  governance: IssueSnapshotGovernance;
+  queenSummary?: IssueSnapshotQueenSummary;
+  queenVoting?: IssueSnapshotQueenVoting;
+}
+
+export interface IssueSnapshotResult {
+  schemaVersion: 1;
+  kind: "issue_snapshot";
+  generatedAt: string;
+  repo: RepoRef;
+  issue: IssueSnapshotIssue;
+}
+
+// === Internal types ===
+
+interface RawIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: Array<{ name: string }>;
+  assignees: Array<{ login: string }>;
+  author: { login: string } | null;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GraphQLReactionNode {
+  content: string;
+  user: { login: string } | null;
+}
+
+interface GraphQLComment {
+  id: string;
+  url: string;
+  body: string;
+  createdAt: string;
+  author: { login: string } | null;
+  reactions: {
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+    nodes: GraphQLReactionNode[];
+  };
+}
+
+interface IssueCommentsConnection {
+  pageInfo?: {
+    hasPreviousPage?: boolean;
+    startCursor?: string | null;
+  };
+  nodes: GraphQLComment[];
+}
+
+interface IssueSnapshotCommentsResponse {
+  data: {
+    repository: {
+      issue: { comments: IssueCommentsConnection } | null;
+    };
+  };
+}
+
+// === Constants ===
+
+const TRUSTED_QUEEN_LOGINS = new Set(["hivemoot", "hivemoot[bot]"]);
+const METADATA_RE = /<!--\s*hivemoot-metadata:\s*(\{[\s\S]*?\})\s*-->/;
+
+// Phase priority: first match wins; more active states take precedence.
+const PHASE_LABEL_PRIORITY: Array<[GovernanceLabelKey, string]> = [
+  ["VOTING", "voting"],
+  ["EXTENDED_VOTING", "extended-voting"],
+  ["READY_TO_IMPLEMENT", "ready-to-implement"],
+  ["IMPLEMENTATION", "candidate"],
+  ["MERGE_READY", "merge-ready"],
+  ["DISCUSSION", "discussion"],
+  ["IMPLEMENTED", "implemented"],
+  ["REJECTED", "rejected"],
+  ["INCONCLUSIVE", "inconclusive"],
+  ["NEEDS_HUMAN", "needs-human"],
+  ["STALE", "stale"],
+];
+
+// GraphQL query for paginated issue comments with reactions
+const ISSUE_SNAPSHOT_COMMENTS_QUERY = `
+query ($owner: String!, $repo: String!, $number: Int!, $commentsCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      comments(last: 100, before: $commentsCursor) {
+        pageInfo {
+          hasPreviousPage
+          startCursor
+        }
+        nodes {
+          id
+          url
+          body
+          createdAt
+          author { login }
+          reactions(first: 100) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              content
+              user { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// === Helpers ===
+
+function deriveGovernancePhase(labelNames: string[]): string {
+  for (const [key, phase] of PHASE_LABEL_PRIORITY) {
+    if (hasGovernanceLabelName(labelNames, key)) return phase;
+  }
+  return "none";
+}
+
+function parseMeta(body: string): Record<string, unknown> | undefined {
+  const match = body.match(METADATA_RE);
+  if (!match) return undefined;
+  try {
+    return JSON.parse(match[1]) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function stripMetadata(body: string): string {
+  return body.replace(METADATA_RE, "").trim();
+}
+
+function isQueenSummaryComment(comment: GraphQLComment, issueNumber: number): boolean {
+  if (!TRUSTED_QUEEN_LOGINS.has(comment.author?.login ?? "")) return false;
+  const meta = parseMeta(comment.body);
+  if (!meta) return false;
+  return meta.type === "summary" && meta.issueNumber === issueNumber;
+}
+
+function isQueenVotingComment(comment: GraphQLComment, issueNumber: number): boolean {
+  if (!TRUSTED_QUEEN_LOGINS.has(comment.author?.login ?? "")) return false;
+  const meta = parseMeta(comment.body);
+  if (!meta) return false;
+  return meta.type === "voting" && meta.issueNumber === issueNumber;
+}
+
+function countVoteReactions(
+  reactions: GraphQLReactionNode[],
+): { thumbsUp: number; thumbsDown: number } {
+  let thumbsUp = 0;
+  let thumbsDown = 0;
+  for (const r of reactions) {
+    if (r.content === "THUMBS_UP") thumbsUp++;
+    else if (r.content === "THUMBS_DOWN") thumbsDown++;
+  }
+  return { thumbsUp, thumbsDown };
+}
+
+function getUserVoteReaction(
+  reactions: GraphQLReactionNode[],
+  userLogin: string,
+): "thumbsUp" | "thumbsDown" | null {
+  for (const r of reactions) {
+    if (r.user?.login === userLogin) {
+      if (r.content === "THUMBS_UP") return "thumbsUp";
+      if (r.content === "THUMBS_DOWN") return "thumbsDown";
+    }
+  }
+  return null;
+}
+
+// === GitHub API calls ===
+
+async function fetchIssueMetadata(repo: RepoRef, issueNumber: number): Promise<RawIssue> {
+  const raw = await gh([
+    "issue",
+    "view",
+    String(issueNumber),
+    "-R",
+    `${repo.owner}/${repo.repo}`,
+    "--json",
+    "number,title,state,labels,assignees,author,url,createdAt,updatedAt",
+  ]);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliError("Failed to parse issue response from gh CLI", "GH_ERROR", 1);
+  }
+
+  const issue = parsed as RawIssue;
+  if (typeof issue.number !== "number") {
+    throw new CliError(`Issue #${issueNumber} not found`, "GH_NOT_FOUND", 1);
+  }
+  return issue;
+}
+
+async function fetchCommentsPage(
+  repo: RepoRef,
+  issueNumber: number,
+  cursor: string | null,
+): Promise<IssueCommentsConnection | undefined> {
+  const args = [
+    "api",
+    "graphql",
+    "-f",
+    `query=${ISSUE_SNAPSHOT_COMMENTS_QUERY}`,
+    "-F",
+    `owner=${repo.owner}`,
+    "-F",
+    `repo=${repo.repo}`,
+    "-F",
+    `number=${issueNumber}`,
+  ];
+  if (cursor) {
+    args.push("-F", `commentsCursor=${cursor}`);
+  } else {
+    args.push("-f", "commentsCursor=");
+  }
+
+  const raw = await gh(args);
+  const response: IssueSnapshotCommentsResponse = JSON.parse(raw);
+  return response.data?.repository?.issue?.comments;
+}
+
+async function findQueenComments(
+  repo: RepoRef,
+  issueNumber: number,
+): Promise<{ summaryComment?: GraphQLComment; votingComment?: GraphQLComment }> {
+  let summaryComment: GraphQLComment | undefined;
+  let votingComment: GraphQLComment | undefined;
+  let cursor: string | null = null;
+
+  while (true) {
+    const connection = await fetchCommentsPage(repo, issueNumber, cursor);
+    if (!connection) break;
+
+    // Nodes are in ascending order (oldest first) within the page.
+    // Overwrite to capture the latest match in this page.
+    for (const comment of connection.nodes) {
+      if (isQueenVotingComment(comment, issueNumber)) {
+        votingComment = comment;
+      }
+      if (isQueenSummaryComment(comment, issueNumber)) {
+        summaryComment = comment;
+      }
+    }
+
+    // Both found — stop scanning.
+    if (summaryComment && votingComment) break;
+
+    if (!connection.pageInfo?.hasPreviousPage) break;
+    cursor = connection.pageInfo.startCursor ?? null;
+    if (!cursor) break;
+  }
+
+  return { summaryComment, votingComment };
+}
+
+// === Core exported function ===
+
+export async function buildIssueSnapshot(
+  repo: RepoRef,
+  issueNumber: number,
+): Promise<IssueSnapshotResult> {
+  const generatedAt = new Date().toISOString();
+
+  const [rawIssue, currentUser] = await Promise.all([
+    fetchIssueMetadata(repo, issueNumber),
+    fetchCurrentUser(),
+  ]);
+
+  const labelNames = rawIssue.labels.map((l) => l.name);
+  const phase = deriveGovernancePhase(labelNames);
+
+  const { summaryComment, votingComment } = await findQueenComments(repo, issueNumber);
+
+  const issue: IssueSnapshotIssue = {
+    number: rawIssue.number,
+    title: rawIssue.title,
+    state: rawIssue.state,
+    labels: labelNames,
+    assignees: rawIssue.assignees.map((a) => a.login),
+    author: rawIssue.author?.login ?? null,
+    url: rawIssue.url,
+    createdAt: rawIssue.createdAt,
+    updatedAt: rawIssue.updatedAt,
+    governance: { phase },
+  };
+
+  if (summaryComment) {
+    issue.queenSummary = {
+      body: stripMetadata(summaryComment.body),
+      commentId: summaryComment.id,
+      url: summaryComment.url,
+    };
+  }
+
+  if (votingComment) {
+    const { thumbsUp, thumbsDown } = countVoteReactions(votingComment.reactions.nodes);
+    const yourVote = getUserVoteReaction(votingComment.reactions.nodes, currentUser);
+    issue.queenVoting = { thumbsUp, thumbsDown, yourVote };
+  }
+
+  return {
+    schemaVersion: 1,
+    kind: "issue_snapshot",
+    generatedAt,
+    repo,
+    issue,
+  };
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { prSnapshotCommand } from "./commands/pr-snapshot.js";
 import { prPreflightCommand } from "./commands/pr-preflight.js";
 import { issueVoteCommand } from "./commands/issue-vote.js";
 import { issuePostCommentCommand } from "./commands/issue-post-comment.js";
+import { issueSnapshotCommand } from "./commands/issue-snapshot.js";
 import { notificationsPullCommand } from "./commands/notifications-pull.js";
 import { CliError } from "./config/types.js";
 import { setGhToken } from "./github/client.js";
@@ -134,6 +135,25 @@ Examples:
 const issueProgram = program
   .command("issue")
   .description("Issue workflow helpers for autonomous agents");
+
+issueProgram
+  .command("snapshot")
+  .description("Emit a canonical issue context payload")
+  .argument("<issue>", "Issue number")
+  .option("--repo <owner/repo>", "Target repository (default: detect from git)")
+  .option("--json", "Output as JSON")
+  .addHelpText(
+    "after",
+    `
+
+Examples:
+  $ hivemoot issue snapshot 42 --repo hivemoot/hivemoot --json
+    Output schemaVersioned issue context for automation
+
+  $ hivemoot issue snapshot 42
+    Print issue summary in readable form`,
+  )
+  .action(issueSnapshotCommand);
 
 issueProgram
   .command("vote")


### PR DESCRIPTION
Closes #259

## What

Adds `hivemoot issue snapshot <number>` — a canonical issue context payload following the same pattern as `hivemoot pr snapshot`.

**JSON output** (`--json`):
```json
{
  "schemaVersion": 1,
  "kind": "issue_snapshot",
  "generatedAt": "...",
  "repo": { "owner": "hivemoot", "repo": "hivemoot" },
  "issue": {
    "number": 42,
    "title": "feat(web): add role-targeted task delegation",
    "state": "OPEN",
    "labels": ["hivemoot:discussion"],
    "assignees": [],
    "author": "hivemoot-builder",
    "url": "...",
    "createdAt": "...",
    "updatedAt": "...",
    "governance": { "phase": "discussion" },
    "queenSummary": { "body": "...", "commentId": "IC_...", "url": "..." },
    "queenVoting": { "thumbsUp": 7, "thumbsDown": 1, "yourVote": "thumbsUp" }
  }
}
```

**Text output** (default): human-readable summary with header, governance phase, and optional queen comment preview.

## Implementation

- `cli/src/github/issue-snapshot.ts` — fetches issue metadata via REST + scans comments via GraphQL (same paginated backwards approach as `issue-vote.ts`) to find Queen summary and voting comments; derives governance phase from labels using existing `GOVERNANCE_LABEL_ALIASES`
- `cli/src/commands/issue-snapshot.ts` — command handler with text formatter
- `cli/src/commands/issue-snapshot.test.ts` — 18 tests covering text output, JSON output, optional fields (queenSummary/queenVoting), error propagation, and input validation

## Verification

- 715 tests pass (18 new)
- `tsc --noEmit` clean
- Schema matches the spec in #259