### PR TITLE
Fix token_usage validation rejecting missing nullable fields

### DIFF
--- a/apps/web/AGENT_HEALTH_CONTRACT.md
+++ b/apps/web/AGENT_HEALTH_CONTRACT.md
@@ -74,7 +74,7 @@ Each run report represents one completed run for one `agent_id` + `repo`.
 | `next_run_at` | string | ISO-8601, max 64 chars, between `now-5m` and `now+48h` |
 | `run_summary` | string | Markdown, ANSI-stripped, truncated to 4096 chars; empty after stripping rejected |
 | `trigger` | string | `scheduled` \| `mention` \| `manual` \| `task` |
-| `token_usage` | object or `null` | Exact nested schema below; when present as an object, required scalar fields must be present even if their value is `null` |
+| `token_usage` | object or `null` | Exact nested schema below; required numeric counters must be present, nullable fields may be omitted and are normalized to `null` |
 
 #### `token_usage` object shape
 
@@ -84,9 +84,9 @@ When `token_usage` is an object, these top-level fields are accepted:
 |---|---|---|
 | `input_tokens` | integer | Required, non-negative |
 | `output_tokens` | integer | Required, non-negative |
-| `cache_read_input_tokens` | integer or `null` | Required, non-negative when not `null` |
-| `cache_creation_input_tokens` | integer or `null` | Required, non-negative when not `null` |
-| `cost_usd` | number or `null` | Required, non-negative when not `null` |
+| `cache_read_input_tokens` | integer or `null` | Optional; non-negative when present, normalized to `null` when omitted |
+| `cache_creation_input_tokens` | integer or `null` | Optional; non-negative when present, normalized to `null` when omitted |
+| `cost_usd` | number or `null` | Optional; non-negative when present, normalized to `null` when omitted |
 | `num_turns` | integer | Required, non-negative |
 | `model_breakdown` | object or `null` | Optional; keys must match `[a-zA-Z0-9._:/-]+` |
 
@@ -96,9 +96,9 @@ When `token_usage` is an object, these top-level fields are accepted:
 |---|---|---|
 | `input_tokens` | integer | Required, non-negative |
 | `output_tokens` | integer | Required, non-negative |
-| `cache_read_input_tokens` | integer or `null` | Required, non-negative when not `null` |
-| `cache_creation_input_tokens` | integer or `null` | Required, non-negative when not `null` |
-| `cost_usd` | number or `null` | Required, non-negative when not `null` |
+| `cache_read_input_tokens` | integer or `null` | Optional; non-negative when present, normalized to `null` when omitted |
+| `cache_creation_input_tokens` | integer or `null` | Optional; non-negative when present, normalized to `null` when omitted |
+| `cost_usd` | number or `null` | Optional; non-negative when present, normalized to `null` when omitted |
 
 Validation behavior:
 - Maximum payload size: 10KB (checked via `Content-Length` and actual body bytes).

