### PR TITLE
fix(cli): auto-bump publish version

### DIFF
--- a/.agent/skills/hivemoot-contribute/references/implement.md
+++ b/.agent/skills/hivemoot-contribute/references/implement.md
@@ -24,7 +24,7 @@ Push branches to your fork and open PRs from fork branches into the upstream rep
 
 ### CLI Changes
 
-If you change `cli/**`, bump CLI version files in the same PR: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.
+If you change `cli/**`, do not bump `cli/package.json` or `cli/package-lock.json` in the PR. The CLI publish workflow auto-bumps the version on `main` before publishing.
 
 ## Keeping Your PR Moving
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,9 @@ on:
     paths: [cli/**]
   pull_request:
     branches: [main]
-    paths: [cli/**]
+    paths:
+      - cli/**
+      - .github/workflows/cli.yml
   workflow_dispatch:
 
 jobs:
@@ -43,6 +45,11 @@ jobs:
     needs: typecheck-test-build
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: cli-publish
+      cancel-in-progress: false
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: cli
@@ -50,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -62,10 +71,64 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Auto-bump version if needed
+        if: "github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(cli): auto-bump version')"
+        id: auto_bump
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          NPM_LATEST=$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "0.0.0")
+
+          NEXT_VERSION=$(node -e '
+            const current = process.argv[1];
+            const latest = process.argv[2];
+            const parse = (value) => value.split(".").map((part) => Number.parseInt(part, 10));
+            const isValid = (parts) =>
+              parts.length === 3 && parts.every((part) => Number.isInteger(part) && part >= 0);
+            const compare = (left, right) =>
+              left[0] - right[0] || left[1] - right[1] || left[2] - right[2];
+            const currentParts = parse(current);
+            const latestParts = parse(latest);
+
+            if (!isValid(currentParts) || !isValid(latestParts)) {
+              throw new Error(`Unsupported semver for auto-bump: current=${current} latest=${latest}`);
+            }
+
+            if (compare(currentParts, latestParts) > 0) {
+              process.exit(0);
+            }
+
+            latestParts[2] += 1;
+            process.stdout.write(latestParts.join("."));
+          ' "$CURRENT_VERSION" "$NPM_LATEST")
+
+          if [ -z "$NEXT_VERSION" ]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          npm version "$NEXT_VERSION" --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(cli): auto-bump version to $(node -p 'require(\"./package.json\").version')"
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+
       - name: Build
         run: npm run build
 
+      - name: Push auto-bump commit
+        if: steps.auto_bump.outputs.bumped == 'true'
+        id: push_bump
+        working-directory: .
+        run: |
+          if ! git push origin HEAD:main; then
+            echo "::warning::Push failed — main advanced since checkout. Skipping publish; next run will carry these changes."
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check if version is already published
+        if: steps.push_bump.outputs.push_failed != 'true'
         id: check
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
 - **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
 - **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
-- **If you change `cli/**`, bump CLI version files in the same PR**: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.
+- **If you change `cli/**`, do not bump CLI version files in the PR**: the CLI publish workflow auto-bumps `cli/package.json` and `cli/package-lock.json` on `main` so feature PRs can still qualify for automerge.
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 - Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
 - Include a before/after example showing the outcome (the PR template will guide you)
 - Include tests when relevant
-- If you change anything under `cli/**`, bump the CLI package version in both `cli/package.json` and `cli/package-lock.json` in the same PR so the npm publish job can release it.
+- If you change anything under `cli/**`, do not bump `cli/package.json` or `cli/package-lock.json` in the PR. The CLI publish workflow auto-bumps the version on `main` before publishing.
 
 ## Fork-First Publishing
 


### PR DESCRIPTION
Fixes #406

## Why

CLI feature PRs currently have to edit `cli/package.json` and `cli/package-lock.json`, which permanently trips the repo's automerge `denyPaths`. That blocks merge-ready CLI work from qualifying for automerge and leaves the contributor docs pointing agents at the wrong release flow.

## What changed

- auto-bump the CLI patch version in `.github/workflows/cli.yml` when `main` contains an unpublished CLI version
- serialize `publish` jobs and keep the release build on the triggering SHA instead of a newer unvalidated tip
- fail closed when the auto-bump push loses the race because `main` advanced before the workflow could land the bump commit
- run the CLI PR workflow for `.github/workflows/cli.yml` changes so workflow-only release fixes get CI on the PR
- update `AGENTS.md` and `CONTRIBUTING.md` so CLI PRs stop carrying manual version bumps

## Before / After

| Scenario | Before | After |
|---|---|---|
| CLI feature PR touches `cli/**` | Must bump `cli/package*.json`, which hits `denyPaths` and blocks automerge | No version files in the PR; publish owns the bump on `main` |
| Publish job sees `CURRENT == NPM_LATEST` | Skips publish unless the PR already changed version files | Bumps the next patch version and publishes from the same run |
| `main` advances before bump push | No guarded path for auto-bump ownership | Workflow skips publish and lets the next tested run carry the release |
| Workflow-only fix to `.github/workflows/cli.yml` | No CLI PR checks run | CLI PR checks run on the workflow change itself |

## Validation

- `git push --dry-run origin HEAD`
- `npx -y js-yaml .github/workflows/cli.yml >/dev/null`
- `npm ci --prefix cli`
- `npm test --prefix cli`
- `npm run --prefix cli typecheck`
- `npm run --prefix cli build`
