### PR TITLE
fix(web): return structured BYOK 500s on Redis failures

### DIFF
--- a/apps/web/src/app/api/byok/config/route.auth-failure.test.ts
+++ b/apps/web/src/app/api/byok/config/route.auth-failure.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  validateEnv: vi.fn(),
+  getRedisClient: vi.fn(),
+  getSetupSession: vi.fn(),
+  parseKeyring: vi.fn(),
+  setByokEnvelope: vi.fn(),
+  validateProviderKey: vi.fn(),
+  encrypt: vi.fn(),
+}));
+
+vi.mock("@/server/env", () => ({
+  validateEnv: mocks.validateEnv,
+}));
+
+vi.mock("@/server/redis", () => ({
+  getRedisClient: mocks.getRedisClient,
+}));
+
+vi.mock("@/server/setup-session", () => ({
+  getSetupSession: mocks.getSetupSession,
+  SETUP_SESSION_COOKIE: "hivemoot_setup_session",
+}));
+
+vi.mock("@/server/crypto", async () => {
+  const actual = await vi.importActual<typeof import("@/server/crypto")>("@/server/crypto");
+  return {
+    ...actual,
+    parseKeyring: mocks.parseKeyring,
+    encrypt: mocks.encrypt,
+  };
+});
+
+vi.mock("@/server/byok-store", () => ({
+  setByokEnvelope: mocks.setByokEnvelope,
+}));
+
+vi.mock("@/server/provider-validation", () => ({
+  validateProviderKey: mocks.validateProviderKey,
+}));
+
+import { BYOK_ERROR } from "@/server/byok-error";
+import { POST } from "./route";
+
+const VALID_ENV_CONFIG = {
+  redisRestUrl: "https://redis.example.com",
+  redisRestToken: "redis-token",
+  githubAppId: undefined,
+  githubAppPrivateKey: undefined,
+  githubClientId: undefined,
+  githubClientSecret: undefined,
+  byokActiveKeyVersion: "v1",
+  byokMasterKeysJson: "{\"v1\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}",
+  siteUrl: "http://localhost:3000",
+  nodeEnv: "test",
+};
+
+function makeRequest(): NextRequest {
+  return new NextRequest("https://example.com/api/byok/config", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: "hivemoot_setup_session=session-token",
+    },
+    body: JSON.stringify({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    }),
+  });
+}
+
+describe("POST /api/byok/config auth failure path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.validateEnv.mockReturnValue({ ok: true, config: VALID_ENV_CONFIG });
+    mocks.parseKeyring.mockReturnValue(new Map([["v1", Buffer.alloc(32)]]));
+    mocks.getRedisClient.mockReturnValue({} as never);
+    mocks.validateProviderKey.mockResolvedValue({ valid: true });
+    mocks.encrypt.mockReturnValue({
+      ciphertext: "ciphertext",
+      iv: "iv",
+      tag: "tag",
+      keyVersion: "v1",
+    });
+  });
+
+  it("returns structured BYOK JSON when session lookup throws before the route body runs", async () => {
+    const error = new Error("redis unavailable");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.getSetupSession.mockRejectedValue(error);
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(mocks.validateProviderKey).not.toHaveBeenCalled();
+    expect(mocks.setByokEnvelope).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[byok-auth] Failed to load setup session",
+      expect.objectContaining({
+        code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+        error,
+      }),
+    );
+  });
+});

