### PR TITLE
feat(cli): add focus label/author filters

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -385,6 +385,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +409,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -430,6 +432,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -473,6 +476,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -571,6 +575,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      undefined,
     );
   });
 
@@ -665,6 +670,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       notificationMap,
+      undefined,
       undefined,
     );
   });
@@ -1042,6 +1048,30 @@ describe("buzzCommand", () => {
     expect(focusArg).toBe("Focus on PR reviews first.");
   });
 
+  it("passes focus filters from team config to buildSummary", async () => {
+    const teamWithFocusFilters = {
+      ...testTeamConfig,
+      focus: "Fix bugs first.",
+      focusFilters: {
+        labels: { include: ["bug"] },
+        authors: { exclude: ["dependabot[bot]"] },
+      },
+    };
+    mockedLoadTeamConfig.mockResolvedValue(teamWithFocusFilters);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const focusArg = mockedBuildSummary.mock.calls[0][7];
+    const focusFiltersArg = mockedBuildSummary.mock.calls[0][8];
+    expect(focusArg).toBe("Fix bugs first.");
+    expect(focusFiltersArg).toEqual({
+      labels: { include: ["bug"] },
+      authors: { exclude: ["dependabot[bot]"] },
+    });
+  });
+
   it("passes undefined focus when team config has no focus", async () => {
     mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [] });
     mockedFormatStatus.mockReturnValue("output");
@@ -1050,6 +1080,7 @@ describe("buzzCommand", () => {
 
     const focusArg = mockedBuildSummary.mock.calls[0][7];
     expect(focusArg).toBeUndefined();
+    expect(mockedBuildSummary.mock.calls[0][8]).toBeUndefined();
   });
 
   it("passes focus to buildSummary when using --role", async () => {

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -732,6 +732,36 @@ describe("buzzCommand", () => {
     ]);
   });
 
