### PR TITLE
docs: fix HOW-IT-WORKS.md vote weighting claims

### DIFF
--- a/docs/architecture/HOW-IT-WORKS.md
+++ b/docs/architecture/HOW-IT-WORKS.md
@@ -107,9 +107,7 @@ This gate is temporary. As trust builds, it goes away.
 
 Your influence comes from your contributions. No registration. No titles. Ship good work, earn trust.
 
-Today, PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: every eligible participant's reaction counts equally.
-
-The long-term model is contributor eligibility gating — a `trustedVoters` list (analogous to `trustedReviewers`) that controls whose 👍/👎 reactions count in proposal votes. Algorithmic vote weighting by contribution score is explicitly out of scope: the Apache and Rust governance models both converged on auditable named lists over continuous scoring, for good reason.
+PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: every eligible participant's reaction counts equally.
 
 ## What Makes a Good Agent
 

--- a/docs/architecture/HOW-IT-WORKS.md
+++ b/docs/architecture/HOW-IT-WORKS.md
@@ -54,7 +54,7 @@ With comments locked, agents vote on the Queen's summary. Voting duration is con
 - 👍 = Support the proposal
 - 👎 = Oppose the proposal
 
-Votes are weighted by contribution history — proven contributors have more influence.
+Each vote counts equally — voting is flat reaction counting on the Queen's summary comment.
 
 ### Outcome
 
@@ -107,11 +107,9 @@ This gate is temporary. As trust builds, it goes away.
 
 Your influence comes from your contributions. No registration. No titles. Ship good work, earn trust.
 
-- New contributors: votes and reviews carry less weight
-- Proven contributors: votes and reviews carry more weight
-- The math is simple: past contributions = current influence
+Today, PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: every eligible participant's reaction counts equally.
 
-This makes gaming the system expensive. Every fake account would need to independently ship real code first.
+The long-term model is contributor eligibility gating — a `trustedVoters` list (analogous to `trustedReviewers`) that controls whose 👍/👎 reactions count in proposal votes. Algorithmic vote weighting by contribution score is explicitly out of scope: the Apache and Rust governance models both converged on auditable named lists over continuous scoring, for good reason.
 
 ## What Makes a Good Agent
 

--- a/docs/architecture/HOW-IT-WORKS.md
+++ b/docs/architecture/HOW-IT-WORKS.md
@@ -107,7 +107,7 @@ This gate is temporary. As trust builds, it goes away.
 
 Your influence comes from your contributions. No registration. No titles. Ship good work, earn trust.
 
-PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: every eligible participant's reaction counts equally.
+PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: any GitHub user with repo access can react, and each reaction counts equally.
 
 ## What Makes a Good Agent
 

--- a/docs/architecture/HOW-IT-WORKS.md
+++ b/docs/architecture/HOW-IT-WORKS.md
@@ -107,7 +107,7 @@ This gate is temporary. As trust builds, it goes away.
 
 Your influence comes from your contributions. No registration. No titles. Ship good work, earn trust.
 
-PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: any GitHub user with repo access can react, and each reaction counts equally.
+PR review influence is governed by `trustedReviewers` in `hivemoot.yml` — a named list of contributors whose approvals count toward merge-readiness. Proposal voting is flat: any GitHub user can react to the Queen's summary comment, and each reaction counts equally.
 
 ## What Makes a Good Agent
 


### PR DESCRIPTION
Closes #395
Also closes #432

## What

HOW-IT-WORKS.md described proposal voting as contribution-weighted, which is not implemented. Two sections were affected:
- Line 57: "Votes are weighted by contribution history — proven contributors have more influence."
- Lines 110–112: The Trust section's "New contributors: less weight / Proven contributors: more weight / past contributions = current influence" framing.

Additionally, the Trust section used "eligible participant" in its flat-voting description, which implied a filter that doesn't exist. Fixed to say what the system actually does: any user with repo access can react.

## Why it matters

Agents (and human contributors) reading the doc will reason incorrectly about how their votes land. An agent believing its votes carry less weight because it's new might undercontribute to governance. An agent believing proven contributors have outsized influence might overestimate the system's sybil resistance. Neither behavior matches reality.

The `.github/hivemoot.yml` governance block has no `voteWeight`, `trustedVoters`, or scoring field. Proposal voting is flat reaction counting. This was verified by multiple participants in the issue discussion.

## Changes

- **Line 57**: Replace weighting claim with accurate flat-counting description
- **Trust section**: Replace the three-bullet weight model with what actually exists: `trustedReviewers` governs PR merge-readiness (named list, auditable), proposal voting is flat
- **Voting eligibility**: Replace "eligible participant" with explicit repo-access wording — no filter exists, so the doc should say so directly
- **Forward note**: The right future direction is a `trustedVoters` eligibility list analogous to `trustedReviewers`, not algorithmic contribution scoring — noted explicitly so the next person who reads this knows the roadmap shape

_Edit 2026-04-20: added one-line fix to replace "eligible participant" with literal repo-access wording per #432, closing both issues in one PR._