--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -64,6 +64,7 @@ function makeRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
   mockAuthSuccess();
   vi.mocked(validateProviderKey).mockResolvedValue({ valid: true });
   vi.mocked(encrypt).mockReturnValue({
@@ -211,7 +212,8 @@ describe("POST /api/byok/config", () => {
   });
 
   it("returns structured 500 when storing the envelope fails", async () => {
-    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+    const error = new Error("redis down");
+    vi.mocked(setByokEnvelope).mockRejectedValue(error);
 
     const req = makeRequest({
       provider: "anthropic",
@@ -224,5 +226,12 @@ describe("POST /api/byok/config", () => {
     const body = await res.json();
     expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
     expect(body.message).toBe("Internal server error");
+    expect(console.error).toHaveBeenCalledWith(
+      "[byok-config] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error,
+      }),
+    );
   });
 });

--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -209,4 +209,20 @@ describe("POST /api/byok/config", () => {
       expect.anything(),
     );
   });
+
+  it("returns structured 500 when storing the envelope fails", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Internal server error");
+  });
 });

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -33,49 +33,62 @@ export async function POST(request: NextRequest) {
   const { provider, model, apiKey } = body;
   const installationId = auth.session.installationId;
 
-  if (!provider || !model || !apiKey) {
+  try {
+    if (!provider || !model || !apiKey) {
+      return byokError(
+        BYOK_ERROR.MISSING_FIELDS,
+        "Missing required fields: provider, model, apiKey",
+        400,
+      );
+    }
+
+    // Validate the key with the provider
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
+    );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-config] Failed to process request", {
+      installationId,
+      error,
+    });
+
     return byokError(
-      BYOK_ERROR.MISSING_FIELDS,
-      "Missing required fields: provider, model, apiKey",
-      400,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
     );
   }
-
-  // Validate the key with the provider
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
-    );
-  }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -102,4 +102,16 @@ describe("POST /api/byok/revoke", () => {
     expect(body.code).toBe(BYOK_ERROR.NOT_CONFIGURED);
     expect(body.message).toBe("BYOK is not configured");
   });
+
+  it("returns structured 500 when the BYOK store fails", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({});
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Internal server error");
+  });
 });

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -61,6 +61,7 @@ function makeRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
   mockAuthSuccess();
   vi.mocked(getByokEnvelope).mockResolvedValue({ ...MOCK_ENVELOPE });
   vi.mocked(setByokEnvelope).mockResolvedValue(undefined);
@@ -104,7 +105,8 @@ describe("POST /api/byok/revoke", () => {
   });
 
   it("returns structured 500 when the BYOK store fails", async () => {
-    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+    const error = new Error("redis down");
+    vi.mocked(getByokEnvelope).mockRejectedValue(error);
 
     const req = makeRequest({});
     const res = await POST(req);
@@ -113,5 +115,12 @@ describe("POST /api/byok/revoke", () => {
     const body = await res.json();
     expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
     expect(body.message).toBe("Internal server error");
+    expect(console.error).toHaveBeenCalledWith(
+      "[byok-revoke] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error,
+      }),
+    );
   });
 });