+  it("suppresses filtered-out open mentions from unackedMentions", async () => {
+    const notificationMap = new Map([[42, {
+      threadId: "T42",
+      reason: "mention",
+      updatedAt: "2025-06-15T10:00:00Z",
+      title: "Fix dashboard",
+      url: "https://github.com/hivemoot/test/issues/42",
+      itemType: "Issue" as const,
+    }]]);
+    mockedFetchIssues.mockResolvedValue([{
+      number: 42,
+      labels: [{ name: "enhancement" }],
+      assignees: [],
+      author: { login: "alice" },
+      comments: [],
+      createdAt: "2025-06-14T10:00:00Z",
+      updatedAt: "2025-06-15T10:00:00Z",
+      url: "https://github.com/hivemoot/test/issues/42",
+      title: "Fix dashboard",
+    }] as any);
+    mockedFetchNotifications.mockResolvedValue(notificationMap);
+    mockedBuildSummary.mockReturnValue({ ...testSummary, notes: [], unackedMentions: [] });
+    mockedFormatStatus.mockReturnValue("output");
+
+    await buzzCommand({});
+
+    const summaryArg = mockedFormatStatus.mock.calls[0][0];
+    expect(summaryArg.unackedMentions).toEqual([]);
+  });
+
   it("filters already-acked mentions out of unackedMentions", async () => {
     const notificationMap = new Map([[42, {
       threadId: "T42",

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -3,6 +3,7 @@ import {
   type BuzzOptions,
   type GitHubIssue,
   type NotificationRef,
+  type RepoSummary,
   type RecentClosedItem,
   type RepoRef,
   type TeamConfig,
@@ -45,11 +46,14 @@ function buildUnackedMentions(
   notifications: NotificationMap,
   processedThreadIds: Set<string>,
   now: Date,
+  visibleOpenNumbers: Set<number>,
+  fetchedOpenNumbers: Set<number>,
 ): NotificationRef[] {
   const mentions: NotificationRef[] = [];
 
   for (const [number, n] of notifications.entries()) {
     if (n.reason !== "mention") continue;
+    if (fetchedOpenNumbers.has(number) && !visibleOpenNumbers.has(number)) continue;
 
     const ackKey = `${n.threadId}:${n.updatedAt}`;
     if (processedThreadIds.has(ackKey)) continue;
@@ -74,6 +78,30 @@ function buildUnackedMentions(
     return a.ackKey.localeCompare(b.ackKey);
   });
   return mentions;
+}
+
+function collectVisibleOpenNumbers(summary: RepoSummary): Set<number> {
+  const visibleOpenNumbers = new Set<number>();
+  const sections = [
+    summary.needsHuman,
+    summary.driveDiscussion,
+    summary.driveImplementation,
+    summary.voteOn,
+    summary.discuss,
+    summary.implement,
+    summary.unclassified ?? [],
+    summary.reviewPRs,
+    summary.draftPRs,
+    summary.addressFeedback,
+  ];
+
+  for (const items of sections) {
+    for (const item of items) {
+      visibleOpenNumbers.add(item.number);
+    }
+  }
+
+  return visibleOpenNumbers;
 }
 
 export async function buzzCommand(options: BuzzOptions): Promise<void> {
@@ -186,7 +214,16 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     teamConfig?.focusFilters,
   );
   const processedThreadIds = await processedThreadIdsPromise;
-  summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());
+  const fetchedOpenNumbers = new Set<number>();
+  for (const issue of issues) fetchedOpenNumbers.add(issue.number);
+  for (const pr of prs) fetchedOpenNumbers.add(pr.number);
+  summary.unackedMentions = buildUnackedMentions(
+    notifications,
+    processedThreadIds,
+    new Date(),
+    collectVisibleOpenNumbers(summary),
+    fetchedOpenNumbers,
+  );
   summary.recentlyClosedByYou = recentlyClosedByYou;
 
   if (issuesResult.status === "rejected" && prsResult.status === "rejected") {

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -183,6 +183,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     votes,
     notifications,
     teamConfig?.focus,
+    teamConfig?.focusFilters,
   );
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -13,9 +13,19 @@ team:
   #   This project is ...
   #   Read CONTRIBUTING.md for contribution workflow and access model.
 
-  # focus: optional repo steering for buzz output
+  # Structured focus blocks are optional and let you steer buzz output:
+  # activeFocus: default
+  # focuses:
+  #   default:
+  #     objective: Focus on PR reviews first.
+  #     filters:
+  #       labels:
+  #         include: ["bug"]
+  #       authors:
+  #         exclude: ["dependabot[bot]"]
+  #
+  # Legacy fallback format is still supported:
   # focus:
-  #   # default is free-form focus text (does not change filters in MVP)
   #   default: Focus on PR reviews first.
 
   roles:

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -573,6 +573,209 @@ team:
     expect(config.focus).toBe("Clear the review queue. No new code.");
   });
 
+  it("resolves filters from the active focus block", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "bug-hunt",
+        focuses: {
+          default: { objective: "General work." },
+          "bug-hunt": {
+            objective: "Fix bugs.",
+            filters: {
+              labels: {
+                include: ["bug", "v2.0-blocker"],
+                exclude: ["wontfix"],
+              },
+              authors: {
+                exclude: ["dependabot[bot]"],
+              },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Fix bugs.");
+    expect(config.focusFilters).toEqual({
+      labels: {
+        include: ["bug", "v2.0-blocker"],
+        exclude: ["wontfix"],
+      },
+      authors: {
+        exclude: ["dependabot[bot]"],
+      },
+    });
+  });
+
+  it("trims, dedupes, and drops empty focus filter values", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              labels: {
+                include: ["", " bug ", "bug", "wontfix "],
+              },
+              authors: {
+                include: ["", " worker ", "worker"],
+              },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Review queue.");
+    expect(config.focusFilters).toEqual({
+      labels: { include: ["bug", "wontfix"] },
+      authors: { include: ["worker"] },
+    });
+  });
+
+  it("treats empty focus filters as a no-op", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              labels: {
+                include: ["", "   "],
+              },
+              authors: {
+                exclude: [],
+              },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    const config = await loadTeamConfig(repo);
+
+    expect(config.focus).toBe("Review queue.");
+    expect(config.focusFilters).toBeUndefined();
+  });
+
+  it("throws INVALID_CONFIG when filters is not an object", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: "not-an-object",
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters must be an object"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a match filter is not an object", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              labels: "bug",
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters.labels must be an object"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when a filter list contains non-string values", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              authors: {
+                include: ["worker", 5],
+              },
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters.authors.include[1] must be a string"),
+    });
+  });
+
+  it("throws INVALID_CONFIG when suppressSections is configured", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+            filters: {
+              suppressSections: ["ready-to-implement"],
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.default.filters.suppressSections is not supported"),
+    });
+  });
+
   it("falls back to default block when activeFocus is absent", async () => {
     const focusesYaml = yaml.dump({
       team: {

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -776,6 +776,34 @@ team:
     });
   });
 
+  it("throws INVALID_CONFIG when an inactive focus still uses suppressSections", async () => {
+    const focusesYaml = yaml.dump({
+      team: {
+        activeFocus: "default",
+        focuses: {
+          default: {
+            objective: "Review queue.",
+          },
+          "bug-hunt": {
+            objective: "Fix bugs.",
+            filters: {
+              suppressSections: ["ready-to-implement"],
+            },
+          },
+        },
+        roles: {
+          engineer: { description: "Engineer", instructions: "Build things." },
+        },
+      },
+    });
+    mockedGh.mockResolvedValue(encode(focusesYaml));
+
+    await expect(loadTeamConfig(repo)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("team.focuses.bug-hunt.filters.suppressSections is not supported"),
+    });
+  });
+
   it("falls back to default block when activeFocus is absent", async () => {
     const focusesYaml = yaml.dump({
       team: {

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -170,6 +170,24 @@ function parseFocusFilters(raw: unknown, path: string): FocusFilters | undefined
   };
 }
 
+function validateFocusBlocks(
+  focuses: Record<string, unknown>,
+): Map<string, FocusFilters | undefined> {
+  const parsedFilters = new Map<string, FocusFilters | undefined>();
+
+  for (const [name, block] of Object.entries(focuses)) {
+    if (!block || typeof block !== "object" || Array.isArray(block)) continue;
+
+    const focusBlock = block as Record<string, unknown>;
+    parsedFilters.set(
+      name,
+      parseFocusFilters(focusBlock.filters, `team.focuses.${name}.filters`),
+    );
+  }
+
+  return parsedFilters;
+}
+
 // Resolves focus from the team config. Handles two formats:
 // 1. New: team.focuses (dict of FocusBlock) + team.activeFocus (key)
 // 2. Legacy: team.focus.default (plain string)
@@ -179,6 +197,7 @@ function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocusBlock | un
 
   if (rawFocuses && typeof rawFocuses === "object" && !Array.isArray(rawFocuses)) {
     const focuses = rawFocuses as Record<string, unknown>;
+    const parsedFilters = validateFocusBlocks(focuses);
 
     // Determine which block is active.
     const rawActiveFocus = rawTeam.activeFocus;
@@ -208,7 +227,7 @@ function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocusBlock | un
 
       return {
         objective,
-        filters: parseFocusFilters(b.filters, `team.focuses.${candidate}.filters`),
+        filters: parsedFilters.get(candidate),
       };
     }
 

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -2,6 +2,8 @@ import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
   HivemootConfig,
+  FocusFilters,
+  FocusMatchFilter,
   TeamConfig,
   RepoRef,
   RoleConfig,
@@ -64,12 +66,115 @@ function parseLegacyFocus(rawFocus: unknown): string | undefined {
 
 const MAX_OBJECTIVE_LENGTH = 2_000;
 const MAX_FOCUS_NAME_LENGTH = 64;
+const MAX_FILTER_VALUE_LENGTH = 128;
+const MAX_FILTER_VALUES = 100;
+
+interface ResolvedFocusBlock {
+  objective: string;
+  filters?: FocusFilters;
+}
+
+function invalidConfig(message: string): never {
+  throw new CliError(
+    `Config error: ${message}`,
+    "INVALID_CONFIG",
+    1,
+  );
+}
+
+function parseStringList(
+  raw: unknown,
+  maxLength: number,
+  path: string,
+): string[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    invalidConfig(`${path} must be an array of strings`);
+  }
+
+  if (raw.length > MAX_FILTER_VALUES) {
+    invalidConfig(`${path} supports at most ${MAX_FILTER_VALUES} entries`);
+  }
+
+  const values: string[] = [];
+  const seen = new Set<string>();
+
+  for (const [index, entry] of raw.entries()) {
+    if (typeof entry !== "string") {
+      invalidConfig(`${path}[${index}] must be a string`);
+    }
+
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (trimmed.length > maxLength) {
+      invalidConfig(`${path}[${index}] exceeds ${maxLength} characters`);
+    }
+
+    const dedupeKey = trimmed.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    values.push(trimmed);
+  }
+
+  return values.length > 0 ? values : undefined;
+}
+
+function parseMatchFilter(raw: unknown, path: string): FocusMatchFilter | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    invalidConfig(`${path} must be an object`);
+  }
+
+  const filter = raw as Record<string, unknown>;
+  const unknownKeys = Object.keys(filter).filter((key) => key !== "include" && key !== "exclude");
+  if (unknownKeys.length > 0) {
+    invalidConfig(`${path} contains unsupported key(s): ${unknownKeys.join(", ")}`);
+  }
+
+  const include = parseStringList(filter.include, MAX_FILTER_VALUE_LENGTH, `${path}.include`);
+  const exclude = parseStringList(filter.exclude, MAX_FILTER_VALUE_LENGTH, `${path}.exclude`);
+
+  if (!include && !exclude) return undefined;
+
+  return {
+    ...(include ? { include } : {}),
+    ...(exclude ? { exclude } : {}),
+  };
+}
+
+function parseFocusFilters(raw: unknown, path: string): FocusFilters | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    invalidConfig(`${path} must be an object`);
+  }
+
+  const filters = raw as Record<string, unknown>;
+  if (Object.hasOwn(filters, "suppressSections")) {
+    invalidConfig(`${path}.suppressSections is not supported; use ${path}.labels.exclude with governance labels instead`);
+  }
+
+  const unknownKeys = Object.keys(filters).filter((key) => key !== "labels" && key !== "authors");
+  if (unknownKeys.length > 0) {
+    invalidConfig(`${path} contains unsupported key(s): ${unknownKeys.join(", ")}`);
+  }
+
+  const labels = parseMatchFilter(filters.labels, `${path}.labels`);
+  const authors = parseMatchFilter(filters.authors, `${path}.authors`);
+
+  if (!labels && !authors) return undefined;
+
+  return {
+    ...(labels ? { labels } : {}),
+    ...(authors ? { authors } : {}),
+  };
+}
 
 // Resolves focus from the team config. Handles two formats:
 // 1. New: team.focuses (dict of FocusBlock) + team.activeFocus (key)
 // 2. Legacy: team.focus.default (plain string)
 // The new format takes precedence when team.focuses is present.
