### PR TITLE
feat(web): surface task artifact links

### DIFF
--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { TaskArtifact } from "@/server/task-store";
+
+vi.mock("@/server/task-executor-auth", () => ({
+  authenticateTaskExecutorRequest: vi.fn(),
+}));
+
+vi.mock("@/server/task-store", () => ({
+  TASK_ID_PATTERN: /^[a-f0-9]{24}$/,
+  appendTaskArtifacts: vi.fn(),
+  getTask: vi.fn(),
+  verifyTaskClaimToken: vi.fn(),
+}));
+
+import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
+import { appendTaskArtifacts, getTask, verifyTaskClaimToken } from "@/server/task-store";
+import { POST } from "./route";
+
+const BASE_TASK = {
+  task_id: "abc123abc123abc123abc123",
+  status: "running" as const,
+  prompt: "Report outputs",
+  repos: ["hivemoot/hivemoot"],
+  timeout_secs: 300,
+  created_by: "queen",
+  created_at: "2026-03-03T12:00:00.000Z",
+  updated_at: "2026-03-03T12:01:00.000Z",
+};
+
+const VALID_ARTIFACT = {
+  url: "https://github.com/hivemoot/hivemoot/pull/1",
+};
+
+const STORED_ARTIFACTS: TaskArtifact[] = [
+  {
+    type: "pull_request",
+    url: "https://github.com/hivemoot/hivemoot/pull/1",
+    number: 1,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(authenticateTaskExecutorRequest).mockResolvedValue({
+    ok: true,
+    installationId: "inst-1",
+    redis: {} as never,
+  });
+
+  vi.mocked(getTask).mockResolvedValue(BASE_TASK);
+  vi.mocked(verifyTaskClaimToken).mockResolvedValue(true);
+  vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: true, artifacts: STORED_ARTIFACTS });
+});
+
+function makeRequest(body: unknown, claimToken = "claim-token-1", contentLength?: number) {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (claimToken) {
+    headers.set("x-task-claim-token", claimToken);
+  }
+  if (contentLength !== undefined) {
+    headers.set("content-length", String(contentLength));
+  }
+
+  return new NextRequest("https://example.com/api/tasks/abc123abc123abc123abc123/artifacts", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/tasks/[taskId]/artifacts", () => {
+  it("appends artifacts and returns the current artifact list", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+
+    expect(res.status).toBe(200);
+    expect(appendTaskArtifacts).toHaveBeenCalledWith(
+      "inst-1",
+      "abc123abc123abc123abc123",
+      [VALID_ARTIFACT],
+      expect.anything(),
+    );
+    expect(verifyTaskClaimToken).toHaveBeenCalledWith(
+      "inst-1",
+      "abc123abc123abc123abc123",
+      "claim-token-1",
+      expect.anything(),
+    );
+
+    const body = await res.json();
+    expect(body.artifacts).toEqual(STORED_ARTIFACTS);
+  });
+
+  it("returns 404 for missing tasks before claim-token verification", async () => {
+    vi.mocked(getTask).mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+
+    expect(res.status).toBe(404);
+    expect(verifyTaskClaimToken).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.code).toBe("task_not_found");
+  });
+
+  it("returns 401 when executor auth fails", async () => {
+    vi.mocked(authenticateTaskExecutorRequest).mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "task_not_authenticated" }, { status: 401 }),
+    });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when claim token is missing", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, ""));
+
+    expect(res.status).toBe(403);
+    expect(verifyTaskClaimToken).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+  });
+
+  it("returns 403 when claim token is invalid", async () => {
+    vi.mocked(verifyTaskClaimToken).mockResolvedValue(false);
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, "bad-token"));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+  });
+
+  it("returns 413 when payload exceeds the byte limit", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, "claim-token-1", 33 * 1024));
+
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.code).toBe("task_payload_too_large");
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const headers = new Headers({
+      "Content-Type": "application/json",
+      "x-task-claim-token": "claim-token-1",
+    });
+    const req = new NextRequest("https://example.com/api/tasks/abc123abc123abc123abc123/artifacts", {
+      method: "POST",
+      headers,
+      body: "not-json{",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_invalid_json");
+  });
+
+  it("returns 400 when body is not a JSON object", async () => {
+    const res = await POST(makeRequest([VALID_ARTIFACT]));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 400 when artifacts is missing", async () => {
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_missing_fields");
+  });
+
+  it("returns 400 when artifacts is empty", async () => {
+    const res = await POST(makeRequest({ artifacts: [] }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 400 when a request contains more than 20 artifacts", async () => {
+    const artifacts = Array.from({ length: 21 }, () => VALID_ARTIFACT);
+
+    const res = await POST(makeRequest({ artifacts }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 409 when the per-task artifact cap has been reached", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "cap_exceeded" });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 400 when artifact validation fails", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "validation_failed" });
+
+    const res = await POST(makeRequest({ artifacts: [{ url: "https://evil.example.com/pr/1" }] }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 429 on task lock contention", async () => {
+    vi.mocked(appendTaskArtifacts).mockResolvedValue({ ok: false, reason: "lock_timeout" });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.code).toBe("task_lock_timeout");
+  });
+
+  it("returns 500 when appendTaskArtifacts throws unexpectedly", async () => {
+    vi.mocked(appendTaskArtifacts).mockRejectedValue(new Error("redis down"));
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("task_server_error");
+  });
+});

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseContentLength } from "@/server/request-utils";
+import { extractTaskId } from "@/server/task-route-utils";
+import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
+import { TASK_ERROR, taskError } from "@/server/task-error";
+import {
+  appendTaskArtifacts,
+  getTask,
+  TASK_ID_PATTERN,
+  verifyTaskClaimToken,
+} from "@/server/task-store";
+
+const MAX_PAYLOAD_BYTES = 32 * 1024;
+const MAX_ARTIFACTS_PER_REQUEST = 20;
+const textEncoder = new TextEncoder();
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateTaskExecutorRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { pathname } = new URL(request.url);
+  const taskId = extractTaskId(pathname);
+  if (!taskId || !TASK_ID_PATTERN.test(taskId)) {
+    return taskError(TASK_ERROR.INVALID_TASK_ID, "Invalid task id", 400);
+  }
+
+  const contentLength = parseContentLength(request.headers.get("content-length"));
+  if (contentLength !== null && contentLength > MAX_PAYLOAD_BYTES) {
+    return taskError(TASK_ERROR.PAYLOAD_TOO_LARGE, "Payload too large (max 32KB)", 413);
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await request.text();
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  if (textEncoder.encode(bodyText).length > MAX_PAYLOAD_BYTES) {
+    return taskError(TASK_ERROR.PAYLOAD_TOO_LARGE, "Payload too large (max 32KB)", 413);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, "Body must be a JSON object", 400);
+  }
+
+  const obj = body as Record<string, unknown>;
+  if (!Array.isArray(obj.artifacts)) {
+    return taskError(TASK_ERROR.MISSING_FIELDS, "artifacts must be an array", 400);
+  }
+
+  if (obj.artifacts.length === 0) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, "artifacts array must not be empty", 400);
+  }
+
+  if (obj.artifacts.length > MAX_ARTIFACTS_PER_REQUEST) {
+    return taskError(
+      TASK_ERROR.VALIDATION_FAILED,
+      `artifacts array must not exceed ${MAX_ARTIFACTS_PER_REQUEST} entries per request`,
+      400,
+    );
+  }
+
+  try {
+    const task = await getTask(auth.installationId, taskId, auth.redis);
+    if (!task) {
+      return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+    }
+
+    const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";
+    if (!claimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Missing task claim token", 403);
+    }
+
+    const validClaimToken = await verifyTaskClaimToken(
+      auth.installationId,
+      taskId,
+      claimToken,
+      auth.redis,
+    );
+    if (!validClaimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Invalid or expired task claim token", 403);
+    }
+
+    const result = await appendTaskArtifacts(
+      auth.installationId,
+      taskId,
+      obj.artifacts,
+      auth.redis,
+    );
+
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+      }
+      if (result.reason === "cap_exceeded") {
+        return taskError(
+          TASK_ERROR.VALIDATION_FAILED,
+          "Artifact cap reached (max 20 per task)",
+          409,
+        );
+      }
+      if (result.reason === "lock_timeout") {
+        return taskError(
+          TASK_ERROR.LOCK_TIMEOUT,
+          "Task state is temporarily busy, retry shortly",
+          429,
+        );
+      }
+      return taskError(
+        TASK_ERROR.VALIDATION_FAILED,
+        "One or more artifacts are invalid. Use github.com URLs scoped to the task repos.",
+        400,
+      );
+    }
+
+    return NextResponse.json({ artifacts: result.artifacts });
+  } catch (error) {
+    console.error("[tasks] Failed to append artifacts", {
+      installationId: auth.installationId,
+      taskId,
+      error,
+    });
+
+    return taskError(TASK_ERROR.SERVER_ERROR, "Failed to append artifacts", 500);
+  }
+}