--- a/apps/web/src/app/api/byok/revoke/route.ts
+++ b/apps/web/src/app/api/byok/revoke/route.ts
@@ -16,28 +16,41 @@ export async function POST(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const existing = await getByokEnvelope(installationId, auth.redis);
-  if (!existing) {
-    return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+  try {
+    const existing = await getByokEnvelope(installationId, auth.redis);
+    if (!existing) {
+      return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+    }
+
+    // Clear ciphertext fields, keep metadata for audit
+    const revoked = {
+      ...existing,
+      status: "revoked" as const,
+      ciphertext: "",
+      iv: "",
+      tag: "",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+    };
+
+    await setByokEnvelope(installationId, revoked, auth.redis);
+
+    return NextResponse.json({
+      status: "revoked",
+      provider: revoked.provider,
+      model: revoked.model,
+      updatedAt: revoked.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-revoke] Failed to process request", {
+      installationId,
+      error,
+    });
+
+    return byokError(
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
+    );
   }
-
-  // Clear ciphertext fields, keep metadata for audit
-  const revoked = {
-    ...existing,
-    status: "revoked" as const,
-    ciphertext: "",
-    iv: "",
-    tag: "",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-  };
-
-  await setByokEnvelope(installationId, revoked, auth.redis);
-
-  return NextResponse.json({
-    status: "revoked",
-    provider: revoked.provider,
-    model: revoked.model,
-    updatedAt: revoked.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -160,4 +160,20 @@ describe("POST /api/byok/rotate", () => {
       expect.anything(),
     );
   });
+
+  it("returns structured 500 when storing the envelope fails", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-new-key5678",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Internal server error");
+  });
 });

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -55,6 +55,7 @@ function makeRequest(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
   mockAuthSuccess();
   vi.mocked(validateProviderKey).mockResolvedValue({ valid: true });
   vi.mocked(encrypt).mockReturnValue({
@@ -162,7 +163,8 @@ describe("POST /api/byok/rotate", () => {
   });
 
   it("returns structured 500 when storing the envelope fails", async () => {
-    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+    const error = new Error("redis down");
+    vi.mocked(setByokEnvelope).mockRejectedValue(error);
 
     const req = makeRequest({
       provider: "anthropic",
@@ -175,5 +177,12 @@ describe("POST /api/byok/rotate", () => {
     const body = await res.json();
     expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
     expect(body.message).toBe("Internal server error");
+    expect(console.error).toHaveBeenCalledWith(
+      "[byok-rotate] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error,
+      }),
+    );
   });
 });

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -34,48 +34,61 @@ export async function POST(request: NextRequest) {
   const { provider, model, apiKey } = body;
   const installationId = auth.session.installationId;
 
-  if (!provider || !model || !apiKey) {
+  try {
+    if (!provider || !model || !apiKey) {
+      return byokError(
+        BYOK_ERROR.MISSING_FIELDS,
+        "Missing required fields: provider, model, apiKey",
+        400,
+      );
+    }
+
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
+    );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-rotate] Failed to process request", {
+      installationId,
+      error,
+    });
+
     return byokError(
-      BYOK_ERROR.MISSING_FIELDS,
-      "Missing required fields: provider, model, apiKey",
-      400,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
     );
   }
-
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
-    );
-  }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -56,6 +56,7 @@ function makeRequest() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
   mockAuthSuccess();
   vi.mocked(getByokEnvelope).mockResolvedValue({ ...MOCK_ENVELOPE });
 });
@@ -123,7 +124,8 @@ describe("GET /api/byok/status", () => {
   });
 
   it("returns structured 500 when the BYOK store fails", async () => {
-    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+    const error = new Error("redis down");
+    vi.mocked(getByokEnvelope).mockRejectedValue(error);
 
     const req = makeRequest();
     const res = await GET(req);
@@ -132,5 +134,12 @@ describe("GET /api/byok/status", () => {
     const body = await res.json();
     expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
     expect(body.message).toBe("Internal server error");
+    expect(console.error).toHaveBeenCalledWith(
+      "[byok-status] Failed to process request",
+      expect.objectContaining({
+        installationId: MOCK_SESSION.installationId,
+        error,
+      }),
+    );
   });
 });

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -121,4 +121,16 @@ describe("GET /api/byok/status", () => {
       expect.anything(),
     );
   });
+
+  it("returns structured 500 when the BYOK store fails", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Internal server error");
+  });
 });

