### PR TITLE
fix(web): return structured BYOK 500s on Redis failures

### DIFF
--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -209,4 +209,32 @@ describe("POST /api/byok/config", () => {
       expect.anything(),
     );
   });
+
+  it("returns a structured 500 when storage fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[byok-config] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error: expect.any(Error),
+      }),
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -41,41 +41,52 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Validate the key with the provider
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
+  try {
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
+    );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-config] Failed to process request", {
+      installationId,
+      error,
+    });
+
     return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
     );
   }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -102,4 +102,28 @@ describe("POST /api/byok/revoke", () => {
     expect(body.code).toBe(BYOK_ERROR.NOT_CONFIGURED);
     expect(body.message).toBe("BYOK is not configured");
   });
+
+  it("returns a structured 500 when storage fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({});
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[byok-revoke] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error: expect.any(Error),
+      }),
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/revoke/route.ts
+++ b/apps/web/src/app/api/byok/revoke/route.ts
@@ -16,28 +16,40 @@ export async function POST(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const existing = await getByokEnvelope(installationId, auth.redis);
-  if (!existing) {
-    return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+  try {
+    const existing = await getByokEnvelope(installationId, auth.redis);
+    if (!existing) {
+      return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+    }
+
+    const revoked = {
+      ...existing,
+      status: "revoked" as const,
+      ciphertext: "",
+      iv: "",
+      tag: "",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+    };
+
+    await setByokEnvelope(installationId, revoked, auth.redis);
+
+    return NextResponse.json({
+      status: "revoked",
+      provider: revoked.provider,
+      model: revoked.model,
+      updatedAt: revoked.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-revoke] Failed to process request", {
+      installationId,
+      error,
+    });
+
+    return byokError(
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
+    );
   }
-
-  // Clear ciphertext fields, keep metadata for audit
-  const revoked = {
-    ...existing,
-    status: "revoked" as const,
-    ciphertext: "",
-    iv: "",
-    tag: "",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-  };
-
-  await setByokEnvelope(installationId, revoked, auth.redis);
-
-  return NextResponse.json({
-    status: "revoked",
-    provider: revoked.provider,
-    model: revoked.model,
-    updatedAt: revoked.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -160,4 +160,32 @@ describe("POST /api/byok/rotate", () => {
       expect.anything(),
     );
   });
+
+  it("returns a structured 500 when storage fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-new-key5678",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[byok-rotate] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error: expect.any(Error),
+      }),
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -42,40 +42,52 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
+  try {
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
+    );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-rotate] Failed to process request", {
+      installationId,
+      error,
+    });
+
     return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
     );
   }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -121,4 +121,28 @@ describe("GET /api/byok/status", () => {
       expect.anything(),
     );
   });
+
+  it("returns a structured 500 when storage fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[byok-status] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error: expect.any(Error),
+      }),
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/status/route.ts
+++ b/apps/web/src/app/api/byok/status/route.ts
@@ -16,33 +16,46 @@ export async function GET(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const envelope = await getByokEnvelope(installationId, auth.redis);
-  if (!envelope) {
+  try {
+    const envelope = await getByokEnvelope(installationId, auth.redis);
+    if (!envelope) {
+      return byokError(
+        BYOK_ERROR.NOT_CONFIGURED,
+        "BYOK is not configured",
+        404,
+      );
+    }
+
+    if (envelope.status === "revoked") {
+      return byokError(
+        BYOK_ERROR.REVOKED,
+        "BYOK configuration has been revoked",
+        409,
+        {
+          status: envelope.status,
+          provider: envelope.provider,
+          model: envelope.model,
+          updatedAt: envelope.updatedAt,
+        },
+      );
+    }
+
+    return NextResponse.json({
+      status: envelope.status,
+      provider: envelope.provider,
+      model: envelope.model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-status] Failed to process request", {
+      installationId,
+      error,
+    });
+
     return byokError(
-      BYOK_ERROR.NOT_CONFIGURED,
-      "BYOK is not configured",
-      404,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
     );
   }
-
-  if (envelope.status === "revoked") {
-    return byokError(
-      BYOK_ERROR.REVOKED,
-      "BYOK configuration has been revoked",
-      409,
-      {
-        status: envelope.status,
-        provider: envelope.provider,
-        model: envelope.model,
-        updatedAt: envelope.updatedAt,
-      },
-    );
-  }
-
-  return NextResponse.json({
-    status: envelope.status,
-    provider: envelope.provider,
-    model: envelope.model,
-    updatedAt: envelope.updatedAt,
-  });
 }


### PR DESCRIPTION
Fixes #355

Redis-backed BYOK routes were still letting storage failures escape as unhandled Next.js 500 pages. This change makes the four single-install routes return the existing structured BYOK JSON error shape instead, which matches the task-route reliability work and gives clients a stable failure contract.

## Before

When Redis throws inside `/api/byok/config`, `/api/byok/rotate`, `/api/byok/revoke`, or `/api/byok/status`, Next.js can emit an unstructured HTML 500 response.

## After

```json
{
  "code": "byok_server_misconfiguration",
  "message": "Internal server error"
}
```

## Validation

- `cd apps/web && npm test -- --run src/app/api/byok/config/route.test.ts src/app/api/byok/rotate/route.test.ts src/app/api/byok/revoke/route.test.ts src/app/api/byok/status/route.test.ts`
- `cd apps/web && npm run typecheck`
