### PR TITLE
fix(web): add top-level try/catch to BYOK routes

### DIFF
--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -209,4 +209,18 @@ describe("POST /api/byok/config", () => {
       expect.anything(),
     );
   });
+
+  it("returns 500 with byok_server_misconfiguration when Redis write fails", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("Redis connection refused"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+  });
 });

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -41,41 +41,46 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Validate the key with the provider
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
+  try {
+    // Validate the key with the provider
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
     );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-config] Failed to configure BYOK", { installationId, error: err });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -102,4 +102,14 @@ describe("POST /api/byok/revoke", () => {
     expect(body.code).toBe(BYOK_ERROR.NOT_CONFIGURED);
     expect(body.message).toBe("BYOK is not configured");
   });
+
+  it("returns 500 with byok_server_misconfiguration when Redis read fails", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("Redis connection refused"));
+
+    const req = makeRequest({});
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+  });
 });

--- a/apps/web/src/app/api/byok/revoke/route.ts
+++ b/apps/web/src/app/api/byok/revoke/route.ts
@@ -16,28 +16,33 @@ export async function POST(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const existing = await getByokEnvelope(installationId, auth.redis);
-  if (!existing) {
-    return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+  try {
+    const existing = await getByokEnvelope(installationId, auth.redis);
+    if (!existing) {
+      return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+    }
+
+    // Clear ciphertext fields, keep metadata for audit
+    const revoked = {
+      ...existing,
+      status: "revoked" as const,
+      ciphertext: "",
+      iv: "",
+      tag: "",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+    };
+
+    await setByokEnvelope(installationId, revoked, auth.redis);
+
+    return NextResponse.json({
+      status: "revoked",
+      provider: revoked.provider,
+      model: revoked.model,
+      updatedAt: revoked.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-revoke] Failed to revoke BYOK config", { installationId, error: err });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  // Clear ciphertext fields, keep metadata for audit
-  const revoked = {
-    ...existing,
-    status: "revoked" as const,
-    ciphertext: "",
-    iv: "",
-    tag: "",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-  };
-
-  await setByokEnvelope(installationId, revoked, auth.redis);
-
-  return NextResponse.json({
-    status: "revoked",
-    provider: revoked.provider,
-    model: revoked.model,
-    updatedAt: revoked.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -160,4 +160,18 @@ describe("POST /api/byok/rotate", () => {
       expect.anything(),
     );
   });
+
+  it("returns 500 with byok_server_misconfiguration when Redis write fails", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("Redis connection refused"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-new-key5678",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+  });
 });

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -42,40 +42,45 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
+  try {
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
     );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-rotate] Failed to rotate BYOK key", { installationId, error: err });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -121,4 +121,14 @@ describe("GET /api/byok/status", () => {
       expect.anything(),
     );
   });
+
+  it("returns 500 with byok_server_misconfiguration when Redis read fails", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("Redis connection refused"));
+
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+  });
 });

--- a/apps/web/src/app/api/byok/status/route.ts
+++ b/apps/web/src/app/api/byok/status/route.ts
@@ -16,33 +16,38 @@ export async function GET(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const envelope = await getByokEnvelope(installationId, auth.redis);
-  if (!envelope) {
-    return byokError(
-      BYOK_ERROR.NOT_CONFIGURED,
-      "BYOK is not configured",
-      404,
-    );
-  }
+  try {
+    const envelope = await getByokEnvelope(installationId, auth.redis);
+    if (!envelope) {
+      return byokError(
+        BYOK_ERROR.NOT_CONFIGURED,
+        "BYOK is not configured",
+        404,
+      );
+    }
 
-  if (envelope.status === "revoked") {
-    return byokError(
-      BYOK_ERROR.REVOKED,
-      "BYOK configuration has been revoked",
-      409,
-      {
-        status: envelope.status,
-        provider: envelope.provider,
-        model: envelope.model,
-        updatedAt: envelope.updatedAt,
-      },
-    );
-  }
+    if (envelope.status === "revoked") {
+      return byokError(
+        BYOK_ERROR.REVOKED,
+        "BYOK configuration has been revoked",
+        409,
+        {
+          status: envelope.status,
+          provider: envelope.provider,
+          model: envelope.model,
+          updatedAt: envelope.updatedAt,
+        },
+      );
+    }
 
-  return NextResponse.json({
-    status: envelope.status,
-    provider: envelope.provider,
-    model: envelope.model,
-    updatedAt: envelope.updatedAt,
-  });
+    return NextResponse.json({
+      status: envelope.status,
+      provider: envelope.provider,
+      model: envelope.model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-status] Failed to fetch BYOK status", { installationId, error: err });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
+  }
 }


### PR DESCRIPTION
Fixes #355

## What changed

Four BYOK routes (`config`, `rotate`, `revoke`, `status`) called Redis via `getByokEnvelope`/`setByokEnvelope` without a top-level try/catch. A Redis outage would propagate as an unhandled exception, producing an HTML 500 response instead of a structured `{"code":"...","message":"..."}` JSON error — the same class of gap fixed for task routes in #307.

**Pattern applied** (matching `byok/re-encrypt`, which already had this):

- Wrapped the Redis-calling section of each route in a `try/catch`
- Catch returns `byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500)`
- Catch logs `console.error("[byok-<route>] ...", { installationId, error })`

**No behavior change** for the happy path or existing error cases (auth failures, missing envelope, provider rejection).

## Tests

Added one regression test per route that mocks a Redis rejection and asserts:
- Response status `500`
- Response body `code` is `byok_server_misconfiguration`

All 31 BYOK route tests pass.