### PR TITLE
fix(web): cap BYOK config and rotate payload at 4 KB

### DIFF
--- a/apps/web/src/app/api/byok/config/route.test.ts
+++ b/apps/web/src/app/api/byok/config/route.test.ts
@@ -195,6 +195,21 @@ describe("POST /api/byok/config", () => {
     expect(parsed).toHaveProperty("model", "gpt-4o");
   });
 
+  it("returns 413 when content-length exceeds 4 KB", async () => {
+    const req = new NextRequest("https://example.com/api/byok/config", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(4 * 1024 + 1),
+      },
+      body: JSON.stringify({ provider: "anthropic", model: "m", apiKey: "k" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.PAYLOAD_TOO_LARGE);
+  });
+
   it("uses installationId from session, not request body", async () => {
     const req = makeRequest({
       provider: "anthropic",

--- a/apps/web/src/app/api/byok/config/route.ts
+++ b/apps/web/src/app/api/byok/config/route.ts
@@ -11,7 +11,10 @@ import { encrypt } from "@/server/crypto";
 import { setByokEnvelope } from "@/server/byok-store";
 import { validateProviderKey } from "@/server/provider-validation";
 import { BYOK_ERROR, byokError } from "@/server/byok-error";
+import { parseContentLength } from "@/server/request-utils";
 import type { ByokEnvelope } from "@/server/byok-store";
+
+const MAX_PAYLOAD_BYTES = 4 * 1024;
 
 interface ConfigRequestBody {
   provider: string;
@@ -22,6 +25,11 @@ interface ConfigRequestBody {
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
+
+  const contentLength = parseContentLength(request.headers.get("content-length"));
+  if (contentLength !== null && contentLength > MAX_PAYLOAD_BYTES) {
+    return byokError(BYOK_ERROR.PAYLOAD_TOO_LARGE, "Request payload too large", 413);
+  }
 
   let body: ConfigRequestBody;
   try {

--- a/apps/web/src/app/api/byok/rotate/route.test.ts
+++ b/apps/web/src/app/api/byok/rotate/route.test.ts
@@ -146,6 +146,21 @@ describe("POST /api/byok/rotate", () => {
     expect(parsed).toHaveProperty("model", "gemini-3-flash-preview");
   });
 
+  it("returns 413 when content-length exceeds 4 KB", async () => {
+    const req = new NextRequest("https://example.com/api/byok/rotate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(4 * 1024 + 1),
+      },
+      body: JSON.stringify({ provider: "anthropic", model: "m", apiKey: "k" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.code).toBe(BYOK_ERROR.PAYLOAD_TOO_LARGE);
+  });
+
   it("uses installationId from session, not request body", async () => {
     const req = makeRequest({
       provider: "anthropic",

--- a/apps/web/src/app/api/byok/rotate/route.ts
+++ b/apps/web/src/app/api/byok/rotate/route.ts
@@ -12,7 +12,10 @@ import { encrypt } from "@/server/crypto";
 import { setByokEnvelope } from "@/server/byok-store";
 import { validateProviderKey } from "@/server/provider-validation";
 import { BYOK_ERROR, byokError } from "@/server/byok-error";
+import { parseContentLength } from "@/server/request-utils";
 import type { ByokEnvelope } from "@/server/byok-store";
+
+const MAX_PAYLOAD_BYTES = 4 * 1024;
 
 interface RotateRequestBody {
   provider: string;
@@ -23,6 +26,11 @@ interface RotateRequestBody {
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
+
+  const contentLength = parseContentLength(request.headers.get("content-length"));
+  if (contentLength !== null && contentLength > MAX_PAYLOAD_BYTES) {
+    return byokError(BYOK_ERROR.PAYLOAD_TOO_LARGE, "Request payload too large", 413);
+  }
 
   let body: RotateRequestBody;
   try {

--- a/apps/web/src/constants/byok-errors.ts
+++ b/apps/web/src/constants/byok-errors.ts
@@ -17,6 +17,7 @@ export const BYOK_ERROR = {
   INSTALLATION_MISMATCH: "byok_installation_mismatch",
   INVALID_JSON: "byok_invalid_json",
   MISSING_FIELDS: "byok_missing_fields",
+  PAYLOAD_TOO_LARGE: "byok_payload_too_large",
   NOT_AUTHENTICATED: "byok_not_authenticated",
   NOT_CONFIGURED: "byok_not_configured",
   PROVIDER_INVALID: "byok_provider_invalid",


### PR DESCRIPTION
Refs #423

## What

Adds a `MAX_PAYLOAD_BYTES = 4 * 1024` check to both BYOK mutation routes (config and rotate) before reading the request body. Requests with a `Content-Length` header exceeding 4 KB receive a `413 byok_payload_too_large` response.

## Why

Finding 3 from security audit #423: neither route bounds the `apiKey`, `provider`, or `model` fields. A maximally large payload passed to `validateProviderKey` would be sent as an HTTP header value to an external provider API (10-second timeout) and then encrypted with AES-GCM — both operations with costs proportional to input size.

A legitimate key + model + provider JSON is typically under 200 bytes. 4 KB is a conservative ceiling that covers every real provider key while cutting off oversized inputs before they reach the validator or crypto stack.

## Pattern

Follows the existing `MAX_PAYLOAD_BYTES = 64 * 1024` check in `tasks/create/route.ts` using the same `parseContentLength` / `request-utils` utility.

## Tests

- New test in `config/route.test.ts`: `returns 413 when content-length exceeds 4 KB`
- New test in `rotate/route.test.ts`: `returns 413 when content-length exceeds 4 KB`
- Full web suite: 615 passed, 1 skipped — no regressions

## Governance note

Issue #423 is in `hivemoot:discussion` due to the Queen bot outage (#414). This PR is pre-governance following the same pattern as #426 and #431 — the fix is ready and correct, and will be properly linked once #423 reaches `hivemoot:ready-to-implement`. The `Refs` keyword is used intentionally until then.