### PR TITLE
Polish health dashboard display

### DIFF
--- a/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -157,6 +157,16 @@ function TriggerBadge({ trigger }: { trigger: TriggerType }) {
 // Helpers: token usage summary
 // ---------------------------------------------------------------------------
 
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  if (m < 60) return s > 0 ? `${m}m ${s}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h ${rm}m` : `${h}h`;
+}
+
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
@@ -171,52 +181,86 @@ function cacheHitRate(tu: TokenUsage): string | null {
   return `${Math.round((read / total) * 100)}%`;
 }
 
+function TokenIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-3.5 w-3.5"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <ellipse cx="8" cy="10" rx="6" ry="2.5" />
+      <ellipse cx="8" cy="6" rx="6" ry="2.5" />
+      <path d="M2 6v4" />
+      <path d="M14 6v4" />
+    </svg>
+  );
+}
+
+function primaryModel(tu: TokenUsage): string | null {
+  if (!tu.model_breakdown) return null;
+  const entries = Object.entries(tu.model_breakdown);
+  if (entries.length === 0) return null;
+  // Pick model with the most output tokens (the main worker model)
+  entries.sort(([, a], [, b]) => (b.output_tokens ?? 0) - (a.output_tokens ?? 0));
+  return entries[0][0];
+}
+
 function TokenSummary({ tu }: { tu: TokenUsage }) {
   const hitRate = cacheHitRate(tu);
   const breakdown = tu.model_breakdown ? Object.entries(tu.model_breakdown) : [];
+  const model = primaryModel(tu);
 
   return (
     <div className="mt-2 space-y-1.5 text-xs text-zinc-500">
+      {model && (
+        <p className="font-mono text-[11px] text-zinc-500">{model}</p>
+      )}
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-        <span>
-          <span className="text-zinc-400">{formatTokens(tu.input_tokens)}</span>
-          {" in"}
-        </span>
-        <span>
-          <span className="text-zinc-400">{formatTokens(tu.output_tokens)}</span>
-          {" out"}
-        </span>
-        {hitRate && (
-          <span>
-            cache <span className="text-green-400/80">{hitRate}</span>
-          </span>
-        )}
-        <span>
-          <span className="text-zinc-400">{tu.num_turns}</span>
-          {" turns"}
-        </span>
         {tu.cost_usd != null && (
           <span className="text-zinc-300">
             ${tu.cost_usd.toFixed(2)}
           </span>
         )}
+        <span className="inline-flex items-center gap-1.5" title="Token usage: input / output">
+          <TokenIcon className="h-3 w-3 text-zinc-600" />
+          <span className="text-zinc-400">{formatTokens(tu.input_tokens)}</span>
+          <span className="text-zinc-600">/</span>
+          <span className="text-zinc-400">{formatTokens(tu.output_tokens)}</span>
+        </span>
+        {hitRate && (
+          <span title="Percentage of input tokens served from prompt cache">
+            <span className="text-green-400/80">{hitRate}</span>
+            {" cached"}
+          </span>
+        )}
+        {tu.num_turns > 1 && (
+          <span title="Number of tool-use turns (agentic loops)">
+            <span className="text-zinc-400">{tu.num_turns}</span>
+            {" turns"}
+          </span>
+        )}
       </div>
-      {breakdown.length > 0 && (
+      {breakdown.length > 1 && (
         <details className="group">
           <summary className="cursor-pointer list-none text-zinc-600 hover:text-zinc-500">
             <span className="inline-flex items-center gap-1">
               <svg className="h-2.5 w-2.5 transition-transform group-open:rotate-90" viewBox="0 0 8 8" fill="currentColor" aria-hidden="true">
                 <path d="M2 1l4 3-4 3V1z" />
               </svg>
-              model breakdown
+              {breakdown.length} models
             </span>
           </summary>
           <div className="mt-1.5 space-y-0.5 pl-4">
             {breakdown.map(([modelId, mu]) => (
               <div key={modelId} className="flex items-center gap-2 font-mono text-[10px]">
                 <span className="min-w-0 flex-1 truncate text-zinc-600">{modelId}</span>
-                <span>{formatTokens(mu.input_tokens)}in</span>
-                <span>{formatTokens(mu.output_tokens)}out</span>
+                <span>{formatTokens(mu.input_tokens ?? 0)} in</span>
+                <span>{formatTokens(mu.output_tokens ?? 0)} out</span>
                 {mu.cost_usd != null && (
                   <span className="text-zinc-400">${mu.cost_usd.toFixed(2)}</span>
                 )}
@@ -465,7 +509,7 @@ export default function AgentHealthDashboard() {
                         {entry.run_id}
                         {entry.duration_secs !== undefined && (
                           <span className="ml-2 text-zinc-500">
-                            {entry.duration_secs}s
+                            {formatDuration(entry.duration_secs)}
                           </span>
                         )}
                       </p>
@@ -474,7 +518,7 @@ export default function AgentHealthDashboard() {
                     {entry.error && (
                       <p className="mt-0.5 text-sm text-red-400">{entry.error}</p>
                     )}
-                    {entry.exit_code !== undefined && (
+                    {entry.exit_code !== undefined && entry.exit_code !== 0 && (
                       <p className="text-xs text-zinc-500">
                         exit code {entry.exit_code}
                       </p>


### PR DESCRIPTION
## Summary

- Format run duration as human-readable (`9m 2s`, `1h 30m`) instead of raw seconds (`542s`)
- Add token icon to visually mark the token stats section
- Show tokens as compact `62 / 26K` with icon instead of `62 in  26K out`
- Show model name (`claude-sonnet-4-6`) prominently above stats instead of hiding in collapsible
- Change `cache 98%` to `98% cached` — clearer what's being cached
- Move cost (`$1.80`) to front of stats line
- Hide `exit code 0` on successful runs
- Hide `1 turns` — only show turn count when > 1
- Show `2 models` instead of `model breakdown` in collapsible (only when multiple models)

## What it looks like

| Element | Before | After |
|---|---|---|
| Duration | `542s` | `9m 2s` |
| Model | Hidden in collapsible | `claude-sonnet-4-6` above stats |
| Tokens | `420K in  4K out` | token-icon `420K / 4K` |
| Cache | `cache 98%` | `98% cached` |
| Cost | End of line | Front of line |
| Exit code 0 | `exit code 0` | (hidden) |
| Single turn | `1 turns` | (hidden) |

## Test plan

- [x] Verified locally with demo data
- [x] No TypeScript errors introduced