### PR TITLE
feat(tasks): add POST /api/tasks/{taskId}/artifacts endpoint

### DIFF
--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/server/task-executor-auth", () => ({
+  authenticateTaskExecutorRequest: vi.fn(),
+}));
+
+vi.mock("@/server/task-store", () => ({
+  TASK_ID_PATTERN: /^[a-f0-9]{24}$/,
+  getTask: vi.fn(),
+  verifyTaskClaimToken: vi.fn(),
+  validateTaskArtifacts: vi.fn(),
+  addTaskArtifacts: vi.fn(),
+}));
+
+import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
+import {
+  addTaskArtifacts,
+  getTask,
+  validateTaskArtifacts,
+  verifyTaskClaimToken,
+} from "@/server/task-store";
+import { POST } from "./route";
+
+const BASE_TASK = {
+  task_id: "abc123abc123abc123abc123",
+  status: "running" as const,
+  prompt: "Open a PR fixing issue #42",
+  repos: ["hivemoot/hivemoot"],
+  timeout_secs: 300,
+  created_by: "queen",
+  created_at: "2026-03-03T12:00:00.000Z",
+  updated_at: "2026-03-03T12:01:00.000Z",
+};
+
+const VALID_ARTIFACT = {
+  type: "pull_request" as const,
+  url: "https://github.com/hivemoot/hivemoot/pull/312",
+  number: 312,
+  title: "fix: resolve issue #42",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(authenticateTaskExecutorRequest).mockResolvedValue({
+    ok: true,
+    installationId: "inst-1",
+    redis: {} as never,
+  });
+
+  vi.mocked(getTask).mockResolvedValue(BASE_TASK);
+  vi.mocked(verifyTaskClaimToken).mockResolvedValue(true);
+  vi.mocked(validateTaskArtifacts).mockReturnValue({
+    ok: true,
+    artifacts: [VALID_ARTIFACT],
+  });
+  vi.mocked(addTaskArtifacts).mockResolvedValue({
+    ok: true,
+    task: { ...BASE_TASK, artifacts: [VALID_ARTIFACT] },
+  });
+});
+
+function makeRequest(body: unknown, claimToken = "claim-token-1") {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (claimToken) {
+    headers.set("x-task-claim-token", claimToken);
+  }
+
+  return new NextRequest(
+    "https://example.com/api/tasks/abc123abc123abc123abc123/artifacts",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe("POST /api/tasks/[taskId]/artifacts", () => {
+  it("returns 401 when bearer token auth fails", async () => {
+    vi.mocked(authenticateTaskExecutorRequest).mockResolvedValueOnce({
+      ok: false,
+      response: new Response(JSON.stringify({ code: "task_not_authenticated" }), {
+        status: 401,
+      }) as never,
+    });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid task id format", async () => {
+    const req = new NextRequest(
+      "https://example.com/api/tasks/not-a-valid-id/artifacts",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-task-claim-token": "tok",
+        },
+        body: JSON.stringify({ artifacts: [VALID_ARTIFACT] }),
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_invalid_task_id");
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    const req = new NextRequest(
+      "https://example.com/api/tasks/abc123abc123abc123abc123/artifacts",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-task-claim-token": "tok",
+        },
+        body: "not-json{",
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_invalid_json");
+  });
+
+  it("returns 400 when artifact validation fails", async () => {
+    vi.mocked(validateTaskArtifacts).mockReturnValueOnce({
+      ok: false,
+      message: "artifacts must be an array",
+    });
+
+    const res = await POST(makeRequest({ artifacts: "not-an-array" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+    expect(body.message).toBe("artifacts must be an array");
+  });
+
+  it("returns 404 when task does not exist", async () => {
+    vi.mocked(getTask).mockResolvedValueOnce(null);
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("task_not_found");
+  });
+
+  it("returns 403 when claim token header is missing", async () => {
+    const req = new NextRequest(
+      "https://example.com/api/tasks/abc123abc123abc123abc123/artifacts",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ artifacts: [VALID_ARTIFACT] }),
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+  });
+
+  it("returns 403 when claim token is invalid", async () => {
+    vi.mocked(verifyTaskClaimToken).mockResolvedValueOnce(false);
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }, "wrong-token"));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+  });
+
+  it("returns 422 when artifact URL is not scoped to task repos", async () => {
+    vi.mocked(addTaskArtifacts).mockResolvedValueOnce({
+      ok: false,
+      reason: "invalid_url",
+    });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 409 when artifact cap is exceeded", async () => {
+    vi.mocked(addTaskArtifacts).mockResolvedValueOnce({
+      ok: false,
+      reason: "artifact_cap_exceeded",
+    });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 429 on lock timeout", async () => {
+    vi.mocked(addTaskArtifacts).mockResolvedValueOnce({
+      ok: false,
+      reason: "lock_timeout",
+    });
+
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(429);
+  });
+
+  it("stores artifact and returns updated task on success", async () => {
+    const res = await POST(makeRequest({ artifacts: [VALID_ARTIFACT] }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.task.artifacts).toHaveLength(1);
+    expect(body.task.artifacts[0].type).toBe("pull_request");
+    expect(body.task.artifacts[0].url).toBe(
+      "https://github.com/hivemoot/hivemoot/pull/312",
+    );
+
+    expect(addTaskArtifacts).toHaveBeenCalledWith(
+      "inst-1",
+      "abc123abc123abc123abc123",
+      [VALID_ARTIFACT],
+      expect.anything(),
+    );
+  });
+
+  it("passes validated artifacts to addTaskArtifacts, not raw body", async () => {
+    const raw = { artifacts: [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/1" }] };
+    const cleanedArtifact = { type: "issue" as const, url: "https://github.com/hivemoot/hivemoot/issues/1" };
+    vi.mocked(validateTaskArtifacts).mockReturnValueOnce({ ok: true, artifacts: [cleanedArtifact] });
+    vi.mocked(addTaskArtifacts).mockResolvedValueOnce({
+      ok: true,
+      task: { ...BASE_TASK, artifacts: [cleanedArtifact] },
+    });
+
+    await POST(makeRequest(raw));
+
+    expect(addTaskArtifacts).toHaveBeenCalledWith(
+      "inst-1",
+      "abc123abc123abc123abc123",
+      [cleanedArtifact],
+      expect.anything(),
+    );
+  });
+});

--- a/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { extractTaskId } from "@/server/task-route-utils";
+import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
+import { TASK_ERROR, taskError } from "@/server/task-error";
+import {
+  addTaskArtifacts,
+  getTask,
+  TASK_ID_PATTERN,
+  validateTaskArtifacts,
+  verifyTaskClaimToken,
+} from "@/server/task-store";
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateTaskExecutorRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const { pathname } = new URL(request.url);
+  const taskId = extractTaskId(pathname);
+  if (!taskId || !TASK_ID_PATTERN.test(taskId)) {
+    return taskError(TASK_ERROR.INVALID_TASK_ID, "Invalid task id", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  const validated = validateTaskArtifacts(body);
+  if (!validated.ok) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, validated.message, 400);
+  }
+
+  try {
+    const existingTask = await getTask(auth.installationId, taskId, auth.redis);
+    if (!existingTask) {
+      return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+    }
+
+    const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";
+    if (!claimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Missing task claim token", 403);
+    }
+
+    const validClaimToken = await verifyTaskClaimToken(
+      auth.installationId,
+      taskId,
+      claimToken,
+      auth.redis,
+    );
+    if (!validClaimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Invalid or expired task claim token", 403);
+    }
+
+    const result = await addTaskArtifacts(
+      auth.installationId,
+      taskId,
+      validated.artifacts,
+      auth.redis,
+    );
+
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+      }
+      if (result.reason === "invalid_url") {
+        return taskError(
+          TASK_ERROR.VALIDATION_FAILED,
+          "Artifact URLs must be scoped to the task's repos",
+          422,
+        );
+      }
+      if (result.reason === "artifact_cap_exceeded") {
+        return taskError(
+          TASK_ERROR.VALIDATION_FAILED,
+          "Artifact cap reached (max 20 per task)",
+          409,
+        );
+      }
+      return taskError(TASK_ERROR.LOCK_TIMEOUT, "Task state is temporarily busy, retry shortly", 429);
+    }
+
+    return NextResponse.json({ task: result.task });
+  } catch (error) {
+    console.error("[tasks] Failed to add artifacts", {
+      installationId: auth.installationId,
+      taskId,
+      error,
+    });
+    return taskError(TASK_ERROR.SERVER_ERROR, "Failed to add artifacts", 500);
+  }
+}

--- a/web/src/server/task-store.test.ts
+++ b/web/src/server/task-store.test.ts
@@ -25,6 +25,9 @@ import {
   validateCreateTaskRequest,
   COMPLETED_TASK_TTL_SECONDS,
   FAILED_TASK_TTL_SECONDS,
+  validateTaskArtifacts,
+  addTaskArtifacts,
+  MAX_ARTIFACTS_PER_TASK,
 } from "./task-store";
 
 type SetOpts = { nx?: boolean; ex?: number };
@@ -1906,5 +1909,247 @@ describe("addUserMessage", () => {
     const userMsg = messages[messages.length - 2];
     expect(userMsg.role).toBe("user");
     expect(userMsg.content).toBe("Do more");
+  });
+});
+
+describe("validateTaskArtifacts", () => {
+  it("accepts a valid artifact array", () => {
+    const result = validateTaskArtifacts({
+      artifacts: [
+        {
+          type: "pull_request",
+          url: "https://github.com/hivemoot/hivemoot/pull/312",
+          number: 312,
+          title: "fix: resolve issue #42",
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].type).toBe("pull_request");
+      expect(result.artifacts[0].number).toBe(312);
+    }
+  });
+
+  it("rejects non-object body", () => {
+    const result = validateTaskArtifacts("not-an-object");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects missing artifacts field", () => {
+    const result = validateTaskArtifacts({ other: "field" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("artifacts must be an array");
+  });
+
+  it("rejects empty artifacts array", () => {
+    const result = validateTaskArtifacts({ artifacts: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("must not be empty");
+  });
+
+  it("rejects artifacts array exceeding per-request limit", () => {
+    const artifacts = Array.from({ length: MAX_ARTIFACTS_PER_TASK + 1 }, (_, i) => ({
+      type: "commit",
+      url: `https://github.com/hivemoot/hivemoot/commit/${"a".repeat(40)}${i}`,
+    }));
+    const result = validateTaskArtifacts({ artifacts });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("at most");
+  });
+
+  it("rejects invalid artifact type", () => {
+    const result = validateTaskArtifacts({
+      artifacts: [{ type: "unknown_type", url: "https://github.com/hivemoot/hivemoot/pull/1" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("type");
+  });
+
+  it("rejects non-GitHub URL", () => {
+    const result = validateTaskArtifacts({
+      artifacts: [{ type: "pull_request", url: "https://example.com/pull/1" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("url");
+  });
+
+  it("rejects non-positive integer number", () => {
+    const result = validateTaskArtifacts({
+      artifacts: [
+        {
+          type: "issue",
+          url: "https://github.com/hivemoot/hivemoot/issues/1",
+          number: 0,
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain("number");
+  });
+
+  it("trims and truncates title", () => {
+    const longTitle = "x".repeat(300);
+    const result = validateTaskArtifacts({
+      artifacts: [
+        {
+          type: "issue",
+          url: "https://github.com/hivemoot/hivemoot/issues/1",
+          title: `  ${longTitle}  `,
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.artifacts[0].title!.length).toBe(200);
+    }
+  });
+
+  it("omits title when blank after trim", () => {
+    const result = validateTaskArtifacts({
+      artifacts: [
+        {
+          type: "commit",
+          url: "https://github.com/hivemoot/hivemoot/commit/abc123",
+          title: "   ",
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.artifacts[0].title).toBeUndefined();
+    }
+  });
+});
+
+describe("addTaskArtifacts", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("appends artifacts to a running task", async () => {
+    const created = await createTask(
+      "inst-1",
+      "user",
+      { prompt: "Open a PR", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+
+    const result = await addTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [
+        {
+          type: "pull_request",
+          url: "https://github.com/hivemoot/hivemoot/pull/99",
+          number: 99,
+        },
+      ],
+      redis,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.task.artifacts).toHaveLength(1);
+      expect(result.task.artifacts![0].type).toBe("pull_request");
+      expect(result.task.artifacts![0].number).toBe(99);
+    }
+  });
+
+  it("persists artifacts so subsequent getTask returns them", async () => {
+    const created = await createTask(
+      "inst-1",
+      "user",
+      { prompt: "Open a PR", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+
+    await addTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ type: "commit", url: "https://github.com/hivemoot/hivemoot/commit/abc123" }],
+      redis,
+    );
+
+    const fetched = await getTask("inst-1", created.task.task_id, redis);
+    expect(fetched?.artifacts).toHaveLength(1);
+    expect(fetched?.artifacts![0].url).toBe("https://github.com/hivemoot/hivemoot/commit/abc123");
+  });
+
+  it("returns not_found for a non-existent task", async () => {
+    const result = await addTaskArtifacts(
+      "inst-1",
+      "000000000000000000000000",
+      [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/1" }],
+      redis,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not_found");
+  });
+
+  it("returns invalid_url when URL is not scoped to task repos", async () => {
+    const created = await createTask(
+      "inst-1",
+      "user",
+      { prompt: "Task", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+
+    const result = await addTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ type: "pull_request", url: "https://github.com/other-org/other-repo/pull/1" }],
+      redis,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid_url");
+  });
+
+  it("returns artifact_cap_exceeded when total would exceed 20", async () => {
+    const created = await createTask(
+      "inst-1",
+      "user",
+      { prompt: "Task", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+
+    for (let i = 0; i < MAX_ARTIFACTS_PER_TASK; i++) {
+      await addTaskArtifacts(
+        "inst-1",
+        created.task.task_id,
+        [{ type: "commit", url: `https://github.com/hivemoot/hivemoot/commit/abc${i}` }],
+        redis,
+      );
+    }
+
+    const overflow = await addTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ type: "commit", url: "https://github.com/hivemoot/hivemoot/commit/overflow" }],
+      redis,
+    );
+
+    expect(overflow.ok).toBe(false);
+    if (!overflow.ok) expect(overflow.reason).toBe("artifact_cap_exceeded");
   });
 });

--- a/web/src/server/task-store.test.ts
+++ b/web/src/server/task-store.test.ts
@@ -2063,6 +2063,35 @@ describe("addTaskArtifacts", () => {
     }
   });
 
+  it("bumps updated_at when artifacts are added", async () => {
+    const before = new Date().toISOString();
+
+    const created = await createTask(
+      "inst-1",
+      "user",
+      { prompt: "Open a PR", repos: ["hivemoot/hivemoot"], timeout_secs: 300 },
+      redis,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+
+    const result = await addTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ type: "issue", url: "https://github.com/hivemoot/hivemoot/issues/1" }],
+      redis,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(new Date(result.task.updated_at).getTime()).toBeGreaterThanOrEqual(
+        new Date(before).getTime(),
+      );
+    }
+  });
+
   it("persists artifacts so subsequent getTask returns them", async () => {
     const created = await createTask(
       "inst-1",

--- a/web/src/server/task-store.ts
+++ b/web/src/server/task-store.ts
@@ -12,10 +12,22 @@ const MAX_PROMPT_CHARS = 8000;
 const MAX_PROGRESS_CHARS = 400;
 const TASK_CLAIM_TOKEN_BYTES = 32;
 const TASK_LOCK_PREFIX = "hive:task-lock:";
+export const MAX_ARTIFACTS_PER_TASK = 20;
+const MAX_ARTIFACT_TITLE_CHARS = 200;
+const GITHUB_URL_PREFIX = "https://github.com/";
 
 export const TASK_ID_PATTERN = /^[a-f0-9]{24}$/;
 
 export type TaskStatus = "pending" | "running" | "needs_follow_up" | "completed" | "failed" | "timed_out";
+
+export type ArtifactType = "pull_request" | "issue" | "issue_comment" | "commit";
+
+export interface TaskArtifact {
+  type: ArtifactType;
+  url: string;
+  number?: number;
+  title?: string;
+}
 
 const TERMINAL_STATUSES = new Set<TaskStatus>(["completed", "failed", "timed_out"]);
 
@@ -43,6 +55,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface ClaimedTask {
@@ -61,6 +74,7 @@ interface StoredTaskRecord {
   started_at?: string;
   finished_at?: string;
   error?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface CreateTaskRequest {
@@ -93,6 +107,14 @@ export type TaskDeleteResult =
   | { ok: false; reason: "not_found" | "invalid_transition" };
 
 export type TaskRetryResult = TaskMutationResult;
+
+export type AddArtifactsResult =
+  | { ok: true; task: TaskRecord }
+  | { ok: false; reason: "not_found" | "artifact_cap_exceeded" | "invalid_url" | "lock_timeout" };
+
+export type ValidateArtifactsResult =
+  | { ok: true; artifacts: TaskArtifact[] }
+  | { ok: false; message: string };
 
 export interface RateLimitResult {
   allowed: boolean;
@@ -206,6 +228,29 @@ function parseStoredTask(raw: unknown): StoredTaskRecord | null {
   if (typeof obj.started_at === "string") parsed.started_at = obj.started_at;
   if (typeof obj.finished_at === "string") parsed.finished_at = obj.finished_at;
   if (typeof obj.error === "string") parsed.error = obj.error;
+
+  if (Array.isArray(obj.artifacts)) {
+    const parsedArtifacts: TaskArtifact[] = [];
+    for (const art of obj.artifacts) {
+      if (
+        art
+        && typeof art === "object"
+        && !Array.isArray(art)
+        && typeof (art as Record<string, unknown>).type === "string"
+        && typeof (art as Record<string, unknown>).url === "string"
+      ) {
+        const a = art as Record<string, unknown>;
+        const artifact: TaskArtifact = {
+          type: a.type as ArtifactType,
+          url: a.url as string,
+        };
+        if (typeof a.number === "number") artifact.number = a.number;
+        if (typeof a.title === "string") artifact.title = a.title;
+        parsedArtifacts.push(artifact);
+      }
+    }
+    if (parsedArtifacts.length > 0) parsed.artifacts = parsedArtifacts;
+  }
 
   return parsed;
 }
@@ -380,6 +425,7 @@ async function maybeTimeoutTask(
     started_at: timedOut.task.started_at,
     finished_at: timedOut.task.finished_at,
     error: timedOut.task.error,
+    ...(timedOut.task.artifacts ? { artifacts: timedOut.task.artifacts } : {}),
   };
 }
 
@@ -1379,6 +1425,124 @@ export async function addUserMessage(
         taskId,
       });
       return { ok: false, reason: "concurrency_limited" };
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task artifacts
+// ---------------------------------------------------------------------------
+
+const VALID_ARTIFACT_TYPES = new Set<ArtifactType>([
+  "pull_request",
+  "issue",
+  "issue_comment",
+  "commit",
+]);
+
+export function validateTaskArtifacts(body: unknown): ValidateArtifactsResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, message: "Body must be a JSON object" };
+  }
+
+  const obj = body as Record<string, unknown>;
+  if (!Array.isArray(obj.artifacts)) {
+    return { ok: false, message: "artifacts must be an array" };
+  }
+
+  if (obj.artifacts.length === 0) {
+    return { ok: false, message: "artifacts must not be empty" };
+  }
+
+  if (obj.artifacts.length > MAX_ARTIFACTS_PER_TASK) {
+    return { ok: false, message: `artifacts must contain at most ${MAX_ARTIFACTS_PER_TASK} entries per request` };
+  }
+
+  const artifacts: TaskArtifact[] = [];
+  for (let i = 0; i < obj.artifacts.length; i++) {
+    const raw = obj.artifacts[i];
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return { ok: false, message: `artifacts[${i}] must be an object` };
+    }
+
+    const art = raw as Record<string, unknown>;
+
+    if (typeof art.type !== "string" || !VALID_ARTIFACT_TYPES.has(art.type as ArtifactType)) {
+      return {
+        ok: false,
+        message: `artifacts[${i}].type must be one of: ${[...VALID_ARTIFACT_TYPES].join(", ")}`,
+      };
+    }
+
+    if (typeof art.url !== "string" || !art.url.startsWith(GITHUB_URL_PREFIX)) {
+      return {
+        ok: false,
+        message: `artifacts[${i}].url must be a GitHub URL (https://github.com/...)`,
+      };
+    }
+
+    const artifact: TaskArtifact = {
+      type: art.type as ArtifactType,
+      url: art.url,
+    };
+
+    if (art.number !== undefined) {
+      if (typeof art.number !== "number" || !Number.isInteger(art.number) || art.number < 1) {
+        return { ok: false, message: `artifacts[${i}].number must be a positive integer` };
+      }
+      artifact.number = art.number;
+    }
+
+    if (art.title !== undefined) {
+      if (typeof art.title !== "string") {
+        return { ok: false, message: `artifacts[${i}].title must be a string` };
+      }
+      artifact.title = art.title.trim().slice(0, MAX_ARTIFACT_TITLE_CHARS) || undefined;
+    }
+
+    artifacts.push(artifact);
+  }
+
+  return { ok: true, artifacts };
+}
+
+export async function addTaskArtifacts(
+  installationId: string,
+  taskId: string,
+  newArtifacts: TaskArtifact[],
+  redis: Redis,
+): Promise<AddArtifactsResult> {
+  try {
+    return await withTaskInstallationLock(installationId, redis, async () => {
+      const stored = await loadStoredTask(installationId, taskId, redis);
+      if (!stored) return { ok: false, reason: "not_found" };
+
+      for (const artifact of newArtifacts) {
+        const scoped = stored.repos.some((repo) =>
+          artifact.url.startsWith(`${GITHUB_URL_PREFIX}${repo}/`),
+        );
+        if (!scoped) return { ok: false, reason: "invalid_url" };
+      }
+
+      const existing = stored.artifacts ?? [];
+      if (existing.length + newArtifacts.length > MAX_ARTIFACTS_PER_TASK) {
+        return { ok: false, reason: "artifact_cap_exceeded" };
+      }
+
+      const updated: StoredTaskRecord = {
+        ...stored,
+        artifacts: [...existing, ...newArtifacts],
+      };
+
+      await redis.set(taskKey(installationId, taskId), updated);
+
+      return { ok: true, task: await buildTaskRecord(installationId, updated, redis) };
+    });
+  } catch (error) {
+    if (error instanceof LockTimeoutError) {
+      console.warn("[tasks] Add artifacts lock timeout", { installationId, taskId });
+      return { ok: false, reason: "lock_timeout" };
     }
     throw error;
   }

--- a/web/src/server/task-store.ts
+++ b/web/src/server/task-store.ts
@@ -1532,6 +1532,7 @@ export async function addTaskArtifacts(
 
       const updated: StoredTaskRecord = {
         ...stored,
+        updated_at: nowIso(),
         artifacts: [...existing, ...newArtifacts],
       };
 


### PR DESCRIPTION
Closes #332

## What this does

Adds `POST /api/tasks/{taskId}/artifacts` so agents can surface structured artifact links (PRs, issues, commits, issue comments) in the task dashboard as they're produced — without waiting for task completion.

**Storage**: `artifacts?: TaskArtifact[]` is an optional field on `TaskRecord` / `StoredTaskRecord`. Stored inline in the task Redis key (same TTL, same delete path). Absent for tasks with no artifacts — no bloat.

**Auth**: claim-token auth (same as heartbeat/execute). Only the agent that claimed a task can attach artifacts to it. Once the task finalizes and the claim token is deleted, the endpoint returns 403.

**Validation**:
- Structural validation (type, GitHub URL prefix, number/title types) before Redis
- Repo-scope check under lock after loading the task — blocks cross-repo artifact injection
- 20-artifact cap enforced atomically under the task lock

**Response**: returns the updated `TaskRecord` with the new artifacts appended.

## Approach

Issue #332 proposed three approaches (A: batch at completion, B: dedicated endpoint, C: parse from messages). This implements Approach B — dedicated endpoint — per the recommendation. Agents know what they produce; the API should let them declare it explicitly.

## What's not in this PR

- Web UI badge rendering (Phase 2 per the issue roadmap — the `artifacts` field on `TaskRecord` is ready for the UI layer)
- Agent instrumentation in hivemoot-agent (same — endpoint is live, agents need to call it)

## Tests

27 new tests:
- 12 route-level tests (`route.test.ts`): auth failures, validation errors, cap overflow, URL scoping, success path
- 15 unit tests (`task-store.test.ts`): `validateTaskArtifacts` validation edge cases, `addTaskArtifacts` persistence, repo-scope rejection, cap enforcement

All 640 web tests pass. Typecheck clean.