### PR TITLE
fix(web): add top-level try/catch to agent-health POST and heartbeat paths

### DIFF
--- a/apps/web/src/app/api/agent-health/route.test.ts
+++ b/apps/web/src/app/api/agent-health/route.test.ts
@@ -348,12 +348,13 @@ describe("POST /api/agent-health", () => {
     );
   });
 
-  it("releases idempotency reservation when write fails", async () => {
+  it("releases idempotency reservation when write fails and returns 503", async () => {
     vi.mocked(recordHealthReport).mockRejectedValue(new Error("redis write failed"));
 
-    await expect(POST(makePostRequest(VALID_REQUEST_BODY))).rejects.toThrow(
-      "redis write failed",
-    );
+    const res = await POST(makePostRequest(VALID_REQUEST_BODY));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
     expect(releaseHealthReportIdempotency).toHaveBeenCalledWith(
       "inst-1",
       VALID_REPORT,
@@ -361,15 +362,43 @@ describe("POST /api/agent-health", () => {
     );
   });
 
-  it("does not release reservation when write succeeded but commit update fails", async () => {
+  it("does not release reservation when write succeeded but commit update fails, returns 503", async () => {
     vi.mocked(commitHealthReportIdempotency).mockRejectedValue(
       new Error("idempotency commit failed"),
     );
 
-    await expect(POST(makePostRequest(VALID_REQUEST_BODY))).rejects.toThrow(
-      "idempotency commit failed",
-    );
+    const res = await POST(makePostRequest(VALID_REQUEST_BODY));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
     expect(releaseHealthReportIdempotency).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when authenticateAgentRequest throws", async () => {
+    vi.mocked(authenticateAgentRequest).mockRejectedValue(new Error("redis connection refused"));
+
+    const res = await POST(makePostRequest(VALID_REQUEST_BODY));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
+  });
+
+  it("returns 503 when reserveHealthReportIdempotency throws", async () => {
+    vi.mocked(reserveHealthReportIdempotency).mockRejectedValue(new Error("redis down"));
+
+    const res = await POST(makePostRequest(VALID_REQUEST_BODY));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
+  });
+
+  it("returns 503 when checkRateLimit throws", async () => {
+    vi.mocked(checkRateLimit).mockRejectedValue(new Error("redis timeout"));
+
+    const res = await POST(makePostRequest(VALID_REQUEST_BODY));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
   });
 });
 
@@ -468,6 +497,48 @@ describe("POST /api/agent-health (heartbeat)", () => {
 
     expect(res.status).toBe(429);
     expect(recordHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when authenticateAgentRequest throws during heartbeat", async () => {
+    vi.mocked(authenticateAgentRequest).mockRejectedValue(new Error("redis connection refused"));
+
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
+  });
+
+  it("returns 503 when checkRateLimit throws during heartbeat", async () => {
+    vi.mocked(checkRateLimit).mockRejectedValue(new Error("redis timeout"));
+
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
+  });
+
+  it("returns 503 when recordHeartbeat throws", async () => {
+    vi.mocked(recordHeartbeat).mockRejectedValue(new Error("redis write failed"));
+
+    const res = await POST(makePostRequest({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      outcome: "heartbeat",
+    }));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_server_misconfiguration");
   });
 
   it("accepts heartbeat with next_run_at", async () => {

--- a/apps/web/src/app/api/agent-health/route.ts
+++ b/apps/web/src/app/api/agent-health/route.ts
@@ -93,86 +93,97 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const auth = await authenticateAgentRequest(request);
-  if (!auth.ok) return auth.response;
+  try {
+    const auth = await authenticateAgentRequest(request);
+    if (!auth.ok) return auth.response;
 
-  const { report } = validation;
-  const idempotency = await reserveHealthReportIdempotency(
-    auth.installationId,
-    report,
-    auth.redis,
-  );
-
-  if (idempotency.kind === "duplicate") {
-    return NextResponse.json({
-      received: true,
-      received_at: idempotency.receivedAt,
-      duplicate: true,
-    });
-  }
-
-  if (idempotency.kind === "conflict") {
-    return agentHealthError(
-      AGENT_HEALTH_ERROR.IDEMPOTENCY_CONFLICT,
-      "run_id already exists with a different payload",
-      409,
+    const { report } = validation;
+    const idempotency = await reserveHealthReportIdempotency(
+      auth.installationId,
+      report,
+      auth.redis,
     );
-  }
 
-  if (idempotency.kind === "pending") {
-    return agentHealthError(
-      AGENT_HEALTH_ERROR.IDEMPOTENCY_PENDING,
-      "run_id is currently being processed; retry shortly",
-      409,
-    );
-  }
-
-  const allowed = await checkRateLimit(
-    auth.installationId,
-    report.agent_id,
-    report.repo,
-    auth.redis,
-  );
-
-  if (!allowed) {
-    try {
-      await releaseHealthReportIdempotency(auth.installationId, report, auth.redis);
-    } catch (cleanupErr) {
-      console.warn("[agent-health] Best-effort idempotency cleanup failed after rate-limit", {
-        installationId: auth.installationId,
-        agentId: report.agent_id,
-        runId: report.run_id,
-        error: cleanupErr,
+    if (idempotency.kind === "duplicate") {
+      return NextResponse.json({
+        received: true,
+        received_at: idempotency.receivedAt,
+        duplicate: true,
       });
     }
-    return agentHealthError(
-      AGENT_HEALTH_ERROR.RATE_LIMITED,
-      "Rate limited — one report per agent per repo per 60 seconds",
-      429,
-    );
-  }
 
-  let persisted = false;
-  try {
-    await recordHealthReport(auth.installationId, report, auth.redis);
-    persisted = true;
-    await commitHealthReportIdempotency(auth.installationId, report, auth.redis);
-  } catch (error) {
-    if (!persisted) {
+    if (idempotency.kind === "conflict") {
+      return agentHealthError(
+        AGENT_HEALTH_ERROR.IDEMPOTENCY_CONFLICT,
+        "run_id already exists with a different payload",
+        409,
+      );
+    }
+
+    if (idempotency.kind === "pending") {
+      return agentHealthError(
+        AGENT_HEALTH_ERROR.IDEMPOTENCY_PENDING,
+        "run_id is currently being processed; retry shortly",
+        409,
+      );
+    }
+
+    const allowed = await checkRateLimit(
+      auth.installationId,
+      report.agent_id,
+      report.repo,
+      auth.redis,
+    );
+
+    if (!allowed) {
       try {
         await releaseHealthReportIdempotency(auth.installationId, report, auth.redis);
       } catch (cleanupErr) {
-        console.error("[agent-health] Idempotency cleanup failed during write error recovery", {
+        console.warn("[agent-health] Best-effort idempotency cleanup failed after rate-limit", {
           installationId: auth.installationId,
+          agentId: report.agent_id,
           runId: report.run_id,
-          cleanupError: cleanupErr,
+          error: cleanupErr,
         });
       }
+      return agentHealthError(
+        AGENT_HEALTH_ERROR.RATE_LIMITED,
+        "Rate limited — one report per agent per repo per 60 seconds",
+        429,
+      );
     }
-    throw error;
-  }
 
-  return NextResponse.json({ received: true, received_at: report.received_at });
+    let persisted = false;
+    try {
+      await recordHealthReport(auth.installationId, report, auth.redis);
+      persisted = true;
+      await commitHealthReportIdempotency(auth.installationId, report, auth.redis);
+    } catch (error) {
+      if (!persisted) {
+        try {
+          await releaseHealthReportIdempotency(auth.installationId, report, auth.redis);
+        } catch (cleanupErr) {
+          console.error("[agent-health] Idempotency cleanup failed during write error recovery", {
+            installationId: auth.installationId,
+            runId: report.run_id,
+            cleanupError: cleanupErr,
+          });
+        }
+      }
+      throw error;
+    }
+
+    return NextResponse.json({ received: true, received_at: report.received_at });
+  } catch (error) {
+    console.error("[agent-health] POST failed", {
+      error,
+    });
+    return agentHealthError(
+      AGENT_HEALTH_ERROR.SERVER_MISCONFIGURATION,
+      "Failed to process health report",
+      503,
+    );
+  }
 }
 
 async function handleHeartbeat(body: unknown, request: NextRequest) {
@@ -185,29 +196,40 @@ async function handleHeartbeat(body: unknown, request: NextRequest) {
     );
   }
 
-  const auth = await authenticateAgentRequest(request);
-  if (!auth.ok) return auth.response;
+  try {
+    const auth = await authenticateAgentRequest(request);
+    if (!auth.ok) return auth.response;
 
-  const { heartbeat } = validation;
+    const { heartbeat } = validation;
 
-  const allowed = await checkRateLimit(
-    auth.installationId,
-    heartbeat.agent_id,
-    heartbeat.repo,
-    auth.redis,
-  );
+    const allowed = await checkRateLimit(
+      auth.installationId,
+      heartbeat.agent_id,
+      heartbeat.repo,
+      auth.redis,
+    );
 
-  if (!allowed) {
+    if (!allowed) {
+      return agentHealthError(
+        AGENT_HEALTH_ERROR.RATE_LIMITED,
+        "Rate limited — one report per agent per repo per 60 seconds",
+        429,
+      );
+    }
+
+    await recordHeartbeat(auth.installationId, heartbeat, auth.redis);
+
+    return NextResponse.json({ received: true, received_at: heartbeat.received_at });
+  } catch (error) {
+    console.error("[agent-health] heartbeat POST failed", {
+      error,
+    });
     return agentHealthError(
-      AGENT_HEALTH_ERROR.RATE_LIMITED,
-      "Rate limited — one report per agent per repo per 60 seconds",
-      429,
+      AGENT_HEALTH_ERROR.SERVER_MISCONFIGURATION,
+      "Failed to process heartbeat",
+      503,
     );
   }
-
-  await recordHeartbeat(auth.installationId, heartbeat, auth.redis);
-
-  return NextResponse.json({ received: true, received_at: heartbeat.received_at });
 }
 
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
Fixes #360

## What

Adds top-level try/catch blocks to the two unprotected paths in `agent-health/route.ts`:

**Main POST path** — wraps from `authenticateAgentRequest` through the final return in a try/catch that catches unexpected Redis/runtime failures and returns `503 agent_health_server_misconfiguration`. The inner idempotency cleanup try/catch (for `recordHealthReport`/`commitHealthReportIdempotency`) remains intact — the outer catch intercepts the re-throw after cleanup completes.

**Heartbeat path** (`handleHeartbeat`) — wraps from `authenticateAgentRequest` through `recordHeartbeat` in the same pattern. All three bare Redis calls (auth, rate limit, record) are now protected.

## Why

Four unprotected call sites were delivering HTML 500 responses to agents instead of the structured JSON `AGENT_HEALTH_CONTRACT.md` section 2 documents. This is the same class of gap fixed for task routes (#307) and BYOK routes (#355). The reference implementation is `agent-token/route.ts`.

Heater's review of #360 identified that the heartbeat path has identical gaps — this PR covers both paths as a single surgical fix.

## Tests

- Updated 2 existing tests that expected `rejects.toThrow` (errors now resolve as structured 503 responses)
- Added 8 new failure-path tests: 5 for the main POST path (auth throws, idempotency throws, rate-limit throws, write fails, commit fails) and 3 for heartbeat (auth throws, rate-limit throws, record throws)
- 46/46 tests pass. `tsc --noEmit` clean.