--- a/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -195,7 +195,7 @@ function TokenSummary({ tu }: { tu: TokenUsage }) {
           <span className="text-zinc-400">{tu.num_turns}</span>
           {" turns"}
         </span>
-        {tu.cost_usd !== null && (
+        {tu.cost_usd != null && (
           <span className="text-zinc-300">
             ${tu.cost_usd.toFixed(2)}
           </span>
@@ -217,7 +217,7 @@ function TokenSummary({ tu }: { tu: TokenUsage }) {
                 <span className="min-w-0 flex-1 truncate text-zinc-600">{modelId}</span>
                 <span>{formatTokens(mu.input_tokens)}in</span>
                 <span>{formatTokens(mu.output_tokens)}out</span>
-                {mu.cost_usd !== null && (
+                {mu.cost_usd != null && (
                   <span className="text-zinc-400">${mu.cost_usd.toFixed(2)}</span>
                 )}
               </div>

--- a/apps/web/src/server/agent-health-store.test.ts
+++ b/apps/web/src/server/agent-health-store.test.ts
@@ -585,6 +585,64 @@ describe("validateReport", () => {
     }
   });
 
+  it("accepts token_usage with omitted nullable fields and normalizes them to null", () => {
+    const result = validateReport({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 120,
+      consecutive_failures: 0,
+      token_usage: {
+        input_tokens: 300,
+        output_tokens: 60,
+        cache_read_input_tokens: 130,
+        num_turns: 2,
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.token_usage?.cache_creation_input_tokens).toBeNull();
+      expect(result.report.token_usage?.cost_usd).toBeNull();
+      expect(result.report.token_usage?.model_breakdown).toBeNull();
+    }
+  });
+
+  it("accepts model_breakdown with omitted nullable fields and normalizes them to null", () => {
+    const result = validateReport({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 180,
+      consecutive_failures: 0,
+      token_usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+        cost_usd: null,
+        num_turns: 1,
+        model_breakdown: {
+          "claude-sonnet-4-6": {
+            input_tokens: 100,
+            output_tokens: 50,
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.token_usage?.model_breakdown?.["claude-sonnet-4-6"]).toEqual({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+        cost_usd: null,
+      });
+    }
+  });
+
   it("accepts token_usage: null (unsupported provider)", () => {
     const result = validateReport({
       agent_id: "bee-1",
@@ -708,6 +766,32 @@ describe("validateReport", () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.message).toContain("model_breakdown");
+  });
+
+  it("rejects token_usage with model_breakdown missing required input_tokens", () => {
+    const result = validateReport({
+      agent_id: "bee-1",
+      repo: "hivemoot/sandbox",
+      run_id: "run-1",
+      outcome: "success",
+      duration_secs: 1,
+      consecutive_failures: 0,
+      token_usage: {
+        input_tokens: 100,
+        output_tokens: 10,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+        cost_usd: null,
+        num_turns: 1,
+        model_breakdown: {
+          "claude-sonnet-4-6": {
+            output_tokens: 10,
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("model_breakdown.claude-sonnet-4-6.input_tokens");
   });
 });
 

--- a/apps/web/src/server/agent-health-store.ts
+++ b/apps/web/src/server/agent-health-store.ts
@@ -408,19 +408,19 @@ export function validateReport(body: unknown): ValidationResult {
       return { ok: false, message: "token_usage.output_tokens must be a non-negative integer" };
     }
     if (
-      t.cache_read_input_tokens !== null
+      t.cache_read_input_tokens != null
       && (typeof t.cache_read_input_tokens !== "number" || !Number.isInteger(t.cache_read_input_tokens) || t.cache_read_input_tokens < 0)
     ) {
       return { ok: false, message: "token_usage.cache_read_input_tokens must be a non-negative integer or null" };
     }
     if (
-      t.cache_creation_input_tokens !== null
+      t.cache_creation_input_tokens != null
       && (typeof t.cache_creation_input_tokens !== "number" || !Number.isInteger(t.cache_creation_input_tokens) || t.cache_creation_input_tokens < 0)
     ) {
       return { ok: false, message: "token_usage.cache_creation_input_tokens must be a non-negative integer or null" };
     }
     if (
-      t.cost_usd !== null
+      t.cost_usd != null
       && (typeof t.cost_usd !== "number" || t.cost_usd < 0)
     ) {
       return { ok: false, message: "token_usage.cost_usd must be a non-negative number or null" };
@@ -441,26 +441,26 @@ export function validateReport(body: unknown): ValidationResult {
           return { ok: false, message: `token_usage.model_breakdown.${modelId} must be an object` };
         }
         const u = usage as Record<string, unknown>;
-        if (typeof u.input_tokens !== "number" || !Number.isInteger(u.input_tokens) || u.input_tokens < 0) {
+        if (u.input_tokens != null && (typeof u.input_tokens !== "number" || !Number.isInteger(u.input_tokens) || u.input_tokens < 0)) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.input_tokens must be a non-negative integer` };
         }
-        if (typeof u.output_tokens !== "number" || !Number.isInteger(u.output_tokens) || u.output_tokens < 0) {
+        if (u.output_tokens != null && (typeof u.output_tokens !== "number" || !Number.isInteger(u.output_tokens) || u.output_tokens < 0)) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.output_tokens must be a non-negative integer` };
         }
         if (
-          u.cache_read_input_tokens !== null
+          u.cache_read_input_tokens != null
           && (typeof u.cache_read_input_tokens !== "number" || !Number.isInteger(u.cache_read_input_tokens) || u.cache_read_input_tokens < 0)
         ) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.cache_read_input_tokens must be a non-negative integer or null` };
         }
         if (
-          u.cache_creation_input_tokens !== null
+          u.cache_creation_input_tokens != null
           && (typeof u.cache_creation_input_tokens !== "number" || !Number.isInteger(u.cache_creation_input_tokens) || u.cache_creation_input_tokens < 0)
         ) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.cache_creation_input_tokens must be a non-negative integer or null` };
         }
         if (
-          u.cost_usd !== null
+          u.cost_usd != null
           && (typeof u.cost_usd !== "number" || u.cost_usd < 0)
         ) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.cost_usd must be a non-negative number or null` };

--- a/apps/web/src/server/agent-health-store.ts
+++ b/apps/web/src/server/agent-health-store.ts
@@ -394,6 +394,8 @@ export function validateReport(body: unknown): ValidationResult {
     return { ok: false, message: "trigger must be one of: scheduled, mention, manual" };
   }
 
+  let normalizedTokenUsage: TokenUsage | null | undefined;
+
   if (obj.token_usage !== undefined && obj.token_usage !== null) {
     const tu = obj.token_usage;
     if (typeof tu !== "object" || Array.isArray(tu)) {
@@ -428,11 +430,13 @@ export function validateReport(body: unknown): ValidationResult {
     if (typeof t.num_turns !== "number" || !Number.isInteger(t.num_turns) || t.num_turns < 0) {
       return { ok: false, message: "token_usage.num_turns must be a non-negative integer" };
     }
+    let normalizedModelBreakdown: Record<string, ModelTokenUsage> | null = null;
     if (t.model_breakdown !== null && t.model_breakdown !== undefined) {
       if (typeof t.model_breakdown !== "object" || Array.isArray(t.model_breakdown)) {
         return { ok: false, message: "token_usage.model_breakdown must be an object or null" };
       }
       const mb = t.model_breakdown as Record<string, unknown>;
+      normalizedModelBreakdown = {};
       for (const [modelId, usage] of Object.entries(mb)) {
         if (!MODEL_PATTERN.test(modelId)) {
           return { ok: false, message: `token_usage.model_breakdown key must match [a-zA-Z0-9._:/-]+ (got: ${modelId})` };
@@ -441,10 +445,10 @@ export function validateReport(body: unknown): ValidationResult {
           return { ok: false, message: `token_usage.model_breakdown.${modelId} must be an object` };
         }
         const u = usage as Record<string, unknown>;
-        if (u.input_tokens != null && (typeof u.input_tokens !== "number" || !Number.isInteger(u.input_tokens) || u.input_tokens < 0)) {
+        if (typeof u.input_tokens !== "number" || !Number.isInteger(u.input_tokens) || u.input_tokens < 0) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.input_tokens must be a non-negative integer` };
         }
-        if (u.output_tokens != null && (typeof u.output_tokens !== "number" || !Number.isInteger(u.output_tokens) || u.output_tokens < 0)) {
+        if (typeof u.output_tokens !== "number" || !Number.isInteger(u.output_tokens) || u.output_tokens < 0) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.output_tokens must be a non-negative integer` };
         }
         if (
@@ -465,8 +469,26 @@ export function validateReport(body: unknown): ValidationResult {
         ) {
           return { ok: false, message: `token_usage.model_breakdown.${modelId}.cost_usd must be a non-negative number or null` };
         }
+        normalizedModelBreakdown[modelId] = {
+          input_tokens: u.input_tokens,
+          output_tokens: u.output_tokens,
+          cache_read_input_tokens: typeof u.cache_read_input_tokens === "number" ? u.cache_read_input_tokens : null,
+          cache_creation_input_tokens: typeof u.cache_creation_input_tokens === "number" ? u.cache_creation_input_tokens : null,
+          cost_usd: typeof u.cost_usd === "number" ? u.cost_usd : null,
+        };
       }
     }
+    normalizedTokenUsage = {
+      input_tokens: t.input_tokens,
+      output_tokens: t.output_tokens,
+      cache_read_input_tokens: typeof t.cache_read_input_tokens === "number" ? t.cache_read_input_tokens : null,
+      cache_creation_input_tokens: typeof t.cache_creation_input_tokens === "number" ? t.cache_creation_input_tokens : null,
+      cost_usd: typeof t.cost_usd === "number" ? t.cost_usd : null,
+      num_turns: t.num_turns,
+      model_breakdown: normalizedModelBreakdown,
+    };
+  } else if (obj.token_usage === null) {
+    normalizedTokenUsage = null;
   }
 
   const report: HealthReport = {
@@ -485,7 +507,7 @@ export function validateReport(body: unknown): ValidationResult {
   if (typeof obj.next_run_at === "string") report.next_run_at = obj.next_run_at;
   if (typeof obj.run_summary === "string") report.run_summary = sanitizeRunSummary(obj.run_summary);
   if (typeof obj.trigger === "string") report.trigger = obj.trigger as TriggerType;
-  if (obj.token_usage !== undefined) report.token_usage = obj.token_usage as TokenUsage | null;
+  if (normalizedTokenUsage !== undefined) report.token_usage = normalizedTokenUsage;
 
   return { ok: true, report };
 }


### PR DESCRIPTION
## What

Normalize nullable `token_usage` fields on ingest without widening the per-model contract.

Related hotfix tracking: `hivemoot/hivemoot-agent#447`

## Why

Current agent health ingestion drifted in two places:

- Codex omits nullable `token_usage` fields like `cache_creation_input_tokens` and `cost_usd`
- The web validator treated those omissions as invalid and returned 400s

This PR fixes the web side by accepting omitted nullable fields, normalizing them to explicit `null` before storage, and preserving strict validation for required per-model counters so empty `model_breakdown` entries still fail until the companion agent extractor fix lands.

## What it looks like

| Scenario | Before | After |
|---|---|---|
| Codex payload omits `cache_creation_input_tokens` / `cost_usd` | `400 Bad Request` | `200 OK`, stored as explicit `null` |
| `model_breakdown` entry omits nullable cost/cache fields but includes `input_tokens` / `output_tokens` | `400 Bad Request` | `200 OK`, omitted nullable fields normalized to `null` |
| `model_breakdown` entry is `{}` | `400 Bad Request` | `400 Bad Request` (unchanged) |
| Dashboard renders normalized `cost_usd: null` | could crash on `undefined.toFixed(...)` if bad data got through | safely skips cost output |

## Test plan

- [x] `pnpm exec vitest run src/server/agent-health-store.test.ts`
- [x] `pnpm exec vitest run src/app/api/agent-health/route.test.ts`
- [x] Direct runtime repro: Codex-style omitted nullable fields are accepted and normalized to `null`
- [x] Direct runtime repro: empty `model_breakdown` entries are still rejected
- [ ] `pnpm exec tsc --noEmit` (repo has pre-existing unrelated type errors in `MarkdownContent.tsx` and missing module type declarations)

## Companion work

- `hivemoot/hivemoot-agent#446` still needs to land for Claude camelCase `modelUsage` extraction
- This PR intentionally does **not** accept empty per-model breakdown objects from the broken Claude extractor
