### PR TITLE
feat(cli): auto-bump version on publish — remove per-PR bump requirement

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -65,6 +65,7 @@ jobs:
         run: npm ci
 
       - name: Auto-bump version if needed
+        if: github.event_name == 'push'
         run: |
           # Skip if this commit is itself an auto-bump (prevents trigger loop)
           if git log -1 --format=%s | grep -q "^chore(cli): auto-bump version"; then

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,6 +43,8 @@ jobs:
     needs: typecheck-test-build
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: cli
@@ -64,6 +66,26 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Auto-bump version if needed
+        run: |
+          # Skip if this commit is itself an auto-bump (prevents trigger loop)
+          if git log -1 --format=%s | grep -q "^chore(cli): auto-bump version"; then
+            echo "Skipping: triggered by auto-bump commit"
+            exit 0
+          fi
+          CURRENT=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NPM_LATEST=$(npm view "${PACKAGE_NAME}" version 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT" = "$NPM_LATEST" ]; then
+            npm version patch --no-git-tag-version
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package.json package-lock.json
+            git commit -m "chore(cli): auto-bump version to $(node -p "require('./package.json').version")"
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi
 
       - name: Check if version is already published
         id: check

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -55,10 +55,9 @@ jobs:
         working-directory: cli
 
     steps:
-      - name: Checkout latest main
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -117,18 +116,22 @@ jobs:
 
       - name: Push auto-bump commit
         if: steps.auto_bump.outputs.bumped == 'true'
+        id: push_bump
         working-directory: .
         run: |
           if git push origin HEAD:main; then
-            exit 0
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            # main moved while we were building — our tested build cannot be
+            # safely published from a commit that predates the current tip.
+            # The next merge-triggered job will include these changes and
+            # publish them from a freshly tested state.
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           fi
-          # Another commit landed while we were building — rebase and retry.
-          git fetch origin main
-          git rebase origin/main
-          git push origin HEAD:main
 
       - name: Check if version is already published
         id: check
+        if: steps.auto_bump.outputs.bumped != 'true' || steps.push_bump.outputs.pushed == 'true'
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           PACKAGE_NAME=$(node -p "require('./package.json').name")

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -88,12 +88,10 @@ jobs:
           fi
 
       - name: Build
-        if: steps.auto_bump.outputs.bumped != 'true'
         run: npm run build
 
       - name: Check if version is already published
         id: check
-        if: steps.auto_bump.outputs.bumped != 'true'
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           PACKAGE_NAME=$(node -p "require('./package.json').name")
@@ -104,7 +102,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: steps.auto_bump.outputs.bumped != 'true' && steps.check.outputs.published == 'false'
+        if: steps.check.outputs.published == 'false'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -65,6 +65,7 @@ jobs:
         run: npm ci
 
       - name: Auto-bump version if needed
+        id: auto_bump
         if: github.event_name == 'push'
         run: |
           # Skip if this commit is itself an auto-bump (prevents trigger loop)
@@ -83,13 +84,16 @@ jobs:
             git commit -m "chore(cli): auto-bump version to $(node -p "require('./package.json').version")"
             git pull --rebase origin main
             git push origin HEAD:main
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build
+        if: steps.auto_bump.outputs.bumped != 'true'
         run: npm run build
 
       - name: Check if version is already published
         id: check
+        if: steps.auto_bump.outputs.bumped != 'true'
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           PACKAGE_NAME=$(node -p "require('./package.json').name")
@@ -100,7 +104,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: steps.check.outputs.published == 'false'
+        if: steps.auto_bump.outputs.bumped != 'true' && steps.check.outputs.published == 'false'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -64,9 +64,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
       - name: Auto-bump version if needed
         run: |
           # Skip if this commit is itself an auto-bump (prevents trigger loop)
@@ -86,6 +83,9 @@ jobs:
             git pull --rebase origin main
             git push origin HEAD:main
           fi
+
+      - name: Build
+        run: npm run build
 
       - name: Check if version is already published
         id: check

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,9 @@ on:
     paths: [cli/**]
   pull_request:
     branches: [main]
-    paths: [cli/**]
+    paths:
+      - cli/**
+      - .github/workflows/cli.yml
   workflow_dispatch:
 
 jobs:
@@ -43,6 +45,9 @@ jobs:
     needs: typecheck-test-build
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: cli-publish
+      cancel-in-progress: false
     permissions:
       contents: write
     defaults:
@@ -50,8 +55,11 @@ jobs:
         working-directory: cli
 
     steps:
-      - name: Checkout
+      - name: Checkout latest main
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,29 +74,58 @@ jobs:
 
       - name: Auto-bump version if needed
         id: auto_bump
-        if: github.event_name == 'push'
+        # Skip if this push was the auto-bump commit itself — prevents an infinite
+        # trigger loop where the bump push re-queues a new publish job that bumps again.
+        if: "github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(cli): auto-bump version')"
         run: |
-          # Skip if this commit is itself an auto-bump (prevents trigger loop)
-          if git log -1 --format=%s | grep -q "^chore(cli): auto-bump version"; then
-            echo "Skipping: triggered by auto-bump commit"
-            exit 0
-          fi
           CURRENT=$(node -p "require('./package.json').version")
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           NPM_LATEST=$(npm view "${PACKAGE_NAME}" version 2>/dev/null || echo "0.0.0")
-          if [ "$CURRENT" = "$NPM_LATEST" ]; then
-            npm version patch --no-git-tag-version
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add package.json package-lock.json
-            git commit -m "chore(cli): auto-bump version to $(node -p "require('./package.json').version")"
-            git pull --rebase origin main
-            git push origin HEAD:main
-            echo "bumped=true" >> "$GITHUB_OUTPUT"
+
+          # Compute next patch version. If CURRENT is already ahead of NPM_LATEST
+          # (e.g. a manual bump in a previous PR), skip auto-bump — publish will use
+          # whatever version is already in package.json.
+          NEXT_VERSION=$(node -e '
+            const current = process.argv[1];
+            const latest = process.argv[2];
+            const parse = (v) => v.split(".").map((n) => parseInt(n, 10));
+            const isValid = (p) => p.length === 3 && p.every((n) => Number.isInteger(n) && n >= 0);
+            const compare = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+            const c = parse(current), l = parse(latest);
+            if (!isValid(c) || !isValid(l)) {
+              throw new Error("Unsupported semver: current=" + current + " latest=" + latest);
+            }
+            if (compare(c, l) > 0) { process.exit(0); }
+            l[2] += 1;
+            process.stdout.write(l.join("."));
+          ' "$CURRENT" "$NPM_LATEST")
+
+          if [ -z "$NEXT_VERSION" ]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          npm version "$NEXT_VERSION" --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(cli): auto-bump version to $(node -p "require('./package.json').version")"
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: npm run build
+
+      - name: Push auto-bump commit
+        if: steps.auto_bump.outputs.bumped == 'true'
+        working-directory: .
+        run: |
+          if git push origin HEAD:main; then
+            exit 0
+          fi
+          # Another commit landed while we were building — rebase and retry.
+          git fetch origin main
+          git rebase origin/main
+          git push origin HEAD:main
 
       - name: Check if version is already published
         id: check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
 - **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
 - **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
-- **If you change `cli/**`, bump CLI version files in the same PR**: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.
+- **If you change `cli/**`, do not bump `cli/package.json`**: the publish workflow auto-bumps the patch version on merge. Bumping in the PR breaks automerge (version files are in `denyPaths`).
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 - Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
 - Include a before/after example showing the outcome (the PR template will guide you)
 - Include tests when relevant
-- If you change anything under `cli/**`, bump the CLI package version in both `cli/package.json` and `cli/package-lock.json` in the same PR so the npm publish job can release it.
+- If you change anything under `cli/**`, do not bump the CLI package version in the PR. The publish workflow auto-bumps the patch version on merge. Including a version bump in the PR breaks automerge.
 
 ## Fork-First Publishing
 


### PR DESCRIPTION
Closes #406

## What changed

**`cli.yml`**: The `publish` job now has an "Auto-bump version if needed" step that runs before the existing published-version check. If the version in `package.json` matches the latest version on npm (meaning the merged PR didn't include a manual bump), it patches the version via `npm version patch`, commits, and pushes back to main before proceeding to publish.

A commit-message guard (`chore(cli): auto-bump version`) prevents the auto-bump commit from triggering a second auto-bump when the workflow re-fires. The existing `Check if version is already published` step is preserved as an idempotency gate, so concurrent runs don't double-publish.

`contents: write` permission is added to the `publish` job so it can push the version-bump commit.

**`AGENTS.md`** and **`CONTRIBUTING.md`**: The per-PR version bump requirement is replaced with an explicit instruction *not* to bump — including the reason (version files are in `denyPaths`, which permanently blocks automerge for CLI PRs).

## Before / After

**Before**: Every CLI PR had to bump `cli/package.json` + `cli/package-lock.json`. Those files are in `automerge.denyPaths`, so CLI PRs with new commands were permanently blocked from automerge regardless of approvals or CI status.

**After**: CLI PRs make no version changes. On merge, `cli.yml` auto-bumps the patch version and publishes. `package.json` never appears in feature PR diffs, so denyPaths doesn't apply.

## Race condition handling

Two concurrent CLI merges within a single CI cycle (~3 min): the second auto-bump commit would `git pull --rebase origin main` before pushing, so it picks up the first bump and then increments again. The published-version check ensures only one publish succeeds for each version. Both jobs completing independently for different versions is the expected steady state.

## Validation

- A CLI PR with no `package.json` change passes `automerge.denyPaths` → qualifies for automerge
- On merge: publish job auto-bumps, `npm view @hivemoot-dev/cli version` reflects the new version within ~10 min
- Auto-bump commit re-triggers the workflow → commit-message guard fires → auto-bump step exits early → published-version check sees the version is already there → publish skipped