### PR TITLE
feat(cli): configurable governance.labelMapping in hivemoot.yml

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/buzz.test.ts
+++ b/cli/src/commands/buzz.test.ts
@@ -385,6 +385,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch issues (issues boom) — showing PRs only.");
@@ -408,6 +409,7 @@ describe("buzzCommand", () => {
       expect.any(Map),
       expect.any(Map),
       undefined,
+      undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
     expect(summaryArg.notes).toContain("Could not fetch pull requests (prs boom) — showing issues only.");
@@ -430,6 +432,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -473,6 +476,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       expect.any(Map),
+      undefined,
       undefined,
     );
     const summaryArg = mockedFormatStatus.mock.calls[0][0];
@@ -571,6 +575,7 @@ describe("buzzCommand", () => {
       voteMap,
       expect.any(Map),
       undefined,
+      undefined,
     );
   });
 
@@ -665,6 +670,7 @@ describe("buzzCommand", () => {
       expect.any(Date),
       expect.any(Map),
       notificationMap,
+      undefined,
       undefined,
     );
   });

--- a/cli/src/commands/buzz.ts
+++ b/cli/src/commands/buzz.ts
@@ -18,7 +18,7 @@ import { fetchNotifications } from "../github/notifications.js";
 import type { NotificationMap } from "../github/notifications.js";
 import { fetchRecentClosedByAuthor } from "../github/recent.js";
 import { buildSummary } from "../summary/builder.js";
-import { isVotingIssue, timeAgo } from "../summary/utils.js";
+import { isVotingIssue, resolveLabelAliases, timeAgo } from "../summary/utils.js";
 import { formatBuzz, formatStatus } from "../output/formatter.js";
 import { jsonBuzz, jsonStatus } from "../output/json.js";
 import { loadStateWithStatus, mergeAckJournal } from "../watch/state.js";
@@ -147,9 +147,12 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
   const currentUser = userResult.status === "fulfilled" ? userResult.value : "";
   const notifications: NotificationMap = notificationsResult.status === "fulfilled" ? notificationsResult.value : new Map();
 
+  // Resolve label aliases once — respects custom labelMapping from hivemoot.yml
+  const labelAliases = resolveLabelAliases(teamConfig?.labelMapping);
+
   // Fetch vote reactions for voting-phase issues
   const votingIssueNumbers = issues
-    .filter((issue: GitHubIssue) => isVotingIssue(issue.labels))
+    .filter((issue: GitHubIssue) => isVotingIssue(issue.labels, labelAliases))
     .map((issue: GitHubIssue) => issue.number);
 
   let votes = new Map<number, { reaction: string; createdAt: string }>();
@@ -183,6 +186,7 @@ export async function buzzCommand(options: BuzzOptions): Promise<void> {
     votes,
     notifications,
     teamConfig?.focus,
+    teamConfig?.labelMapping,
   );
   const processedThreadIds = await processedThreadIdsPromise;
   summary.unackedMentions = buildUnackedMentions(notifications, processedThreadIds, new Date());

--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -814,3 +814,104 @@ team:
     expect(config.roles.engineer.instructions).toHaveLength(10_000);
   });
 });
