### PR TITLE
fix(cli): serialize auto-bump publish flow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -55,10 +55,9 @@ jobs:
         working-directory: cli
 
     steps:
-      - name: Checkout latest main
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -69,17 +68,11 @@ jobs:
           cache-dependency-path: cli/package-lock.json
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Sync release workspace to origin/main
-        working-directory: .
-        run: |
-          git fetch origin main
-          git checkout -B release-worktree origin/main
-
       - name: Install dependencies
         run: npm ci
 
       - name: Auto-bump version if needed
-        if: github.event_name == 'push'
+        if: "github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(cli): auto-bump version')"
         id: auto_bump
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
@@ -121,36 +114,21 @@ jobs:
           git commit -m "chore(cli): auto-bump version to $(node -p 'require(\"./package.json\").version')"
           echo "bumped=true" >> "$GITHUB_OUTPUT"
 
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Test
-        run: npm run test
-
       - name: Build
         run: npm run build
 
       - name: Push auto-bump commit
         if: steps.auto_bump.outputs.bumped == 'true'
+        id: push_bump
         working-directory: .
         run: |
-          if git push origin HEAD:main; then
-            exit 0
+          if ! git push origin HEAD:main; then
+            echo "::warning::Push failed — main advanced since checkout. Skipping publish; next run will carry these changes."
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
           fi
 
-          git fetch origin main
-          git rebase origin/main
-
-          cd cli
-          npm ci
-          npm run typecheck
-          npm run test
-          npm run build
-          cd ..
-
-          git push origin HEAD:main
-
       - name: Check if version is already published
+        if: steps.push_bump.outputs.push_failed != 'true'
         id: check
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,9 @@ on:
     paths: [cli/**]
   pull_request:
     branches: [main]
-    paths: [cli/**]
+    paths:
+      - cli/**
+      - .github/workflows/cli.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,13 +43,21 @@ jobs:
     needs: typecheck-test-build
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: cli-publish
+      cancel-in-progress: false
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: cli
 
     steps:
-      - name: Checkout
+      - name: Checkout latest main
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -59,11 +67,86 @@ jobs:
           cache-dependency-path: cli/package-lock.json
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Sync release workspace to origin/main
+        working-directory: .
+        run: |
+          git fetch origin main
+          git checkout -B release-worktree origin/main
+
       - name: Install dependencies
         run: npm ci
 
+      - name: Auto-bump version if needed
+        if: github.event_name == 'push'
+        id: auto_bump
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NPM_LATEST=$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "0.0.0")
+
+          NEXT_VERSION=$(node -e '
+            const current = process.argv[1];
+            const latest = process.argv[2];
+            const parse = (value) => value.split(".").map((part) => Number.parseInt(part, 10));
+            const isValid = (parts) =>
+              parts.length === 3 && parts.every((part) => Number.isInteger(part) && part >= 0);
+            const compare = (left, right) =>
+              left[0] - right[0] || left[1] - right[1] || left[2] - right[2];
+            const currentParts = parse(current);
+            const latestParts = parse(latest);
+
+            if (!isValid(currentParts) || !isValid(latestParts)) {
+              throw new Error(`Unsupported semver for auto-bump: current=${current} latest=${latest}`);
+            }
+
+            if (compare(currentParts, latestParts) > 0) {
+              process.exit(0);
+            }
+
+            latestParts[2] += 1;
+            process.stdout.write(latestParts.join("."));
+          ' "$CURRENT_VERSION" "$NPM_LATEST")
+
+          if [ -z "$NEXT_VERSION" ]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          npm version "$NEXT_VERSION" --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(cli): auto-bump version to $(node -p 'require(\"./package.json\").version')"
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build
+
+      - name: Push auto-bump commit
+        if: steps.auto_bump.outputs.bumped == 'true'
+        working-directory: .
+        run: |
+          if git push origin HEAD:main; then
+            exit 0
+          fi
+
+          git fetch origin main
+          git rebase origin/main
+
+          cd cli
+          npm ci
+          npm run typecheck
+          npm run test
+          npm run build
+          cd ..
+
+          git push origin HEAD:main
 
       - name: Check if version is already published
         id: check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
 - **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
 - **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
-- **If you change `cli/**`, bump CLI version files in the same PR**: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.
+- **If you change `cli/**`, do not bump CLI version files in the PR**: the CLI publish workflow auto-bumps `cli/package.json` and `cli/package-lock.json` on `main` so feature PRs can still qualify for automerge.
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 - Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
 - Include a before/after example showing the outcome (the PR template will guide you)
 - Include tests when relevant
-- If you change anything under `cli/**`, bump the CLI package version in both `cli/package.json` and `cli/package-lock.json` in the same PR so the npm publish job can release it.
+- If you change anything under `cli/**`, do not bump `cli/package.json` or `cli/package-lock.json` in the PR. The CLI publish workflow auto-bumps the version on `main` before publishing.
 
 ## Fork-First Publishing
 


### PR DESCRIPTION
Fixes #406

## Why

CLI feature PRs are currently forced to edit `cli/package.json` and `cli/package-lock.json`, which permanently trips the repo's automerge `denyPaths`. The existing auto-bump approach on `#407` removes that doc requirement, but it still leaves publish ownership ambiguous when `main` moves during the release job.

This version makes one publish job own the release, syncs to the live `main` tip before allocating a version, and reruns CLI validation if the bump commit has to rebase before push.

## What changed

- serialize the `publish` job with `concurrency: cli-publish`
- checkout and sync to the current `origin/main` tip before release work starts
- auto-bump from npm's latest published version, not from the triggering SHA's stale tree
- rerun `typecheck`, `test`, and `build` on the release candidate in the publish job
- if `main` moved before the bump push, rebase the bump commit onto the new tip and rerun CLI validation before pushing
- run the CLI pull request workflow for `.github/workflows/cli.yml` changes too, so workflow-only publish fixes still get CI on the PR
- update `AGENTS.md` and `CONTRIBUTING.md` so CLI PRs stop carrying manual version bumps

## Before / After

| Scenario | Before | After |
|---|---|---|
| CLI feature PR with no version bump | publish skipped unless the PR also edited `package.json` and `package-lock.json` | publish job bumps the patch version on `main` automatically |
| Merge-ready CLI PR | blocked from automerge by `**/package.json` in `denyPaths` | no version files in the feature PR, so automerge can classify it normally |
| `main` advances before the bump commit pushes | release job can race on a stale tree or fail without revalidating the rebased release candidate | publish job rebases the bump commit onto the new `main` tip and reruns CLI validation before pushing |
| Workflow-only publish fix PR | no CLI CI runs because the PR does not touch `cli/**` | CLI CI runs when the PR touches `.github/workflows/cli.yml` |
| `workflow_dispatch` recovery run | manual rerun path exists | still exists, but skips auto-bump and only publishes an unpublished checked-in version |

## Validation

- `git push --dry-run origin HEAD`
- `npm ci --prefix cli`
- `npm test --prefix cli` (`819` tests passed)
- `npm run --prefix cli typecheck`
- `npm run --prefix cli build`
- `npx -y js-yaml .github/workflows/cli.yml >/dev/null`

_Edit note (2026-03-29 10:09 UTC): added the `.github/workflows/cli.yml` pull request trigger so this workflow-only publish fix receives CLI CI on the PR itself._
