### PR TITLE
docs: surface zero-setup contribution path at top of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,27 @@ If `git push --dry-run origin HEAD` fails, do not continue implementation work u
 
 ## Development
 
-### CLI
+### Start Here — No Credentials Required
+
+In under 5 minutes, with no Redis, no GitHub App, and no env vars:
+
+**CLI** — run all tests, build, iterate on logic:
+```bash
+cd cli && npm ci && npm test
+```
+
+**Web app** — run all unit tests:
+```bash
+cd apps/web && npm ci && npm test
+```
+
+Unit tests in `src/**/*.test.ts` do not require live services and can run without any env vars set. You can fix bugs, improve docs, and contribute code changes this way.
+
+Full OAuth/BYOK development requires Redis (Upstash) and a GitHub App. See [Full Setup](#full-setup) below.
+
+### Full Setup
+
+#### CLI
 
 ```bash
 cd cli
@@ -53,7 +73,7 @@ npm test
 npm run build
 ```
 
-### Web app (`apps/web`)
+#### Web app (`apps/web`)
 
 The web app is a Next.js app that requires Redis (Upstash) and a GitHub App to run the full OAuth + BYOK setup flow. For local development:
 
@@ -67,5 +87,3 @@ npm test           # runs Vitest unit tests
 npm run typecheck  # TypeScript checks
 npm run lint       # ESLint
 ```
-
-Unit tests in `src/**/*.test.ts` do not require live services and can run without any env vars set.


### PR DESCRIPTION
Fixes #376

## What

Restructures the Development section of CONTRIBUTING.md so the first thing a reader encounters is what they can do *without* any external services.

**Before:** Line 58 says "requires Redis (Upstash) and a GitHub App" — newcomers stop reading here. The unit-test path was a footnote at line 71.

**After:** A "Start Here — No Credentials Required" block leads the section with the two `npm ci && npm test` commands. The full Redis/GitHub App setup moves below it under "Full Setup."

## Acceptance Criteria (from #376)

- [x] `npm ci && npm test` appears before `requires Redis (Upstash)` in CONTRIBUTING.md
- [x] "Unit tests ... do not require live services" is the headline, not the last line
- [x] Fork-first and full-setup sections preserved, positioned after the zero-setup intro