--- a/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/apps/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -11,7 +11,7 @@ import {
   taskComposerPlaceholder,
 } from "../task-helpers";
 import { MarkdownContent } from "../../MarkdownContent";
-import { type TaskMessage, type TaskRecord } from "../types";
+import { type TaskArtifact, type TaskMessage, type TaskRecord } from "../types";
 
 // ---------------------------------------------------------------------------
 // Icons
@@ -192,6 +192,25 @@ function RepoIcon({ className }: { className?: string }) {
   );
 }
 
+function ExternalLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-3 w-3"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+      <path d="M10 2h4v4" />
+      <line x1="14" y1="2" x2="7" y2="9" />
+    </svg>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -310,6 +329,31 @@ function canSendMessage(status: string): boolean {
 
 function messageEndpoint(status: string): "messages" | "follow-up" {
   return status === "needs_follow_up" ? "follow-up" : "messages";
+}
+
+function artifactLabel(artifact: TaskArtifact): string {
+  if (artifact.title) return artifact.title;
+  if (artifact.number !== undefined) {
+    if (artifact.type === "pull_request") return `PR #${artifact.number}`;
+    if (artifact.type === "issue") return `Issue #${artifact.number}`;
+    if (artifact.type === "issue_comment") return `Comment #${artifact.number}`;
+  }
+  if (artifact.type === "commit") return "Commit";
+  return artifact.type.replace(/_/g, " ");
+}
+
+function ArtifactBadge({ artifact }: { artifact: TaskArtifact }) {
+  return (
+    <a
+      href={artifact.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] bg-white/[0.04] px-2.5 py-1 text-xs text-zinc-400 transition-colors hover:border-white/10 hover:text-zinc-300"
+    >
+      <ExternalLinkIcon className="h-3 w-3 shrink-0 text-zinc-600" />
+      <span>{artifactLabel(artifact)}</span>
+    </a>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -652,6 +696,17 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
         {task.error && isTerminal(task.status) && (
           <div className="mt-4 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2.5">
             <p className="text-sm text-red-400">{task.error}</p>
+          </div>
+        )}
+
+        {task.artifacts && task.artifacts.length > 0 && (
+          <div className="mt-4">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-zinc-600">Outputs</p>
+            <div className="flex flex-wrap gap-2">
+              {task.artifacts.map((artifact, index) => (
+                <ArtifactBadge key={`${artifact.url}-${index}`} artifact={artifact} />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/apps/web/src/app/dashboard/tasks/types.ts
+++ b/apps/web/src/app/dashboard/tasks/types.ts
@@ -1,5 +1,12 @@
 // Shared client-side task models used by the dashboard task views.
 // Keep these aligned with the task store payload shape.
+export interface TaskArtifact {
+  type: "pull_request" | "issue" | "issue_comment" | "commit";
+  url: string;
+  number?: number;
+  title?: string;
+}
+
 export interface TaskRecord {
   task_id: string;
   status: string;
@@ -13,6 +20,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface TaskMessage {

--- a/apps/web/src/server/task-store.test.ts
+++ b/apps/web/src/server/task-store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type Redis } from "@upstash/redis";
 import {
   addUserMessage,
+  appendTaskArtifacts,
   appendTaskMessage,
   checkTaskCreateRateLimit,
   claimNextPendingTask,
@@ -1182,6 +1183,37 @@ describe("post-transition append failure resilience", () => {
       verifyTaskClaimToken("inst-1", secondClaim.task.task_id, secondClaim.claim_token, redis),
     ).resolves.toBe(false);
   });
+
+  it("expires the artifacts key alongside the messages key on terminal transition", async () => {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      {
+        prompt: "Investigate",
+        repos: ["hivemoot/hivemoot"],
+        timeout_secs: 300,
+      },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+    const appendResult = await appendTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ url: "https://github.com/hivemoot/hivemoot/pull/1" }],
+      redis,
+    );
+    expect(appendResult.ok).toBe(true);
+
+    await completeTask("inst-1", created.task.task_id, "Done", redis);
+
+    const artifactsKey = `task:inst-1:${created.task.task_id}:artifacts`;
+    const messagesKey = `task:inst-1:${created.task.task_id}:messages`;
+    expect(redis._ttl.has(artifactsKey)).toBe(true);
+    expect(redis._ttl.get(artifactsKey)).toBe(redis._ttl.get(messagesKey));
+  });
 });
 
 describe("deleteTask", () => {
@@ -1623,6 +1655,47 @@ describe("retryTask", () => {
     expect(afterRetry[afterRetry.length - 1].content).toContain("retried");
   });
 
+  it("removes artifact TTLs when retrying a failed task", async () => {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      {
+        prompt: "Retry me",
+        repos: ["hivemoot/hivemoot"],
+        timeout_secs: 300,
+      },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+    const appendResult = await appendTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ url: "https://github.com/hivemoot/hivemoot/issues/22" }],
+      redis,
+    );
+    expect(appendResult.ok).toBe(true);
+    await failTask("inst-1", created.task.task_id, "boom", redis);
+
+    const artifactsKey = `task:inst-1:${created.task.task_id}:artifacts`;
+    expect(redis._ttl.has(artifactsKey)).toBe(true);
+
+    const retried = await retryTask("inst-1", created.task.task_id, redis);
+    expect(retried.ok).toBe(true);
+    expect(redis._ttl.has(artifactsKey)).toBe(false);
+
+    const task = await getTask("inst-1", created.task.task_id, redis);
+    expect(task?.artifacts).toEqual([
+      {
+        type: "issue",
+        url: "https://github.com/hivemoot/hivemoot/issues/22",
+        number: 22,
+      },
+    ]);
+  });
+
   it("returns not_found for a nonexistent task", async () => {
     const result = await retryTask("inst-1", "aabbccddeeff001122334455", redis);
     expect(result).toEqual({ ok: false, reason: "not_found" });
@@ -1868,6 +1941,41 @@ describe("addUserMessage", () => {
     expect(redis._ttl.has(taskTtlKey)).toBe(false);
   });
 
+  it("removes artifact TTLs when reviving a completed task", async () => {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Task", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+    const appendResult = await appendTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ url: "https://github.com/hivemoot/hivemoot/commit/abc1234" }],
+      redis,
+    );
+    expect(appendResult.ok).toBe(true);
+    await completeTask("inst-1", created.task.task_id, "Done", redis);
+
+    const artifactsKey = `task:inst-1:${created.task.task_id}:artifacts`;
+    expect(redis._ttl.has(artifactsKey)).toBe(true);
+
+    await addUserMessage("inst-1", created.task.task_id, "Reopen", redis);
+    expect(redis._ttl.has(artifactsKey)).toBe(false);
+
+    const task = await getTask("inst-1", created.task.task_id, redis);
+    expect(task?.artifacts).toEqual([
+      {
+        type: "commit",
+        url: "https://github.com/hivemoot/hivemoot/commit/abc1234",
+      },
+    ]);
+  });
+
   it("does not return success when terminal TTL removal fails", async () => {
     const created = await createTask(
       "inst-1",
@@ -1953,5 +2061,194 @@ describe("addUserMessage", () => {
     const userMsg = messages[messages.length - 2];
     expect(userMsg.role).toBe("user");
     expect(userMsg.content).toBe("Do more");
+  });
+});
+
+describe("appendTaskArtifacts", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  async function createRunningTask() {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Do the thing", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error("task creation failed");
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+    return created.task.task_id;
+  }
+
+  it("appends artifacts and exposes them through getTask", async () => {
+    const taskId = await createRunningTask();
+
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [
+        { url: "https://github.com/hivemoot/hivemoot/pull/12", title: "Fix the deploy bug" },
+        { url: "https://github.com/hivemoot/hivemoot/issues/18" },
+      ],
+      redis,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.artifacts).toEqual([
+      {
+        type: "pull_request",
+        url: "https://github.com/hivemoot/hivemoot/pull/12",
+        number: 12,
+        title: "Fix the deploy bug",
+      },
+      {
+        type: "issue",
+        url: "https://github.com/hivemoot/hivemoot/issues/18",
+        number: 18,
+      },
+    ]);
+
+    const task = await getTask("inst-1", taskId, redis);
+    expect(task?.artifacts).toEqual(result.artifacts);
+  });
+
+  it("rejects artifacts scoped to a different repo", async () => {
+    const taskId = await createRunningTask();
+
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/other-org/other-repo/pull/1" }],
+      redis,
+    );
+
+    expect(result).toEqual({ ok: false, reason: "validation_failed" });
+  });
+
+  it("rejects same-repo urls that are not recognized GitHub objects", async () => {
+    const taskId = await createRunningTask();
+
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/hivemoot/hivemoot/releases/tag/v1.0.0" }],
+      redis,
+    );
+
+    expect(result).toEqual({ ok: false, reason: "validation_failed" });
+  });
+
+  it("derives artifact type and number from the url instead of trusting caller input", async () => {
+    const taskId = await createRunningTask();
+
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "issue", number: 999, url: "https://github.com/hivemoot/hivemoot/pull/5" }],
+      redis,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.artifacts).toEqual([
+      {
+        type: "pull_request",
+        url: "https://github.com/hivemoot/hivemoot/pull/5",
+        number: 5,
+      },
+    ]);
+  });
+
+  it("parses issue_comment urls using the comment id in the fragment", async () => {
+    const taskId = await createRunningTask();
+
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/hivemoot/hivemoot/issues/8#issuecomment-12345" }],
+      redis,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.artifacts).toEqual([
+      {
+        type: "issue_comment",
+        url: "https://github.com/hivemoot/hivemoot/issues/8#issuecomment-12345",
+        number: 12345,
+      },
+    ]);
+  });
+
+  it("caps a task at 20 artifacts across multiple requests", async () => {
+    const taskId = await createRunningTask();
+
+    for (let i = 1; i <= 20; i += 1) {
+      const result = await appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ url: `https://github.com/hivemoot/hivemoot/issues/${i}` }],
+        redis,
+      );
+      expect(result.ok).toBe(true);
+    }
+
+    const capped = await appendTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ url: "https://github.com/hivemoot/hivemoot/issues/21" }],
+      redis,
+    );
+
+    expect(capped).toEqual({ ok: false, reason: "cap_exceeded" });
+  });
+
+  it("preserves both concurrent writes under the installation lock", async () => {
+    const taskId = await createRunningTask();
+
+    const [first, second] = await Promise.all([
+      appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ url: "https://github.com/hivemoot/hivemoot/pull/41" }],
+        redis,
+      ),
+      appendTaskArtifacts(
+        "inst-1",
+        taskId,
+        [{ url: "https://github.com/hivemoot/hivemoot/issues/42" }],
+        redis,
+      ),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+
+    const task = await getTask("inst-1", taskId, redis);
+    expect(task?.artifacts).toHaveLength(2);
+    expect(task?.artifacts?.map((artifact) => artifact.url).sort()).toEqual([
+      "https://github.com/hivemoot/hivemoot/issues/42",
+      "https://github.com/hivemoot/hivemoot/pull/41",
+    ]);
+  });
+
+  it("returns not_found for missing tasks", async () => {
+    const result = await appendTaskArtifacts(
+      "inst-1",
+      "aabbccddeeff001122334455",
+      [{ url: "https://github.com/hivemoot/hivemoot/pull/1" }],
+      redis,
+    );
+
+    expect(result).toEqual({ ok: false, reason: "not_found" });
   });
 });

