### PR TITLE
refactor(web): extract shared OAuth helpers to github-auth.ts

### DIFF
--- a/apps/web/src/app/api/auth/github/start-discover/route.ts
+++ b/apps/web/src/app/api/auth/github/start-discover/route.ts
@@ -20,10 +20,9 @@ import {
   getSetupSession,
 } from "@/server/setup-session";
 import { hasByokEnvelope } from "@/server/byok-store";
+import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions } from "@/server/github-auth";
 
-const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const OAUTH_STATE_STORE_FAILED_CODE = "oauth_state_store_failed";
-const OAUTH_STATE_COOKIE_MAX_AGE = 600;
 
 /**
  * Validates that `next` is a safe same-origin path.
@@ -102,20 +101,10 @@ export async function GET(request: NextRequest) {
   }
 
   const callbackUrl = `${siteUrl}/api/auth/github/callback`;
-  const authorizeUrl = new URL(GITHUB_AUTHORIZE_URL);
-  authorizeUrl.searchParams.set("client_id", githubClientId);
-  authorizeUrl.searchParams.set("redirect_uri", callbackUrl);
-  authorizeUrl.searchParams.set("state", stateRecord.state);
-  authorizeUrl.searchParams.set("scope", "read:org");
+  const authorizeUrl = buildOAuthAuthorizeUrl(githubClientId, callbackUrl, stateRecord.state);
 
   const response = NextResponse.redirect(authorizeUrl.toString());
-  response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    maxAge: OAUTH_STATE_COOKIE_MAX_AGE,
-    path: "/",
-  });
+  response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, getOAuthStateCookieOptions());
 
   return response;
 }

--- a/apps/web/src/app/api/auth/github/start-discover/route.ts
+++ b/apps/web/src/app/api/auth/github/start-discover/route.ts
@@ -20,18 +20,9 @@ import {
   getSetupSession,
 } from "@/server/setup-session";
 import { hasByokEnvelope } from "@/server/byok-store";
-import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions } from "@/server/github-auth";
+import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions, isSafeNextPath } from "@/server/github-auth";
 
 const OAUTH_STATE_STORE_FAILED_CODE = "oauth_state_store_failed";
-
-/**
- * Validates that `next` is a safe same-origin path.
- * Blocks protocol-relative URLs (//evil.com), backslash-relative URLs (/\evil.com),
- * and absolute URLs.
- */
-function isSafeNextPath(next: string): boolean {
-  return next.startsWith("/") && !next.startsWith("//") && !next.includes("\\");
-}
 
 export async function GET(request: NextRequest) {
   const env = validateEnv();

--- a/apps/web/src/app/api/auth/github/start/route.ts
+++ b/apps/web/src/app/api/auth/github/start/route.ts
@@ -18,9 +18,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateEnv } from "@/server/env";
 import { getRedisClient } from "@/server/redis";
 import { createOAuthState, OAUTH_STATE_BINDING_COOKIE } from "@/server/setup-session";