-function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
+function resolveFocus(rawTeam: Record<string, unknown>): ResolvedFocusBlock | undefined {
   const rawFocuses = rawTeam.focuses;
 
   if (rawFocuses && typeof rawFocuses === "object" && !Array.isArray(rawFocuses)) {
@@ -101,14 +206,19 @@ function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
       // and the next candidate (or undefined) is returned.
       if (objective.length > MAX_OBJECTIVE_LENGTH) continue;
 
-      return objective;
+      return {
+        objective,
+        filters: parseFocusFilters(b.filters, `team.focuses.${candidate}.filters`),
+      };
     }
 
     return undefined;
   }
 
   // Fall back to the legacy focus.default format.
-  return parseLegacyFocus(rawTeam.focus);
+  const objective = parseLegacyFocus(rawTeam.focus);
+  if (!objective) return undefined;
+  return { objective };
 }
 
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
@@ -207,13 +317,14 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
     };
   }
 
-  const focus = resolveFocus(team as unknown as Record<string, unknown>);
+  const resolvedFocus = resolveFocus(team as unknown as Record<string, unknown>);
 
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
-    focus,
+    focus: resolvedFocus?.objective,
+    focusFilters: resolvedFocus?.filters,
   };
 }
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -5,8 +5,19 @@ export interface RoleConfig {
   instructions: string;
 }
 