--- a/apps/web/src/server/task-store.ts
+++ b/apps/web/src/server/task-store.ts
@@ -32,6 +32,17 @@ export interface TaskMessage {
 
 const MAX_MESSAGE_CONTENT_CHARS = 128_000;
 const MAX_MESSAGES_PER_TASK = 200;
+const MAX_ARTIFACTS_PER_TASK = 20;
+const MAX_ARTIFACT_TITLE_CHARS = 200;
+
+export type TaskArtifactType = "pull_request" | "issue" | "issue_comment" | "commit";
+
+export interface TaskArtifact {
+  type: TaskArtifactType;
+  url: string;
+  number?: number;
+  title?: string;
+}
 
 export interface TaskRecord {
   task_id: string;
@@ -46,6 +57,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface ClaimedTask {
@@ -119,6 +131,10 @@ function taskMessagesKey(installationId: string, taskId: string): string {
 
 function taskClaimTokenHashKey(installationId: string, taskId: string): string {
   return `task:${installationId}:${taskId}:claim-token-hash`;
+}
+
+function taskArtifactsKey(installationId: string, taskId: string): string {
+  return `task:${installationId}:${taskId}:artifacts`;
 }
 
 function pendingKey(installationId: string): string {
@@ -303,6 +319,7 @@ async function cleanupMissingTask(
     .del(taskProgressKey(installationId, taskId))
     .del(taskMessagesKey(installationId, taskId))
     .del(taskClaimTokenHashKey(installationId, taskId))
+    .del(taskArtifactsKey(installationId, taskId))
     .exec();
 }
 
@@ -329,13 +346,19 @@ async function buildTaskRecord(
   stored: StoredTaskRecord,
   redis: Redis,
 ): Promise<TaskRecord> {
-  const progressRaw = await redis.get(taskProgressKey(installationId, stored.task_id));
+  const [progressRaw, artifactsRaw] = await Promise.all([
+    redis.get(taskProgressKey(installationId, stored.task_id)),
+    redis.get(taskArtifactsKey(installationId, stored.task_id)),
+  ]);
 
   const task: TaskRecord = {
     ...stored,
   };
 
   if (typeof progressRaw === "string") task.progress = progressRaw;
+  if (Array.isArray(artifactsRaw) && artifactsRaw.length > 0) {
+    task.artifacts = artifactsRaw as TaskArtifact[];
+  }
 
   return task;
 }
@@ -621,12 +644,15 @@ async function finalizeTask(
         .zadd(recentKey(installationId), { score: Date.now(), member: taskId })
         .exec();
 
-      // Best-effort: expire the messages list alongside the task data.
+      // Best-effort: expire the messages/artifacts keys alongside the task data.
       // The task has already been finalized so a failure here must not propagate.
       try {
-        await redis.expire(taskMessagesKey(installationId, taskId), ttl);
+        await Promise.all([
+          redis.expire(taskMessagesKey(installationId, taskId), ttl),
+          redis.expire(taskArtifactsKey(installationId, taskId), ttl),
+        ]);
       } catch (error) {
-        console.error("[tasks] Failed to expire messages key (task finalized)", {
+        console.error("[tasks] Failed to expire task side-channel keys (task finalized)", {
           installationId,
           taskId,
           error,
@@ -1017,6 +1043,7 @@ export async function deleteTask(
       .del(taskKey(installationId, taskId))
       .del(taskProgressKey(installationId, taskId))
       .del(taskMessagesKey(installationId, taskId))
+      .del(taskArtifactsKey(installationId, taskId))
       .zrem(pendingKey(installationId), taskId)
       .zrem(runningKey(installationId), taskId)
       .zrem(recentKey(installationId), taskId)
@@ -1056,6 +1083,7 @@ export async function retryTask(
         .persist(taskKey(installationId, taskId))
         .persist(taskProgressKey(installationId, taskId))
         .persist(taskMessagesKey(installationId, taskId))
+        .persist(taskArtifactsKey(installationId, taskId))
         .set(taskKey(installationId, taskId), nextStored)
         .set(taskProgressKey(installationId, taskId), progress)
         .zrem(runningKey(installationId), taskId)
@@ -1164,6 +1192,154 @@ export async function getTaskMessages(
   }
 
   return messages;
+}
+
+function parseArtifactMetadata(
+  url: string,
+): { type: TaskArtifactType; number?: number } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+    return null;
+  }
+
+  const parts = parsed.pathname.replace(/^\//, "").split("/");
+  if (parts.length < 4) return null;
+
+  const kind = parts[2];
+  const segment = parts[3];
+
+  if (kind === "pull") {
+    const number = Number.parseInt(segment, 10);
+    if (!Number.isInteger(number) || number <= 0 || String(number) !== segment) {
+      return null;
+    }
+    return { type: "pull_request", number };
+  }
+
+  if (kind === "issues") {
+    const issueNumber = Number.parseInt(segment, 10);
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0 || String(issueNumber) !== segment) {
+      return null;
+    }
+
+    const commentMatch = parsed.hash.match(/^#issuecomment-(\d+)$/);
+    if (commentMatch) {
+      const commentId = Number.parseInt(commentMatch[1], 10);
+      if (!Number.isInteger(commentId) || commentId <= 0) {
+        return null;
+      }
+      return { type: "issue_comment", number: commentId };
+    }
+
+    return { type: "issue", number: issueNumber };
+  }
+
+  if (kind === "commit") {
+    if (!/^[0-9a-f]{7,40}$/i.test(segment)) {
+      return null;
+    }
+    return { type: "commit" };
+  }
+
+  return null;
+}
+
+function validateArtifactRepoScope(url: string, repos: string[]): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+      return false;
+    }
+
+    const pathParts = parsed.pathname.replace(/^\//, "").split("/");
+    if (pathParts.length < 2) return false;
+
+    const repoSlug = `${pathParts[0]}/${pathParts[1]}`.toLowerCase();
+    return repos.some((repo) => repo.toLowerCase() === repoSlug);
+  } catch {
+    return false;
+  }
+}
+
+function parseArtifact(raw: unknown, repos: string[]): TaskArtifact | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.url !== "string" || !validateArtifactRepoScope(obj.url, repos)) {
+    return null;
+  }
+
+  const metadata = parseArtifactMetadata(obj.url);
+  if (!metadata) return null;
+
+  const artifact: TaskArtifact = {
+    type: metadata.type,
+    url: obj.url,
+  };
+
+  if (metadata.number !== undefined) {
+    artifact.number = metadata.number;
+  }
+
+  if (typeof obj.title === "string" && obj.title.trim().length > 0) {
+    artifact.title = obj.title.trim().slice(0, MAX_ARTIFACT_TITLE_CHARS);
+  }
+
+  return artifact;
+}
+
+export type AppendArtifactsResult =
+  | { ok: true; artifacts: TaskArtifact[] }
+  | { ok: false; reason: "not_found" | "cap_exceeded" | "validation_failed" | "lock_timeout" };
+
+export async function appendTaskArtifacts(
+  installationId: string,
+  taskId: string,
+  incoming: unknown[],
+  redis: Redis,
+): Promise<AppendArtifactsResult> {
+  try {
+    return await withTaskInstallationLock(installationId, redis, async () => {
+      const stored = await loadStoredTask(installationId, taskId, redis);
+      if (!stored) {
+        return { ok: false, reason: "not_found" };
+      }
+
+      const parsedArtifacts: TaskArtifact[] = [];
+      for (const raw of incoming) {
+        const artifact = parseArtifact(raw, stored.repos);
+        if (!artifact) {
+          return { ok: false, reason: "validation_failed" };
+        }
+        parsedArtifacts.push(artifact);
+      }
+
+      const existingRaw = await redis.get(taskArtifactsKey(installationId, taskId));
+      const existingArtifacts = Array.isArray(existingRaw)
+        ? existingRaw as TaskArtifact[]
+        : [];
+
+      if (existingArtifacts.length + parsedArtifacts.length > MAX_ARTIFACTS_PER_TASK) {
+        return { ok: false, reason: "cap_exceeded" };
+      }
+
+      const updatedArtifacts = [...existingArtifacts, ...parsedArtifacts];
+      await redis.set(taskArtifactsKey(installationId, taskId), updatedArtifacts);
+
+      return { ok: true, artifacts: updatedArtifacts };
+    });
+  } catch (error) {
+    if (error instanceof LockTimeoutError) {
+      return { ok: false, reason: "lock_timeout" };
+    }
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1379,6 +1555,7 @@ export async function addUserMessage(
         .persist(taskKey(installationId, taskId))
         .persist(taskProgressKey(installationId, taskId))
         .persist(taskMessagesKey(installationId, taskId))
+        .persist(taskArtifactsKey(installationId, taskId))
         .set(taskKey(installationId, taskId), nextStored)
         .set(taskProgressKey(installationId, taskId), "Re-queued with new message")
         .zadd(pendingKey(installationId), { score: Date.now(), member: taskId })


### PR DESCRIPTION
## What

Add executor-reported task artifact links to the task store/API and render them in task detail so users can jump straight to the GitHub output a task produced.

Fixes #332

## Why

Task review currently shows status and transcript, but not the PR, issue, comment, or commit the agent actually created. That forces users to dig through chat logs to find the result of a task run.

## What it looks like

**Before:**

```text
Task detail
- Status and transcript are visible
- GitHub outputs are only discoverable by reading the full chat log
```

**After:**

```text
Task detail
- Status and transcript stay visible
- Outputs badges link directly to the GitHub artifacts the task produced
  PR #123 | Issue #45 | Commit
```

## Notes

- Adds `POST /api/tasks/{taskId}/artifacts` with executor-token auth plus the existing claim-token guard.
- Validates `github.com/{owner}/{repo}` URLs against the task repos and derives artifact type/number from the URL path.
- Preserves artifact links when a task is retried or reopened so earlier outputs remain visible on the same task.
- Validation:
  `npm test -- --run src/server/task-store.test.ts src/app/api/tasks/[taskId]/artifacts/route.test.ts`
  `npm run typecheck`
  `npx eslint src/server/task-store.ts src/server/task-store.test.ts src/app/api/tasks/[taskId]/artifacts/route.ts src/app/api/tasks/[taskId]/artifacts/route.test.ts src/app/dashboard/tasks/[taskId]/TaskDetail.tsx src/app/dashboard/tasks/types.ts`
  `npm run build`
