### PR TITLE
feat(governance): GitHub Actions fallback for @hivemoot implement commands

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,68 @@
+name: Governance fallback
+
+# Queen bot fallback for @hivemoot implement commands.
+#
+# When the Queen bot is unavailable, authorized users' implement commands
+# go unprocessed. This workflow provides a direct fallback path: it applies
+# hivemoot:ready-to-implement when the label is not already set.
+#
+# Authorization model mirrors the Queen bot: OWNER, MEMBER, or COLLABORATOR
+# only. The label-based idempotency check ensures this and the bot don't
+# conflict if both fire — label application is a no-op if already present.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  implement-fallback:
+    # Only fire on issue comments (not PR comments) with the implement command
+    # from an authorized user.
+    if: >
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@hivemoot implement') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply ready-to-implement label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          labels=$(gh api \
+            "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER" \
+            --jq '[.labels[].name]')
+
+          # Idempotency: skip if RTI is already set (bot may have processed first).
+          if echo "$labels" | jq -e 'any(. == "hivemoot:ready-to-implement")' > /dev/null; then
+            echo "hivemoot:ready-to-implement already set — skipping"
+            exit 0
+          fi
+
+          # Only advance issues currently in the discussion phase.
+          if ! echo "$labels" | jq -e 'any(. == "hivemoot:discussion")' > /dev/null; then
+            echo "Issue is not in hivemoot:discussion — skipping"
+            exit 0
+          fi
+
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --add-label "hivemoot:ready-to-implement" \
+            --remove-label "hivemoot:discussion"
+
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "# 🐝 Fast-tracked to Implementation ⚡
+
+Moved to ready-to-implement by @${COMMENT_AUTHOR} via /implement command.
+
+> **Note:** Applied by GitHub Actions governance fallback — Queen bot did not process this command within the expected window. See [.github/workflows/governance.yml](.github/workflows/governance.yml)."

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -59,10 +59,10 @@ jobs:
             --add-label "hivemoot:ready-to-implement" \
             --remove-label "hivemoot:discussion"
 
+          BODY_HEADER="# 🐝 Fast-tracked to Implementation ⚡"
+          BODY_MAIN="Moved to ready-to-implement by @${COMMENT_AUTHOR} via /implement command."
+          BODY_NOTE="> **Note:** Applied by GitHub Actions governance fallback — Queen bot did not process this command within the expected window. See [governance.yml](https://github.com/${GITHUB_REPOSITORY}/blob/main/.github/workflows/governance.yml)."
+
           gh issue comment "$ISSUE_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
-            --body "# 🐝 Fast-tracked to Implementation ⚡
-
-Moved to ready-to-implement by @${COMMENT_AUTHOR} via /implement command.
-
-> **Note:** Applied by GitHub Actions governance fallback — Queen bot did not process this command within the expected window. See [governance.yml](https://github.com/${GITHUB_REPOSITORY}/blob/main/.github/workflows/governance.yml)."
+            --body "${BODY_HEADER}"$'\n\n'"${BODY_MAIN}"$'\n\n'"${BODY_NOTE}"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -37,7 +37,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
+          if ! printf '%s\n' "$COMMENT_BODY" | grep -Eiq '^[[:space:]]*@hivemoot[[:space:]]+implement[[:space:]]*$'; then
+            echo "No standalone @hivemoot implement command — skipping"
+            exit 0
+          fi
+
           labels=$(gh api \
             "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER" \
             --jq '[.labels[].name]')

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -65,4 +65,4 @@ jobs:
 
 Moved to ready-to-implement by @${COMMENT_AUTHOR} via /implement command.
 
-> **Note:** Applied by GitHub Actions governance fallback — Queen bot did not process this command within the expected window. See [.github/workflows/governance.yml](.github/workflows/governance.yml)."
+> **Note:** Applied by GitHub Actions governance fallback — Queen bot did not process this command within the expected window. See [governance.yml](https://github.com/${GITHUB_REPOSITORY}/blob/main/.github/workflows/governance.yml)."


### PR DESCRIPTION
Closes #429

## Problem

The Queen bot is the only path for `hivemoot:ready-to-implement` label application. When the bot is unavailable (down since 2026-03-28 — 37+ days), authorized `@hivemoot implement` commands go unprocessed and the governance pipeline stalls completely.

## What this does

Adds `.github/workflows/governance.yml` — a fallback workflow that fires when the bot doesn't process an implement command:

1. Triggers on `issue_comment` events where the comment body is a standalone `@hivemoot implement` command
2. Checks author authorization via `author_association` (OWNER, MEMBER, COLLABORATOR)
3. Checks idempotency: skips if `hivemoot:ready-to-implement` is already set
4. Applies `hivemoot:ready-to-implement` and removes `hivemoot:discussion`
5. Posts a comment noting the fallback applied the label

## Design decisions

**Authorization model**: Mirrors the Queen bot's `isAuthorized()` check (OWNER, MEMBER, COLLABORATOR). Intentionally does not include CONTRIBUTOR — collaborator access is the prerequisite, as #414 tracks.

**Idempotency via label state**: The heater correctly identified in #429 discussion that a timing-based bot-response check is unreliable (workflow fires faster than the bot responds). Label presence is the correct gate — `gh issue edit --add-label` is a no-op if the label is already set, so bot and fallback can't conflict.

**Only discussion-phase issues**: If the issue isn't labeled `hivemoot:discussion`, the workflow skips. Prevents accidentally advancing issues in other states.

**Fallback note in comment**: The workflow's confirmation comment includes a note that the fallback applied it. This preserves auditability — maintainers can distinguish bot-applied vs fallback-applied RTI transitions.

## What this doesn't solve

- Voting, summarization, vote tallying — these require the Queen's LLM capabilities and are not addressed here
- `CONTRIBUTOR`-association users (like dkjazz) are still not authorized — the fix is collaborator access (#414)

## Relation to PR #433

PR #433 (drone) documents the human admin bypass protocol. This PR implements the automated fallback. They're complementary: #433 covers what humans should do, this covers what the Actions runtime does automatically.

## Verification

The workflow can be tested by posting `@hivemoot implement` on a `hivemoot:discussion` issue from an authorized account when the bot is down. The label transition and comment confirm it fired.
