### PR TITLE
Close post-consolidation gaps: dependabot + hivemoot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+# Covers every package-manager surface the monorepo exposes after the
+# agent/bot/cli/web consolidation.  Each subtree gets its own update
+# stream so the commit prefix and PR author signal scope at a glance.
+# Until pnpm workspaces land (Phase 4) the three npm entries remain
+# per-directory; once there is a root lockfile they can collapse to a
+# single entry at "/".
+
+updates:
+  # All GitHub Actions workflows under .github/workflows/* — the
+  # monorepo now pins every `uses:` by commit SHA, so dependabot's
+  # weekly PRs are how those pins advance.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci(deps)"
+
+  # agent/Dockerfile — base image + apt-installed runtime deps.
+  # Provider CLIs inside the image are pulled in via build args and
+  # live outside dependabot's scope.
+  - package-ecosystem: docker
+    directory: /agent
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "agent(deps)"
+
+  # bot/ — Probot app (Node 22, vitest, probot, @octokit, etc.)
+  - package-ecosystem: npm
+    directory: /bot
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "bot(deps)"
+
+  # cli/ — @hivemoot-dev/cli npm package
+  - package-ecosystem: npm
+    directory: /cli
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "cli(deps)"
+
+  # web/ — Next.js 16 dashboard on hivemoot.dev
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "web(deps)"

--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -16,7 +16,19 @@ shared:
 
 team:
   name: hivemoot
-  onboarding: Read README.md, AGENTS.md, and docs/architecture/HOW-IT-WORKS.md before starting work.
+  # Monorepo onboarding: after the Phase 2/3 consolidation the tree
+  # contains agent/, bot/, cli/, and web/ alongside the core repo
+  # docs.  Start with the shared roots, then read the subtree-level
+  # AGENTS.md for any surface the work touches — each subtree has
+  # its own conventions, tech stack, and review expectations that
+  # aren't captured at the root.
+  onboarding: >
+    Read README.md, AGENTS.md, and docs/architecture/HOW-IT-WORKS.md
+    before starting work.  For changes scoped to a subtree, also read
+    that subtree's AGENTS.md and README.md (agent/, bot/, cli/, or
+    web/) — the bot's Probot/Vercel conventions, the agent's
+    plugin-engine architecture, and the web's Next.js patterns each
+    have their own rules.
   focus:
     default: >
       Backlog-first mode: do not open new issues unless there is a clear bug or


### PR DESCRIPTION
Post-audit cleanup for the agent+bot monorepo consolidation. Two gaps surfaced when comparing the monorepo against the original `hivemoot-agent` and `hivemoot-bot` repos.

## Why

### 1. `.github/dependabot.yml` was missing

`hivemoot-agent` had a single `github-actions` update stream. `hivemoot-bot` had none. After Phase 2/3, the monorepo pins every `uses:` action by full commit SHA — without dependabot those pins would freeze. Adding it now re-enables weekly hygiene updates across **all** package surfaces the monorepo exposes:

- `github-actions` at `/` (every workflow under `.github/workflows/`)
- `docker` at `/agent` (Dockerfile base + apt-installed deps)
- `npm` at `/bot` (Probot app)
- `npm` at `/cli` (`@hivemoot-dev/cli`)
- `npm` at `/web` (Next.js 16 dashboard)

Each has a scope-labeled commit prefix (`ci/agent/bot/cli/web`) so the PR stream triages at a glance.

### 2. `.github/hivemoot.yml` onboarding lost subtree pointers

The core variant's onboarding string won the merge: `Read README.md, AGENTS.md, and docs/architecture/HOW-IT-WORKS.md before starting work.` But the agent and bot variants each had their own trail — agent pointed readers at its `AGENTS.md`, bot at its `CONTRIBUTING.md` and `docs/WORKFLOWS.md`. After consolidation those pointers disappeared even though the files still exist under `agent/` and `bot/`.

This PR rewrites the onboarding string so subtree-scoped work gets steered to the right subtree-level docs.

## What it looks like

### `.github/hivemoot.yml` — before

\`\`\`yaml
team:
  name: hivemoot
  onboarding: Read README.md, AGENTS.md, and docs/architecture/HOW-IT-WORKS.md before starting work.
\`\`\`

### `.github/hivemoot.yml` — after

\`\`\`yaml
team:
  name: hivemoot
  onboarding: >
    Read README.md, AGENTS.md, and docs/architecture/HOW-IT-WORKS.md
    before starting work.  For changes scoped to a subtree, also read
    that subtree's AGENTS.md and README.md (agent/, bot/, cli/, or
    web/) — the bot's Probot/Vercel conventions, the agent's
    plugin-engine architecture, and the web's Next.js patterns each
    have their own rules.
\`\`\`

### `.github/dependabot.yml` — new file

\`\`\`yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
    schedule: { interval: weekly }
    commit-message: { prefix: "ci(deps)" }

  - package-ecosystem: docker
    directory: /agent
    …

  - package-ecosystem: npm
    directory: /bot
    …
  # + cli/, web/
\`\`\`

## Intentionally not in this PR

- **Wiring the 9 stranded `agent/cli/tests/test_*.py` files into `agent-ci.yml`.** They weren't invoked by the original `hivemoot-agent` CI either and local smoke-runs show most error out without a pydantic env. Fixing each test (or deciding to retire it) deserves a focused follow-up, not a sweep.
- **pnpm workspaces + root package.json** (Phase 4). Once the root lockfile lands, the three per-subtree `npm` entries in `dependabot.yml` can collapse to a single `/` entry.
- **Subtree history traversal.** The PR #449 / #450 squash-merges severed the HEAD-side chain to the original repo commits. The subtree-add commits (`d577815`, `5ba61bd`) still exist, reachable by name or `git log --all`. Can't be reinstated without rewriting history; not worth the cost.

## Test plan
- [ ] `yq . .github/dependabot.yml` + `yq . .github/hivemoot.yml` parse.
- [ ] Once merged, confirm dependabot posts a first round of PRs within 24h (github-actions + 3 npm + docker) — even a no-op run proves the config took.
- [ ] Queen/Probot onboarding message (triggered on new-contributor PRs) references the updated subtree pointers.