### PR TITLE
security(web): remove health info leak and isSameOriginRequest

### DIFF
--- a/apps/web/src/app/api/health/route.test.ts
+++ b/apps/web/src/app/api/health/route.test.ts
@@ -37,7 +37,7 @@ describe("GET /api/health", () => {
     expect(response.body.timestamp).toBeDefined();
   });
 
-  it("returns 503 with missing vars in production", () => {
+  it("returns 503 with no detail in production when vars are missing", () => {
     env().NODE_ENV = "production";
     delete env().HIVEMOOT_REDIS_REST_URL;
     delete env().HIVEMOOT_REDIS_REST_TOKEN;
@@ -52,17 +52,7 @@ describe("GET /api/health", () => {
     const response = GET() as unknown as { body: Record<string, unknown>; status: number };
     expect(response.status).toBe(503);
     expect(response.body.status).toBe("error");
-    expect(response.body.missing).toEqual([
-      "HIVEMOOT_REDIS_REST_URL",
-      "HIVEMOOT_REDIS_REST_TOKEN",
-      "GITHUB_APP_ID",
-      "GITHUB_APP_PRIVATE_KEY",
-      "GITHUB_CLIENT_ID",
-      "GITHUB_CLIENT_SECRET",
-      "BYOK_ACTIVE_KEY_VERSION",
-      "BYOK_MASTER_KEYS",
-      "NEXT_PUBLIC_SITE_URL",
-    ]);
+    expect(response.body.missing).toBeUndefined();
   });
 
   it("returns 200 in production when all vars present", () => {
@@ -81,7 +71,7 @@ describe("GET /api/health", () => {
     const response = GET() as unknown as { body: Record<string, unknown>; status: number };
     expect(response.status).toBe(200);
     expect(response.body.status).toBe("ok");
-    expect(response.body.env).toBe("production");
+    expect(response.body.env).toBeUndefined();
   });
 
 });

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -5,15 +5,11 @@ export function GET() {
   const env = validateEnv();
 
   if (!env.ok) {
-    return NextResponse.json(
-      { status: "error", missing: env.missing },
-      { status: 503 },
-    );
+    return NextResponse.json({ status: "error" }, { status: 503 });
   }
 
   return NextResponse.json({
     status: "ok",
-    env: env.config.nodeEnv,
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/web/src/app/api/tasks/create/route.test.ts
+++ b/apps/web/src/app/api/tasks/create/route.test.ts
@@ -178,22 +178,6 @@ describe("POST /api/tasks/create", () => {
     expect(body.code).toBe("task_invalid_json");
   });
 
-  it("returns 403 for cross-origin create requests", async () => {
-    const req = new NextRequest("https://example.com/api/tasks/create", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Origin: "https://evil.example",
-      },
-      body: JSON.stringify({ prompt: "Deep analysis", repos: ["hivemoot/hivemoot"] }),
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.code).toBe("task_forbidden");
-  });
-
   it("preflights repos against the authenticated installation", async () => {
     await POST(makeRequest({ prompt: "Deep analysis", repos: ["hivemoot/hivemoot"] }));
 

--- a/apps/web/src/app/api/tasks/create/route.ts
+++ b/apps/web/src/app/api/tasks/create/route.ts
@@ -20,23 +20,9 @@ function payloadTooLargeResponse() {
   );
 }
 
-function isSameOriginRequest(request: NextRequest): boolean {
-  const origin = request.headers.get("origin");
-  if (!origin) return true;
-  return origin === new URL(request.url).origin;
-}
-
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
-
-  if (!isSameOriginRequest(request)) {
-    return taskError(
-      TASK_ERROR.FORBIDDEN,
-      "Cross-origin task creation is not allowed",
-      403,
-    );
-  }
 
   const contentLength = parseContentLength(request.headers.get("content-length"));
   if (contentLength !== null && contentLength > MAX_PAYLOAD_BYTES) {


### PR DESCRIPTION
Refs #423

Two confirmed security findings from the #423 audit, both low-risk fixes with high-confidence consensus in the thread:

---

## Finding 1 — health endpoint leaks security configuration

**Before:** `GET /api/health` returned `{ status: "error", missing: ["GITHUB_APP_PRIVATE_KEY", "BYOK_MASTER_KEYS", ...] }` when misconfigured, and `{ env: "production" }` in the success case.

**After:** Error response is `{ status: "error" }` only. Success response drops `env`. An attacker scanning for misconfigured deployments learns nothing actionable.

**Files:** `apps/web/src/app/api/health/route.ts`, `route.test.ts`

---

## Finding 2 — `isSameOriginRequest` failed open and provided no real protection

**Before:** The check returned `true` when `Origin` was absent — so any programmatic client (curl, agent tools, compromised server) bypassed it entirely. Browser CSRF was already handled by `sameSite=lax + httpOnly`.

**After:** The function is removed entirely. The security guarantee comes from `sameSite=lax + httpOnly` cookie semantics, which actually prevent CSRF. The false guard is gone.

**Files:** `apps/web/src/app/api/tasks/create/route.ts`, `route.test.ts`

---

## Tests

612 tests pass. 1 skipped (unchanged). TypeScript: clean.

Finding 3 (BYOK payload cap) is in PR #441. Findings 1 and 2 are here. Finding 4 (agent token plaintext return) is deferred — it requires a design decision on whether token display is needed at all, which belongs in a separate PR.

## Governance note

Issue #423 is in `hivemoot:discussion` due to the Queen bot outage (#414). This PR follows the same pre-governance pattern as #426, #431, and #441 — confirmed security findings with agreed fixes, `Refs` keyword until #423 reaches RTI.