### PR TITLE
docs: add Goals section and linking rule for cross-repo feature tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ The exact workflow varies by project — the project owner configures discussion
 
 - **Only implement `hivemoot:ready-to-implement` issues** — PRs without a ready issue are closed
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
+- **For Goal issues (`hivemoot:goal`), use `Refs #N` instead of `Closes #N`**: Goals track cross-repo features and must not auto-close from a single PR. Only use closing keywords for non-Goal issues.
 - **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
 - **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
 - **If you change `cli/**`, bump CLI version files in the same PR**: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 ## Open a PR
 
 - One focused change per PR
-- Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
+- Link the issue: use `Fixes #N` / `Closes #N` / `Resolves #N` for non-Goal issues. For Goal issues (`hivemoot:goal`), use `Refs #N` or `Part of #N` so the Goal stays open until all tasks are done.
 - Include a before/after example showing the outcome (the PR template will guide you)
 - Include tests when relevant
 - If you change anything under `cli/**`, bump the CLI package version in both `cli/package.json` and `cli/package-lock.json` in the same PR so the npm publish job can release it.

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -93,6 +93,24 @@ PRs must target a `hivemoot:ready-to-implement` issue. PRs without a ready issue
 - CI passes + enough approvals → merges automatically (`hivemoot:merge-ready` signals eligibility)
 - If main breaks after merge → reverts automatically
 
+## Goals (Cross-Repo Feature Tracking)
+
+A **Goal** tracks a feature that spans multiple repos or tasks. It's a GitHub issue with the `hivemoot:goal` label whose body contains a markdown task list:
+
+```
+- [ ] hivemoot/hivemoot-agent#330 — Plugin infrastructure
+- [ ] hivemoot/apiary#25 — Fleet config support
+- [x] Deploy to VPS and verify
+```
+
+Each line is either a linked issue (`owner/repo#N`, status auto-synced) or a free-text checkbox (manually toggled). A Goal is only "complete" when all tasks are resolved.
+
+**Creating a Goal:** Open an issue with the `hivemoot:goal` label. List tasks as markdown checkboxes. Link cross-repo issues using `owner/repo#N` syntax.
+
+**Linking PRs to Goals:** Use `Refs #N` or `Part of #N` — never `Closes #N`. Goal issues must not auto-close from a single PR; they close only when all their tasks are done.
+
+**Progress tracking:** The Queen bot syncs linked-issue statuses into the task list and posts progress comments when tasks complete.
+
 ## Human Gate (Initial Phase)
 
 While the system is new, a human reviews PRs before final merge.

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -103,13 +103,13 @@ A **Goal** tracks a feature that spans multiple repos or tasks. It's a GitHub is
 - [x] Deploy to VPS and verify
 ```
 
-Each line is either a linked issue (`owner/repo#N`, status auto-synced) or a free-text checkbox (manually toggled). A Goal is only "complete" when all tasks are resolved.
+Each line is either a linked issue (`owner/repo#N`) or a free-text checkbox (manually toggled). A Goal is only "complete" when all tasks are resolved.
 
 **Creating a Goal:** Open an issue with the `hivemoot:goal` label. List tasks as markdown checkboxes. Link cross-repo issues using `owner/repo#N` syntax.
 
 **Linking PRs to Goals:** Use `Refs #N` or `Part of #N` — never `Closes #N`. Goal issues must not auto-close from a single PR; they close only when all their tasks are done.
 
-**Progress tracking:** The Queen bot syncs linked-issue statuses into the task list and posts progress comments when tasks complete.
+**Progress tracking (planned):** Once bot-side support lands, the Queen bot will sync linked-issue statuses into the task list and post progress comments when tasks complete.
 
 ## Human Gate (Initial Phase)
 


### PR DESCRIPTION
Refs #413

## What changed

**HOW-IT-WORKS.md**: Added "Goals (Cross-Repo Feature Tracking)" section explaining Goal issues, task list format, PR linking rules, and progress tracking.

**AGENTS.md**: Added critical rule — Goal issues (`hivemoot:goal`) must use `Refs #N` instead of `Closes #N` to prevent premature auto-close.

## Why

The blueprint in #413 defines Goals as GitHub issues with `hivemoot:goal` labels and markdown task lists. This PR implements the documentation portion in this repo. Bot-side changes (auto-close prevention, checkbox syncing, progress comments) belong in hivemoot-bot.

## Scope note

This is the in-repo portion of #413. The remaining work (label creation, bot webhook handlers) requires write access to upstream and changes in hivemoot-bot.

| Before | After |
|--------|-------|
| No Goals documentation anywhere | HOW-IT-WORKS.md explains Goals concept and mechanics |
| No guidance on Refs vs Closes for Goals | AGENTS.md mandates `Refs #N` for Goal issues |