+export interface FocusMatchFilter {
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface FocusFilters {
+  labels?: FocusMatchFilter;
+  authors?: FocusMatchFilter;
+}
+
 export interface FocusBlock {
   objective: string;
+  filters?: FocusFilters;
 }
 
 export interface TeamConfig {
@@ -14,6 +25,7 @@ export interface TeamConfig {
   onboarding?: string;
   roles: Record<string, RoleConfig>;
   focus?: string;
+  focusFilters?: FocusFilters;
 }
 
 export interface HivemootConfig {

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -450,6 +450,39 @@ describe("buildSummary()", () => {
     expect(summary.implement[0].competingPRs).toBe(2);
   });
 
+  it("counts filtered-out competing PRs toward visible implement items", () => {
+    const issue = makeIssue({
+      number: 452,
+      title: "Bug queue",
+      labels: [{ name: "bug" }, { name: "hivemoot:ready-to-implement" }],
+    });
+    const pr1 = makePR({
+      number: 1002,
+      labels: [{ name: "bug" }],
+      closingIssuesReferences: [{ number: 452 }],
+    });
+    const pr2 = makePR({
+      number: 1003,
+      labels: [{ name: "enhancement" }],
+      closingIssuesReferences: [{ number: 452 }],
+    });
+
+    const summary = buildSummary(
+      repo,
+      [issue],
+      [pr1, pr2],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"] } },
+    );
+
+    expect(summary.implement).toHaveLength(1);
+    expect(summary.implement[0].competingPRs).toBe(2);
+  });
+
   it("does not set competingPRs when no competing PRs exist", () => {
     const issue = makeIssue({ number: 45, title: "User Dashboard" });
 

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1312,4 +1312,199 @@ describe("buildSummary()", () => {
       "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.",
     );
   });
+
+  it("filters issues by label include rules before classification", () => {
+    const issues = [
+      makeIssue({ number: 700, labels: [{ name: "bug" }, { name: "hivemoot:ready-to-implement" }] }),
+      makeIssue({ number: 701, labels: [{ name: "enhancement" }, { name: "hivemoot:ready-to-implement" }] }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"] } },
+    );
+
+    expect(summary.implement.map((item) => item.number)).toEqual([700]);
+  });
+
+  it("keeps repository health and issue pipeline based on unfiltered data", () => {
+    const issues = [
+      makeIssue({ number: 705, labels: [{ name: "bug" }] }),
+      makeIssue({ number: 706, labels: [{ name: "hivemoot:discussion" }] }),
+      makeIssue({ number: 707, labels: [{ name: "hivemoot:ready-to-implement" }] }),
+    ];
+    const prs = [
+      makePR({
+        number: 708,
+        labels: [{ name: "bug" }],
+        author: { login: "alice" },
+        reviewDecision: "APPROVED",
+        mergeable: "MERGEABLE",
+      }),
+      makePR({
+        number: 709,
+        labels: [{ name: "enhancement" }],
+        author: { login: "bob" },
+        reviewDecision: "CHANGES_REQUESTED",
+      }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      prs,
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"] } },
+    );
+
+    expect(summary.unclassified.map((item) => item.number)).toEqual([705]);
+    expect(summary.reviewPRs.map((item) => item.number)).toEqual([708]);
+    expect(summary.repositoryHealth?.openPRs).toEqual({
+      total: 2,
+      mergeReady: 1,
+      changesRequested: 1,
+      draft: 0,
+    });
+    expect(summary.repositoryHealth?.issuePipeline).toEqual({
+      discussion: 1,
+      voting: 0,
+      readyToImplement: 1,
+    });
+    expect(summary.notes).not.toContain(
+      "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.",
+    );
+  });
+
+  it("uses exclude-wins precedence when include and exclude both match", () => {
+    const issues = [
+      makeIssue({
+        number: 710,
+        labels: [{ name: "bug" }, { name: "wontfix" }, { name: "hivemoot:ready-to-implement" }],
+      }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { labels: { include: ["bug"], exclude: ["wontfix"] } },
+    );
+
+    expect(summary.implement).toHaveLength(0);
+  });
+
+  it("filters items by author include/exclude rules", () => {
+    const issues = [
+      makeIssue({ number: 720, author: { login: "dependabot[bot]" } }),
+      makeIssue({ number: 721, author: { login: "alice" } }),
+      makeIssue({ number: 724, author: null }),
+    ];
+    const prs = [
+      makePR({ number: 722, author: { login: "alice" } }),
+      makePR({ number: 723, author: { login: "bob" } }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      prs,
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { authors: { include: ["alice", "dependabot[bot]"], exclude: ["dependabot[bot]"] } },
+    );
+
+    expect(summary.implement.map((item) => item.number)).toEqual([721]);
+    expect(summary.reviewPRs.map((item) => item.number)).toEqual([722]);
+  });
+
+  it("keeps null-author items visible when only author excludes are configured", () => {
+    const issues = [
+      makeIssue({ number: 725, author: null }),
+      makeIssue({ number: 726, author: { login: "dependabot[bot]" } }),
+    ];
+
+    const summary = buildSummary(
+      repo,
+      issues,
+      [],
+      "testuser",
+      now,
+      new Map(),
+      new Map(),
+      undefined,
+      { authors: { exclude: ["dependabot[bot]"] } },
+    );
+
+    expect(summary.implement.map((item) => item.number)).toEqual([725]);
+  });
+
+  it("suppresses notifications for filtered-out open items", () => {
+    const discussionIssue = makeIssue({
+      number: 730,
+      labels: [{ name: "hivemoot:discussion" }, { name: "enhancement" }],
+    });
+    const readyIssue = makeIssue({
+      number: 731,
+      labels: [{ name: "bug" }, { name: "hivemoot:ready-to-implement" }],
+    });
+    const notifications = new Map([
+      [730, { threadId: "T730", reason: "comment", updatedAt: "2025-06-15T11:00:00Z" }],
+      [999, {
+        threadId: "T999",
+        reason: "mention",
+        updatedAt: "2025-06-15T12:00:00Z",
+        title: "Still unread",
+        url: "https://github.com/hivemoot/colony/issues/999",
+        itemType: "Issue" as const,
+      }],
+    ]);
+
+    const summary = buildSummary(
+      repo,
+      [discussionIssue, readyIssue],
+      [],
+      "testuser",
+      now,
+      new Map(),
+      notifications,
+      undefined,
+      { labels: { include: ["bug"] } },
+    );
+
+    expect(summary.discuss).toHaveLength(0);
+    expect(summary.implement.map((item) => item.number)).toEqual([731]);
+    expect(summary.notifications).toEqual([
+      {
+        number: 999,
+        title: "Still unread",
+        url: "https://github.com/hivemoot/colony/issues/999",
+        itemType: "Issue",
+        threadId: "T999",
+        reason: "mention",
+        timestamp: "2025-06-15T12:00:00Z",
+        age: "just now",
+        ackKey: "T999:2025-06-15T12:00:00Z",
+        section: "other",
+      },
+    ]);
+  });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -450,7 +450,7 @@ export function buildSummary(
   }
 
   // Annotate implement items with competing PR counts
-  const competitionMap = currentUser ? buildCompetitionMap(visiblePRs, currentUser) : new Map<number, number>();
+  const competitionMap = currentUser ? buildCompetitionMap(prs, currentUser) : new Map<number, number>();
   for (const item of implement) {
     const count = competitionMap.get(item.number) ?? 0;
     if (count > 0) {

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -1,4 +1,5 @@
 import type {
+  FocusFilters,
   GitHubIssue,
   GitHubPR,
   NotificationRef,
@@ -36,6 +37,71 @@ interface IssuePipelineCounts {
 
 const OMITTED_PIPELINE_NOTE =
   "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.";
+
+interface NormalizedFocusFilters {
+  labelInclude?: Set<string>;
+  labelExclude?: Set<string>;
+  authorInclude?: Set<string>;
+  authorExclude?: Set<string>;
+}
+
+function normalizeFilterValues(values?: string[]): Set<string> | undefined {
+  if (!values || values.length === 0) return undefined;
+  const normalized = values
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+  if (normalized.length === 0) return undefined;
+  return new Set(normalized);
+}
+
+function normalizeFocusFilters(focusFilters?: FocusFilters): NormalizedFocusFilters {
+  return {
+    labelInclude: normalizeFilterValues(focusFilters?.labels?.include),
+    labelExclude: normalizeFilterValues(focusFilters?.labels?.exclude),
+    authorInclude: normalizeFilterValues(focusFilters?.authors?.include),
+    authorExclude: normalizeFilterValues(focusFilters?.authors?.exclude),
+  };
+}
+
+function hasItemFilters(filters: NormalizedFocusFilters): boolean {
+  return Boolean(
+    filters.labelInclude ||
+    filters.labelExclude ||
+    filters.authorInclude ||
+    filters.authorExclude,
+  );
+}
+
+function matchesFocusFilters(
+  labels: Array<{ name: string }>,
+  authorLogin: string | undefined,
+  filters: NormalizedFocusFilters,
+): boolean {
+  if (!hasItemFilters(filters)) return true;
+
+  const normalizedLabels = labels.map((label) => label.name.toLowerCase());
+  const normalizedAuthor = authorLogin?.toLowerCase();
+
+  if (filters.labelExclude && normalizedLabels.some((label) => filters.labelExclude?.has(label))) {
+    return false;
+  }
+
+  if (filters.labelInclude && !normalizedLabels.some((label) => filters.labelInclude?.has(label))) {
+    return false;
+  }
+
+  if (filters.authorExclude && normalizedAuthor && filters.authorExclude.has(normalizedAuthor)) {
+    return false;
+  }
+
+  if (filters.authorInclude) {
+    if (!normalizedAuthor || !filters.authorInclude.has(normalizedAuthor)) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 function isMergeReadyPR(pr: GitHubPR): boolean {
   if (pr.isDraft) return false;
@@ -79,6 +145,7 @@ function classifyIssue(
   currentUser: string,
   now: Date,
 ): { bucket: "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified"; item: SummaryItem } {
+  const bucket = classifyIssueBucket(issue);
   const age = timeAgo(issue.createdAt, now);
   const assigned =
     issue.assignees.length > 0
@@ -110,37 +177,57 @@ function classifyIssue(
     }
   }
 
-  // Issues needing human attention are excluded from all actionable buckets
-  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) {
+  // Issues needing human attention are excluded from all actionable buckets.
+  if (bucket === "needsHuman") {
     return {
       bucket: "needsHuman",
       item: { ...base, assigned },
     };
   }
 
-  // Bot governance labels (canonical + legacy aliases)
-  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) {
+  // Bot governance labels (canonical + legacy aliases).
+  if (bucket === "voteOn") {
     return { bucket: "voteOn", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) {
+  if (bucket === "discuss") {
     return { bucket: "discuss", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) {
+  if (bucket === "implement") {
     return { bucket: "implement", item: { ...base, assigned } };
-  }
-
-  // Keyword fallback (repos without the bot)
-  if (hasLabel(issue.labels, "vote")) {
-    return { bucket: "voteOn", item: base };
-  }
-  if (hasLabel(issue.labels, "discuss")) {
-    return { bucket: "discuss", item: base };
   }
 
   return {
     bucket: "unclassified",
     item: { ...base, assigned },
   };
+}
+
+function classifyIssueBucket(issue: GitHubIssue): "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified" {
+  // Issues needing human attention are excluded from all actionable buckets.
+  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) {
+    return "needsHuman";
+  }
+
+  // Bot governance labels (canonical + legacy aliases).
+  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) {
+    return "voteOn";
+  }
+  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) {
+    return "discuss";
+  }
+  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) {
+    return "implement";
+  }
+
+  // Keyword fallback (repos without the bot).
+  if (hasLabel(issue.labels, "vote")) {
+    return "voteOn";
+  }
+  if (hasLabel(issue.labels, "discuss")) {
+    return "discuss";
+  }
+
+  return "unclassified";
 }
 
 function classifyPR(
@@ -311,6 +398,7 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  focusFilters?: FocusFilters,
 ): RepoSummary {
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
@@ -322,7 +410,28 @@ export function buildSummary(
   const addressFeedback: SummaryItem[] = [];
   const notes: string[] = [];
 
+  const normalizedFocusFilters = normalizeFocusFilters(focusFilters);
+  const shouldFilterItems = hasItemFilters(normalizedFocusFilters);
+  const visibleIssues = shouldFilterItems
+    ? issues.filter((issue) =>
+      matchesFocusFilters(issue.labels, issue.author?.login ?? undefined, normalizedFocusFilters))
+    : issues;
+  const visiblePRs = shouldFilterItems
+    ? prs.filter((pr) =>
+      matchesFocusFilters(pr.labels, pr.author?.login ?? undefined, normalizedFocusFilters))
+    : prs;
+
+  let fullDiscussionCount = 0;
+  let fullVotingCount = 0;
+  let fullReadyToImplementCount = 0;
   for (const issue of issues) {
+    const bucket = classifyIssueBucket(issue);
+    if (bucket === "discuss") fullDiscussionCount += 1;
+    else if (bucket === "voteOn") fullVotingCount += 1;
+    else if (bucket === "implement") fullReadyToImplementCount += 1;
+  }
+
+  for (const issue of visibleIssues) {
     const { bucket, item } = classifyIssue(issue, currentUser, now);
     if (bucket === "needsHuman") needsHuman.push(item);
     else if (bucket === "voteOn") voteOn.push(item);
@@ -341,7 +450,7 @@ export function buildSummary(
   }
 
   // Annotate implement items with competing PR counts
-  const competitionMap = currentUser ? buildCompetitionMap(prs, currentUser) : new Map<number, number>();
+  const competitionMap = currentUser ? buildCompetitionMap(visiblePRs, currentUser) : new Map<number, number>();
   for (const item of implement) {
     const count = competitionMap.get(item.number) ?? 0;
     if (count > 0) {
@@ -349,7 +458,7 @@ export function buildSummary(
     }
   }
 
-  for (const pr of prs) {
+  for (const pr of visiblePRs) {
     const { bucket, item } = classifyPR(pr, now);
     const ctx = reviewContext(pr, currentUser, now);
     if (ctx) {
@@ -416,6 +525,9 @@ export function buildSummary(
   // Annotate all items with unread notification status and collect notification refs
   const notificationRefs: NotificationRef[] = [];
   const matchedNumbers = new Set<number>();
+  const fetchedOpenNumbers = new Set<number>();
+  for (const issue of issues) fetchedOpenNumbers.add(issue.number);
+  for (const pr of prs) fetchedOpenNumbers.add(pr.number);
 
   for (const [section, items] of sectionEntries) {
     for (const item of items) {
@@ -448,8 +560,11 @@ export function buildSummary(
 
   // Include unread notification threads that do not map to currently fetched
   // open items (e.g. closed threads or items beyond fetch limit).
+  // Skip items that are open but filtered out by focus — they are
+  // intentionally hidden and should not surface as "other" notifications.
   for (const [number, n] of notifications.entries()) {
     if (matchedNumbers.has(number)) continue;
+    if (fetchedOpenNumbers.has(number)) continue;
 
     const ackKey = `${n.threadId}:${n.updatedAt}`;
     notificationRefs.push({
@@ -480,9 +595,9 @@ export function buildSummary(
   );
   const issuePipeline: IssuePipelineCounts | undefined = hasPhaseLabels
     ? {
-        discussion: discuss.length,
-        voting: voteOn.length,
-        readyToImplement: implement.length,
+        discussion: fullDiscussionCount,
+        voting: fullVotingCount,
+        readyToImplement: fullReadyToImplementCount,
       }
     : undefined;
   const repositoryHealth = buildRepositoryHealth(issues, prs, currentUser, now, issuePipeline);


### PR DESCRIPTION
## What

Add structured label/author filters to team focus blocks so `hivemoot buzz` can hide non-matching open work in code, not just in prompt text.

Fixes #178

## Why

Issue #178 still needs a fresh implementation after the older candidate PR closed. The current review direction narrowed scope to label/author filtering only. Without this change, focus blocks can describe priorities, but they cannot enforce them, and stale `suppressSections` configs fail silently.

## What it looks like

**Before:**

```text
team:
  activeFocus: default
  focuses:
    default:
      objective: Fix bugs first.
      filters:
        labels:
          include: ["bug"]

$ hivemoot buzz
... still shows bug and non-bug open work because filters are ignored
```

**After:**

```text
team:
  activeFocus: default
  focuses:
    default:
      objective: Fix bugs first.
      filters:
        labels:
          include: ["bug"]
        authors:
          exclude: ["dependabot[bot]"]

$ hivemoot buzz
... shows only matching open items, while repo health still reflects the full repo state

$ hivemoot buzz
Config error: team.focuses.default.filters.suppressSections is not supported; use team.focuses.default.filters.labels.exclude with governance labels instead
```

## Notes

- Repository health and issue-pipeline metrics stay based on unfiltered issues/PRs.
- Unread notifications for filtered-out open items stay hidden instead of reappearing under `other`.
- CLI version bumped to `0.2.2` per repo policy.
- Verification: `npm test`, `npm run typecheck`, `npm run build` in `cli/`.
