### PR TITLE
Accept heartbeat payloads in agent health endpoint

### DIFF
--- a/apps/web/AGENT_HEALTH_CONTRACT.md
+++ b/apps/web/AGENT_HEALTH_CONTRACT.md
@@ -27,7 +27,31 @@ Auth split is intentional:
 
 ## 2. POST /api/agent-health Contract
 
-Each POST represents one run for one `agent_id` + `repo`.
+Each POST represents either a **run report** or a **heartbeat**.
+
+### 2a. Heartbeat Payloads
+
+Heartbeats are lightweight liveness signals sent between runs. They carry no run data and use a separate validation path.
+
+| Field | Type | Required | Constraints |
+|---|---|---|---|
+| `agent_id` | string | yes | 1-64 chars, regex `[a-z0-9_-]+` |
+| `repo` | string | yes | 1-200 chars, `owner/name` format |
+| `outcome` | string | yes | Must be `"heartbeat"` |
+| `next_run_at` | string | no | ISO-8601, max 64 chars, between `now-5m` and `now+48h` |
+
+Heartbeat behavior:
+- Detected by `outcome === "heartbeat"` before run-report validation.
+- No `run_id`, `duration_secs`, or `consecutive_failures` — these are rejected as unknown fields.
+- Skips idempotency (no `run_id` to dedupe).
+- Rate-limited at one per agent per repo per 60 seconds (shared bucket with run reports).
+- If a prior run report exists in the `latest` key, the heartbeat patches `received_at` (and optionally `next_run_at`) while preserving all run data. If no prior report exists, a minimal heartbeat entry is stored.
+- Heartbeats are NOT added to the runs sorted set (they aren't runs).
+- Success response: `200` + `{"received": true, "received_at": "<iso>"}`.
+
+### 2b. Run Report Payloads
+
+Each run report represents one completed run for one `agent_id` + `repo`.
 
 ### Required Fields
 
@@ -49,7 +73,7 @@ Each POST represents one run for one `agent_id` + `repo`.
 | `exit_code` | integer | Any integer |
 | `next_run_at` | string | ISO-8601, max 64 chars, between `now-5m` and `now+48h` |
 | `run_summary` | string | Markdown, ANSI-stripped, truncated to 4096 chars; empty after stripping rejected |
-| `trigger` | string | `scheduled` \| `mention` \| `manual` |
+| `trigger` | string | `scheduled` \| `mention` \| `manual` \| `task` |
 | `token_usage` | object or `null` | Exact nested schema below; when present as an object, required scalar fields must be present even if their value is `null` |
 
 #### `token_usage` object shape
@@ -117,7 +141,7 @@ Dashboard status values:
 - `unknown`: no valid latest report.
 - `failed`: latest outcome is `failure` or `timeout`.
 - `late`: latest outcome is `success` and now is beyond `next_run_at` plus a 50% interval buffer.
-- `ok`: all other successful states.
+- `ok`: latest outcome is `success` (within schedule), or `heartbeat` (agent alive, no run yet).
 
 Read behavior:
 - Overview is sorted by `received_at` descending.

--- a/apps/web/src/app/api/agent-health/route.test.ts
+++ b/apps/web/src/app/api/agent-health/route.test.ts
@@ -14,8 +14,10 @@ vi.mock("@/server/agent-health-auth", () => ({
 vi.mock("@/server/agent-health-store", () => ({
   AGENT_ID_PATTERN: /^[a-z0-9_-]+$/,
   validateReport: vi.fn(),
+  validateHeartbeat: vi.fn(),
   checkRateLimit: vi.fn(),
   recordHealthReport: vi.fn(),
+  recordHeartbeat: vi.fn(),
   reserveHealthReportIdempotency: vi.fn(),
   commitHealthReportIdempotency: vi.fn(),
   releaseHealthReportIdempotency: vi.fn(),
@@ -47,8 +49,10 @@ import { authenticateByokRequest } from "@/server/byok-auth";
 import { authenticateAgentRequest } from "@/server/agent-health-auth";
 import {
   validateReport,
+  validateHeartbeat,
   checkRateLimit,
   recordHealthReport,
+  recordHeartbeat,
   reserveHealthReportIdempotency,
   commitHealthReportIdempotency,
   releaseHealthReportIdempotency,
@@ -164,6 +168,16 @@ beforeEach(() => {
   vi.mocked(recordHealthReport).mockResolvedValue(undefined);
   vi.mocked(commitHealthReportIdempotency).mockResolvedValue(undefined);
   vi.mocked(releaseHealthReportIdempotency).mockResolvedValue(undefined);
+  vi.mocked(validateHeartbeat).mockReturnValue({
+    ok: true,
+    heartbeat: {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+      received_at: "2026-03-14T12:00:00Z",
+    },
+  });
+  vi.mocked(recordHeartbeat).mockResolvedValue(undefined);
   vi.mocked(getOverview).mockResolvedValue([]);
   vi.mocked(getHistory).mockResolvedValue([]);
 });
@@ -356,6 +370,132 @@ describe("POST /api/agent-health", () => {
       "idempotency commit failed",
     );
     expect(releaseHealthReportIdempotency).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — POST heartbeat
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-health (heartbeat)", () => {
+  it("accepts a valid heartbeat and returns confirmation", async () => {
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.received).toBe(true);
+    expect(body.received_at).toBeDefined();
+  });
+
+  it("routes heartbeat to validateHeartbeat instead of validateReport", async () => {
+    await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(validateHeartbeat).toHaveBeenCalled();
+    expect(validateReport).not.toHaveBeenCalled();
+  });
+
+  it("calls recordHeartbeat instead of recordHealthReport", async () => {
+    await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(recordHeartbeat).toHaveBeenCalledWith(
+      "inst-1",
+      expect.objectContaining({ agent_id: "bee-1", outcome: "heartbeat" }),
+      expect.anything(),
+    );
+    expect(recordHealthReport).not.toHaveBeenCalled();
+  });
+
+  it("skips idempotency for heartbeats", async () => {
+    await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(reserveHealthReportIdempotency).not.toHaveBeenCalled();
+    expect(commitHealthReportIdempotency).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when heartbeat validation fails", async () => {
+    vi.mocked(validateHeartbeat).mockReturnValue({
+      ok: false,
+      message: "agent_id must be 1-64 chars",
+    });
+
+    const res = await POST(makePostRequest({
+      agent_id: "",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_validation_failed");
+  });
+
+  it("returns 401 when heartbeat is not authenticated", async () => {
+    mockAgentAuthFailure(401, "agent_health_not_authenticated", "Invalid token");
+
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when heartbeat is rate-limited", async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue(false);
+
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(429);
+    expect(recordHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("accepts heartbeat with next_run_at", async () => {
+    const futureIso = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
+    vi.mocked(validateHeartbeat).mockReturnValue({
+      ok: true,
+      heartbeat: {
+        agent_id: "bee-1",
+        repo: "hivemoot/sandbox",
+        outcome: "heartbeat",
+        next_run_at: futureIso,
+        received_at: "2026-03-14T12:00:00Z",
+      },
+    });
+
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+      next_run_at: futureIso,
+    }));
+
+    expect(res.status).toBe(200);
+    expect(recordHeartbeat).toHaveBeenCalledWith(
+      "inst-1",
+      expect.objectContaining({ next_run_at: futureIso }),
+      expect.anything(),
+    );
   });
 });
 

--- a/apps/web/src/app/api/agent-health/route.ts
+++ b/apps/web/src/app/api/agent-health/route.ts
@@ -20,8 +20,10 @@ import { parseContentLength } from "@/server/request-utils";
 import {
   AGENT_ID_PATTERN,
   validateReport,
+  validateHeartbeat,
   checkRateLimit,
   recordHealthReport,
+  recordHeartbeat,
   reserveHealthReportIdempotency,
   commitHealthReportIdempotency,
   releaseHealthReportIdempotency,
@@ -71,6 +73,15 @@ export async function POST(request: NextRequest) {
       "Invalid JSON body",
       400,
     );
+  }
+
+  // Heartbeats have a separate validation + recording path (no run_id,
+  // no idempotency, no run history — just refresh the latest key TTL).
+  if (
+    typeof body === "object" && body !== null && !Array.isArray(body)
+    && (body as Record<string, unknown>).outcome === "heartbeat"
+  ) {
+    return handleHeartbeat(body, request);
   }
 
   const validation = validateReport(body);
@@ -162,6 +173,41 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ received: true, received_at: report.received_at });
+}
+
+async function handleHeartbeat(body: unknown, request: NextRequest) {
+  const validation = validateHeartbeat(body);
+  if (!validation.ok) {
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.VALIDATION_FAILED,
+      validation.message,
+      400,
+    );
+  }
+
+  const auth = await authenticateAgentRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { heartbeat } = validation;
+
+  const allowed = await checkRateLimit(
+    auth.installationId,
+    heartbeat.agent_id,
+    heartbeat.repo,
+    auth.redis,
+  );
+
+  if (!allowed) {
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.RATE_LIMITED,
+      "Rate limited — one report per agent per repo per 60 seconds",
+      429,
+    );
+  }
+
+  await recordHeartbeat(auth.installationId, heartbeat, auth.redis);
+
+  return NextResponse.json({ received: true, received_at: heartbeat.received_at });
 }
 
 export async function GET(request: NextRequest) {

--- a/apps/web/src/server/agent-health-store.test.ts
+++ b/apps/web/src/server/agent-health-store.test.ts
@@ -2,14 +2,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { type Redis } from "@upstash/redis";
 import {
   validateReport,
+  validateHeartbeat,
   reserveHealthReportIdempotency,
   commitHealthReportIdempotency,
   releaseHealthReportIdempotency,
   checkRateLimit,
   recordHealthReport,
+  recordHeartbeat,
   getOverview,
   getHistory,
   type HealthReport,
+  type HeartbeatPayload,
 } from "./agent-health-store";
 
 // ---------------------------------------------------------------------------
@@ -1245,5 +1248,263 @@ describe("getHistory", () => {
   it("trims stale entries before returning", async () => {
     await getHistory("inst-1", "bee-1", "repo", redis);
     expect(redis.zremrangebyscore).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — validateHeartbeat
+// ---------------------------------------------------------------------------
+
+describe("validateHeartbeat", () => {
+  it("accepts a minimal heartbeat", () => {
+    const result = validateHeartbeat({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.heartbeat.agent_id).toBe("bee-1");
+      expect(result.heartbeat.repo).toBe("hivemoot/sandbox");
+      expect(result.heartbeat.outcome).toBe("heartbeat");
+      expect(result.heartbeat.received_at).toBeDefined();
+    }
+  });
+
+  it("accepts heartbeat with next_run_at", () => {
+    const futureIso = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
+    const result = validateHeartbeat({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+      next_run_at: futureIso,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.heartbeat.next_run_at).toBe(futureIso);
+    }
+  });
+
+  it("rejects unknown fields", () => {
+    const result = validateHeartbeat({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+      run_id: "should-not-be-here",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("Unknown field");
+  });
+
+  it("rejects non-heartbeat outcome", () => {
+    const result = validateHeartbeat({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "success",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("heartbeat");
+  });
+
+  it("rejects invalid agent_id", () => {
+    const result = validateHeartbeat({
+      agent_id: "BEE#1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("agent_id");
+  });
+
+  it("rejects invalid repo format", () => {
+    const result = validateHeartbeat({
+      agent_id: "bee-1",
+      repo: "no-slash",
+      outcome: "heartbeat",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("repo");
+  });
+
+  it("rejects non-object body", () => {
+    expect(validateHeartbeat("string").ok).toBe(false);
+    expect(validateHeartbeat(null).ok).toBe(false);
+    expect(validateHeartbeat([]).ok).toBe(false);
+  });
+
+  it("rejects next_run_at in the far past", () => {
+    const pastIso = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const result = validateHeartbeat({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+      next_run_at: pastIso,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("past");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — recordHeartbeat
+// ---------------------------------------------------------------------------
+
+describe("recordHeartbeat", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redis = makeMockRedis();
+  });
+
+  const baseHeartbeat: HeartbeatPayload = {
+    agent_id: "bee-1",
+    repo: "hivemoot/sandbox",
+    outcome: "heartbeat",
+    received_at: "2026-03-14T12:00:00Z",
+  };
+
+  it("stores a minimal heartbeat entry when no prior report exists", async () => {
+    await recordHeartbeat("inst-1", baseHeartbeat, redis);
+
+    expect(redis.multi).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith(
+      "agent-health:latest:inst-1:bee-1:hivemoot/sandbox",
+      expect.objectContaining({ outcome: "heartbeat" }),
+      expect.objectContaining({ ex: expect.any(Number) }),
+    );
+    expect(redis.sadd).toHaveBeenCalledWith(
+      "agent-health:index:inst-1",
+      "bee-1:hivemoot/sandbox",
+    );
+  });
+
+  it("does not add to the runs sorted set", async () => {
+    await recordHeartbeat("inst-1", baseHeartbeat, redis);
+
+    expect(redis.zadd).not.toHaveBeenCalled();
+  });
+
+  it("patches existing report preserving run data", async () => {
+    const existingReport: HealthReport = {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-42",
+      outcome: "success",
+      duration_secs: 300,
+      consecutive_failures: 0,
+      received_at: "2026-03-14T10:00:00Z",
+    };
+
+    redis._store.set(
+      "agent-health:latest:inst-1:bee-1:hivemoot/sandbox",
+      existingReport,
+    );
+
+    await recordHeartbeat("inst-1", baseHeartbeat, redis);
+
+    const stored = redis._store.get(
+      "agent-health:latest:inst-1:bee-1:hivemoot/sandbox",
+    ) as Record<string, unknown>;
+
+    // Run data preserved
+    expect(stored.run_id).toBe("run-42");
+    expect(stored.outcome).toBe("success");
+    expect(stored.duration_secs).toBe(300);
+    // Timestamps refreshed
+    expect(stored.received_at).toBe("2026-03-14T12:00:00Z");
+  });
+
+  it("updates next_run_at on existing report when provided", async () => {
+    const futureIso = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
+    const existingReport: HealthReport = {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-42",
+      outcome: "success",
+      duration_secs: 300,
+      consecutive_failures: 0,
+      received_at: "2026-03-14T10:00:00Z",
+    };
+
+    redis._store.set(
+      "agent-health:latest:inst-1:bee-1:hivemoot/sandbox",
+      existingReport,
+    );
+
+    await recordHeartbeat("inst-1", { ...baseHeartbeat, next_run_at: futureIso }, redis);
+
+    const stored = redis._store.get(
+      "agent-health:latest:inst-1:bee-1:hivemoot/sandbox",
+    ) as Record<string, unknown>;
+
+    expect(stored.next_run_at).toBe(futureIso);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — deriveStatus with heartbeat
+// ---------------------------------------------------------------------------
+
+describe("getOverview (heartbeat status)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redis = makeMockRedis();
+  });
+
+  it("derives ok status for a heartbeat-only entry", async () => {
+    redis._sets.set("agent-health:index:inst-1", new Set(["bee-1:hivemoot/sandbox"]));
+    redis._store.set("agent-health:latest:inst-1:bee-1:hivemoot/sandbox", {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+      received_at: new Date().toISOString(),
+    });
+
+    const result = await getOverview("inst-1", redis);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("ok");
+    expect(result[0].outcome).toBe("heartbeat");
+  });
+
+  it("preserves failed status from patched report (heartbeat does not mask failure)", async () => {
+    // Simulate: a failed run was stored, then a heartbeat patched received_at
+    redis._sets.set("agent-health:index:inst-1", new Set(["bee-1:hivemoot/sandbox"]));
+    redis._store.set("agent-health:latest:inst-1:bee-1:hivemoot/sandbox", {
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-42",
+      outcome: "failure",
+      duration_secs: 300,
+      consecutive_failures: 3,
+      error: "timeout",
+      received_at: new Date().toISOString(),
+    });
+
+    const result = await getOverview("inst-1", redis);
+    expect(result[0].status).toBe("failed");
+    expect(result[0].outcome).toBe("failure");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — validateReport trigger: "task"
+// ---------------------------------------------------------------------------
+
+describe("validateReport trigger extensions", () => {
+  it("accepts trigger: 'task'", () => {
+    const result = validateReport({
+      agent_id: "attendant",
+      repo: "hivemoot/sandbox",
+      run_id: "task-run-1",
+      outcome: "success",
+      duration_secs: 60,
+      consecutive_failures: 0,
+      trigger: "task",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.report.trigger).toBe("task");
   });
 });

--- a/apps/web/src/server/agent-health-store.ts
+++ b/apps/web/src/server/agent-health-store.ts
@@ -43,7 +43,7 @@ const ANSI_ESCAPE_PATTERN = /[\u001B\u009B](?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 // Types
 // ---------------------------------------------------------------------------
 
-export type TriggerType = "scheduled" | "mention" | "manual";
+export type TriggerType = "scheduled" | "mention" | "manual" | "task";
 
 export interface ModelTokenUsage {
   input_tokens: number;
@@ -80,13 +80,21 @@ export interface HealthReport {
   received_at: string; // ISO 8601, server-assigned
 }
 
+export interface HeartbeatPayload {
+  agent_id: string;
+  repo: string;
+  outcome: "heartbeat";
+  next_run_at?: string;
+  received_at: string; // server-assigned
+}
+
 export type AgentStatus = "ok" | "failed" | "late" | "unknown";
 
 export interface HealthOverviewEntry {
   agent_id: string;
   repo: string;
   run_id?: string;
-  outcome?: HealthReport["outcome"];
+  outcome?: HealthReport["outcome"] | "heartbeat";
   duration_secs?: number;
   consecutive_failures?: number;
   model?: string;
@@ -219,7 +227,7 @@ export type IdempotencyReservation =
 // ---------------------------------------------------------------------------
 
 const VALID_OUTCOMES = new Set(["success", "failure", "timeout"]);
-const VALID_TRIGGERS = new Set<TriggerType>(["scheduled", "mention", "manual"]);
+const VALID_TRIGGERS = new Set<TriggerType>(["scheduled", "mention", "manual", "task"]);
 const ALLOWED_FIELDS = new Set([
   "agent_id",
   "repo",
@@ -235,6 +243,14 @@ const ALLOWED_FIELDS = new Set([
   "trigger",
   "token_usage",
 ]);
+const HEARTBEAT_ALLOWED_FIELDS = new Set([
+  "agent_id",
+  "repo",
+  "outcome",
+  "next_run_at",
+]);
+// Superset of VALID_OUTCOMES — includes "heartbeat" for stored latest entries.
+const DISPLAY_OUTCOMES = new Set(["success", "failure", "timeout", "heartbeat"]);
 
 export type ValidationResult = {
   ok: true;
@@ -475,6 +491,93 @@ export function validateReport(body: unknown): ValidationResult {
 }
 
 // ---------------------------------------------------------------------------
+// Heartbeat validation
+// ---------------------------------------------------------------------------
+
+export type HeartbeatValidationResult = {
+  ok: true;
+  heartbeat: HeartbeatPayload;
+} | {
+  ok: false;
+  message: string;
+};
+
+/**
+ * Validates a heartbeat payload — the lightweight liveness signal agents send
+ * between runs. Only agent_id, repo, outcome ("heartbeat"), and optional
+ * next_run_at are accepted.
+ */
+export function validateHeartbeat(body: unknown): HeartbeatValidationResult {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, message: "Body must be a JSON object" };
+  }
+
+  const obj = body as Record<string, unknown>;
+
+  for (const key of Object.keys(obj)) {
+    if (!HEARTBEAT_ALLOWED_FIELDS.has(key)) {
+      return { ok: false, message: `Unknown field for heartbeat: ${key}` };
+    }
+  }
+
+  if (
+    typeof obj.agent_id !== "string"
+    || obj.agent_id.length < 1
+    || obj.agent_id.length > 64
+    || !AGENT_ID_PATTERN.test(obj.agent_id)
+  ) {
+    return {
+      ok: false,
+      message: "agent_id must be 1-64 chars and match [a-z0-9_-]",
+    };
+  }
+
+  if (
+    typeof obj.repo !== "string"
+    || obj.repo.length < 1
+    || obj.repo.length > 200
+    || !obj.repo.includes("/")
+  ) {
+    return {
+      ok: false,
+      message: "repo must be 1-200 chars in owner/name format",
+    };
+  }
+
+  if (obj.outcome !== "heartbeat") {
+    return { ok: false, message: "outcome must be 'heartbeat'" };
+  }
+
+  if (obj.next_run_at !== undefined) {
+    if (typeof obj.next_run_at !== "string" || obj.next_run_at.length > 64) {
+      return { ok: false, message: "next_run_at must be a string (max 64 chars) if provided" };
+    }
+    const ts = new Date(obj.next_run_at).getTime();
+    if (Number.isNaN(ts)) {
+      return { ok: false, message: "next_run_at must be a valid ISO 8601 timestamp" };
+    }
+    const now = Date.now();
+    if (ts < now - 5 * 60 * 1000) {
+      return { ok: false, message: "next_run_at must not be more than 5 minutes in the past" };
+    }
+    if (ts > now + 48 * 60 * 60 * 1000) {
+      return { ok: false, message: "next_run_at must not be more than 48 hours in the future" };
+    }
+  }
+
+  const heartbeat: HeartbeatPayload = {
+    agent_id: obj.agent_id,
+    repo: obj.repo,
+    outcome: "heartbeat",
+    received_at: new Date().toISOString(),
+  };
+
+  if (typeof obj.next_run_at === "string") heartbeat.next_run_at = obj.next_run_at;
+
+  return { ok: true, heartbeat };
+}
+
+// ---------------------------------------------------------------------------
 // Idempotency
 // ---------------------------------------------------------------------------
 
@@ -587,7 +690,7 @@ export async function checkRateLimit(
  * dashboard even if they miss a cycle. When next_run_at is provided and
  * 2x the gap exceeds 24h, the TTL extends to cover that instead.
  */
-function computeLatestTtl(report: HealthReport): number {
+function computeLatestTtl(report: { next_run_at?: string }): number {
   if (typeof report.next_run_at === "string") {
     const nextRunMs = new Date(report.next_run_at).getTime();
     if (!Number.isNaN(nextRunMs)) {
@@ -638,6 +741,48 @@ export async function recordHealthReport(
     .exec();
 }
 
+/**
+ * Records a heartbeat — refreshes the latest key TTL and optionally updates
+ * next_run_at without overwriting run history data. If an existing latest
+ * report exists, its run fields are preserved. If no prior report exists,
+ * a minimal heartbeat entry is stored so the agent appears on the dashboard.
+ *
+ * Heartbeats are NOT added to the runs sorted set (they aren't runs).
+ */
+export async function recordHeartbeat(
+  installId: string,
+  heartbeat: HeartbeatPayload,
+  redis: Redis,
+): Promise<void> {
+  const { agent_id, repo } = heartbeat;
+  const key = latestKey(installId, agent_id, repo);
+
+  // Read existing latest report to preserve run data
+  const existing = await redis.get(key);
+
+  let dataToStore: Record<string, unknown>;
+
+  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+    // Patch existing report: refresh timestamps, keep run data intact
+    dataToStore = { ...(existing as Record<string, unknown>) };
+    dataToStore.received_at = heartbeat.received_at;
+    if (heartbeat.next_run_at) {
+      dataToStore.next_run_at = heartbeat.next_run_at;
+    }
+  } else {
+    // No prior report — store minimal heartbeat entry
+    dataToStore = { ...heartbeat };
+  }
+
+  const ttl = computeLatestTtl(dataToStore as { next_run_at?: string });
+
+  await redis
+    .multi()
+    .set(key, dataToStore, { ex: ttl })
+    .sadd(indexKey(installId), `${agent_id}:${repo}`)
+    .exec();
+}
+
 // ---------------------------------------------------------------------------
 // Status derivation
 // ---------------------------------------------------------------------------
@@ -652,9 +797,15 @@ export async function recordHealthReport(
 function deriveStatus(report: Partial<HealthReport> | null): AgentStatus {
   if (!report || typeof report.outcome !== "string") return "unknown";
 
-  if (report.outcome === "failure" || report.outcome === "timeout") return "failed";
+  // Runtime data from Redis may contain "heartbeat" — cast for the check.
+  const outcome = report.outcome as string;
 
-  if (report.outcome === "success") {
+  if (outcome === "failure" || outcome === "timeout") return "failed";
+
+  // Heartbeat: agent is alive and checking in between runs
+  if (outcome === "heartbeat") return "ok";
+
+  if (outcome === "success") {
     const nextRunAt = report.next_run_at;
     if (typeof nextRunAt === "string") {
       const nextRunMs = new Date(nextRunAt).getTime();
@@ -729,8 +880,8 @@ export async function getOverview(
           agent_id: report.agent_id,
           repo: report.repo,
           run_id: typeof report.run_id === "string" ? report.run_id : undefined,
-          outcome: VALID_OUTCOMES.has(report.outcome ?? "")
-            ? (report.outcome as HealthReport["outcome"])
+          outcome: DISPLAY_OUTCOMES.has((report.outcome as string) ?? "")
+            ? (report.outcome as HealthOverviewEntry["outcome"])
             : undefined,
           duration_secs: typeof report.duration_secs === "number" ? report.duration_secs : undefined,
           consecutive_failures: typeof report.consecutive_failures === "number"


### PR DESCRIPTION
## Summary

- Adds heartbeat support to `POST /api/agent-health` — the controller sends `{agent_id, repo, outcome: "heartbeat"[, next_run_at]}` between runs to keep agents visible on the dashboard
- Backend was rejecting these with 400 because `validateReport()` requires `run_id`, `duration_secs`, etc.
- Heartbeats get a separate validation + recording path that patches the existing latest key (preserving run data) and refreshes TTL without entering run history
- Also adds `"task"` to valid trigger types for dispatch services

## What it looks like

| Scenario | Before | After |
|---|---|---|
| Controller sends heartbeat between runs | `400 agent_health_validation_failed: run_id must be a string (1-128 chars)` | `200 {"received": true, "received_at": "..."}` |
| Agent with no prior run sends heartbeat | N/A (rejected) | Agent appears on dashboard with status `ok` |
| Agent with prior failed run sends heartbeat | N/A (rejected) | Latest key TTL refreshed, status stays `failed` (heartbeat doesn't mask failures) |
| Dispatch service reports trigger: "task" | `400 trigger must be one of: scheduled, mention, manual` | Accepted |

## Test plan

- [x] 119 tests pass (79 store + 40 route)
- [x] `validateHeartbeat` accepts minimal heartbeat, heartbeat with `next_run_at`, rejects unknown fields and non-heartbeat outcomes
- [x] `recordHeartbeat` patches existing report preserving run data, stores minimal entry when no prior report exists, does NOT add to runs sorted set
- [x] Route correctly detects `outcome === "heartbeat"` and routes to heartbeat path, skipping idempotency
- [x] Rate limiting, auth, and validation errors all work for heartbeat path
- [x] `deriveStatus` returns `ok` for heartbeat-only entries
- [x] Overview displays `outcome: "heartbeat"` for fresh heartbeat entries
- [x] `trigger: "task"` accepted in run reports