+
+describe("loadTeamConfig() — governance.labelMapping", () => {
+  const repo = { owner: "hivemoot", repo: "colony" };
+
+  function makeYaml(governance: string): string {
+    return `
+team:
+  roles:
+    engineer:
+      description: Build things.
+      instructions: Write code.
+${governance}
+`.trim();
+  }
+
+  it("returns undefined labelMapping when governance section is absent", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml("")));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping).toBeUndefined();
+  });
+
+  it("returns undefined labelMapping when governance.labelMapping is absent", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml("governance:\n  voting: true")));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping).toBeUndefined();
+  });
+
+  it("parses a single phase mapping correctly", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    discussion:\n      - status:in-progress`)));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping).toEqual({ discussion: ["status:in-progress"] });
+  });
+
+  it("parses multiple phase mappings and lowercases values", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(
+      `governance:\n  labelMapping:\n    discussion:\n      - STATUS:OPEN\n    voting:\n      - custom:vote`
+    )));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping?.discussion).toEqual(["status:open"]);
+    expect(config.labelMapping?.voting).toEqual(["custom:vote"]);
+  });
+
+  it("trims whitespace from label values", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    readyToImplement:\n      - "  my-label  "`)));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping?.readyToImplement).toEqual(["my-label"]);
+  });
+
+  it("skips empty string label values", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    discussion:\n      - ""\n      - real-label`)));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping?.discussion).toEqual(["real-label"]);
+  });
+
+  it("returns undefined when all label values are empty strings", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    discussion:\n      - ""`)));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping).toBeUndefined();
+  });
+
+  it("throws when governance.labelMapping is not an object", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml("governance:\n  labelMapping: true")));
+    await expect(loadTeamConfig(repo)).rejects.toThrow("governance.labelMapping must be an object");
+  });
+
+  it("throws when a phase value is not an array", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    discussion: "not-an-array"`)));
+    await expect(loadTeamConfig(repo)).rejects.toThrow("governance.labelMapping.discussion must be an array");
+  });
+
+  it("throws when a label entry is not a string", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    discussion:\n      - 123`)));
+    await expect(loadTeamConfig(repo)).rejects.toThrow("governance.labelMapping.discussion[0] must be a string");
+  });
+
+  it("throws when a label exceeds 100 characters", async () => {
+    const longLabel = "a".repeat(101);
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    voting:\n      - ${longLabel}`)));
+    await expect(loadTeamConfig(repo)).rejects.toThrow("exceeds 100 characters");
+  });
+
+  it("throws when a phase has more than 50 labels", async () => {
+    const labels = Array.from({ length: 51 }, (_, i) => `      - label-${i}`).join("\n");
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    discussion:\n${labels}`)));
+    await expect(loadTeamConfig(repo)).rejects.toThrow("exceeds 50 entries");
+  });
+
+  it("throws when an unknown key is present in labelMapping", async () => {
+    mockedGh.mockResolvedValue(encode(makeYaml(`governance:\n  labelMapping:\n    unknownPhase:\n      - my-label`)));
+    await expect(loadTeamConfig(repo)).rejects.toThrow("unknown key(s): unknownPhase");
+  });
+
+  it("accepts all valid phase keys without error", async () => {
+    const yaml = `governance:\n  labelMapping:\n    discussion: [d]\n    voting: [v]\n    extendedVoting: [ev]\n    readyToImplement: [rti]\n    needsHuman: [nh]\n    implementation: [impl]\n    rejected: [rej]\n    inconclusive: [inc]\n    stale: [stale]\n    implemented: [done]\n    mergeReady: [mr]`;
+    mockedGh.mockResolvedValue(encode(makeYaml(yaml)));
+    const config = await loadTeamConfig(repo);
+    expect(config.labelMapping).toBeDefined();
+    expect(config.labelMapping?.discussion).toEqual(["d"]);
+    expect(config.labelMapping?.mergeReady).toEqual(["mr"]);
+  });
+});

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -2,6 +2,7 @@ import yaml from "js-yaml";
 import { gh } from "../github/client.js";
 import type {
   HivemootConfig,
+  LabelMapping,
   TeamConfig,
   RepoRef,
   RoleConfig,
@@ -111,6 +112,88 @@ function resolveFocus(rawTeam: Record<string, unknown>): string | undefined {
   return parseLegacyFocus(rawTeam.focus);
 }
 
+const LABEL_MAPPING_KEYS: Array<keyof LabelMapping> = [
+  "discussion", "voting", "extendedVoting", "readyToImplement", "needsHuman",
+  "implementation", "rejected", "inconclusive", "stale", "implemented", "mergeReady",
+];
+const MAX_LABELS_PER_PHASE = 50;
+const MAX_LABEL_LENGTH = 100;
+
+function parseLabelMapping(rawGovernance: unknown): LabelMapping | undefined {
+  if (!rawGovernance || typeof rawGovernance !== "object" || Array.isArray(rawGovernance)) {
+    return undefined;
+  }
+  const gov = rawGovernance as Record<string, unknown>;
+  if (!Object.hasOwn(gov, "labelMapping")) return undefined;
+
+  const rawMapping = gov.labelMapping;
+  if (rawMapping === null || rawMapping === undefined) return undefined;
+  if (typeof rawMapping !== "object" || Array.isArray(rawMapping)) {
+    throw new CliError(
+      "Config error: governance.labelMapping must be an object",
+      "INVALID_CONFIG",
+      1,
+    );
+  }
+
+  const mapping = rawMapping as Record<string, unknown>;
+  const result: LabelMapping = {};
+  const unknownKeys = Object.keys(mapping).filter(
+    (k) => !LABEL_MAPPING_KEYS.includes(k as keyof LabelMapping),
+  );
+  if (unknownKeys.length > 0) {
+    throw new CliError(
+      `Config error: governance.labelMapping contains unknown key(s): ${unknownKeys.join(", ")}`,
+      "INVALID_CONFIG",
+      1,
+    );
+  }
+
+  for (const key of LABEL_MAPPING_KEYS) {
+    const raw = mapping[key];
+    if (raw === undefined) continue;
+    if (!Array.isArray(raw)) {
+      throw new CliError(
+        `Config error: governance.labelMapping.${key} must be an array of strings`,
+        "INVALID_CONFIG",
+        1,
+      );
+    }
+    if (raw.length > MAX_LABELS_PER_PHASE) {
+      throw new CliError(
+        `Config error: governance.labelMapping.${key} exceeds ${MAX_LABELS_PER_PHASE} entries`,
+        "INVALID_CONFIG",
+        1,
+      );
+    }
+    const labels: string[] = [];
+    for (const [i, entry] of raw.entries()) {
+      if (typeof entry !== "string") {
+        throw new CliError(
+          `Config error: governance.labelMapping.${key}[${i}] must be a string`,
+          "INVALID_CONFIG",
+          1,
+        );
+      }
+      const trimmed = entry.trim().toLowerCase();
+      if (!trimmed) continue;
+      if (trimmed.length > MAX_LABEL_LENGTH) {
+        throw new CliError(
+          `Config error: governance.labelMapping.${key}[${i}] exceeds ${MAX_LABEL_LENGTH} characters`,
+          "INVALID_CONFIG",
+          1,
+        );
+      }
+      labels.push(trimmed);
+    }
+    if (labels.length > 0) {
+      (result as Record<string, string[]>)[key] = labels;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function validateTeamConfig(raw: HivemootConfig): TeamConfig {
   if (!raw.team) {
     throw new CliError(
@@ -208,12 +291,14 @@ function validateTeamConfig(raw: HivemootConfig): TeamConfig {
   }
 
   const focus = resolveFocus(team as unknown as Record<string, unknown>);
+  const labelMapping = parseLabelMapping(raw.governance);
 
   return {
     name: typeof team.name === "string" ? team.name : undefined,
     onboarding: typeof team.onboarding === "string" ? team.onboarding : undefined,
     roles: validatedRoles,
     focus,
+    labelMapping,
   };
 }
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -9,11 +9,26 @@ export interface FocusBlock {
   objective: string;
 }
 
+export interface LabelMapping {
+  discussion?: string[];
+  voting?: string[];
+  extendedVoting?: string[];
+  readyToImplement?: string[];
+  needsHuman?: string[];
+  implementation?: string[];
+  rejected?: string[];
+  inconclusive?: string[];
+  stale?: string[];
+  implemented?: string[];
+  mergeReady?: string[];
+}
+
 export interface TeamConfig {
   name?: string;
   onboarding?: string;
   roles: Record<string, RoleConfig>;
   focus?: string;
+  labelMapping?: LabelMapping;
 }
 
 export interface HivemootConfig {

--- a/cli/src/summary/builder.test.ts
+++ b/cli/src/summary/builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildSummary } from "./builder.js";
-import type { GitHubIssue, GitHubPR, RepoRef } from "../config/types.js";
+import type { GitHubIssue, GitHubPR, LabelMapping, RepoRef } from "../config/types.js";
 
 const repo: RepoRef = { owner: "hivemoot", repo: "colony" };
 const now = new Date("2025-06-15T12:00:00Z");
@@ -1311,5 +1311,82 @@ describe("buildSummary()", () => {
     expect(summary.notes).toContain(
       "Issue pipeline and implementation-gap metrics are omitted because no governance phase labels were detected.",
     );
+  });
+});
+
+describe("buildSummary() — labelMapping", () => {
+  function makeIssueWithLabel(label: string, number = 1): GitHubIssue {
+    return {
+      number,
+      title: `Issue ${number}`,
+      labels: [{ name: label }],
+      assignees: [],
+      author: { login: "alice" },
+      comments: [],
+      createdAt: "2025-06-15T12:00:00Z",
+      updatedAt: "2025-06-15T12:00:00Z",
+      url: `https://github.com/hivemoot/colony/issues/${number}`,
+    };
+  }
+
+  it("buckets issue into discuss using a custom discussion label", () => {
+    const labelMapping: LabelMapping = { discussion: ["status:open"] };
+    const issue = makeIssueWithLabel("status:open");
+    const summary = buildSummary(repo, [issue], [], "testuser", now, new Map(), new Map(), undefined, labelMapping);
+    expect(summary.discuss.some((i) => i.number === 1)).toBe(true);
+  });
+
+  it("buckets issue into voteOn using a custom voting label", () => {
+    const labelMapping: LabelMapping = { voting: ["custom:vote"] };
+    const issue = makeIssueWithLabel("custom:vote");
+    const summary = buildSummary(repo, [issue], [], "testuser", now, new Map(), new Map(), undefined, labelMapping);
+    expect(summary.voteOn.some((i) => i.number === 1)).toBe(true);
+  });
+
+  it("buckets issue into implement using a custom readyToImplement label", () => {
+    const labelMapping: LabelMapping = { readyToImplement: ["status:approved"] };
+    const issue = makeIssueWithLabel("status:approved");
+    const summary = buildSummary(repo, [issue], [], "testuser", now, new Map(), new Map(), undefined, labelMapping);
+    expect(summary.implement.some((i) => i.number === 1)).toBe(true);
+  });
+
+  it("built-in labels still work when custom mapping is provided (additive)", () => {
+    const labelMapping: LabelMapping = { discussion: ["custom:discuss"] };
+    const builtInIssue = makeIssueWithLabel("hivemoot:discussion", 1);
+    const customIssue = makeIssueWithLabel("custom:discuss", 2);
+    const summary = buildSummary(repo, [builtInIssue, customIssue], [], "testuser", now, new Map(), new Map(), undefined, labelMapping);
+    expect(summary.discuss.some((i) => i.number === 1)).toBe(true);
+    expect(summary.discuss.some((i) => i.number === 2)).toBe(true);
+  });
+
+  it("custom label matching is case-insensitive (stored lowercase, compared lowercase)", () => {
+    const labelMapping: LabelMapping = { voting: ["custom:vote"] };
+    const issue = makeIssueWithLabel("Custom:Vote");
+    const summary = buildSummary(repo, [issue], [], "testuser", now, new Map(), new Map(), undefined, labelMapping);
+    expect(summary.voteOn.some((i) => i.number === 1)).toBe(true);
+  });
+
+  it("populates issuePipeline when only custom labels are present", () => {
+    const labelMapping: LabelMapping = {
+      discussion: ["status:open"],
+      voting: ["status:vote"],
+      readyToImplement: ["status:approved"],
+    };
+    const issues = [
+      makeIssueWithLabel("status:open", 1),
+      makeIssueWithLabel("status:vote", 2),
+      makeIssueWithLabel("status:approved", 3),
+    ];
+    const summary = buildSummary(repo, issues, [], "testuser", now, new Map(), new Map(), undefined, labelMapping);
+    expect(summary.repositoryHealth?.issuePipeline).toBeDefined();
+    expect(summary.repositoryHealth?.issuePipeline?.discussion).toBe(1);
+    expect(summary.repositoryHealth?.issuePipeline?.voting).toBe(1);
+    expect(summary.repositoryHealth?.issuePipeline?.readyToImplement).toBe(1);
+  });
+
+  it("does not affect bucketing when labelMapping is undefined", () => {
+    const issue = makeIssueWithLabel("hivemoot:discussion");
+    const summary = buildSummary(repo, [issue], [], "testuser", now);
+    expect(summary.discuss.some((i) => i.number === 1)).toBe(true);
   });
 });

--- a/cli/src/summary/builder.ts
+++ b/cli/src/summary/builder.ts
@@ -1,6 +1,7 @@
 import type {
   GitHubIssue,
   GitHubPR,
+  LabelMapping,
   NotificationRef,
   PrioritySignal,
   RepoRef,
@@ -26,7 +27,9 @@ import {
   daysSince,
   hasGovernanceLabel,
   hasGovernanceLabelName,
+  resolveLabelAliases,
 } from "./utils.js";
+import type { ResolvedLabelAliases } from "./utils.js";
 
 interface IssuePipelineCounts {
   discussion: number;
@@ -78,6 +81,7 @@ function classifyIssue(
   issue: GitHubIssue,
   currentUser: string,
   now: Date,
+  aliases: ResolvedLabelAliases,
 ): { bucket: "voteOn" | "discuss" | "implement" | "needsHuman" | "unclassified"; item: SummaryItem } {
   const age = timeAgo(issue.createdAt, now);
   const assigned =
@@ -111,21 +115,21 @@ function classifyIssue(
   }
 
   // Issues needing human attention are excluded from all actionable buckets
-  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN")) {
+  if (hasGovernanceLabel(issue.labels, "NEEDS_HUMAN", aliases)) {
     return {
       bucket: "needsHuman",
       item: { ...base, assigned },
     };
   }
 
-  // Bot governance labels (canonical + legacy aliases)
-  if (hasGovernanceLabel(issue.labels, "VOTING") || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING")) {
+  // Bot governance labels (canonical + legacy aliases + custom mapping)
+  if (hasGovernanceLabel(issue.labels, "VOTING", aliases) || hasGovernanceLabel(issue.labels, "EXTENDED_VOTING", aliases)) {
     return { bucket: "voteOn", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "DISCUSSION")) {
+  if (hasGovernanceLabel(issue.labels, "DISCUSSION", aliases)) {
     return { bucket: "discuss", item: base };
   }
-  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")) {
+  if (hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT", aliases)) {
     return { bucket: "implement", item: { ...base, assigned } };
   }
 
@@ -311,7 +315,9 @@ export function buildSummary(
   votes: VoteMap = new Map(),
   notifications: NotificationMap = new Map(),
   focus?: string,
+  labelMapping?: LabelMapping,
 ): RepoSummary {
+  const aliases = resolveLabelAliases(labelMapping);
   const needsHuman: SummaryItem[] = [];
   const voteOn: SummaryItem[] = [];
   const discuss: SummaryItem[] = [];
@@ -323,7 +329,7 @@ export function buildSummary(
   const notes: string[] = [];
 
   for (const issue of issues) {
-    const { bucket, item } = classifyIssue(issue, currentUser, now);
+    const { bucket, item } = classifyIssue(issue, currentUser, now, aliases);
     if (bucket === "needsHuman") needsHuman.push(item);
     else if (bucket === "voteOn") voteOn.push(item);
     else if (bucket === "discuss") discuss.push(item);
@@ -377,7 +383,7 @@ export function buildSummary(
   });
 
   const filteredVoteOn = voteOn.filter((item) => {
-    if (item.author === currentUser && hasGovernanceLabelName(item.tags, "EXTENDED_VOTING")) {
+    if (item.author === currentUser && hasGovernanceLabelName(item.tags, "EXTENDED_VOTING", aliases)) {
       driveDiscussion.push(item);
       return false;
     }
@@ -473,10 +479,10 @@ export function buildSummary(
   });
 
   const hasPhaseLabels = issues.some((issue) =>
-    hasGovernanceLabel(issue.labels, "DISCUSSION") ||
-    hasGovernanceLabel(issue.labels, "VOTING") ||
-    hasGovernanceLabel(issue.labels, "EXTENDED_VOTING") ||
-    hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT")
+    hasGovernanceLabel(issue.labels, "DISCUSSION", aliases) ||
+    hasGovernanceLabel(issue.labels, "VOTING", aliases) ||
+    hasGovernanceLabel(issue.labels, "EXTENDED_VOTING", aliases) ||
+    hasGovernanceLabel(issue.labels, "READY_TO_IMPLEMENT", aliases)
   );
   const issuePipeline: IssuePipelineCounts | undefined = hasPhaseLabels
     ? {

--- a/cli/src/summary/utils.ts
+++ b/cli/src/summary/utils.ts
@@ -1,4 +1,19 @@
-import type { GitHubPR } from "../config/types.js";
+import type { GitHubPR, LabelMapping } from "../config/types.js";
+
+export type GovernanceLabelKey =
+  | "DISCUSSION"
+  | "VOTING"
+  | "EXTENDED_VOTING"
+  | "READY_TO_IMPLEMENT"
+  | "NEEDS_HUMAN"
+  | "IMPLEMENTATION"
+  | "REJECTED"
+  | "INCONCLUSIVE"
+  | "STALE"
+  | "IMPLEMENTED"
+  | "MERGE_READY";
+
+export type ResolvedLabelAliases = Record<GovernanceLabelKey, readonly string[]>;
 
 export const GOVERNANCE_LABEL_ALIASES = {
   DISCUSSION: ["hivemoot:discussion", "phase:discussion"],
@@ -12,24 +27,50 @@ export const GOVERNANCE_LABEL_ALIASES = {
   STALE: ["hivemoot:stale", "stale"],
   IMPLEMENTED: ["hivemoot:implemented", "implemented"],
   MERGE_READY: ["hivemoot:merge-ready", "merge-ready"],
-} as const;
+} as const satisfies ResolvedLabelAliases;
 
-export type GovernanceLabelKey = keyof typeof GOVERNANCE_LABEL_ALIASES;
+const LABEL_MAPPING_TO_KEY: Record<keyof LabelMapping, GovernanceLabelKey> = {
+  discussion: "DISCUSSION",
+  voting: "VOTING",
+  extendedVoting: "EXTENDED_VOTING",
+  readyToImplement: "READY_TO_IMPLEMENT",
+  needsHuman: "NEEDS_HUMAN",
+  implementation: "IMPLEMENTATION",
+  rejected: "REJECTED",
+  inconclusive: "INCONCLUSIVE",
+  stale: "STALE",
+  implemented: "IMPLEMENTED",
+  mergeReady: "MERGE_READY",
+};
+
+export function resolveLabelAliases(custom?: LabelMapping): ResolvedLabelAliases {
+  if (!custom) return GOVERNANCE_LABEL_ALIASES;
+
+  const result = {} as ResolvedLabelAliases;
+  for (const [mappingKey, governanceKey] of Object.entries(LABEL_MAPPING_TO_KEY) as Array<[keyof LabelMapping, GovernanceLabelKey]>) {
+    const defaults = GOVERNANCE_LABEL_ALIASES[governanceKey];
+    const overrides = custom[mappingKey];
+    result[governanceKey] = overrides ? [...defaults, ...overrides] : defaults;
+  }
+  return result;
+}
 
 export function hasGovernanceLabel(
   labels: Array<{ name: string }>,
   key: GovernanceLabelKey,
+  aliases: ResolvedLabelAliases = GOVERNANCE_LABEL_ALIASES,
 ): boolean {
-  const aliases = GOVERNANCE_LABEL_ALIASES[key];
-  return labels.some((label) => aliases.some((alias) => alias === label.name.toLowerCase()));
+  const resolved = aliases[key];
+  return labels.some((label) => resolved.some((alias) => alias === label.name.toLowerCase()));
 }
 
 export function hasGovernanceLabelName(
   labelNames: string[],
   key: GovernanceLabelKey,
+  aliases: ResolvedLabelAliases = GOVERNANCE_LABEL_ALIASES,
 ): boolean {
-  const aliases = GOVERNANCE_LABEL_ALIASES[key];
-  return labelNames.some((name) => aliases.some((alias) => alias === name.toLowerCase()));
+  const resolved = aliases[key];
+  return labelNames.some((name) => resolved.some((alias) => alias === name.toLowerCase()));
 }
 
 // ── Comment context ──────────────────────────────────────────────
@@ -66,10 +107,13 @@ export function commentContext(
  * Whether an issue is in a voting phase based on its labels.
  * Matches canonical/legacy voting labels, or the keyword "vote".
  */
-export function isVotingIssue(labels: Array<{ name: string }>): boolean {
+export function isVotingIssue(
+  labels: Array<{ name: string }>,
+  aliases: ResolvedLabelAliases = GOVERNANCE_LABEL_ALIASES,
+): boolean {
   return (
-    hasGovernanceLabel(labels, "VOTING") ||
-    hasGovernanceLabel(labels, "EXTENDED_VOTING") ||
+    hasGovernanceLabel(labels, "VOTING", aliases) ||
+    hasGovernanceLabel(labels, "EXTENDED_VOTING", aliases) ||
     hasLabel(labels, "vote")
   );
 }


### PR DESCRIPTION
Closes #387

## What

Adds `governance.labelMapping` to `.github/hivemoot.yml`, letting repos declare custom phase labels that map into `hivemoot buzz` bucketing. Custom labels are **additive** — built-in `hivemoot:*` and `phase:*` aliases remain active, so existing repos keep current behavior without any config changes.

```yaml
governance:
  labelMapping:
    discussion: ["status:in-progress"]
    voting: ["custom:vote"]
    extendedVoting: ["status:extended"]
    readyToImplement: ["status:approved"]
    needsHuman: ["needs:attention"]
```

## How it works

**`types.ts`** — `LabelMapping` interface (one `string[]` per phase key) + `labelMapping?: LabelMapping` on `TeamConfig`.

**`loader.ts`** — `parseLabelMapping()` reads `governance.labelMapping` and validates: must be an object, each value must be a `string[]`, max 50 labels per phase, max 100 chars per label, labels normalized to lowercase, unknown keys are rejected with a clear error.

**`utils.ts`** — `resolveLabelAliases(custom?)` merges custom labels with built-in defaults into a `ResolvedLabelAliases` object. `hasGovernanceLabel`, `hasGovernanceLabelName`, and `isVotingIssue` all accept an optional `ResolvedLabelAliases` parameter (defaults to built-in aliases for backward compatibility).

**`builder.ts`** — resolves aliases once at the top of `buildSummary`; `classifyIssue` and `issuePipeline` detection both use the resolved set.

**`buzz.ts`** — threads `teamConfig?.labelMapping` through to `buildSummary` and `isVotingIssue`, so vote fetching also respects custom labels.

## Tests

21 new tests: 13 in `loader.test.ts` covering all validation paths (unknown keys, non-array values, non-string entries, length limits, empty string filtering, whitespace trimming, lowercase normalization, all valid phase keys), and 7 in `builder.test.ts` covering bucketing with custom labels, built-in fallback when custom mapping is provided, case-insensitive matching, and `issuePipeline` population with custom-only labels.

Full `cli` suite now passes after rebase: 985 tests, all passing. Typecheck clean. CLI version bumped to 0.3.7 for the `cli/` change.

## Notes

- No breaking changes: existing repos with no `governance.labelMapping` get identical behavior.
- Custom labels are additive, not replacement — the built-in aliases always stay active.
- Normalization happens at config load time (parse+lowercase); all downstream consumers use the pre-resolved set, never raw strings.
