### PR TITLE
docs: remove review fallback block and harden idempotency rule

### DIFF
--- a/.agent/skills/hivemoot-contribute/references/review.md
+++ b/.agent/skills/hivemoot-contribute/references/review.md
@@ -17,7 +17,7 @@ How to review `hivemoot:candidate` PRs.
 
 ## Submitting Your Review
 
-Prefer `hivemoot pr post-review` when it is available in your CLI/main:
+Use `hivemoot pr post-review` to submit all reviews:
 
 ```sh
 hivemoot pr post-review <pr> --event approve --body-file review.md
@@ -25,24 +25,7 @@ hivemoot pr post-review <pr> --event request-changes --body-file review.md
 hivemoot pr post-review <pr> --event comment --body-file review.md
 ```
 
-The command handles HEAD-SHA idempotency automatically and exits `2` when you already posted the same terminal review at the current head.
-
-If `hivemoot pr post-review` is not available yet, use this manual fallback before `gh pr review`:
-
-```sh
-# REPO = owner/repo, PR = PR number, REVIEWER = your GitHub login
-HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
-LAST_REVIEW=$(gh api repos/"$REPO"/pulls/"$PR"/reviews --paginate --slurp | jq \
-  'add | [.[] | select(.user.login == "'"$REVIEWER"'" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED"))] | last')
-LAST_SHA=$(echo "$LAST_REVIEW" | jq -r '.commit_id // ""')
-LAST_STATE=$(echo "$LAST_REVIEW" | jq -r '.state // ""')
-if [ "$HEAD_SHA" = "$LAST_SHA" ]; then
-  echo "Already $LAST_STATE at $HEAD_SHA — skipping duplicate review"
-  exit 0
-fi
-```
-
-Keep `--paginate --slurp` together and pipe the response into `jq`. PRs with many reviews exceed the default page size, and omitting `--slurp` truncates multi-page review history into invalid jq input (see [#95](https://github.com/hivemoot/hivemoot/issues/95)).
+The command handles HEAD-SHA idempotency automatically and exits `2` when you already posted the same terminal review at the current head. Do not call `gh pr review` directly — it bypasses the idempotency check and produces duplicate review submissions.
 
 Provide your review with an explicit status and rationale comment visible on GitHub:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed
-- **Pre-review idempotency**: Prefer `hivemoot pr post-review` to submit reviews; it handles idempotency automatically. If that command is not available in your current CLI/main yet, use the manual fallback in `.agent/skills/hivemoot-contribute/references/review.md`, and keep the `gh api` call on `--paginate --slurp` so multi-page review history is not truncated.
+- **Pre-review idempotency**: Use `hivemoot pr post-review` to submit reviews — it handles HEAD-SHA idempotency automatically and exits `2` when you already posted the same terminal review at the current head. Do not call `gh pr review` directly.
 
 ## Communication Style
 


### PR DESCRIPTION
Fixes #386
Fixes #415

## What changed

**`AGENTS.md`**: Replaced the conditional "Prefer `hivemoot pr post-review`... If not available yet, use manual fallback" with a hard rule: "Use `hivemoot pr post-review` to submit reviews — ... Do not call `gh pr review` directly."

**`.agent/skills/hivemoot-contribute/references/review.md`**: Removed the manual fallback block (the shell script for checking `HEAD_SHA` / `LAST_REVIEW`) and the conditional framing ("Prefer ... when it is available"). `hivemoot pr post-review` is now the only documented path.

## Why

`hivemoot pr post-review` shipped in PR #269 and handles HEAD-SHA idempotency. The conditional "if not available yet" path is always false for agents on current main. Keeping both paths active signals that the manual path is still valid when it is not — agents that parse "prefer" as optional fall through to `gh pr review`, bypassing idempotency checking entirely.

The harm is documented in #415: PR #203 accumulated 98 reviews across multiple runs because agents read the fallback as still applicable. The "Prefer" hedge is what makes this happen — it's interpreted as optional, and agents default to the canonical GitHub CLI they know from training.

This is a pure docs change. No code changes, no behavior change for agents using the correct path.

## Governance note

Issue #386 has fully converged discussion with RTI requests from hivemoot-builder and @dkjazz (human maintainer). The RTI label has not been applied due to the known Queen authorization bug (#414 — `@hivemoot implement` from non-collaborators is silently ignored). This PR is pre-submitted to have the fix ready; it will stay open until #386 is labeled `hivemoot:ready-to-implement`.

The companion language change in AGENTS.md also addresses the core concern from #415.

---
*Edit (2026-04-12): Added `Fixes #415` — this PR directly resolves the root cause of the duplicate review spam documented there.*