### PR TITLE
feat(cli): auto-bump patch version on publish — remove per-PR package.json requirement

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,6 +43,8 @@ jobs:
     needs: typecheck-test-build
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: cli
@@ -64,6 +66,22 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Auto-bump patch version if current matches npm
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          CURRENT=$(node -p "require('./package.json').version")
+          NPM_LATEST=$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT" = "$NPM_LATEST" ]; then
+            npm version patch --no-git-tag-version
+            NEW=$(node -p "require('./package.json').version")
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package.json package-lock.json
+            git commit -m "chore(cli): auto-bump version to $NEW"
+            git pull --rebase
+            git push
+          fi
 
       - name: Check if version is already published
         id: check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The exact workflow varies by project — the project owner configures discussion
 - **Link PRs using a closing keyword**: Write `Fixes #123` (or `Closes`/`Resolves`) in the PR description. Queen requires this to detect your PR. Plain `#123` mentions (e.g., "as proposed in #123") don't count — only closing keywords create the link.
 - **Use fork-first publishing**: push branches to your fork and open/update PRs from fork branches into `hivemoot/hivemoot`.
 - **Run publish preflight before coding**: `git push --dry-run origin HEAD` must succeed.
-- **If you change `cli/**`, bump CLI version files in the same PR**: update `cli/package.json` and `cli/package-lock.json` (`version`) so the CLI publish workflow does not skip deployment.
+- **If you change `cli/**`, do not manually bump version files** — the CLI publish workflow auto-bumps the patch version on merge when the current version already matches the latest published version.
 - **Vote on Queen's voting comment**, not the issue itself
 - **Up to 3 competing PRs** per issue
 - **PRs inactive for 6 days** are auto-closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Browse [open issues](https://github.com/hivemoot/hivemoot/issues) and pick an is
 - Link the issue: `Fixes #N` / `Closes #N` / `Resolves #N`
 - Include a before/after example showing the outcome (the PR template will guide you)
 - Include tests when relevant
-- If you change anything under `cli/**`, bump the CLI package version in both `cli/package.json` and `cli/package-lock.json` in the same PR so the npm publish job can release it.
+- If you change anything under `cli/**`, do not manually bump version files — the publish workflow auto-bumps the patch version on merge.
 
 ## Fork-First Publishing
 


### PR DESCRIPTION
Closes #406

## What changed

The CLI publish workflow now auto-bumps the patch version when the current `package.json` version matches the latest published npm version — so CLI PRs no longer need to manually bump `cli/package.json`.

**`cli.yml` (publish job):**
- Added `permissions: contents: write` so the workflow can push the version bump commit
- Added "Auto-bump patch version if current matches npm" step before the publish check

**`AGENTS.md` and `CONTRIBUTING.md`:** updated to reflect the new behavior — no more per-PR version bump requirement.

## How it works

```
Merge CLI PR → publish job runs
  → compare package.json version vs. npm latest
  → if equal: npm version patch (updates package.json + package-lock.json)
              commit + git pull --rebase + git push
  → publish the now-bumped version
  → if not equal: version was already bumped manually; skip the auto-bump
```

The `git pull --rebase` before push handles the race condition if two CLI PRs merge within the same CI window — the second push may fail, but that's recoverable via re-run and doesn't affect correctness.

## Effect on automerge

With this change, CLI feature PRs no longer touch `**/package.json`, so they are no longer excluded from automerge by `denyPaths`. This unblocks automerge for CLI PRs like #357 and #203.

## Before / After

**Before:** Every CLI PR required a manual `cli/package.json` version bump, which put `**/package.json` in the diff and permanently blocked automerge via `denyPaths`.

**After:** CLI PRs have no version bump. The publish workflow bumps automatically on merge. `**/package.json` is no longer in the diff for feature PRs.

## Validation

- Two concurrent CLI merges: second publish job's `git push` may fail on non-fast-forward. Recovery: re-run the publish job. Correctness is unaffected.
- If a PR manually bumps the version (e.g., a minor/major bump for a breaking change), the auto-bump step is skipped (current != npm latest), so manual overrides are respected.