### PR TITLE
fix(web): return structured BYOK 500s

### DIFF
--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -209,4 +209,20 @@ describe("POST /api/byok/config", () => {
       expect.anything(),
     );
   });
+
+  it("returns structured 500 when persistence throws", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Failed to save BYOK configuration. Please try again.");
+  });
 });

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -33,49 +33,61 @@ export async function POST(request: NextRequest) {
   const { provider, model, apiKey } = body;
   const installationId = auth.session.installationId;
 
-  if (!provider || !model || !apiKey) {
+  try {
+    if (!provider || !model || !apiKey) {
+      return byokError(
+        BYOK_ERROR.MISSING_FIELDS,
+        "Missing required fields: provider, model, apiKey",
+        400,
+      );
+    }
+
+    // Validate the key with the provider
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
+    );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-config] Failed to save BYOK config", {
+      installationId,
+      error: err,
+    });
     return byokError(
-      BYOK_ERROR.MISSING_FIELDS,
-      "Missing required fields: provider, model, apiKey",
-      400,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Failed to save BYOK configuration. Please try again.",
+      500,
     );
   }
-
-  // Validate the key with the provider
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
-    );
-  }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -102,4 +102,16 @@ describe("POST /api/byok/revoke", () => {
     expect(body.code).toBe(BYOK_ERROR.NOT_CONFIGURED);
     expect(body.message).toBe("BYOK is not configured");
   });
+
+  it("returns structured 500 when persistence throws", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({});
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Failed to revoke BYOK configuration. Please try again.");
+  });
 });

--- a/apps/web/src/app/api/byok/revoke/route.ts
+++ b/apps/web/src/app/api/byok/revoke/route.ts
@@ -16,28 +16,40 @@ export async function POST(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const existing = await getByokEnvelope(installationId, auth.redis);
-  if (!existing) {
-    return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+  try {
+    const existing = await getByokEnvelope(installationId, auth.redis);
+    if (!existing) {
+      return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+    }
+
+    // Clear ciphertext fields, keep metadata for audit
+    const revoked = {
+      ...existing,
+      status: "revoked" as const,
+      ciphertext: "",
+      iv: "",
+      tag: "",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+    };
+
+    await setByokEnvelope(installationId, revoked, auth.redis);
+
+    return NextResponse.json({
+      status: "revoked",
+      provider: revoked.provider,
+      model: revoked.model,
+      updatedAt: revoked.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-revoke] Failed to revoke BYOK config", {
+      installationId,
+      error: err,
+    });
+    return byokError(
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Failed to revoke BYOK configuration. Please try again.",
+      500,
+    );
   }
-
-  // Clear ciphertext fields, keep metadata for audit
-  const revoked = {
-    ...existing,
-    status: "revoked" as const,
-    ciphertext: "",
-    iv: "",
-    tag: "",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-  };
-
-  await setByokEnvelope(installationId, revoked, auth.redis);
-
-  return NextResponse.json({
-    status: "revoked",
-    provider: revoked.provider,
-    model: revoked.model,
-    updatedAt: revoked.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -160,4 +160,20 @@ describe("POST /api/byok/rotate", () => {
       expect.anything(),
     );
   });
+
+  it("returns structured 500 when persistence throws", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-new-key5678",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Failed to rotate BYOK configuration. Please try again.");
+  });
 });

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -34,48 +34,60 @@ export async function POST(request: NextRequest) {
   const { provider, model, apiKey } = body;
   const installationId = auth.session.installationId;
 
-  if (!provider || !model || !apiKey) {
+  try {
+    if (!provider || !model || !apiKey) {
+      return byokError(
+        BYOK_ERROR.MISSING_FIELDS,
+        "Missing required fields: provider, model, apiKey",
+        400,
+      );
+    }
+
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
+    );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-rotate] Failed to rotate BYOK config", {
+      installationId,
+      error: err,
+    });
     return byokError(
-      BYOK_ERROR.MISSING_FIELDS,
-      "Missing required fields: provider, model, apiKey",
-      400,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Failed to rotate BYOK configuration. Please try again.",
+      500,
     );
   }
-
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
-    );
-  }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -121,4 +121,16 @@ describe("GET /api/byok/status", () => {
       expect.anything(),
     );
   });
+
+  it("returns structured 500 when envelope lookup throws", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis down"));
+
+    const req = makeRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.SERVER_MISCONFIGURATION);
+    expect(body.message).toBe("Failed to load BYOK configuration. Please try again.");
+  });
 });

--- a/apps/web/src/app/api/byok/status/route.ts
+++ b/apps/web/src/app/api/byok/status/route.ts
@@ -16,33 +16,45 @@ export async function GET(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const envelope = await getByokEnvelope(installationId, auth.redis);
-  if (!envelope) {
+  try {
+    const envelope = await getByokEnvelope(installationId, auth.redis);
+    if (!envelope) {
+      return byokError(
+        BYOK_ERROR.NOT_CONFIGURED,
+        "BYOK is not configured",
+        404,
+      );
+    }
+
+    if (envelope.status === "revoked") {
+      return byokError(
+        BYOK_ERROR.REVOKED,
+        "BYOK configuration has been revoked",
+        409,
+        {
+          status: envelope.status,
+          provider: envelope.provider,
+          model: envelope.model,
+          updatedAt: envelope.updatedAt,
+        },
+      );
+    }
+
+    return NextResponse.json({
+      status: envelope.status,
+      provider: envelope.provider,
+      model: envelope.model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (err) {
+    console.error("[byok-status] Failed to load BYOK config", {
+      installationId,
+      error: err,
+    });
     return byokError(
-      BYOK_ERROR.NOT_CONFIGURED,
-      "BYOK is not configured",
-      404,
+      BYOK_ERROR.SERVER_MISCONFIGURATION,
+      "Failed to load BYOK configuration. Please try again.",
+      500,
     );
   }
-
-  if (envelope.status === "revoked") {
-    return byokError(
-      BYOK_ERROR.REVOKED,
-      "BYOK configuration has been revoked",
-      409,
-      {
-        status: envelope.status,
-        provider: envelope.provider,
-        model: envelope.model,
-        updatedAt: envelope.updatedAt,
-      },
-    );
-  }
-
-  return NextResponse.json({
-    status: envelope.status,
-    provider: envelope.provider,
-    model: envelope.model,
-    updatedAt: envelope.updatedAt,
-  });
 }


### PR DESCRIPTION
Fixes #355

## What changed
- wrap `POST /api/byok/config` and `POST /api/byok/rotate` in route-level catch blocks so unexpected provider or Redis failures return structured BYOK JSON instead of framework HTML 500s
- wrap `GET /api/byok/status` and `POST /api/byok/revoke` in the same structured failure handling
- add regression tests for the new structured 500 responses in all four routes

## Why
A first-time setup failure in BYOK currently degrades into an HTML error page for several routes. That forces the client onto the generic failure path and hides the actionable BYOK error contract from users. This keeps the failure JSON-shaped even when the underlying store or provider call throws.

## Verification
- `git push --dry-run origin HEAD`
- attempted `npm ci` in `apps/web`, but dependency installation stalled in this environment before completion
- attempted focused Vitest run for the four BYOK route files, but `vitest` was unavailable because install did not complete
