### PR TITLE
fix(web): catch Redis errors in BYOK auth and data paths

### DIFF
--- a/apps/web/BYOK_CONTRACT.md
+++ b/apps/web/BYOK_CONTRACT.md
@@ -68,10 +68,14 @@ These are the wire values the bot resolver should emit/consume for runtime resol
 | `byok_decrypt_failed` | Ciphertext/tag/IV invalid or tampered | Fail closed for this request; emit correlation id |
 | `byok_key_version_unavailable` | Envelope keyVersion missing from keyring | Fail closed for this request; emit correlation id |
 
-Related server-side configuration errors exposed by web routes:
-- `byok_encryption_not_configured`
-- `byok_encryption_config_invalid`
-- `byok_server_misconfiguration`
+Related server-side runtime errors exposed by web routes:
+
+| Code | Meaning | Client behavior |
+|---|---|---|
+| `byok_storage_unavailable` | Redis call failed during request (auth or data path) | Retry after backoff; this is transient |
+| `byok_encryption_not_configured` | `BYOK_ACTIVE_KEY_VERSION` or `BYOK_MASTER_KEYS` missing | Server misconfiguration; operator action required |
+| `byok_encryption_config_invalid` | Keyring JSON malformed or key format invalid | Server misconfiguration; operator action required |
+| `byok_server_misconfiguration` | Environment validation failed | Server misconfiguration; operator action required |
 
 ## 5. Runtime Environment Variables
 

--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -195,6 +195,19 @@ describe("POST /api/byok/config", () => {
     expect(parsed).toHaveProperty("model", "gpt-4o");
   });
 
+  it("returns 503 byok_storage_unavailable when Redis write fails", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("Redis write error"));
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.STORAGE_UNAVAILABLE);
+  });
+
   it("uses installationId from session, not request body", async () => {
     const req = makeRequest({
       provider: "anthropic",

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -70,7 +70,12 @@ export async function POST(request: NextRequest) {
     fingerprint: "",
   };
 
-  await setByokEnvelope(installationId, envelope, auth.redis);
+  try {
+    await setByokEnvelope(installationId, envelope, auth.redis);
+  } catch (err) {
+    console.error("[byok-config] Redis error saving envelope", { installationId, error: err });
+    return byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Failed to save BYOK configuration", 503);
+  }
 
   return NextResponse.json({
     status: "active",

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -102,4 +102,22 @@ describe("POST /api/byok/revoke", () => {
     expect(body.code).toBe(BYOK_ERROR.NOT_CONFIGURED);
     expect(body.message).toBe("BYOK is not configured");
   });
+
+  it("returns 503 byok_storage_unavailable when Redis read fails", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("Redis read error"));
+    const req = makeRequest({});
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.STORAGE_UNAVAILABLE);
+  });
+
+  it("returns 503 byok_storage_unavailable when Redis write fails during revocation", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("Redis write error"));
+    const req = makeRequest({});
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.STORAGE_UNAVAILABLE);
+  });
 });

