### PR TITLE
Rename GHCR image: hivemoot-agent → agent

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -7,7 +7,9 @@ name: Agent — Publish Docker Image
 # monorepo from day one.  The legacy ghcr.io/hivemoot/hivemoot-agent
 # package is no longer pushed to; its existing sha-* tags remain
 # available for rollback until it is explicitly retired.  Apiary's
-# fleet config and the hive's docker pull point at the new path.
+# fleet config and the hive's docker pull will repoint at the new
+# path via a companion apiary PR that must merge before the next
+# fleet deploy.
 
 on:
   push:

--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -1,11 +1,13 @@
 name: Agent — Publish Docker Image
 
 # Ported from hivemoot-agent's docker-publish.yml under the monorepo
-# consolidation.  The published image name is pinned to
-# hivemoot/hivemoot-agent (not ${{ github.repository }}) so existing
-# image consumers — apiary's fleet config, the hive's docker pull
-# script, any external runners — keep resolving the same tag after
-# the repo merge.
+# consolidation.  Image name is pinned to hivemoot/agent (not
+# ${{ github.repository }}, which would produce the ambiguous
+# hivemoot/hivemoot) so the package has a clean home under the
+# monorepo from day one.  The legacy ghcr.io/hivemoot/hivemoot-agent
+# package is no longer pushed to; its existing sha-* tags remain
+# available for rollback until it is explicitly retired.  Apiary's
+# fleet config and the hive's docker pull point at the new path.
 
 on:
   push:
@@ -20,7 +22,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: hivemoot/hivemoot-agent
+  IMAGE_NAME: hivemoot/agent
   DOCKER_METADATA_SHORT_SHA_LENGTH: 7
 
 jobs:


### PR DESCRIPTION
## Why

The `ghcr.io/hivemoot/hivemoot-agent` GHCR package is tied to the `hivemoot/hivemoot-agent` repo, which is being retired after the monorepo consolidation (#449/#450). Keeping the old image name has two problems:

1. **Orphaning risk.** When the legacy repo is deleted, the package's source-repo link breaks. The package still exists (GitHub doesn't auto-delete packages with a deleted linked repo) but it loses its "home" in the UI and permission management gets murky.
2. **Vestigial name.** A repo called `hivemoot/hivemoot` pulling an image called `hivemoot-agent` is the kind of thing every new contributor asks about. The `hivemoot-agent` string should stop being a moving part.

## What

Rename the published image from `ghcr.io/hivemoot/hivemoot-agent` → `ghcr.io/hivemoot/agent`. Matches the monorepo's `agent/` subtree, leaves room for sibling packages (`hivemoot/bot`, `hivemoot/cli`) if those ever need their own images.

## Cutover plan

1. **This PR** — publisher starts pushing `ghcr.io/hivemoot/agent:latest` + `sha-*` tags on every `agent/**` change to `main`. First push creates the new package, linked to `hivemoot/hivemoot` automatically.
2. **Companion apiary PR** (next) — `deploy-apiary.sh` fallback, `apiary.yaml` comment, and `AGENTS.md` docs flip to the new path.
3. **Hive deploy** picks up the new image on next `deploy-apiary.sh` run.
4. **Legacy `ghcr.io/hivemoot/hivemoot-agent` package** — stops receiving new pushes today; remains pullable for rollback. Can be retired at leisure.

Zero-downtime: running containers keep their current image until the next restart, which happens as part of the deploy that also picks up the new path.

## Test plan
- [ ] Workflow run on merge creates `ghcr.io/hivemoot/agent` as a new package.
- [ ] `sha-*` tag lands alongside `latest`.
- [ ] Package page shows `hivemoot/hivemoot` as linked repo.
- [ ] Companion apiary PR lands before next fleet deploy.