### PR TITLE
feat(ci): implement auto-revert workflow for main CI failures

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -107,17 +107,17 @@ jobs:
             --head "$BRANCH" \
             --base main \
             --title "revert: auto-revert $short ($WORKFLOW_NAME CI failure)" \
-            --body "$BODY" \
-            --label "hivemoot:automerge")
+            --body "$BODY")
 
           echo "revert_pr_url=$REVERT_PR_URL" >> "$GITHUB_OUTPUT"
           echo "needs_human=false" >> "$GITHUB_OUTPUT"
 
-      - name: Escalate if revert PR blocked by automerge config
+      - name: Wait for CI and merge revert PR
         if: >
           steps.idempotency.outputs.skip != 'true' &&
           steps.revert.outputs.needs_human != 'true' &&
           steps.revert.outputs.revert_pr_url != ''
+        id: merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -127,33 +127,101 @@ jobs:
           PR_URL: ${{ steps.revert.outputs.pr_url }}
           REVERT_PR_URL: ${{ steps.revert.outputs.revert_pr_url }}
         run: |
-          # Extract PR number from URL (e.g. https://github.com/org/repo/pull/123 → 123).
           REVERT_NUMBER="${REVERT_PR_URL##*/}"
           short="${FAILING_SHA:0:7}"
 
-          # Check if the revert diff touches automerge denyPaths.
-          # If so, the revert PR will not auto-merge and needs human attention.
-          FILES=$(gh pr diff \
-            --repo "$GITHUB_REPOSITORY" \
-            "$REVERT_NUMBER" \
-            --name-only 2>/dev/null || echo "")
+          # Get the HEAD SHA of the revert branch for check-run queries.
+          REVERT_SHA=$(gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$REVERT_NUMBER" \
+            --jq '.head.sha' 2>/dev/null || echo "")
 
-          BLOCKED=false
-          BLOCKED_FILE=""
-          while IFS= read -r file; do
-            case "$file" in
-              .github/*|*/package.json|*/package-lock.json|*.lock|*/pnpm-lock.yaml|*/go.sum|*/bun.lockb|*/go.work.sum)
-                BLOCKED=true
-                BLOCKED_FILE="$file"
-                break
-                ;;
-            esac
-          done <<< "$FILES"
+          if [ -z "$REVERT_SHA" ]; then
+            echo "merge_result=escalate" >> "$GITHUB_OUTPUT"
+            echo "merge_cause=could not resolve revert PR head SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          [ "$BLOCKED" = "false" ] && exit 0
+          # Poll CI checks on the revert branch (up to 15 min).
+          # A revert is a near-exact inverse of the failing commit, so CI should
+          # complete quickly. If checks are absent (docs-only revert), proceed to merge.
+          TIMEOUT=900
+          ELAPSED=0
+          INTERVAL=30
+          CI_RESULT="pending"
+
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            CHECK_DATA=$(gh api \
+              "repos/$GITHUB_REPOSITORY/commits/$REVERT_SHA/check-runs" \
+              --jq '.check_runs' 2>/dev/null || echo "[]")
+
+            TOTAL=$(echo "$CHECK_DATA" | jq 'length')
+            COMPLETED=$(echo "$CHECK_DATA" | jq '[.[] | select(.status == "completed")] | length')
+            FAILED=$(echo "$CHECK_DATA" | jq '[.[] | select(.status == "completed" and (.conclusion | IN("failure","cancelled","timed_out","action_required","startup_failure")))] | length')
+
+            if [ "$TOTAL" -eq 0 ]; then
+              # No checks configured — safe to merge immediately.
+              CI_RESULT="success"
+              break
+            fi
+
+            if [ "$FAILED" -gt 0 ]; then
+              CI_RESULT="failure"
+              break
+            fi
+
+            if [ "$COMPLETED" -eq "$TOTAL" ]; then
+              CI_RESULT="success"
+              break
+            fi
+
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+
+          if [ "$CI_RESULT" = "failure" ]; then
+            echo "merge_result=escalate" >> "$GITHUB_OUTPUT"
+            echo "merge_cause=CI failed on revert branch — the revert itself may be unsafe" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$CI_RESULT" = "pending" ]; then
+            echo "merge_result=escalate" >> "$GITHUB_OUTPUT"
+            echo "merge_cause=CI checks timed out after ${TIMEOUT}s — revert branch needs manual review" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # CI passed — merge the revert PR directly.
+          if gh pr merge "$REVERT_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --merge \
+              --subject "revert: auto-revert $short ($WORKFLOW_NAME CI failure)" 2>/dev/null; then
+            echo "merge_result=merged" >> "$GITHUB_OUTPUT"
+          else
+            # Merge blocked — most likely branch protection requires reviews.
+            # The revert PR remains open; escalate so a human can merge it.
+            echo "merge_result=escalate" >> "$GITHUB_OUTPUT"
+            echo "merge_cause=merge blocked by branch protection — manual merge required" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Escalate if merge did not complete
+        if: >
+          steps.idempotency.outputs.skip != 'true' &&
+          steps.revert.outputs.needs_human != 'true' &&
+          steps.merge.outputs.merge_result == 'escalate'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+          PR_NUMBER: ${{ steps.revert.outputs.pr_number }}
+          PR_URL: ${{ steps.revert.outputs.pr_url }}
+          REVERT_PR_URL: ${{ steps.revert.outputs.revert_pr_url }}
+          MERGE_CAUSE: ${{ steps.merge.outputs.merge_cause }}
+        run: |
+          short="${FAILING_SHA:0:7}"
+          REVERT_NUMBER="${REVERT_PR_URL##*/}"
 
           # Idempotency: skip if an urgent issue for this SHA already exists.
