### PR TITLE
fix(web): harden BYOK 500 handling

### DIFF
--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -209,4 +209,31 @@ describe("POST /api/byok/config", () => {
       expect.anything(),
     );
   });
+
+  it("returns a structured 500 when storing the envelope throws", async () => {
+    vi.mocked(setByokEnvelope).mockRejectedValue(new Error("redis unavailable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test1234",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[byok-config] Failed to process request",
+      expect.objectContaining({
+        installationId: "123",
+        error: expect.any(Error),
+      }),
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -41,41 +41,49 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Validate the key with the provider
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
+  try {
+    // Validate the key with the provider
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
     );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-config] Failed to process request", {
+      installationId,
+      error,
+    });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/revoke/route.test.ts
+++ b/apps/web/src/app/api/byok/revoke/route.test.ts
@@ -102,4 +102,27 @@ describe("POST /api/byok/revoke", () => {
     expect(body.code).toBe(BYOK_ERROR.NOT_CONFIGURED);
     expect(body.message).toBe("BYOK is not configured");
   });
+
+  it("returns a structured 500 when envelope lookup throws", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis unavailable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const req = makeRequest({});
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[byok-revoke] Failed to process request",
+      expect.objectContaining({
+        installationId: "123",
+        error: expect.any(Error),
+      }),
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/revoke/route.ts
+++ b/apps/web/src/app/api/byok/revoke/route.ts
@@ -15,29 +15,36 @@ export async function POST(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   const installationId = auth.session.installationId;
+  try {
+    const existing = await getByokEnvelope(installationId, auth.redis);
+    if (!existing) {
+      return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+    }
 
-  const existing = await getByokEnvelope(installationId, auth.redis);
-  if (!existing) {
-    return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+    // Clear ciphertext fields, keep metadata for audit
+    const revoked = {
+      ...existing,
+      status: "revoked" as const,
+      ciphertext: "",
+      iv: "",
+      tag: "",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+    };
+
+    await setByokEnvelope(installationId, revoked, auth.redis);
+
+    return NextResponse.json({
+      status: "revoked",
+      provider: revoked.provider,
+      model: revoked.model,
+      updatedAt: revoked.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-revoke] Failed to process request", {
+      installationId,
+      error,
+    });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  // Clear ciphertext fields, keep metadata for audit
-  const revoked = {
-    ...existing,
-    status: "revoked" as const,
-    ciphertext: "",
-    iv: "",
-    tag: "",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-  };
-
-  await setByokEnvelope(installationId, revoked, auth.redis);
-
-  return NextResponse.json({
-    status: "revoked",
-    provider: revoked.provider,
-    model: revoked.model,
-    updatedAt: revoked.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -160,4 +160,31 @@ describe("POST /api/byok/rotate", () => {
       expect.anything(),
     );
   });
+
+  it("returns a structured 500 when provider validation throws", async () => {
+    vi.mocked(validateProviderKey).mockRejectedValue(new Error("provider unavailable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const req = makeRequest({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-new-key5678",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[byok-rotate] Failed to process request",
+      expect.objectContaining({
+        installationId: "123",
+        error: expect.any(Error),
+      }),
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -42,40 +42,48 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const validation = await validateProviderKey(provider, apiKey, model);
-  if (!validation.valid) {
-    return byokError(
-      BYOK_ERROR.PROVIDER_INVALID,
-      validation.reason ?? "Provider rejected API key",
-      400,
+  try {
+    const validation = await validateProviderKey(provider, apiKey, model);
+    if (!validation.valid) {
+      return byokError(
+        BYOK_ERROR.PROVIDER_INVALID,
+        validation.reason ?? "Provider rejected API key",
+        400,
+      );
+    }
+
+    // Encrypt the full payload so provider and model are GCM-authenticated
+    const encrypted = encrypt(
+      JSON.stringify({ apiKey, provider, model }),
+      auth.activeKeyVersion,
+      auth.keyring,
     );
+    const envelope: ByokEnvelope = {
+      provider,
+      model,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      tag: encrypted.tag,
+      keyVersion: encrypted.keyVersion,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+      updatedBy: auth.session.userLogin,
+      fingerprint: "",
+    };
+
+    await setByokEnvelope(installationId, envelope, auth.redis);
+
+    return NextResponse.json({
+      status: "active",
+      provider,
+      model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-rotate] Failed to process request", {
+      installationId,
+      error,
+    });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  // Encrypt the full payload so provider and model are GCM-authenticated
-  const encrypted = encrypt(
-    JSON.stringify({ apiKey, provider, model }),
-    auth.activeKeyVersion,
-    auth.keyring,
-  );
-  const envelope: ByokEnvelope = {
-    provider,
-    model,
-    ciphertext: encrypted.ciphertext,
-    iv: encrypted.iv,
-    tag: encrypted.tag,
-    keyVersion: encrypted.keyVersion,
-    status: "active",
-    updatedAt: new Date().toISOString(),
-    updatedBy: auth.session.userLogin,
-    fingerprint: "",
-  };
-
-  await setByokEnvelope(installationId, envelope, auth.redis);
-
-  return NextResponse.json({
-    status: "active",
-    provider,
-    model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/app/api/byok/status/route.test.ts
+++ b/apps/web/src/app/api/byok/status/route.test.ts
@@ -121,4 +121,27 @@ describe("GET /api/byok/status", () => {
       expect.anything(),
     );
   });
+
+  it("returns a structured 500 when envelope lookup throws", async () => {
+    vi.mocked(getByokEnvelope).mockRejectedValue(new Error("redis unavailable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const req = makeRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[byok-status] Failed to process request",
+      expect.objectContaining({
+        installationId: "123",
+        error: expect.any(Error),
+      }),
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/apps/web/src/app/api/byok/status/route.ts
+++ b/apps/web/src/app/api/byok/status/route.ts
@@ -15,34 +15,41 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return auth.response;
 
   const installationId = auth.session.installationId;
+  try {
+    const envelope = await getByokEnvelope(installationId, auth.redis);
+    if (!envelope) {
+      return byokError(
+        BYOK_ERROR.NOT_CONFIGURED,
+        "BYOK is not configured",
+        404,
+      );
+    }
 
-  const envelope = await getByokEnvelope(installationId, auth.redis);
-  if (!envelope) {
-    return byokError(
-      BYOK_ERROR.NOT_CONFIGURED,
-      "BYOK is not configured",
-      404,
-    );
+    if (envelope.status === "revoked") {
+      return byokError(
+        BYOK_ERROR.REVOKED,
+        "BYOK configuration has been revoked",
+        409,
+        {
+          status: envelope.status,
+          provider: envelope.provider,
+          model: envelope.model,
+          updatedAt: envelope.updatedAt,
+        },
+      );
+    }
+
+    return NextResponse.json({
+      status: envelope.status,
+      provider: envelope.provider,
+      model: envelope.model,
+      updatedAt: envelope.updatedAt,
+    });
+  } catch (error) {
+    console.error("[byok-status] Failed to process request", {
+      installationId,
+      error,
+    });
+    return byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500);
   }
-
-  if (envelope.status === "revoked") {
-    return byokError(
-      BYOK_ERROR.REVOKED,
-      "BYOK configuration has been revoked",
-      409,
-      {
-        status: envelope.status,
-        provider: envelope.provider,
-        model: envelope.model,
-        updatedAt: envelope.updatedAt,
-      },
-    );
-  }
-
-  return NextResponse.json({
-    status: envelope.status,
-    provider: envelope.provider,
-    model: envelope.model,
-    updatedAt: envelope.updatedAt,
-  });
 }

--- a/apps/web/src/server/byok-auth.test.ts
+++ b/apps/web/src/server/byok-auth.test.ts
@@ -161,4 +161,29 @@ describe("authenticateByokRequest freshness gate", () => {
       code: "byok_session_stale",
     });
   });
+
+  it("returns a structured 500 when session lookup throws", async () => {
+    mocks.getSetupSession.mockRejectedValue(new Error("redis unavailable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { authenticateByokRequest } = await import("./byok-auth");
+
+    const result = await authenticateByokRequest(makeRequest());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected failure");
+    expect(result.response.status).toBe(500);
+    await expect(result.response.json()).resolves.toMatchObject({
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      message: "Internal server error",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[byok-auth] Failed to load setup session",
+      expect.objectContaining({
+        code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+        error: expect.any(Error),
+      }),
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/apps/web/src/server/byok-auth.ts
+++ b/apps/web/src/server/byok-auth.ts
@@ -13,7 +13,7 @@ import { getRedisClient } from "@/server/redis";
 import { getSetupSession, isSessionFresh, SETUP_SESSION_COOKIE } from "@/server/setup-session";
 import { parseKeyring } from "@/server/crypto";
 import { BYOK_ERROR, byokError } from "@/server/byok-error";
-import type { SetupSessionPayload } from "@/server/setup-session";
+import type { SetupSessionPayload, SetupSessionResult } from "@/server/setup-session";
 
 type AuthSuccess = {
   ok: true;
@@ -171,7 +171,20 @@ export async function authenticateByokRequest(
     };
   }
 
-  const session = await getSetupSession(token, redis);
+  let session: SetupSessionResult | null;
+  try {
+    session = await getSetupSession(token, redis);
+  } catch (error) {
+    console.error("[byok-auth] Failed to load setup session", {
+      code: BYOK_ERROR.SERVER_MISCONFIGURATION,
+      error,
+    });
+    return {
+      ok: false,
+      response: byokError(BYOK_ERROR.SERVER_MISCONFIGURATION, "Internal server error", 500),
+    };
+  }
+
   if (!session) {
     return {
       ok: false,


### PR DESCRIPTION
Fixes #355

## Why

BYOK setup routes still leaked framework HTML 500s when shared session lookup or route-level provider/store calls threw. That breaks the structured JSON error contract the setup flow depends on.

## What changed

- catch `getSetupSession()` failures inside `authenticateByokRequest()` and return structured BYOK 500 JSON
- wrap the main server-side work in `config`, `rotate`, `revoke`, and `status` so provider/store failures also return the same JSON contract
- add regression coverage for the shared auth failure path and each affected route handler

## Before / After

| Scenario | Before | After |
|---|---|---|
| Redis/session lookup throws during BYOK auth | framework HTML 500 | `500 {"code":"byok_server_misconfiguration","message":"Internal server error"}` |
| Provider validation or BYOK store call throws in config/rotate/revoke/status | framework HTML 500 | same structured BYOK JSON 500 |

## Validation

- `cd apps/web && npm test -- --run src/server/byok-auth.test.ts src/app/api/byok/config/route.test.ts src/app/api/byok/rotate/route.test.ts src/app/api/byok/revoke/route.test.ts src/app/api/byok/status/route.test.ts`
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm run lint`

`npm run lint` passes; it still reports two pre-existing warnings in unrelated files: `src/server/agent-token.ts` and `src/server/github-contents.test.ts`.
