### PR TITLE
feat(cli): add focus label/author filters (Phase 2, clean implementation)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -385,6 +385,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +409,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -430,6 +432,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -473,6 +476,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -571,6 +575,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      undefined,
     );
   });
 
@@ -665,6 +670,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       notificationMap,
+      undefined,
       undefined,
     );
   });

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -183,6 +183,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     votes,
     notifications,
     teamConfig?.focus,
+    teamConfig?.focusFilters,
   );
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -2,6 +2,8 @@ import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
   HivemootConfig,
+  FocusFilters,
+  FocusMatchFilter,
   TeamConfig,
   RepoRef,
   RoleConfig,
@@ -64,12 +66,75 @@ function parseLegacyFocus(rawFocus: unknown): string | undefined {
 
 const MAX_OBJECTIVE_LENGTH = 2_000;
 const MAX_FOCUS_NAME_LENGTH = 64;
+const MAX_FILTER_VALUE_LENGTH = 128;
+const MAX_FILTER_VALUES = 100;
+
+interface ResolvedFocusBlock {
+  objective: string;
+  filters?: FocusFilters;
+}
+
+function parseStringList(
+  raw: unknown,
+  maxLength: number,
+): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+
+  const values: string[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (trimmed.length > maxLength) continue;
+
+    const dedupeKey = trimmed.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    values.push(trimmed);
+    if (values.length >= MAX_FILTER_VALUES) break;
+  }
+
+  return values.length > 0 ? values : undefined;
+}
+
+function parseMatchFilter(raw: unknown): FocusMatchFilter | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+  const filter = raw as Record<string, unknown>;
+  const include = parseStringList(filter.include, MAX_FILTER_VALUE_LENGTH);
+  const exclude = parseStringList(filter.exclude, MAX_FILTER_VALUE_LENGTH);
+
+  if (!include && !exclude) return undefined;
+
+  return {
+    ...(include ? { include } : {}),
+    ...(exclude ? { exclude } : {}),
+  };
+}
+
+function parseFocusFilters(raw: unknown): FocusFilters | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+  const filters = raw as Record<string, unknown>;
+  const labels = parseMatchFilter(filters.labels);
+  const authors = parseMatchFilter(filters.authors);
+
+  if (!labels && !authors) return undefined;
+
+  return {
+    ...(labels ? { labels } : {}),
+    ...(authors ? { authors } : {}),
+  };
+}
 
 // Resolves focus from the team config. Handles two formats:
 // 1. New: team.focuses (dict of FocusBlock) + team.activeFocus (key)
 // 2. Legacy: team.focus.default (plain string)
 // The new format takes precedence when team.focuses is present.
-function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
+function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocusBlock | undefined {
   const rawFocuses = rawTeam.focuses;
 
   if (rawFocuses && typeof rawFocuses === "object" && !Array.isArray(rawFocuses)) {
@@ -101,14 +166,19 @@ function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
       // and the next candidate (or undefined) is returned.
       if (objective.length > MAX_OBJECTIVE_LENGTH) continue;
 
-      return objective;
+      return {
+        objective,
+        filters: parseFocusFilters(b.filters),
+      };
     }
 
     return undefined;
   }
 
   // Fall back to the legacy focus.default format.
-  return parseLegacyFocus(rawTeam.focus);
+  const objective = parseLegacyFocus(rawTeam.focus);
+  if (!objective) return undefined;
+  return { objective };
 }
 
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
@@ -207,13 +277,14 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
     };
   }
 
-  const focus = resolveFocus(team as unknown as Record<string, unknown>);
+  const resolvedFocus = resolveFocus(team as unknown as Record<string, unknown>);
 
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
-    focus,
+    focus: resolvedFocus?.objective,
+    focusFilters: resolvedFocus?.filters,
   };
 }
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -5,8 +5,19 @@ export interface RoleConfig {
   instructions: string;
 }
 
