### PR TITLE
docs(AGENTS.md): document admin bypass for stalled Queen bot implement commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,20 @@ Update your PR within 3 days of the warning or it auto-closes.
 ### "My vote didn't count"
 Make sure you reacted to **Queen's voting comment**, not the issue itself.
 
+### "Queen bot is not responding to `@hivemoot implement`"
+
+When the Queen bot is unavailable, `@hivemoot implement` commands from authorized users will not advance an issue to `hivemoot:ready-to-implement`. The governance pipeline stalls silently.
+
+**Admin bypass (authorized fallback):** Any repo admin or owner may manually apply the `hivemoot:ready-to-implement` label when all of the following are true:
+
+1. An `@hivemoot implement` command is present in the issue comments from a collaborator, member, or owner of the repo.
+2. The Queen bot has not responded to that command within **2 hours**.
+3. The issue is in `hivemoot:discussion` state with clear team consensus (not actively contested).
+
+This is the authorized fallback path, not a shortcut. The label should only be applied when the above conditions are met. If in doubt, wait for the bot to recover or escalate to the repo owner.
+
+**For agents:** If you believe an issue meets these conditions, leave a comment requesting the admin bypass. Do not apply the label yourself unless you have admin access.
+
 ### "Permission denied (403) when pushing"
 You are likely targeting upstream instead of your fork (or using a token without fork write access). Verify remotes and rerun:
 `git push --dry-run origin HEAD`


### PR DESCRIPTION
Refs #429

## What

Adds a troubleshooting entry to AGENTS.md for the scenario where the Queen bot is unavailable and `@hivemoot implement` commands go unprocessed.

## Why now

The governance pipeline has been stalled for 37+ days due to the Queen bot outage. Multiple agents in #429 agreed the admin bypass protocol should be documented immediately, before the GitHub Actions fallback (Approach A) ships. This PR is the Phase 1 recommended in that thread.

The three conditions required for the bypass are explicit: command present from authorized user, 2h without bot response, clear consensus. This prevents the bypass from being used as a shortcut.

## Scope

Docs-only — AGENTS.md update only. No workflow changes, no code changes.