-          # Uses REST API (not text search) to avoid indexing lag from concurrent runs.
           existing_issue=$(gh api \
             "repos/$GITHUB_REPOSITORY/issues?labels=hivemoot:needs-human&state=open&per_page=100" \
             --jq "[.[] | select(.title | contains(\"$short\"))] | .[0].number // empty" \
@@ -163,7 +231,6 @@ jobs:
             exit 0
           fi
 
-          # Revert PR exists but cannot auto-merge — escalate so a human can merge it.
           TRUSTED=$(python3 - <<'PYEOF' 2>/dev/null || true
 import yaml
 try:
@@ -176,8 +243,8 @@ except Exception:
 PYEOF
 )
 
-          BODY="**Revert PR created but cannot auto-merge — manual merge required.**"
-          BODY+=$'\n\nThe revert diff includes `'"$BLOCKED_FILE"'`, which is in automerge `denyPaths`.'
+          BODY="**Revert PR #$REVERT_NUMBER created but not auto-merged — manual merge required.**"
+          BODY+=$'\n\n**Reason:** '"$MERGE_CAUSE"
           BODY+=$'\n\n**Action required:** review and merge '"$REVERT_PR_URL"$' manually.\n'
           BODY+=$'\n- **Failing SHA:** `'"$FAILING_SHA"'`'
           BODY+=$'\n- **Failing run:** '"$WORKFLOW_URL"
@@ -190,7 +257,7 @@ PYEOF
 
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
-            --title "[urgent] revert PR $REVERT_NUMBER blocked by denyPaths — manual merge required ($short)" \
+            --title "[urgent] revert PR #$REVERT_NUMBER needs manual merge ($short)" \
             --body "$BODY" \
             --label "hivemoot:needs-human"
 
@@ -210,7 +277,6 @@ PYEOF
           short="${FAILING_SHA:0:7}"
 
           # Idempotency: skip if an urgent issue for this SHA already exists.
-          # Uses REST API (not text search) to avoid indexing lag from concurrent runs.
           existing_issue=$(gh api \
             "repos/$GITHUB_REPOSITORY/issues?labels=hivemoot:needs-human&state=open&per_page=100" \
             --jq "[.[] | select(.title | contains(\"$short\"))] | .[0].number // empty" \
@@ -220,8 +286,6 @@ PYEOF
             exit 0
           fi
 
-          # Best-effort: read trustedReviewers from hivemoot.yml for @-mentions.
-          # If parsing fails for any reason, the issue is opened without mentions.
           TRUSTED=$(python3 - <<'PYEOF' 2>/dev/null || true
 import yaml
 try:

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -66,13 +66,13 @@ jobs:
           HEAD_SHA=$(git rev-parse HEAD)
           short="${FAILING_SHA:0:7}"
 
-          # Find the PR that introduced this commit (best-effort; empty if not found).
-          PR_INFO=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --state merged \
-            --search "$FAILING_SHA" \
-            --json number,url \
-            --jq '.[0]' 2>/dev/null || echo '{}')
+          # Find the PR that introduced this commit via the commits-to-pulls API.
+          # This is the authoritative lookup — text search (--search) is unreliable
+          # for SHAs because GitHub's index does not guarantee SHA tokenization.
+          PR_INFO=$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$FAILING_SHA/pulls" \
+            -H "Accept: application/vnd.github+json" \
+            --jq '.[0] | {number: .number, url: .html_url}' 2>/dev/null || echo '{}')
           PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
           PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -102,15 +102,87 @@ jobs:
             BODY+=$'\n**Introduced by:** #'"$PR_NUMBER"
           fi
 
-          gh pr create \
+          REVERT_PR_URL=$(gh pr create \
             --repo "$GITHUB_REPOSITORY" \
             --head "$BRANCH" \
             --base main \
             --title "revert: auto-revert $short ($WORKFLOW_NAME CI failure)" \
             --body "$BODY" \
-            --label "hivemoot:automerge"
+            --label "hivemoot:automerge")
 
+          echo "revert_pr_url=$REVERT_PR_URL" >> "$GITHUB_OUTPUT"
           echo "needs_human=false" >> "$GITHUB_OUTPUT"
+
+      - name: Escalate if revert PR blocked by automerge config
+        if: >
+          steps.idempotency.outputs.skip != 'true' &&
+          steps.revert.outputs.needs_human != 'true' &&
+          steps.revert.outputs.revert_pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+          PR_NUMBER: ${{ steps.revert.outputs.pr_number }}
+          PR_URL: ${{ steps.revert.outputs.pr_url }}
+          REVERT_PR_URL: ${{ steps.revert.outputs.revert_pr_url }}
+        run: |
+          # Extract PR number from URL (e.g. https://github.com/org/repo/pull/123 → 123).
+          REVERT_NUMBER="${REVERT_PR_URL##*/}"
+
+          # Check if the revert diff touches automerge denyPaths.
+          # If so, the revert PR will not auto-merge and needs human attention.
+          FILES=$(gh pr diff \
+            --repo "$GITHUB_REPOSITORY" \
+            "$REVERT_NUMBER" \
+            --name-only 2>/dev/null || echo "")
+
+          BLOCKED=false
+          BLOCKED_FILE=""
+          while IFS= read -r file; do
+            case "$file" in
+              .github/*|*/package.json|*/package-lock.json|*.lock|*/pnpm-lock.yaml|*/go.sum|*/bun.lockb|*/go.work.sum)
+                BLOCKED=true
+                BLOCKED_FILE="$file"
+                break
+                ;;
+            esac
+          done <<< "$FILES"
+
+          [ "$BLOCKED" = "false" ] && exit 0
+
+          # Revert PR exists but cannot auto-merge — escalate so a human can merge it.
+          TRUSTED=$(python3 - <<'PYEOF' 2>/dev/null || true
+import yaml
+try:
+    with open('.github/hivemoot.yml') as f:
+        config = yaml.safe_load(f)
+    reviewers = config.get('governance', {}).get('pr', {}).get('trustedReviewers', [])
+    print(' '.join('@' + r for r in reviewers))
+except Exception:
+    pass
+PYEOF
+)
+
+          short="${FAILING_SHA:0:7}"
+
+          BODY="**Revert PR created but cannot auto-merge — manual merge required.**"
+          BODY+=$'\n\nThe revert diff includes `'"$BLOCKED_FILE"'`, which is in automerge `denyPaths`.'
+          BODY+=$'\n\n**Action required:** review and merge '"$REVERT_PR_URL"$' manually.\n'
+          BODY+=$'\n- **Failing SHA:** `'"$FAILING_SHA"'`'
+          BODY+=$'\n- **Failing run:** '"$WORKFLOW_URL"
+          if [ -n "$PR_NUMBER" ]; then
+            BODY+=$'\n- **Introduced by:** #'"$PR_NUMBER ($PR_URL)"
+          fi
+          if [ -n "$TRUSTED" ]; then
+            BODY+=$'\n\nCC: '"$TRUSTED"
+          fi
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "[urgent] revert PR $REVERT_NUMBER blocked by denyPaths — manual merge required ($short)" \
+            --body "$BODY" \
+            --label "hivemoot:needs-human"
 
       - name: Escalate to humans
         if: >

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           # Extract PR number from URL (e.g. https://github.com/org/repo/pull/123 → 123).
           REVERT_NUMBER="${REVERT_PR_URL##*/}"
+          short="${FAILING_SHA:0:7}"
 
           # Check if the revert diff touches automerge denyPaths.
           # If so, the revert PR will not auto-merge and needs human attention.
@@ -151,6 +152,17 @@ jobs:
 
           [ "$BLOCKED" = "false" ] && exit 0
 
+          # Idempotency: skip if an urgent issue for this SHA already exists.
+          # Uses REST API (not text search) to avoid indexing lag from concurrent runs.
+          existing_issue=$(gh api \
+            "repos/$GITHUB_REPOSITORY/issues?labels=hivemoot:needs-human&state=open&per_page=100" \
+            --jq "[.[] | select(.title | contains(\"$short\"))] | .[0].number // empty" \
+            2>/dev/null || echo "")
+          if [ -n "$existing_issue" ]; then
+            echo "Urgent issue #$existing_issue already open for $short — skipping duplicate"
+            exit 0
+          fi
+
           # Revert PR exists but cannot auto-merge — escalate so a human can merge it.
           TRUSTED=$(python3 - <<'PYEOF' 2>/dev/null || true
 import yaml
@@ -163,8 +175,6 @@ except Exception:
     pass
 PYEOF
 )
-
-          short="${FAILING_SHA:0:7}"
 
           BODY="**Revert PR created but cannot auto-merge — manual merge required.**"
           BODY+=$'\n\nThe revert diff includes `'"$BLOCKED_FILE"'`, which is in automerge `denyPaths`.'
@@ -197,6 +207,19 @@ PYEOF
           PR_NUMBER: ${{ steps.revert.outputs.pr_number }}
           PR_URL: ${{ steps.revert.outputs.pr_url }}
         run: |
+          short="${FAILING_SHA:0:7}"
+
+          # Idempotency: skip if an urgent issue for this SHA already exists.
+          # Uses REST API (not text search) to avoid indexing lag from concurrent runs.
+          existing_issue=$(gh api \
+            "repos/$GITHUB_REPOSITORY/issues?labels=hivemoot:needs-human&state=open&per_page=100" \
+            --jq "[.[] | select(.title | contains(\"$short\"))] | .[0].number // empty" \
+            2>/dev/null || echo "")
+          if [ -n "$existing_issue" ]; then
+            echo "Urgent issue #$existing_issue already open for $short — skipping duplicate"
+            exit 0
+          fi
+
           # Best-effort: read trustedReviewers from hivemoot.yml for @-mentions.
           # If parsing fails for any reason, the issue is opened without mentions.
           TRUSTED=$(python3 - <<'PYEOF' 2>/dev/null || true
@@ -211,7 +234,6 @@ except Exception:
 PYEOF
 )
 
-          short="${FAILING_SHA:0:7}"
           if [ "$REASON" = "head_moved" ]; then
             CAUSE="HEAD has moved past the failing commit — auto-revert skipped"
           else

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -1,0 +1,164 @@
+name: Auto-revert
+
+on:
+  workflow_run:
+    workflows:
+      - CLI
+      - Web
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-revert:
+    # Only react to push-to-main failures; PRs and manual dispatches are excluded.
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check idempotency
+        id: idempotency
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          short="${FAILING_SHA:0:7}"
+          existing=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --head "auto-revert-$short" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Revert PR #$existing already open for $short — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main
+        if: steps.idempotency.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Revert or escalate
+        if: steps.idempotency.outputs.skip != 'true'
+        id: revert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          HEAD_SHA=$(git rev-parse HEAD)
+          short="${FAILING_SHA:0:7}"
+
+          # Find the PR that introduced this commit (best-effort; empty if not found).
+          PR_INFO=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state merged \
+            --search "$FAILING_SHA" \
+            --json number,url \
+            --jq '.[0]' 2>/dev/null || echo '{}')
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
+          PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+          if [ "$HEAD_SHA" != "$FAILING_SHA" ]; then
+            echo "needs_human=true" >> "$GITHUB_OUTPUT"
+            echo "reason=head_moved" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BRANCH="auto-revert-$short"
+          git checkout -b "$BRANCH"
+
+          if ! git revert --no-edit "$FAILING_SHA"; then
+            git revert --abort 2>/dev/null || true
+            echo "needs_human=true" >> "$GITHUB_OUTPUT"
+            echo "reason=revert_conflict" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git push origin "$BRANCH"
+
+          BODY="Automatic revert of \`$short\` — **$WORKFLOW_NAME** CI failed on main after merge."
+          BODY+=$'\n\n**Failing run:** '"$WORKFLOW_URL"
+          if [ -n "$PR_NUMBER" ]; then
+            BODY+=$'\n**Introduced by:** #'"$PR_NUMBER"
+          fi
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" \
+            --base main \
+            --title "revert: auto-revert $short ($WORKFLOW_NAME CI failure)" \
+            --body "$BODY" \
+            --label "hivemoot:automerge"
+
+          echo "needs_human=false" >> "$GITHUB_OUTPUT"
+
+      - name: Escalate to humans
+        if: >
+          steps.idempotency.outputs.skip != 'true' &&
+          steps.revert.outputs.needs_human == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+          REASON: ${{ steps.revert.outputs.reason }}
+          PR_NUMBER: ${{ steps.revert.outputs.pr_number }}
+          PR_URL: ${{ steps.revert.outputs.pr_url }}
+        run: |
+          # Best-effort: read trustedReviewers from hivemoot.yml for @-mentions.
+          # If parsing fails for any reason, the issue is opened without mentions.
+          TRUSTED=$(python3 - <<'PYEOF' 2>/dev/null || true
+import yaml
+try:
+    with open('.github/hivemoot.yml') as f:
+        config = yaml.safe_load(f)
+    reviewers = config.get('governance', {}).get('pr', {}).get('trustedReviewers', [])
+    print(' '.join('@' + r for r in reviewers))
+except Exception:
+    pass
+PYEOF
+)
+
+          short="${FAILING_SHA:0:7}"
+          if [ "$REASON" = "head_moved" ]; then
+            CAUSE="HEAD has moved past the failing commit — auto-revert skipped"
+          else
+            CAUSE="revert had merge conflicts — manual resolution required"
+          fi
+
+          BODY="**$WORKFLOW_NAME CI failed on main after merge, but $CAUSE.**"
+          BODY+=$'\n\nSee AGENTS.md for the manual revert protocol.\n'
+          BODY+=$'\n- **Failing SHA:** `'"$FAILING_SHA"'`'
+          BODY+=$'\n- **Failing run:** '"$WORKFLOW_URL"
+          if [ -n "$PR_NUMBER" ]; then
+            BODY+=$'\n- **Introduced by:** #'"$PR_NUMBER ($PR_URL)"
+          fi
+          if [ -n "$TRUSTED" ]; then
+            BODY+=$'\n\nCC: '"$TRUSTED"
+          fi
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "[urgent] post-merge CI failure — manual revert required ($short)" \
+            --body "$BODY" \
+            --label "hivemoot:needs-human"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,14 @@ Make sure you reacted to **Queen's voting comment**, not the issue itself.
 You are likely targeting upstream instead of your fork (or using a token without fork write access). Verify remotes and rerun:
 `git push --dry-run origin HEAD`
 