--- a/apps/web/src/app/api/byok/revoke/route.ts
+++ b/apps/web/src/app/api/byok/revoke/route.ts
@@ -16,7 +16,13 @@ export async function POST(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const existing = await getByokEnvelope(installationId, auth.redis);
+  let existing: Awaited<ReturnType<typeof getByokEnvelope>>;
+  try {
+    existing = await getByokEnvelope(installationId, auth.redis);
+  } catch (err) {
+    console.error("[byok-revoke] Redis error reading envelope", { installationId, error: err });
+    return byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Failed to read BYOK configuration", 503);
+  }
   if (!existing) {
     return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
   }
@@ -32,7 +38,12 @@ export async function POST(request: NextRequest) {
     updatedBy: auth.session.userLogin,
   };
 
-  await setByokEnvelope(installationId, revoked, auth.redis);
+  try {
+    await setByokEnvelope(installationId, revoked, auth.redis);
+  } catch (err) {
+    console.error("[byok-revoke] Redis error saving revocation", { installationId, error: err });
+    return byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Failed to save revocation", 503);
+  }
 
   return NextResponse.json({
     status: "revoked",

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -146,6 +146,19 @@ describe("POST /api/byok/rotate", () => {
     expect(parsed).toHaveProperty("model", "gemini-3-flash-preview");
   });
 
+  it("returns 503 byok_storage_unavailable when Redis write fails", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("Redis write error"));
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-new-key5678",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.STORAGE_UNAVAILABLE);
+  });
+
   it("uses installationId from session, not request body", async () => {
     const req = makeRequest({
       provider: "anthropic",

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -70,7 +70,12 @@ export async function POST(request: NextRequest) {
     fingerprint: "",
   };
 
-  await setByokEnvelope(installationId, envelope, auth.redis);
+  try {
+    await setByokEnvelope(installationId, envelope, auth.redis);
+  } catch (err) {
+    console.error("[byok-rotate] Redis error saving envelope", { installationId, error: err });
+    return byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Failed to save BYOK configuration", 503);
+  }
 
   return NextResponse.json({
     status: "active",

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -112,6 +112,15 @@ describe("GET /api/byok/status", () => {
     expect(body.message).toBe("BYOK is not configured");
   });
 
+  it("returns 503 byok_storage_unavailable when Redis read fails", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("Redis read error"));
+    const req = makeRequest();
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.STORAGE_UNAVAILABLE);
+  });
+
   it("uses installationId from session, not query params", async () => {
     const req = makeRequest();
     await GET(req);

--- a/apps/web/src/app/api/byok/status/route.ts
+++ b/apps/web/src/app/api/byok/status/route.ts
@@ -16,7 +16,13 @@ export async function GET(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
-  const envelope = await getByokEnvelope(installationId, auth.redis);
+  let envelope: Awaited<ReturnType<typeof getByokEnvelope>>;
+  try {
+    envelope = await getByokEnvelope(installationId, auth.redis);
+  } catch (err) {
+    console.error("[byok-status] Redis error reading envelope", { installationId, error: err });
+    return byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Failed to read BYOK configuration", 503);
+  }
   if (!envelope) {
     return byokError(
       BYOK_ERROR.NOT_CONFIGURED,

--- a/apps/web/src/constants/byok-errors.ts
+++ b/apps/web/src/constants/byok-errors.ts
@@ -25,6 +25,7 @@ export const BYOK_ERROR = {
   SESSION_INVALID: "byok_session_invalid",
   SESSION_STALE: "byok_session_stale",
   SESSION_STORAGE_NOT_CONFIGURED: "byok_session_storage_not_configured",
+  STORAGE_UNAVAILABLE: "byok_storage_unavailable",
 } as const;
 
 export type ByokErrorCode = (typeof BYOK_ERROR)[keyof typeof BYOK_ERROR];

--- a/apps/web/src/server/byok-auth.test.ts
+++ b/apps/web/src/server/byok-auth.test.ts
@@ -118,6 +118,30 @@ describe("authenticateByokRequest runtime config cache", () => {
   });
 });
 
+describe("authenticateByokRequest Redis error handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mocks.validateEnv.mockReturnValue({ ok: true, config: VALID_ENV_CONFIG });
+    mocks.parseKeyring.mockReturnValue(new Map([["v1", Buffer.alloc(32)]]));
+    mocks.getRedisClient.mockReturnValue({} as never);
+    mocks.isSessionFresh.mockReturnValue(true);
+  });
+
+  it("returns 503 byok_storage_unavailable when getSetupSession throws", async () => {
+    mocks.getSetupSession.mockRejectedValue(new Error("Redis connection refused"));
+    const { authenticateByokRequest } = await import("./byok-auth");
+    const result = await authenticateByokRequest(makeRequest());
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected failure");
+    expect(result.response.status).toBe(503);
+    await expect(result.response.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.STORAGE_UNAVAILABLE,
+    });
+  });
+});
+
 describe("authenticateByokRequest freshness gate", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/web/src/server/byok-auth.ts
+++ b/apps/web/src/server/byok-auth.ts
@@ -171,7 +171,16 @@ export async function authenticateByokRequest(
     };
   }
 
-  const session = await getSetupSession(token, redis);
+  let session: Awaited<ReturnType<typeof getSetupSession>>;
+  try {
+    session = await getSetupSession(token, redis);
+  } catch (err) {
+    console.error("[byok-auth] Redis error during session lookup", { error: err });
+    return {
+      ok: false,
+      response: byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Session storage unavailable", 503),
+    };
+  }
   if (!session) {
     return {
       ok: false,


### PR DESCRIPTION
Fixes #355

## What changed

Both competing PRs (#365, #411) have the same structural gap: they add try/catch blocks *after* `authenticateByokRequest()` is called, but `authenticateByokRequest()` itself awaits `getSetupSession(token, redis)` — a Redis call that can throw. Auth-phase Redis failures bypass the route-level catches entirely and still produce unhandled HTML 500s.

This PR covers both failure points:

### 1. Auth phase (`byok-auth.ts`)

Wrapped `getSetupSession(token, redis)` in a try/catch that returns a structured `byok_storage_unavailable` 503:

```ts
let session: Awaited<ReturnType<typeof getSetupSession>>;
try {
  session = await getSetupSession(token, redis);
} catch (err) {
  console.error("[byok-auth] Redis error during session lookup", { error: err });
  return {
    ok: false,
    response: byokError(BYOK_ERROR.STORAGE_UNAVAILABLE, "Session storage unavailable", 503),
  };
}
```

All five BYOK routes (config, rotate, revoke, status, re-encrypt) use `authenticateByokRequest()`, so they all get this coverage at once. No changes to route call sites needed.

### 2. Data phase (four routes)

Wrapped the Redis data operations in `config`, `rotate`, `revoke`, and `status` with try/catch returning the same 503. `re-encrypt` already had this coverage.

### 3. New error code

Added `STORAGE_UNAVAILABLE: "byok_storage_unavailable"` to `byok-errors.ts`. Distinguishes transient storage failures from static misconfiguration (`byok_server_misconfiguration`) and unconfigured state (`byok_session_storage_not_configured`).

## Before / After

**Before:** Redis down during session lookup → `getSetupSession` throws → unhandled → Next.js catches → HTML 500 response

**After:** Redis down during session lookup → caught in `authenticateByokRequest` → `{ ok: false, response: NextResponse.json({ code: "byok_storage_unavailable", ... }, { status: 503 }) }` → route returns structured JSON

## Validation

TypeScript typecheck passes (`npx tsc --noEmit` in `apps/web` — no errors).

The existing `re-encrypt` route behavior is unchanged (its data-phase try/catch predates this PR). The auth-phase fix applies to all routes via the shared helper.