### PR TITLE
feat(cli): surface Goals in buzz output

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -14,6 +14,10 @@ vi.mock("../github/issues.js", () => ({
   fetchIssues: vi.fn(),
 }));
 
+vi.mock("../github/goals.js", () => ({
+  fetchGoalIssues: vi.fn(),
+}));
+
 vi.mock("../github/pulls.js", () => ({
   fetchPulls: vi.fn(),
 }));
@@ -61,6 +65,7 @@ vi.mock("../output/json.js", () => ({
 import { loadTeamConfig } from "../config/loader.js";
 import { fetchRepoPushAccess, resolveRepo } from "../github/repo.js";
 import { fetchIssues } from "../github/issues.js";
+import { fetchGoalIssues } from "../github/goals.js";
 import { fetchPulls } from "../github/pulls.js";
 import { fetchCurrentUser } from "../github/user.js";
 import { fetchVotes } from "../github/votes.js";
@@ -77,6 +82,7 @@ const mockedResolveRepo = vi.mocked(resolveRepo);
 const mockedFetchRepoPushAccess = vi.mocked(fetchRepoPushAccess);
 const mockedLoadTeamConfig = vi.mocked(loadTeamConfig);
 const mockedFetchIssues = vi.mocked(fetchIssues);
+const mockedFetchGoalIssues = vi.mocked(fetchGoalIssues);
 const mockedFetchPulls = vi.mocked(fetchPulls);
 const mockedFetchCurrentUser = vi.mocked(fetchCurrentUser);
 const mockedFetchVotes = vi.mocked(fetchVotes);
@@ -126,6 +132,7 @@ beforeEach(() => {
   mockedRunPublishPreflight.mockResolvedValue({ command: "git push --dry-run origin HEAD", ok: true, originUrl: "https://github.com/hivemoot-guard/test.git" });
   mockedLoadTeamConfig.mockResolvedValue(testTeamConfig);
   mockedFetchIssues.mockResolvedValue([]);
+  mockedFetchGoalIssues.mockResolvedValue([]);
   mockedFetchPulls.mockResolvedValue([]);
   mockedFetchCurrentUser.mockResolvedValue("testuser");
   mockedFetchVotes.mockResolvedValue(new Map());
@@ -385,6 +392,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      [],
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +416,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      [],
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -431,6 +440,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      [],
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain(
@@ -474,6 +484,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      [],
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain(
@@ -571,6 +582,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      [],
     );
   });
 
@@ -666,6 +678,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       notificationMap,
       undefined,
+      [],
     );
   });
 

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -11,6 +11,7 @@ import { loadTeamConfig } from "../config/loader.js";
 import { fetchRepoPushAccess, resolveRepo } from "../github/repo.js";
 import { runPublishPreflight } from "../github/publish.js";
 import { fetchIssues } from "../github/issues.js";
+import { fetchGoalIssues } from "../github/goals.js";
 import { fetchPulls } from "../github/pulls.js";
 import { fetchCurrentUser } from "../github/user.js";
 import { fetchVotes } from "../github/votes.js";
@@ -110,13 +111,14 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
 
   // Fetch summary data in parallel with optional team config loading.
   // Focus is additive and should not delay base status data.
-  const [issuesResult, prsResult, userResult, notificationsResult, pushAccessResult, publishPreflightResult] = await Promise.allSettled([
+  const [issuesResult, prsResult, userResult, notificationsResult, pushAccessResult, publishPreflightResult, goalIssuesResult] = await Promise.allSettled([
     fetchIssues(repo, fetchLimit),
     fetchPulls(repo, fetchLimit),
     fetchCurrentUser(),
     fetchNotifications(repo),
     fetchRepoPushAccess(repo),
     runPublishPreflight(),
+    fetchGoalIssues(repo),
   ]);
 
   try {
@@ -174,6 +176,8 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     }
   }
 
+  const goalIssues = goalIssuesResult.status === "fulfilled" ? goalIssuesResult.value : undefined;
+
   const summary = buildSummary(
     repo,
     issues,
@@ -183,6 +187,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     votes,
     notifications,
     teamConfig?.focus,
+    goalIssues,
   );
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -36,6 +36,20 @@ export interface GitHubIssue {
   url: string;
 }
 
+export interface GitHubGoalIssue extends GitHubIssue {
+  body: string;
+}
+
+export interface GoalItem {
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  age: string;
+  tasksTotal: number;
+  tasksComplete: number;
+}
+
 export interface StatusCheck {
   context: string;
   state: string | undefined;
@@ -181,6 +195,7 @@ export interface RepoSummary {
   currentUser: string;
   unackedMentions?: NotificationRef[];
   recentlyClosedByYou?: RecentClosedItem[];
+  goals?: GoalItem[];
   needsHuman: SummaryItem[];
   driveDiscussion: SummaryItem[];
   driveImplementation: SummaryItem[];

--- a/cli/src/github/goals.test.ts
+++ b/cli/src/github/goals.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parseGoalProgress } from "./goals.js";
+
+describe("parseGoalProgress", () => {
+  it("counts checked and unchecked task items", () => {
+    const body = `
+## Tasks
+- [x] hivemoot/hivemoot-agent#330 — Plugin infrastructure
+- [x] hivemoot/apiary#25 — Fleet config support
+- [ ] hivemoot/colony#603 — Deploy to production
+- [ ] Write documentation
+`;
+    const result = parseGoalProgress(body);
+    expect(result.total).toBe(4);
+    expect(result.complete).toBe(2);
+  });
+
+  it("returns zero counts for body with no task items", () => {
+    const body = "Just a description with no checkboxes.";
+    const result = parseGoalProgress(body);
+    expect(result.total).toBe(0);
+    expect(result.complete).toBe(0);
+  });
+
+  it("handles all tasks complete", () => {
+    const body = "- [x] Task A\n- [x] Task B\n- [x] Task C\n";
+    const result = parseGoalProgress(body);
+    expect(result.total).toBe(3);
+    expect(result.complete).toBe(3);
+  });
+
+  it("handles all tasks incomplete", () => {
+    const body = "- [ ] Task A\n- [ ] Task B\n";
+    const result = parseGoalProgress(body);
+    expect(result.total).toBe(2);
+    expect(result.complete).toBe(0);
+  });
+
+  it("is case-insensitive for checked marker", () => {
+    const body = "- [X] uppercase checked\n- [x] lowercase checked\n- [ ] unchecked\n";
+    const result = parseGoalProgress(body);
+    expect(result.total).toBe(3);
+    expect(result.complete).toBe(2);
+  });
+
+  it("ignores non-task lines even if they contain brackets", () => {
+    const body = `
+Some text [not a task] here
+- [x] Real task one
+- [ ] Real task two
+A code block: - [ ] this is NOT a task (indented differently)
+`;
+    const result = parseGoalProgress(body);
+    expect(result.total).toBe(2);
+    expect(result.complete).toBe(1);
+  });
+
+  it("handles empty string body", () => {
+    const result = parseGoalProgress("");
+    expect(result.total).toBe(0);
+    expect(result.complete).toBe(0);
+  });
+});

--- a/cli/src/github/goals.ts
+++ b/cli/src/github/goals.ts
@@ -1,0 +1,53 @@
+import type { GitHubGoalIssue, RepoRef } from "../config/types.js";
+import { CliError } from "../config/types.js";
+import { gh } from "./client.js";
+
+export async function fetchGoalIssues(repo: RepoRef): Promise<GitHubGoalIssue[]> {
+  const json = await gh([
+    "issue",
+    "list",
+    "-R",
+    `${repo.owner}/${repo.repo}`,
+    "--state",
+    "open",
+    "--label",
+    "hivemoot:goal",
+    "--json",
+    "number,title,body,labels,assignees,author,comments,createdAt,updatedAt,url",
+    "--limit",
+    "50",
+  ]);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new CliError(
+      "Failed to parse goal issues response from gh CLI",
+      "GH_ERROR",
+      1,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new CliError(
+      "Unexpected goal issues response format from gh CLI",
+      "GH_ERROR",
+      1,
+    );
+  }
+  return parsed as GitHubGoalIssue[];
+}
+
+export function parseGoalProgress(body: string): { total: number; complete: number } {
+  let total = 0;
+  let complete = 0;
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    if (/^- \[x\]/i.test(trimmed)) {
+      total++;
+      complete++;
+    } else if (/^- \[ \]/.test(trimmed)) {
+      total++;
+    }
+  }
+  return { total, complete };
+}

--- a/cli/src/output/formatter.ts
+++ b/cli/src/output/formatter.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { NotificationRef, PublishReadiness, RepoSummary, RoleConfig, SummaryItem, TeamConfig } from "../config/types.js";
+import type { GoalItem, NotificationRef, PublishReadiness, RepoSummary, RoleConfig, SummaryItem, TeamConfig } from "../config/types.js";
 
 const DIVIDER_WIDTH = 50;
 
@@ -225,6 +225,28 @@ function formatPublishReadinessSection(readiness: PublishReadiness): string {
   return lines.join("\n");
 }
 
+function formatGoalsSection(goals: GoalItem[], limit?: number): string {
+  if (goals.length === 0) return "";
+
+  const displayed = limit ? goals.slice(0, limit) : goals;
+  const header = sectionDivider("GOALS", goals.length);
+  const lines = displayed.map((g) => {
+    const num = chalk.cyan(`#${g.number}`);
+    const progress =
+      g.tasksTotal > 0
+        ? chalk.dim(`${g.tasksComplete}/${g.tasksTotal} tasks`)
+        : chalk.dim("no tasks");
+    const meta = `  by: ${chalk.dim(g.author)} | created: ${chalk.dim(g.age)}`;
+    return `  ${num} ${g.title}  ${progress}\n${meta}`;
+  });
+
+  const parts = [header, ...lines];
+  if (limit && goals.length > limit) {
+    parts.push(chalk.dim(`  ... and ${goals.length - limit} more`));
+  }
+  return parts.join("\n\n");
+}
+
 function formatSummaryBody(summary: RepoSummary, limit?: number): string {
   const u = summary.currentUser;
   const sections: string[] = [];
@@ -235,6 +257,7 @@ function formatSummaryBody(summary: RepoSummary, limit?: number): string {
       formatNotificationsSection("UNACKED MENTIONS", summary.unackedMentions ?? [], limit),
       formatRepositoryHealth(summary),
       formatPrioritySignals(summary),
+      formatGoalsSection(summary.goals ?? [], limit),
       formatSection("NEEDS HUMAN", summary.needsHuman, u, "needsHuman", limit),
       formatSection("DRIVE THE DISCUSSION", summary.driveDiscussion, u, "driveDiscussion", limit),
       formatSection("DRIVE THE IMPLEMENTATION", summary.driveImplementation, u, "driveImplementation", limit),

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1363,6 +1363,14 @@ describe("buildSummary() — Goals", () => {
     expect(summary.goals![0].tasksComplete).toBe(0);
   });
 
+  it("handles goal with null body without crashing", () => {
+    const goal = makeGoalIssue({ body: null as unknown as string });
+    const summary = buildSummary(repo, [], [], "testuser", now, undefined, undefined, undefined, [goal]);
+
+    expect(summary.goals![0].tasksTotal).toBe(0);
+    expect(summary.goals![0].tasksComplete).toBe(0);
+  });
+
   it("maps multiple goal issues", () => {
     const goals = [
       makeGoalIssue({ number: 413, title: "Goal A", body: "- [x] done\n- [ ] pending\n" }),

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildSummary } from "./builder.js";
-import type { GitHubIssue, GitHubPR, RepoRef } from "../config/types.js";
+import type { GitHubGoalIssue, GitHubIssue, GitHubPR, RepoRef } from "../config/types.js";
 
 const repo: RepoRef = { owner: "hivemoot", repo: "colony" };
 const now = new Date("2025-06-15T12:00:00Z");
@@ -1311,5 +1311,69 @@ describe("buildSummary()", () => {
     expect(summary.notes).toContain(
       "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.",
     );
+  });
+});
+
+describe("buildSummary() — Goals", () => {
+  function makeGoalIssue(overrides: Partial<GitHubGoalIssue> = {}): GitHubGoalIssue {
+    return {
+      number: 413,
+      title: "MCP Plugin System",
+      body: "- [x] hivemoot/hivemoot-agent#330 — Plugin infrastructure\n- [ ] hivemoot/apiary#25 — Fleet config support\n",
+      labels: [{ name: "hivemoot:goal" }],
+      assignees: [],
+      author: { login: "hivemoot-builder" },
+      comments: [],
+      createdAt: "2025-06-01T12:00:00Z",
+      updatedAt: "2025-06-10T12:00:00Z",
+      url: "https://github.com/hivemoot/hivemoot/issues/413",
+      ...overrides,
+    };
+  }
+
+  it("returns undefined goals when goalIssues is not provided", () => {
+    const summary = buildSummary(repo, [], [], "testuser", now);
+    expect(summary.goals).toBeUndefined();
+  });
+
+  it("returns empty goals array when goalIssues is empty", () => {
+    const summary = buildSummary(repo, [], [], "testuser", now, undefined, undefined, undefined, []);
+    expect(summary.goals).toEqual([]);
+  });
+
+  it("maps goal issues to GoalItem with correct progress", () => {
+    const goal = makeGoalIssue();
+    const summary = buildSummary(repo, [], [], "testuser", now, undefined, undefined, undefined, [goal]);
+
+    expect(summary.goals).toHaveLength(1);
+    const g = summary.goals![0];
+    expect(g.number).toBe(413);
+    expect(g.title).toBe("MCP Plugin System");
+    expect(g.tasksTotal).toBe(2);
+    expect(g.tasksComplete).toBe(1);
+    expect(g.author).toBe("hivemoot-builder");
+    expect(g.url).toBe("https://github.com/hivemoot/hivemoot/issues/413");
+  });
+
+  it("handles goal with no task items", () => {
+    const goal = makeGoalIssue({ body: "Just a description, no checkboxes." });
+    const summary = buildSummary(repo, [], [], "testuser", now, undefined, undefined, undefined, [goal]);
+
+    expect(summary.goals![0].tasksTotal).toBe(0);
+    expect(summary.goals![0].tasksComplete).toBe(0);
+  });
+
+  it("maps multiple goal issues", () => {
+    const goals = [
+      makeGoalIssue({ number: 413, title: "Goal A", body: "- [x] done\n- [ ] pending\n" }),
+      makeGoalIssue({ number: 414, title: "Goal B", body: "- [x] done\n- [x] done2\n" }),
+    ];
+    const summary = buildSummary(repo, [], [], "testuser", now, undefined, undefined, undefined, goals);
+
+    expect(summary.goals).toHaveLength(2);
+    expect(summary.goals![0].tasksTotal).toBe(2);
+    expect(summary.goals![0].tasksComplete).toBe(1);
+    expect(summary.goals![1].tasksTotal).toBe(2);
+    expect(summary.goals![1].tasksComplete).toBe(2);
   });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -307,7 +307,7 @@ function buildPrioritySignals(
 
 function buildGoalItems(goalIssues: GitHubGoalIssue[], now: Date): GoalItem[] {
   return goalIssues.map((issue) => {
-    const { total, complete } = parseGoalProgress(issue.body);
+    const { total, complete } = parseGoalProgress(issue.body ?? "");
     return {
       number: issue.number,
       title: issue.title,

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -1,6 +1,8 @@
 import type {
+  GitHubGoalIssue,
   GitHubIssue,
   GitHubPR,
+  GoalItem,
   NotificationRef,
   PrioritySignal,
   RepoRef,
@@ -10,6 +12,7 @@ import type {
 } from "../config/types.js";
 import type { VoteMap } from "../github/votes.js";
 import type { NotificationMap } from "../github/notifications.js";
+import { parseGoalProgress } from "../github/goals.js";
 import {
   hasLabel,
   hasCIFailure,
@@ -302,6 +305,21 @@ function buildPrioritySignals(
     });
 }
 
+function buildGoalItems(goalIssues: GitHubGoalIssue[], now: Date): GoalItem[] {
+  return goalIssues.map((issue) => {
+    const { total, complete } = parseGoalProgress(issue.body);
+    return {
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      author: issue.author?.login ?? "ghost",
+      age: timeAgo(issue.createdAt, now),
+      tasksTotal: total,
+      tasksComplete: complete,
+    };
+  });
+}
+
 export function buildSummary(
   repo: RepoRef,
   issues: GitHubIssue[],
@@ -311,6 +329,7 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  goalIssues?: GitHubGoalIssue[],
 ): RepoSummary {
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
@@ -493,6 +512,7 @@ export function buildSummary(
     repo,
     currentUser,
     unackedMentions: [],
+    goals: goalIssues ? buildGoalItems(goalIssues, now) : undefined,
     needsHuman,
     driveDiscussion,
     driveImplementation,


### PR DESCRIPTION
Closes #413

## What changed

**`cli/src/github/goals.ts`** (new): `fetchGoalIssues()` fetches open `hivemoot:goal` issues with their bodies, needed to parse task-list progress. `parseGoalProgress()` counts `- [x]` and `- [ ]` markdown items to produce `{ total, complete }`.

**`cli/src/summary/builder.ts`**: `buildSummary()` accepts an optional `goalIssues` 9th parameter. When provided, a new `buildGoalItems()` maps each goal issue into a `GoalItem` (number, title, url, author, age, tasksTotal, tasksComplete).

**`cli/src/output/formatter.ts`**: New `formatGoalsSection()` renders a `GOALS (N)` section showing each goal's progress inline: `#413 MCP Plugin System  1/2 tasks`. Goals appear after PRIORITY SIGNALS and before NEEDS HUMAN.

**`cli/src/commands/buzz.ts`**: `fetchGoalIssues()` is added to the `Promise.allSettled` parallel fetch. A failed goal fetch is silent — the section is omitted rather than crashing.

## Why this is scoped to this repo

The bot-side work (checkbox auto-sync, progress comments, Goal auto-close) belongs in hivemoot-bot. PR #418 covers the AGENTS.md/HOW-IT-WORKS.md documentation. This PR implements the CLI surface that agents actually see during a run — the part that matters most for day-to-day usage.

## Test plan

- `src/github/goals.test.ts` (7 tests): `parseGoalProgress` — checked, unchecked, empty, case-insensitive `[X]`, non-task lines ignored
- `src/summary/builder.test.ts` (5 new tests): `buildSummary` with goals — undefined when not provided, empty array, correct progress mapping, null body, multiple goals
- `src/commands/buzz.test.ts`: `fetchGoalIssues` mocked; all 6 `buildSummary` call assertions updated to expect the new 9th arg

831 tests pass.