+export interface FocusMatchFilter {
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface FocusFilters {
+  labels?: FocusMatchFilter;
+  authors?: FocusMatchFilter;
+}
+
 export interface FocusBlock {
   objective: string;
+  filters?: FocusFilters;
 }
 
 export interface TeamConfig {
@@ -14,6 +25,7 @@ export interface TeamConfig {
   onboarding?: string;
   roles: Record<string, RoleConfig>;
   focus?: string;
+  focusFilters?: FocusFilters;
 }
 
 export interface HivemootConfig {

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -1,4 +1,5 @@
 import type {
+  FocusFilters,
   GitHubIssue,
   GitHubPR,
   NotificationRef,
@@ -36,6 +37,77 @@ interface IssuePipelineCounts {
 
 const OMITTED_PIPELINE_NOTE =
   "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.";
+
+// Returns the classification bucket for an issue without building a SummaryItem.
+// Used to compute unfiltered pipeline counts when focus filtering is active.
+function classifyIssueBucket(issue: GitHubIssue): "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified" {
+  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) return "needsHuman";
+  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) return "voteOn";
+  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) return "discuss";
+  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) return "implement";
+  if (hasLabel(issue.labels, "vote")) return "voteOn";
+  if (hasLabel(issue.labels, "discuss")) return "discuss";
+  return "unclassified";
+}
+
+interface NormalizedFocusFilters {
+  labelInclude?: Set<string>;
+  labelExclude?: Set<string>;
+  authorInclude?: Set<string>;
+  authorExclude?: Set<string>;
+}
+
+function normalizeFilterValues(values?: string[]): Set<string> | undefined {
+  if (!values || values.length === 0) return undefined;
+  const normalized = values
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+  if (normalized.length === 0) return undefined;
+  return new Set(normalized);
+}
+
+function normalizeFocusFilters(focusFilters?: FocusFilters): NormalizedFocusFilters {
+  return {
+    labelInclude: normalizeFilterValues(focusFilters?.labels?.include),
+    labelExclude: normalizeFilterValues(focusFilters?.labels?.exclude),
+    authorInclude: normalizeFilterValues(focusFilters?.authors?.include),
+    authorExclude: normalizeFilterValues(focusFilters?.authors?.exclude),
+  };
+}
+
+function hasItemFilters(filters: NormalizedFocusFilters): boolean {
+  return Boolean(
+    filters.labelInclude ||
+    filters.labelExclude ||
+    filters.authorInclude ||
+    filters.authorExclude,
+  );
+}
+
+function matchesFocusFilters(
+  labels: Array<{ name: string }>,
+  author: string | undefined,
+  filters: NormalizedFocusFilters,
+): boolean {
+  const normalizedLabels = labels.map((l) => l.name.trim().toLowerCase());
+  const normalizedAuthor = author?.trim().toLowerCase();
+
+  if (filters.labelExclude && normalizedLabels.some((label) => filters.labelExclude?.has(label))) {
+    return false;
+  }
+  if (filters.labelInclude && !normalizedLabels.some((label) => filters.labelInclude?.has(label))) {
+    return false;
+  }
+  if (filters.authorExclude && normalizedAuthor && filters.authorExclude.has(normalizedAuthor)) {
+    return false;
+  }
+  if (filters.authorInclude) {
+    if (!normalizedAuthor || !filters.authorInclude.has(normalizedAuthor)) {
+      return false;
+    }
+  }
+  return true;
+}
 
 function isMergeReadyPR(pr: GitHubPR): boolean {
   if (pr.isDraft) return false;
@@ -311,6 +383,7 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  focusFilters?: FocusFilters,
 ): RepoSummary {
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
@@ -322,7 +395,30 @@ export function buildSummary(
   const addressFeedback: SummaryItem[] = [];
   const notes: string[] = [];
 
+  const normalizedFocusFilters = normalizeFocusFilters(focusFilters);
+  const shouldFilterItems = hasItemFilters(normalizedFocusFilters);
+  const visibleIssues = shouldFilterItems
+    ? issues.filter((issue) =>
+      matchesFocusFilters(issue.labels, issue.author?.login ?? undefined, normalizedFocusFilters))
+    : issues;
+  const visiblePRs = shouldFilterItems
+    ? prs.filter((pr) =>
+      matchesFocusFilters(pr.labels, pr.author?.login ?? undefined, normalizedFocusFilters))
+    : prs;
+
+  // Track full pipeline counts from unfiltered issues so repository health
+  // metrics are accurate even when focus filtering is active.
+  let fullDiscussionCount = 0;
+  let fullVotingCount = 0;
+  let fullReadyToImplementCount = 0;
   for (const issue of issues) {
+    const bucket = classifyIssueBucket(issue);
+    if (bucket === "discuss") fullDiscussionCount += 1;
+    else if (bucket === "voteOn") fullVotingCount += 1;
+    else if (bucket === "implement") fullReadyToImplementCount += 1;
+  }
+
+  for (const issue of visibleIssues) {
     const { bucket, item } = classifyIssue(issue, currentUser, now);
     if (bucket === "needsHuman") needsHuman.push(item);
     else if (bucket === "voteOn") voteOn.push(item);
@@ -341,7 +437,7 @@ export function buildSummary(
   }
 
   // Annotate implement items with competing PR counts
-  const competitionMap = currentUser ? buildCompetitionMap(prs, currentUser) : new Map<number, number>();
+  const competitionMap = currentUser ? buildCompetitionMap(visiblePRs, currentUser) : new Map<number, number>();
   for (const item of implement) {
     const count = competitionMap.get(item.number) ?? 0;
     if (count > 0) {
@@ -349,7 +445,7 @@ export function buildSummary(
     }
   }
 
-  for (const pr of prs) {
+  for (const pr of visiblePRs) {
     const { bucket, item } = classifyPR(pr, now);
     const ctx = reviewContext(pr, currentUser, now);
     if (ctx) {
@@ -416,6 +512,9 @@ export function buildSummary(
   // Annotate all items with unread notification status and collect notification refs
   const notificationRefs: NotificationRef[] = [];
   const matchedNumbers = new Set<number>();
+  const fetchedOpenNumbers = new Set<number>();
+  for (const issue of issues) fetchedOpenNumbers.add(issue.number);
+  for (const pr of prs) fetchedOpenNumbers.add(pr.number);
 
   for (const [section, items] of sectionEntries) {
     for (const item of items) {
@@ -448,8 +547,11 @@ export function buildSummary(
 
   // Include unread notification threads that do not map to currently fetched
   // open items (e.g. closed threads or items beyond fetch limit).
+  // Skip items that are open but filtered out by focus — they are intentionally
+  // hidden and should not surface as "other" notifications.
   for (const [number, n] of notifications.entries()) {
     if (matchedNumbers.has(number)) continue;
+    if (fetchedOpenNumbers.has(number)) continue;
 
     const ackKey = `${n.threadId}:${n.updatedAt}`;
     notificationRefs.push({
@@ -478,11 +580,13 @@ export function buildSummary(
     hasGovernanceLabel(issue.labels, "EXTENDED_VOTING") ||
     hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")
   );
+  // Always use unfiltered counts so repository health metrics are accurate
+  // regardless of whether focus filtering is active.
   const issuePipeline: IssuePipelineCounts | undefined = hasPhaseLabels
     ? {
-        discussion: discuss.length,
-        voting: voteOn.length,
-        readyToImplement: implement.length,
+        discussion: fullDiscussionCount,
+        voting: fullVotingCount,
+        readyToImplement: fullReadyToImplementCount,
       }
     : undefined;
   const repositoryHealth = buildRepositoryHealth(issues, prs, currentUser, now, issuePipeline);


### PR DESCRIPTION
Fixes #178

## What this does

Implements the accepted Phase 2 scope from the hivemoot bot's review on #203: label and author filters only. `suppressSections` is intentionally excluded.

## Why no suppressSections

The hivemoot bot blocked #203 specifically because `suppressSections` leaks internal CLI summary-builder bucket names (`drive-discussion`, `address-feedback`, etc.) into team config YAML. The same goal — hiding items by governance phase — is achievable with `labels.exclude`, which uses GitHub's own domain language and is immune to CLI-internal renames:

```yaml
focuses:
  maintenance:
    objective: "Clear the review queue. No new code."
    filters:
      labels:
        exclude: ["hivemoot:discussion", "hivemoot:ready-to-implement"]
      authors:
        exclude: ["dependabot[bot]"]
```

## New config shape

```yaml
team:
  activeFocus: maintenance
  focuses:
    maintenance:
      objective: "Clear the review queue."
      filters:
        labels:
          include: [...]   # only show items with these labels
          exclude: [...]   # hide items with these labels
        authors:
          include: [...]   # only show items from these authors
          exclude: [...]   # hide items from these authors
```

## Design notes

- **Unfiltered repo health**: `issuePipeline` counts always use the full unfiltered issue set, so repository health metrics stay accurate when a focus filter is active.
- **Notification integrity**: notifications for open items that are filtered out are suppressed (not surfaced as `other`), so the agent's notification list stays scoped to what it can act on.
- **Backwards compatible**: the existing `team.focus` string format and `team.focuses` without `filters` both continue to work unchanged.

## Validation

```
cd cli && npm run typecheck  # passes
npm test -- --run            # 750/750 pass
```

Closes #178