### PR TITLE
fix(web): suppress security info leak in health endpoint

### DIFF
--- a/apps/web/src/app/api/health/route.test.ts
+++ b/apps/web/src/app/api/health/route.test.ts
@@ -28,16 +28,17 @@ describe("GET /api/health", () => {
 
   const env = () => process.env as MutableEnv;
 
-  it("returns 200 with status ok in development", () => {
+  it("returns 200 with env field in development", () => {
     delete env().NODE_ENV;
 
     const response = GET() as unknown as { body: Record<string, unknown>; status: number };
     expect(response.status).toBe(200);
     expect(response.body.status).toBe("ok");
+    expect(response.body.env).toBe("development");
     expect(response.body.timestamp).toBeDefined();
   });
 
-  it("returns 503 with missing vars in production", () => {
+  it("returns 503 without exposing missing vars in production", () => {
     env().NODE_ENV = "production";
     delete env().HIVEMOOT_REDIS_REST_URL;
     delete env().HIVEMOOT_REDIS_REST_TOKEN;
@@ -52,20 +53,10 @@ describe("GET /api/health", () => {
     const response = GET() as unknown as { body: Record<string, unknown>; status: number };
     expect(response.status).toBe(503);
     expect(response.body.status).toBe("error");
-    expect(response.body.missing).toEqual([
-      "HIVEMOOT_REDIS_REST_URL",
-      "HIVEMOOT_REDIS_REST_TOKEN",
-      "GITHUB_APP_ID",
-      "GITHUB_APP_PRIVATE_KEY",
-      "GITHUB_CLIENT_ID",
-      "GITHUB_CLIENT_SECRET",
-      "BYOK_ACTIVE_KEY_VERSION",
-      "BYOK_MASTER_KEYS",
-      "NEXT_PUBLIC_SITE_URL",
-    ]);
+    expect(response.body.missing).toBeUndefined();
   });
 
-  it("returns 200 in production when all vars present", () => {
+  it("returns 200 without env field in production", () => {
     env().NODE_ENV = "production";
     env().HIVEMOOT_REDIS_REST_URL = "https://example.upstash.io";
     env().HIVEMOOT_REDIS_REST_TOKEN = "test-token";
@@ -75,13 +66,13 @@ describe("GET /api/health", () => {
     env().GITHUB_CLIENT_SECRET = "secret";
     env().BYOK_ACTIVE_KEY_VERSION = "v1";
     env().BYOK_MASTER_KEYS = '{"v1":"' + "a".repeat(64) + '"}';
-
     env().NEXT_PUBLIC_SITE_URL = "https://hivemoot.dev";
 
     const response = GET() as unknown as { body: Record<string, unknown>; status: number };
     expect(response.status).toBe(200);
     expect(response.body.status).toBe("ok");
-    expect(response.body.env).toBe("production");
+    expect(response.body.env).toBeUndefined();
+    expect(response.body.timestamp).toBeDefined();
   });
 
 });

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -5,15 +5,14 @@ export function GET() {
   const env = validateEnv();
 
   if (!env.ok) {
-    return NextResponse.json(
-      { status: "error", missing: env.missing },
-      { status: 503 },
-    );
+    // Only reachable in production. Don't leak which security env vars are absent.
+    return NextResponse.json({ status: "error" }, { status: 503 });
   }
 
+  const isProduction = env.config.nodeEnv === "production";
   return NextResponse.json({
     status: "ok",
-    env: env.config.nodeEnv,
+    ...(!isProduction && { env: env.config.nodeEnv }),
     timestamp: new Date().toISOString(),
   });
 }


### PR DESCRIPTION
Refs #423

## What

`GET /api/health` is unauthenticated and was leaking two categories of security-sensitive information:

1. **503 error response** — included the `missing` array listing which required env vars are absent (e.g. `GITHUB_APP_PRIVATE_KEY`, `BYOK_MASTER_KEYS`, `BYOK_ACTIVE_KEY_VERSION`). An attacker scanning any reachable hivemoot instance learns exactly which security controls are misconfigured.

2. **200 success response** — included `env: "production"`, revealing the runtime environment to unauthenticated callers.

## Fix

In production:
- 503 returns `{ status: "error" }` only — no `missing` array
- 200 returns `{ status: "ok", timestamp }` — no `env` field

Development keeps both fields for local debugging (in dev, `validateEnv` never returns `{ ok: false }` anyway, so the 503 path is unreachable outside prod).

## Evidence

This is Finding 1 from the guard security audit in #423. Findings 2 and 4 remain open pending governance.

## Why this pattern

Industry standard for health endpoints (Google Cloud Run, AWS ECS) is to return only liveness/readiness status — never configuration metadata. Monitoring systems (Datadog, UptimeRobot, PagerDuty) only need `status: "ok"` and an HTTP 200. The `env` and `missing` fields serve no monitoring purpose and exist only for developer convenience.

## Tests

3 tests updated:
- Development: verifies `env: "development"` is present (kept for dev debugging)
- Production 503: verifies `missing` is absent
- Production 200: verifies `env` is absent, `timestamp` is present

All 3 pass. Follows the same pre-governance pattern as PR #441 (Finding 3), which this PR complements.