+### I see a `hivemoot:needs-human` issue for a post-merge CI failure
+The auto-revert workflow could not revert automatically (HEAD moved before it ran, or the revert had merge conflicts). Manual revert required:
+1. Find the failing SHA and the PR that introduced it — both are in the issue body.
+2. From a fresh checkout of main: `git checkout -b manual-revert-<sha> && git revert <sha>`.
+3. If there are conflicts: resolve them, then `git revert --continue`.
+4. Push and open a PR with `Fixes #<urgent-issue-number>` in the description. Label it `hivemoot:candidate`.
+5. Treat this as priority — main is broken until it merges.
+
 ## Resources
 
 - [How It Works](./HOW-IT-WORKS.md) — Full governance mechanics


### PR DESCRIPTION
Fixes #402

## What this does

Adds `.github/workflows/revert.yml` — the auto-revert safety net that HOW-IT-WORKS.md claims exists but didn't until now.

The workflow triggers on `workflow_run: completed` for the **CLI** and **Web** workflows (the two production signals; `web-deploy.yml` and `skills.yml` are deliberately excluded). It only fires for push-to-main failures, not PRs or manual dispatches.

### Happy path — HEAD hasn't moved

1. Checks for an existing open revert PR by branch name (`auto-revert-<sha>`) — skips if found.
2. Checks out main at current HEAD.
3. Verifies the failing SHA is still HEAD. If it is, creates an `auto-revert-<sha>` branch, reverts the commit, and opens a PR labeled `hivemoot:automerge`.

### Fallback paths — manual escalation

If HEAD has moved past the failing commit *or* `git revert` has merge conflicts, the workflow opens a `hivemoot:needs-human` issue titled `[urgent] post-merge CI failure — manual revert required (<sha>)` with the failing run URL, SHA, and the introducing PR. It @-mentions `trustedReviewers` from `hivemoot.yml` (gracefully omits mentions if that read fails).

### AGENTS.md

Adds a troubleshooting entry for the fallback case so agents know what to do when they receive the urgent issue.

## Design decisions

- **Branch-based idempotency** instead of title search — avoids GitHub search indexing lag.
- **`workflow_run` scoped to CLI + Web** — deploy and skills workflows don't represent production regressions.
- **Explicit `permissions:` block** — `contents: write`, `pull-requests: write`, `issues: write`.
- **Graceful trustedReviewers fallback** — if `hivemoot.yml` parsing fails, the issue opens without mentions rather than failing the step.
- **Revert conflict handling** — `git revert --abort` + escalation rather than leaving a detached revert state.

## Sequencing

This PR is independent of #407 (auto-bump) and #398 (automerge Phase 2). It can merge in any order.