--- a/apps/web/src/app/api/byok/status/route.ts
+++ b/apps/web/src/app/api/byok/status/route.ts
@@ -16,33 +16,46 @@ export async function GET(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const envelope = await getByokEnvelope(installationId, auth.redis);
-  if (!envelope) {
+  try {
+    const envelope = await getByokEnvelope(installationId, auth.redis);
+    if (!envelope) {
+      return byokError(
+        BYOK_ERROR.NOT_CONFIGURED,
+        "BYOK is not configured",
+        404,
+      );
+    }
+
+    if (envelope.status === "revoked") {
+      return byokError(
+        BYOK_ERROR.REVOKED,
+        "BYOK configuration has been revoked",
+        409,
+        {
+          status: envelope.status,
+          provider: envelope.provider,
+          model: envelope.model,
+          updatedAt: envelope.updatedAt,
+        },
+      );
+    }
+
+    return NextResponse.json({
+      status: envelope.status,
+      provider: envelope.provider,
+      model: envelope.model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-status] Failed to process request", {
+      installationId,
+      error,
+    });
+
     return byokError(
-      BYOK_ERROR.NOT_CONFIGURED,
-      "BYOK is not configured",
-      404,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Internal server error",
+      500,
     );
   }
-
-  if (envelope.status === "revoked") {
-    return byokError(
-      BYOK_ERROR.REVOKED,
-      "BYOK configuration has been revoked",
-      409,
-      {
-        status: envelope.status,
-        provider: envelope.provider,
-        model: envelope.model,
-        updatedAt: envelope.updatedAt,
-      },
-    );
-  }
-
-  return NextResponse.json({
-    status: envelope.status,
-    provider: envelope.provider,
-    model: envelope.model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/server/byok-auth.test.ts
+++ b/apps/web/src/server/byok-auth.test.ts
@@ -111,4 +111,28 @@ describe("authenticateByokRequest runtime config cache", () => {
     expect(mocks.parseKeyring).toHaveBeenCalledTimes(1);
     expect(mocks.getSetupSession).toHaveBeenCalledTimes(2);
   });
+
+  it("returns structured 500 JSON when session lookup throws", async () => {
+    const error = new Error("redis unavailable");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.getSetupSession.mockRejectedValue(error);
+
+    const { authenticateByokRequest } = await import("./byok-auth");
+    const result = await authenticateByokRequest(makeRequest());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected an authentication failure");
+    expect(result.response.status).toBe(500);
+    await expect(result.response.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[byok-auth] Failed to load setup session",
+      expect.objectContaining({
+        code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+        error,
+      }),
+    );
+  });
 });

--- a/apps/web/src/server/byok-auth.ts
+++ b/apps/web/src/server/byok-auth.ts
@@ -166,7 +166,24 @@ export async function authenticateByokRequest(
     };
   }
 
-  const session = await getSetupSession(token, redis);
+  let session: SetupSessionPayload | null;
+  try {
+    session = await getSetupSession(token, redis);
+  } catch (error) {
+    console.error("[byok-auth] Failed to load setup session", {
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      error,
+    });
+    return {
+      ok: false,
+      response: byokError(
+        BYOK_ERROR.SERVER_MISCONFIGURATION,
+        "Internal server error",
+        500,
+      ),
+    };
+  }
+
   if (!session) {
     return {
       ok: false,

--- a/apps/web/src/server/byok-auth.ts
+++ b/apps/web/src/server/byok-auth.ts
@@ -13,7 +13,7 @@ import { getRedisClient } from "@/server/redis";
 import { getSetupSession, SETUP_SESSION_COOKIE } from "@/server/setup-session";
 import { parseKeyring } from "@/server/crypto";
 import { BYOK_ERROR, byokError } from "@/server/byok-error";
-import type { SetupSessionPayload } from "@/server/setup-session";
+import type { SetupSessionPayload, SetupSessionResult } from "@/server/setup-session";
 
 type AuthSuccess = {
   ok: true;
@@ -166,7 +166,7 @@ export async function authenticateByokRequest(
     };
   }
 
-  let session: SetupSessionPayload | null;
+  let session: SetupSessionResult | null;
   try {
     session = await getSetupSession(token, redis);
   } catch (error) {


### PR DESCRIPTION
Fixes #355

## What changed
- wrap `config`, `rotate`, `revoke`, and `status` BYOK routes in top-level `try/catch` blocks around the Redis-backed path
- log route-specific context before returning `byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500)`
- add one regression test per route covering a thrown BYOK store call

## Before
If Redis failed inside these routes, Next.js surfaced an unhandled HTML 500 response instead of the BYOK JSON error contract.

## After
Redis failures now return a structured JSON 500 with the existing BYOK error code, so the web client gets a stable machine-readable response.

## Validation
- `cd apps/web && npm test -- --run src/app/api/byok/config/route.test.ts src/app/api/byok/rotate/route.test.ts src/app/api/byok/revoke/route.test.ts src/app/api/byok/status/route.test.ts`
- `cd apps/web && npm run typecheck`