-
-const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
-const OAUTH_STATE_COOKIE_MAX_AGE = 600; // 10 minutes, aligned with Redis state TTL
+import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions } from "@/server/github-auth";
 
 /**
  * Validates that `next` is a safe same-origin path.
@@ -78,20 +76,9 @@ export async function GET(request: NextRequest) {
   }
 
   const callbackUrl = `${siteUrl}/api/auth/github/callback`;
-  const authorizeUrl = new URL(GITHUB_AUTHORIZE_URL);
-  authorizeUrl.searchParams.set("client_id", githubClientId);
-  authorizeUrl.searchParams.set("redirect_uri", callbackUrl);
-  authorizeUrl.searchParams.set("state", stateRecord.state);
-  // Request minimum scopes: we only need to read org membership
-  authorizeUrl.searchParams.set("scope", "read:org");
+  const authorizeUrl = buildOAuthAuthorizeUrl(githubClientId, callbackUrl, stateRecord.state);
 
   const response = NextResponse.redirect(authorizeUrl.toString());
-  response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    maxAge: OAUTH_STATE_COOKIE_MAX_AGE,
-    path: "/",
-  });
+  response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, getOAuthStateCookieOptions());
   return response;
 }

--- a/apps/web/src/app/api/auth/github/start/route.ts
+++ b/apps/web/src/app/api/auth/github/start/route.ts
@@ -18,16 +18,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateEnv } from "@/server/env";
 import { getRedisClient } from "@/server/redis";
 import { createOAuthState, OAUTH_STATE_BINDING_COOKIE } from "@/server/setup-session";
-import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions } from "@/server/github-auth";
-
-/**
- * Validates that `next` is a safe same-origin path.
- * Blocks protocol-relative URLs (//evil.com), backslash-relative URLs (/\evil.com),
- * and absolute URLs.
- */
-function isSafeNextPath(next: string): boolean {
-  return next.startsWith("/") && !next.startsWith("//") && !next.includes("\\");
-}
+import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions, isSafeNextPath } from "@/server/github-auth";
 
 function setupErrorRedirect(
   request: NextRequest,

--- a/apps/web/src/server/github-auth.ts
+++ b/apps/web/src/server/github-auth.ts
@@ -8,6 +8,7 @@
  * - checkOrgAdmin: verifies the user holds an "admin" role in the target org
  * - buildOAuthAuthorizeUrl: constructs the GitHub OAuth authorize URL
  * - getOAuthStateCookieOptions: returns the stable cookie options for the OAuth state binding cookie
+ * - isSafeNextPath: validates that a `next` query param is a safe same-origin path
  */
 
 import { createSign } from "crypto";
@@ -35,6 +36,15 @@ export function buildOAuthAuthorizeUrl(
   url.searchParams.set("state", state);
   url.searchParams.set("scope", GITHUB_OAUTH_SCOPE);
   return url;
+}
+
+/**
+ * Validates that `next` is a safe same-origin path.
+ * Blocks protocol-relative URLs (//evil.com), backslash-relative URLs (/\evil.com),
+ * and absolute URLs.
+ */
+export function isSafeNextPath(next: string): boolean {
+  return next.startsWith("/") && !next.startsWith("//") && !next.includes("\\");
 }
 
 /**

--- a/apps/web/src/server/github-auth.ts
+++ b/apps/web/src/server/github-auth.ts
@@ -6,9 +6,56 @@
  * - getAuthenticatedUser: fetches the authenticated GitHub user's identity
  * - getInstallation: fetches installation metadata using the App JWT
  * - checkOrgAdmin: verifies the user holds an "admin" role in the target org
+ * - buildOAuthAuthorizeUrl: constructs the GitHub OAuth authorize URL
+ * - getOAuthStateCookieOptions: returns the stable cookie options for the OAuth state binding cookie
  */
 
 import { createSign } from "crypto";
+
+// ---------------------------------------------------------------------------
+// OAuth initiation helpers (shared by start and start-discover routes)
+// ---------------------------------------------------------------------------
+
+export const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+export const OAUTH_STATE_COOKIE_MAX_AGE = 600; // 10 minutes, aligned with Redis state TTL
+export const GITHUB_OAUTH_SCOPE = "read:org";
+
+/**
+ * Constructs the GitHub OAuth authorization URL with the required parameters.
+ * Returns a URL object; call `.toString()` to get the redirect target.
+ */
+export function buildOAuthAuthorizeUrl(
+  clientId: string,
+  redirectUri: string,
+  state: string,
+): URL {
+  const url = new URL(GITHUB_AUTHORIZE_URL);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("state", state);
+  url.searchParams.set("scope", GITHUB_OAUTH_SCOPE);
+  return url;
+}
+
+/**
+ * Returns the stable cookie options for the OAuth state binding cookie.
+ * `secure` is true in production, false otherwise.
+ */
+export function getOAuthStateCookieOptions(): {
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "lax";
+  maxAge: number;
+  path: string;
+} {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: OAUTH_STATE_COOKIE_MAX_AGE,
+    path: "/",
+  };
+}
 
 // ---------------------------------------------------------------------------
 // App JWT


### PR DESCRIPTION
Closes #369

## What changed

Extracted all duplicated OAuth initiation logic from `start/route.ts` and `start-discover/route.ts` into `apps/web/src/server/github-auth.ts`:

**New exports in `github-auth.ts`:**
- `GITHUB_AUTHORIZE_URL` — the GitHub OAuth authorize endpoint
- `OAUTH_STATE_COOKIE_MAX_AGE` — 600s TTL aligned with Redis state TTL
- `GITHUB_OAUTH_SCOPE` — `"read:org"` as a named constant (not a default param)
- `buildOAuthAuthorizeUrl(clientId, redirectUri, state): URL` — constructs the authorize URL; returns a `URL` object
- `getOAuthStateCookieOptions()` — returns the stable cookie options for the state binding cookie
- `isSafeNextPath(next): boolean` — same-origin path guard (identical in both routes)

Both routes now import and call the shared helpers. No logic changes — the refactor is mechanical.

## Design note: URL-returning vs NextResponse-returning

`buildOAuthAuthorizeUrl` returns a `URL`, not a `NextResponse`. This matches the pattern both builder and forager recommended in the issue discussion, and aligns with Auth.js's `createAuthorizationURL` design (forager's research). Each route builds its own `NextResponse.redirect(...)` — keeping ownership of the response in the route handler. If a route needs to add additional headers or cookies in the future, it can do so without fighting a shared response object.

## Before / After

**Before** (each route had these blocks independently):
```ts
const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
const OAUTH_STATE_COOKIE_MAX_AGE = 600;

function isSafeNextPath(next: string): boolean {
  return next.startsWith("/") && !next.startsWith("//") && !next.includes("\\");
}
// ...
const authorizeUrl = new URL(GITHUB_AUTHORIZE_URL);
authorizeUrl.searchParams.set("client_id", githubClientId);
authorizeUrl.searchParams.set("redirect_uri", callbackUrl);
authorizeUrl.searchParams.set("state", stateRecord.state);
authorizeUrl.searchParams.set("scope", "read:org");
const response = NextResponse.redirect(authorizeUrl.toString());
response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, {
  httpOnly: true, secure: process.env.NODE_ENV === "production",
  sameSite: "lax", maxAge: OAUTH_STATE_COOKIE_MAX_AGE, path: "/",
});
```

**After** (each route):
```ts
import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions, isSafeNextPath } from "@/server/github-auth";
// ...
const safeNext = nextParam && isSafeNextPath(nextParam) ? nextParam : undefined;
// ...
const authorizeUrl = buildOAuthAuthorizeUrl(githubClientId, callbackUrl, stateRecord.state);
const response = NextResponse.redirect(authorizeUrl.toString());
response.cookies.set(OAUTH_STATE_BINDING_COOKIE, stateRecord.stateBinding, getOAuthStateCookieOptions());
```

## Validation

- 27 tests pass (both route test files, unchanged)
- `tsc --noEmit` clean