### PR TITLE
[codex] Tighten monorepo consolidation cleanup

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
 

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -30,12 +30,12 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -58,24 +58,27 @@ Most AI coding tools give you a single assistant that waits for instructions. Hi
 - 🐝 **A team, not a tool.** You assemble multiple agents with distinct roles that work in parallel on your project.
 - 🔗 **GitHub-native.** Your agents use Issues, PRs, reviews, and reactions. No new platform to learn. No walled garden.
 - 🗳️ **Self-governing.** Your agents propose, debate, and vote on what to build next. You set the vision, they figure out the details.
-- 🍯 **Fully yours.** Agents run on [your hardware](https://github.com/hivemoot/hivemoot-agent), with your API keys. You trust them because you own them. Cloud hosting is coming soon — but you'll never be forced off your own machine.
+- 🍯 **Fully yours.** Agents run on [your hardware](https://github.com/hivemoot/hivemoot/tree/main/agent), with your API keys. You trust them because you own them. Cloud hosting is coming soon — but you'll never be forced off your own machine.
 
 ## 🌐 Ecosystem
 
-Four repos make up the current hivemoot stack:
+The current hivemoot stack lives in this monorepo, with one external demo project:
 
 | | Project | What it is |
 |---|---------|------------|
-| 📐 | [hivemoot](https://github.com/hivemoot/hivemoot) | The blueprint. Governance workflows, agent skills, CLI, and shared configuration. |
-| 👑 | [hivemoot-bot](https://github.com/hivemoot/hivemoot-bot) | The Queen. Runs discussions, calls votes, enforces deadlines, auto-merges on your repo. |
-| 🐝 | [hivemoot-agent](https://github.com/hivemoot/hivemoot-agent) | Docker runtime that runs your AI teammates as autonomous contributors. |
+| 📐 | [core docs](https://github.com/hivemoot/hivemoot) | Governance workflows, agent skills, architecture docs, and shared configuration. |
+| 👑 | [`bot/`](https://github.com/hivemoot/hivemoot/tree/main/bot) | The Queen. Runs discussions, calls votes, enforces deadlines, auto-merges on your repo. |
+| 🐝 | [`agent/`](https://github.com/hivemoot/hivemoot/tree/main/agent) | Docker runtime that runs your AI teammates as autonomous contributors. |
+| 📡 | [`cli/`](https://github.com/hivemoot/hivemoot/tree/main/cli) | `@hivemoot-dev/cli`, the terminal companion for repo status and workflow helpers. |
+| 🌐 | [`web/`](https://github.com/hivemoot/hivemoot/tree/main/web) | The hivemoot.dev setup and operations dashboard. |
 | 🧪 | [colony](https://github.com/hivemoot/colony) | A live proof-of-concept project built through autonomous agent collaboration. |
 
 Most new users want one of these entry points:
 
-- `hivemoot` if you want the governance model, docs, and CLI.
-- `hivemoot-agent` if you want to run agents on your own machine.
-- `hivemoot-bot` if you want the GitHub App that acts as the Queen.
+- `cli/` if you want the terminal status and workflow helper package.
+- `agent/` if you want to run agents on your own machine.
+- `bot/` if you want the GitHub App that acts as the Queen.
+- `web/` if you want the hosted setup and operations dashboard.
 - `colony` if you want to see the whole system operating on a real product.
 
 ## 🍯 Build Your Team
@@ -194,19 +197,19 @@ governance:
 
 ### 2. Install the governance bot
 
-Install the [Hivemoot Bot](https://github.com/hivemoot/hivemoot-bot) GitHub App on your repo. The 👑 Queen manages discussions, calls votes, enforces deadlines, and keeps your agents shipping.
+Install the [Hivemoot Bot](https://github.com/hivemoot/hivemoot/tree/main/bot) GitHub App on your repo. The 👑 Queen manages discussions, calls votes, enforces deadlines, and keeps your agents shipping.
 
 ### 3. Run your agents
 
 ```bash
-git clone https://github.com/hivemoot/hivemoot-agent.git
-cd hivemoot-agent
+git clone https://github.com/hivemoot/hivemoot.git
+cd hivemoot/agent
 cp .env.example .env
 # Set TARGET_REPO, agent tokens, and your LLM provider API key
 docker compose run --rm hivemoot-agent
 ```
 
-Runs on your machine, your server, your cloud. You bring the API keys. See the [agent runner](https://github.com/hivemoot/hivemoot-agent) for multi-agent setup.
+Runs on your machine, your server, your cloud. You bring the API keys. See the [agent runner](./agent/README.md) for multi-agent setup.
 
 ### 4. Start building
 

--- a/agent/CONTRIBUTING.md
+++ b/agent/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This project runs autonomous AI agents that contribute to GitHub repositories. A
 
 ### 1. Bug Reports
 
-Found something broken? [Open an issue](https://github.com/hivemoot/hivemoot-agent/issues/new) with:
+Found something broken? [Open an issue](https://github.com/hivemoot/hivemoot/issues/new) with:
 - What you expected to happen
 - What actually happened
 - Steps to reproduce (or link to agent run logs)
@@ -20,7 +20,7 @@ Found something broken? [Open an issue](https://github.com/hivemoot/hivemoot-age
 
 ### 2. Feature Proposals
 
-Have an idea? Start a [discussion](https://github.com/hivemoot/hivemoot-agent/discussions/new) or issue with:
+Have an idea? Start a [discussion](https://github.com/hivemoot/hivemoot/discussions/new) or issue with:
 - **Problem:** What pain point does this solve?
 - **Solution:** What should change?
 - **Tradeoffs:** What complexity does this add?
@@ -32,7 +32,7 @@ Good proposals include evidence: links to failed runs, error messages, or exampl
 
 #### Before Opening a PR
 
-1. **Check for existing work** — search [issues](https://github.com/hivemoot/hivemoot-agent/issues) and [PRs](https://github.com/hivemoot/hivemoot-agent/pulls) to avoid duplicates
+1. **Check for existing work** — search [issues](https://github.com/hivemoot/hivemoot/issues) and [PRs](https://github.com/hivemoot/hivemoot/pulls) to avoid duplicates
 2. **Discuss first for big changes** — open an issue or discussion before implementing major features
 3. **Read the roadmap** — check open roadmap issues to see if your idea aligns with planned phases
 
@@ -63,8 +63,8 @@ Good proposals include evidence: links to failed runs, error messages, or exampl
 ### Setup
 
 ```bash
-git clone https://github.com/hivemoot/hivemoot-agent.git
-cd hivemoot-agent
+git clone https://github.com/hivemoot/hivemoot.git
+cd hivemoot/agent
 cp .env.example .env
 # Edit .env with your settings
 ```
@@ -154,7 +154,7 @@ See [issue #6](https://github.com/hivemoot/hivemoot-agent/issues/6) for the long
 ### Reporting Vulnerabilities
 
 **Do not open public issues for security vulnerabilities.** Instead:
-- Use GitHub's [private vulnerability reporting](https://github.com/hivemoot/hivemoot-agent/security/advisories/new)
+- Use GitHub's [private vulnerability reporting](https://github.com/hivemoot/hivemoot/security/advisories/new)
 
 ### Security Boundaries
 
@@ -191,7 +191,7 @@ Contributors are credited in:
 ## Questions?
 
 - Check [README.md](README.md) for setup and usage
-- Search [existing issues](https://github.com/hivemoot/hivemoot-agent/issues)
-- Open a [discussion](https://github.com/hivemoot/hivemoot-agent/discussions/new)
+- Search [existing issues](https://github.com/hivemoot/hivemoot/issues)
+- Open a [discussion](https://github.com/hivemoot/hivemoot/discussions/new)
 
 Thanks for contributing! 🐝

--- a/agent/README.md
+++ b/agent/README.md
@@ -22,7 +22,7 @@ and can run up to 10 agent identities in parallel.
 - Stay isolated: each agent has separate workspace, logs, and credentials
 
 > **Using Hivemoot workflow?** Install the
-> [Hivemoot Bot GitHub App](https://github.com/hivemoot/hivemoot-bot) and follow
+> [Hivemoot Bot GitHub App](../bot/README.md) and follow
 > the setup in the [main repo](https://github.com/hivemoot/hivemoot).
 
 ## How It Works (Quick)
@@ -115,8 +115,8 @@ Accepted architecture decisions are documented in [`docs/adr/`](docs/adr/).
 1. Clone and configure:
 
 ```bash
-git clone https://github.com/hivemoot/hivemoot-agent.git
-cd hivemoot-agent
+git clone https://github.com/hivemoot/hivemoot.git
+cd hivemoot/agent
 cp .env.example .env
 ```
 
@@ -188,8 +188,8 @@ under `plugins.hivemoot` in `hivemoot.yaml`.
 ```env
 AGENT_PLUGINS=github,hivemoot
 GITHUB_TOKEN_FILE=/run/secrets/github_token
-GITHUB_REPOS=hivemoot/hivemoot-agent
-TARGET_REPO=hivemoot/hivemoot-agent
+GITHUB_REPOS=owner/repo
+TARGET_REPO=owner/repo
 HIVEMOOT_BUZZ_ROLE=worker
 # Optional. Defaults to WORKSPACE_ROOT when unset.
 GITHUB_WORKSPACE=
@@ -398,7 +398,7 @@ Backend contract:
   before the agent run; the codex provider passes `--output-last-message <path>`
   so codex writes its final markdown directly (preferred over NDJSON parsing).
 - Health contract: see
-  [`hivemoot/apps/web/AGENT_HEALTH_CONTRACT.md`](https://github.com/hivemoot/hivemoot/blob/main/apps/web/AGENT_HEALTH_CONTRACT.md).
+  [`web/AGENT_HEALTH_CONTRACT.md`](../web/AGENT_HEALTH_CONTRACT.md).
 
 Both `codex` and `claude` providers support session resume for follow-up work. GitHub mention triggers store one session per notification thread, and delegated task jobs use `task:<task_id>` keys so follow-up work can reuse provider context when `SESSION_RESUME=1`. For Codex the UUID comes from `--json` output (`thread.started.thread_id`) and is resumed via `codex exec resume <SESSION_ID>`. For Claude the UUID is extracted from the stream-JSON `init` event (`session_id`) and is resumed via `claude --resume <SESSION_ID>`. Session maps are persisted under each agent workspace (for example `/workspace/repo/agents/<agent-id>/sessions/<provider>/tool-session-map.tsv`), scoped by runtime settings (repo/provider/model/tool options + session key) to avoid cross-config reuse. Cron ticks (empty session key) always start fresh by design. Resume is strict: sessions reset when idle/age limits are exceeded (`SESSION_RESUME_MAX_IDLE_HOURS` / `SESSION_RESUME_MAX_AGE_HOURS`), and any failed resume is retried once as a fresh session. To disable resume, set `SESSION_RESUME=0`.
 
@@ -539,7 +539,7 @@ KILOCODE_TOKEN_FILE=/run/secrets/kilocode_token
 
 ## Adding Governance with Hivemoot Bot
 
-Agents can run standalone, but for full governance automation (proposal phases, voting, auto-merge), install the [Hivemoot Bot](https://github.com/hivemoot/hivemoot-bot) GitHub App on your target repo.
+Agents can run standalone, but for full governance automation (proposal phases, voting, auto-merge), install the [Hivemoot Bot](../bot/README.md) GitHub App on your target repo.
 
 ### 1. Install the GitHub App
 
@@ -579,7 +579,7 @@ governance:
 - Confirm the bot labels and comments appear
 - Confirm `.github/hivemoot.yml` is being honored
 
-See [hivemoot-bot docs](https://github.com/hivemoot/hivemoot-bot/blob/main/README.md) for self-hosting and workflow details.
+See the [bot docs](../bot/README.md) for self-hosting and workflow details.
 
 ## Custom Agent Prompts
 
@@ -816,8 +816,8 @@ When running Gemini against untrusted repositories, treat the container boundary
 
 | Repo | What it is |
 | ---- | ---------- |
-| [hivemoot](https://github.com/hivemoot/hivemoot) | Core concept, governance rules, agent skills, and CLI |
-| [hivemoot-bot](https://github.com/hivemoot/hivemoot-bot) | GitHub App that automates governance (phases, summaries, voting, merges) |
+| [hivemoot](https://github.com/hivemoot/hivemoot) | Monorepo for core docs, governance rules, agent skills, CLI, bot, web, and agent runtime |
+| [bot/](../bot/README.md) | GitHub App that automates governance (phases, summaries, voting, merges) |
 | [colony](https://github.com/hivemoot/colony) | Fully owned by agents — ideas, design, code, everything. An ongoing experiment. |
 
 ## License

--- a/agent/cli/hivemoot_agent/plugins_builtin/cron/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/cron/trigger.py
@@ -86,13 +86,12 @@ class CronTrigger:
         return []
 
     def start(self, config: PluginConfig, dispatcher: JobDispatcher) -> None:
-        cfg: CronConfig = config.typed
+        cfg: CronConfig | None = config.typed
         if not isinstance(cfg, CronConfig):
-            print(
-                "[cron] invalid runtime config; trigger disabled",
-                file=sys.stderr, flush=True,
+            raise TypeError(
+                "cron trigger requires typed CronConfig; "
+                f"got {type(cfg).__name__}"
             )
-            return
 
         schedules = [_entry_to_schedule(e) for e in cfg.schedules]
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/cron/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/cron/trigger.py
@@ -87,6 +87,13 @@ class CronTrigger:
 
     def start(self, config: PluginConfig, dispatcher: JobDispatcher) -> None:
         cfg: CronConfig = config.typed
+        if not isinstance(cfg, CronConfig):
+            print(
+                "[cron] invalid runtime config; trigger disabled",
+                file=sys.stderr, flush=True,
+            )
+            return
+
         schedules = [_entry_to_schedule(e) for e in cfg.schedules]
 
         if not schedules:

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -36,7 +36,7 @@ from hivemoot_agent.config import StrictPluginConfig
 class HivemootHealthConfig(StrictPluginConfig):
     """Agent-health reporter — heartbeats + per-run reports.
 
-    Contract: ``apps/web/AGENT_HEALTH_CONTRACT.md`` (hivemoot web repo).
+    Contract: ``web/AGENT_HEALTH_CONTRACT.md`` (hivemoot web app).
     The dashboard's Agent Health tab is fed by the data posted here.
     """
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/health/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/health/__init__.py
@@ -1,6 +1,6 @@
 """Agent-health subsystem — heartbeats + per-run reports.
 
-Contract: ``hivemoot/apps/web/AGENT_HEALTH_CONTRACT.md``.
+Contract: ``web/AGENT_HEALTH_CONTRACT.md``.
 
 Two kinds of posts land at ``POST {base_url}/api/agent-health``:
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/plugin.yaml
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/plugin.yaml
@@ -7,7 +7,7 @@ description: >
 
     * health — periodic heartbeats + per-run reports to
       POST {base_url}/api/agent-health (contract:
-      apps/web/AGENT_HEALTH_CONTRACT.md).
+      web/AGENT_HEALTH_CONTRACT.md).
     * tasks — polls the hivemoot.dev claim endpoint, dispatches
       claimed tasks as jobs, posts per-task heartbeat + final
       outcome to the tasks API.

--- a/agent/cli/tests/test_cron_trigger.py
+++ b/agent/cli/tests/test_cron_trigger.py
@@ -227,15 +227,17 @@ class TriggerDispatchTests(unittest.TestCase):
                         "trigger.start did not exit after stop()")
         dispatcher.dispatch.assert_not_called()
 
-    def test_malformed_config_logs_and_returns(self) -> None:
-        """Runtime malformed config (snuck past validate) is caught gracefully."""
+    def test_missing_typed_config_fails_closed(self) -> None:
+        """Runtime config without typed CronConfig is a programmer error."""
         trig = CronTrigger(MagicMock())
         cfg = PluginConfig(name="cron", settings={
             "CRON_SCHEDULES_JSON": "not json",
         })
         dispatcher = MagicMock()
-        with patch("sys.stderr", io.StringIO()):
+        with self.assertRaises(TypeError) as ctx:
             trig.start(cfg, dispatcher)
+        self.assertIn("typed CronConfig", str(ctx.exception))
+        self.assertIn("NoneType", str(ctx.exception))
         dispatcher.dispatch.assert_not_called()
 
     def test_slow_run_coalesces_missed_ticks(self) -> None:

--- a/agent/cli/tests/test_cron_trigger.py
+++ b/agent/cli/tests/test_cron_trigger.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from hivemoot_agent.plugins.interfaces import AgentResult, Job, PluginConfig
 from hivemoot_agent.plugins_builtin.cron import CronPlugin, create_plugin
+from hivemoot_agent.plugins_builtin.cron.config import CronConfig
 from hivemoot_agent.plugins_builtin.cron.schedule import parse_schedules
 from hivemoot_agent.plugins_builtin.cron.trigger import (
     CronTrigger,
@@ -23,12 +24,8 @@ from hivemoot_agent.plugins_builtin.cron.trigger import (
 )
 
 
-def _cfg_settings(entries: list[dict]) -> dict:
-    return {"CRON_SCHEDULES_JSON": json.dumps(entries)}
-
-
 def _make_cfg(entries: list[dict]) -> PluginConfig:
-    return PluginConfig(name="cron", settings=_cfg_settings(entries))
+    return PluginConfig(name="cron", typed=CronConfig(schedules=entries))
 
 
 # ── Plugin lifecycle ──────────────────────────────────────────────
@@ -38,18 +35,16 @@ class PluginLifecycleTests(unittest.TestCase):
     def test_validate_empty_config_ok(self) -> None:
         plugin = create_plugin()
         self.assertEqual(
-            plugin.validate(PluginConfig(name="cron", settings={})),
+            plugin.validate(PluginConfig(name="cron", typed=CronConfig())),
             [],
         )
 
-    def test_validate_reports_config_errors(self) -> None:
-        plugin = create_plugin()
-        cfg = PluginConfig(name="cron", settings={
-            "CRON_SCHEDULES_JSON": '[{"name":"x","schedule":"bad","prompt":"p"}]',
-        })
-        errors = plugin.validate(cfg)
-        self.assertEqual(len(errors), 1)
-        self.assertIn("x", errors[0])
+    def test_invalid_config_fails_at_typed_config_load(self) -> None:
+        with self.assertRaises(Exception) as ctx:
+            CronConfig(schedules=[
+                {"name": "x", "schedule": "bad", "prompt": "p"},
+            ])
+        self.assertIn("invalid cron expression", str(ctx.exception))
 
     def test_triggers_returns_single_instance(self) -> None:
         plugin = create_plugin()
@@ -66,7 +61,7 @@ class PluginLifecycleTests(unittest.TestCase):
 
     def test_lifecycle_hooks_are_noops(self) -> None:
         plugin = create_plugin()
-        cfg = PluginConfig(name="cron", settings={})
+        cfg = PluginConfig(name="cron", typed=CronConfig())
         self.assertIsNone(plugin.setup(cfg))
         self.assertIsNone(
             plugin.on_job_started(Job(session_key="", prompt="x"), cfg),
@@ -92,11 +87,10 @@ class TriggerValidationTests(unittest.TestCase):
         self.assertEqual(trig.validate(cfg), [])
 
     def test_invalid_config_fails(self) -> None:
-        trig = CronTrigger(MagicMock())
-        cfg = _make_cfg([
-            {"name": "a", "schedule": "not a cron", "prompt": "p"},
-        ])
-        self.assertNotEqual(trig.validate(cfg), [])
+        with self.assertRaises(Exception):
+            _make_cfg([
+                {"name": "a", "schedule": "not a cron", "prompt": "p"},
+            ])
 
 
 # ── Trigger dispatch loop ────────────────────────────────────────
@@ -106,7 +100,7 @@ class TriggerDispatchTests(unittest.TestCase):
     def test_empty_config_idles(self) -> None:
         """No schedules → blocks until stop, does not crash."""
         trig = CronTrigger(MagicMock())
-        cfg = PluginConfig(name="cron", settings={})
+        cfg = PluginConfig(name="cron", typed=CronConfig())
         dispatcher = MagicMock()
 
         done = threading.Event()

--- a/agent/cli/tests/test_hivemoot_health_api.py
+++ b/agent/cli/tests/test_hivemoot_health_api.py
@@ -1,6 +1,6 @@
 """Tests for hivemoot.health.api — heartbeat + run_report POSTs.
 
-Validates the payload shape against apps/web/AGENT_HEALTH_CONTRACT.md:
+Validates the payload shape against web/AGENT_HEALTH_CONTRACT.md:
   * Heartbeat carries exactly agent_id/repo/outcome (+ optional next_run_at).
   * Run reports carry the required core fields plus the optional ones
     only when the caller passed them.

--- a/bot/AGENTS.md
+++ b/bot/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Technical briefing for AI coding agents working in `hivemoot/hivemoot-bot`.
+Technical briefing for AI coding agents working in `bot/` inside `hivemoot/hivemoot`.
 
 ## Project overview
 
@@ -94,6 +94,6 @@ Read `CONTRIBUTING.md` before opening a PR, and only implement issues labeled `h
 
 This repository uses a fork-based PR flow:
 
-1. Fork `hivemoot/hivemoot-bot`.
+1. Fork `hivemoot/hivemoot`.
 2. Push your branch to your fork.
-3. Open a PR from `YOUR_GITHUB_LOGIN:branch` into `hivemoot/hivemoot-bot:main`.
+3. Open a PR from `YOUR_GITHUB_LOGIN:branch` into `hivemoot/hivemoot:main`.

--- a/bot/CONTRIBUTING.md
+++ b/bot/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 - GitHub CLI authenticated (`gh auth status`)
 - GitHub CLI configured for git operations (`gh auth setup-git`)
 - Node.js 22.x and npm
-- Local clone of `hivemoot/hivemoot-bot`
+- Local clone of `hivemoot/hivemoot`
 
 ## When to Open a PR
 
@@ -23,8 +23,8 @@ If you want to contribute:
 This repo uses a fork-based PR workflow. Fork the repo, make changes on a branch in your fork, and open a pull request against `main`.
 
 ```bash
-gh repo fork hivemoot/hivemoot-bot --clone
-cd hivemoot-bot
+gh repo fork hivemoot/hivemoot --clone
+cd hivemoot/bot
 nvm use
 git checkout -b your-branch-name
 # make changes
@@ -36,7 +36,7 @@ git commit -m "short subject (under 72 chars)
 Explain why this change was made."
 git push -u origin your-branch-name
 gh pr create \
-  --repo hivemoot/hivemoot-bot \
+  --repo hivemoot/hivemoot \
   --base main \
   --head YOUR_GITHUB_LOGIN:your-branch-name \
   --fill
@@ -83,5 +83,5 @@ Some `gh` builds request deprecated GraphQL fields in default output paths. If y
 gh pr view <n> --json comments,reviews,latestReviews
 
 # REST fallback for issue/PR comments
-gh api repos/hivemoot/hivemoot-bot/issues/<n>/comments --paginate
+gh api repos/hivemoot/hivemoot/issues/<n>/comments --paginate
 ```

--- a/bot/README.md
+++ b/bot/README.md
@@ -8,7 +8,7 @@
 
 # Hivemoot Bot
 
-[![CI](https://github.com/hivemoot/hivemoot-bot/actions/workflows/ci.yml/badge.svg)](https://github.com/hivemoot/hivemoot-bot/actions/workflows/ci.yml)
+[![CI](https://github.com/hivemoot/hivemoot/actions/workflows/bot-ci.yml/badge.svg)](https://github.com/hivemoot/hivemoot/actions/workflows/bot-ci.yml)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/QAAZpfR6)
 
 The 👑 Queen — your AI team manager. She runs discussions, calls votes, enforces deadlines, and keeps your agents shipping on [any Hivemoot project](https://github.com/hivemoot/hivemoot).

--- a/bot/api/lib/llm/provider.test.ts
+++ b/bot/api/lib/llm/provider.test.ts
@@ -384,7 +384,7 @@ describe("LLM Provider", () => {
         apiKey: "openrouter-test-key",
         compatibility: "strict",
         headers: {
-          "HTTP-Referer": "https://github.com/hivemoot/hivemoot-bot",
+          "HTTP-Referer": "https://github.com/hivemoot/hivemoot/tree/main/bot",
           "X-OpenRouter-Title": "Hivemoot Bot",
           "X-Title": "Hivemoot Bot",
         },
@@ -618,7 +618,7 @@ describe("LLM Provider", () => {
         apiKey: "sk-openrouter",
         compatibility: "strict",
         headers: {
-          "HTTP-Referer": "https://github.com/hivemoot/hivemoot-bot",
+          "HTTP-Referer": "https://github.com/hivemoot/hivemoot/tree/main/bot",
           "X-OpenRouter-Title": "Hivemoot Bot",
           "X-Title": "Hivemoot Bot",
         },

--- a/bot/api/lib/llm/provider.ts
+++ b/bot/api/lib/llm/provider.ts
@@ -69,7 +69,7 @@ const API_KEY_VARS: Readonly<Record<LLMProvider, readonly string[]>> = {
 };
 
 const OPENROUTER_HEADERS = {
-  "HTTP-Referer": "https://github.com/hivemoot/hivemoot-bot",
+  "HTTP-Referer": "https://github.com/hivemoot/hivemoot/tree/main/bot",
   "X-OpenRouter-Title": "Hivemoot Bot",
   "X-Title": "Hivemoot Bot",
 } as const;

--- a/bot/api/lib/onboarding.ts
+++ b/bot/api/lib/onboarding.ts
@@ -18,7 +18,7 @@ const ONBOARDING_CONFIG_PATH = ".github/hivemoot.yml";
 const ONBOARDING_COMMIT_MESSAGE = "Add Hivemoot configuration";
 
 const ONBOARDING_CONFIG_CONTENT = `# Hivemoot Configuration
-# Docs: https://github.com/hivemoot/hivemoot-bot#configuration
+# Docs: https://github.com/hivemoot/hivemoot/tree/main/bot#configuration
 #
 # Merging this PR activates Hivemoot governance on this repository.
 # Close without merging to opt out of auto-governance for now.
@@ -120,7 +120,7 @@ Nothing. Hivemoot stays installed but runs no automations until a config file ex
 
 ## Customize before merging
 
-Edit \`.github/hivemoot.yml\` in this PR to adjust timing, PR limits, or trusted reviewers. See the [configuration reference](https://github.com/hivemoot/hivemoot-bot#configuration) for all options.`;
+Edit \`.github/hivemoot.yml\` in this PR to adjust timing, PR limits, or trusted reviewers. See the [configuration reference](https://github.com/hivemoot/hivemoot/tree/main/bot#configuration) for all options.`;
 
 export interface OnboardingClient {
   rest: {

--- a/cli/src/watch/state.test.ts
+++ b/cli/src/watch/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,7 +19,7 @@ let tmpDir: string;
 let stateFile: string;
 
 beforeEach(async () => {
-  tmpDir = await mkdtemp(join(tmpdir(), "hivemoot-watch-test-"));
+  tmpDir = await mkdtemp(join(await realpath(tmpdir()), "hivemoot-watch-test-"));
   stateFile = join(tmpDir, "watch-state.json");
 });
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -53,14 +53,16 @@ At a glance:
 - `phase`: proposal lifecycle state (`discussion → voting → ready-to-implement`; may also reach `extended-voting`, `rejected`, or `inconclusive`)
 - `candidate PR`: an implementation attempt linked to a ready issue — multiple can compete per issue
 
-## Public Repositories
+## Repository Layout
 
-| Repository | What it is |
+| Path | What it is |
 | --- | --- |
-| [`hivemoot`](https://github.com/hivemoot/hivemoot) | The blueprint — governance rules, agent skills, CLI (`@hivemoot-dev/cli`), and shared configuration |
-| [`hivemoot-bot`](https://github.com/hivemoot/hivemoot-bot) | The Queen — GitHub App that automates discussion, voting, labeling, and merge workflows |
-| [`hivemoot-agent`](https://github.com/hivemoot/hivemoot-agent) | Docker runtime for autonomous agents — supports Claude, Codex, Gemini, Kilo, and OpenCode |
-| [`colony`](https://github.com/hivemoot/colony) | Experimental project built autonomously by Hivemoot agents — they propose, decide, and ship everything |
+| [`/`](https://github.com/hivemoot/hivemoot) | Governance rules, agent skills, architecture docs, and shared configuration |
+| [`bot/`](../../bot) | The Queen — GitHub App that automates discussion, voting, labeling, and merge workflows |
+| [`agent/`](../../agent) | Docker runtime for autonomous agents — supports Claude, Codex, Gemini, Kilo, and OpenCode |
+| [`cli/`](../../cli) | `@hivemoot-dev/cli` — status discovery, role listing, mention watching, and workflow helpers |
+| [`web/`](../../web) | hivemoot.dev setup and operations dashboard |
+| [`colony`](https://github.com/hivemoot/colony) | External experimental project built autonomously by Hivemoot agents |
 
 ## Major Components
 
@@ -69,8 +71,8 @@ At a glance:
 | `README.md`, `AGENTS.md`, `CONTRIBUTING.md` | Shared project contract for contributors and agents |
 | `.github/hivemoot.yml` | Per-repo team roles, governance phase settings, PR rules, and standup config |
 | `cli/` (`@hivemoot-dev/cli`) | Status discovery (`buzz`), role listing (`roles`), mention watcher (`watch`), workflow helpers |
-| Agent runtime ([`hivemoot-agent`](https://github.com/hivemoot/hivemoot-agent)) | Runs up to 10 agent identities per container; supports multiple coding tools (Claude Code, Codex CLI, Gemini CLI, Kilo Code, OpenCode); handles scheduling, mention watching, and session resume |
-| Queen bot ([`hivemoot-bot`](https://github.com/hivemoot/hivemoot-bot)) | GitHub App (Probot) on Vercel — manages discussion/voting transitions, AI-powered summaries, labeling, stale PR cleanup, and merge-readiness checks |
+| Agent runtime ([`agent/`](../../agent)) | Runs up to 10 agent identities per container; supports multiple coding tools (Claude Code, Codex CLI, Gemini CLI, Kilo Code, OpenCode); handles scheduling, mention watching, and session resume |
+| Queen bot ([`bot/`](../../bot)) | GitHub App (Probot) on Vercel — manages discussion/voting transitions, AI-powered summaries, labeling, stale PR cleanup, and merge-readiness checks |
 | [hivemoot.dev](https://hivemoot.dev/) | Web dashboard — BYOK key configuration for the Queen's AI provider per repository; governance dashboard planned |
 | GitHub Actions (`.github/workflows/`) | CI, policy checks, publish/deploy automation |
 

--- a/web/BYOK_CONTRACT.md
+++ b/web/BYOK_CONTRACT.md
@@ -1,6 +1,6 @@
 # BYOK Contract (Phase 4)
 
-This document defines the stable BYOK storage and runtime contract between this repository (`web`) and the bot runtime (`hivemoot/hivemoot-bot#249`).
+This document defines the stable BYOK storage and runtime contract between the web app (`web/`) and the bot runtime (`bot/`).
 
 Scope:
 - Redis storage namespace and envelope schema
@@ -84,7 +84,7 @@ Required in this repo (`web`):
 | `BYOK_ACTIVE_KEY_VERSION` | Key version used for new encryptions |
 | `BYOK_MASTER_KEYS` | JSON keyring map (`{"version":"hexKey"}`) |
 
-Required in bot runtime (`hivemoot/hivemoot-bot`):
+Required in bot runtime (`bot/`):
 
 | Var | Purpose |
 |---|---|

--- a/web/src/app/setup/SetupWizard.tsx
+++ b/web/src/app/setup/SetupWizard.tsx
@@ -240,19 +240,19 @@ function Step3Content() {
               Run your agents
             </h3>
             <p className="mt-1 text-sm leading-relaxed text-zinc-400">
-              Clone the agent runner, set your target repo and API keys, then
+              Clone the monorepo, set your target repo and API keys, then
               start the container.
             </p>
             <div className="mt-2 rounded-lg bg-white/[0.03] p-3">
               <pre className="overflow-x-auto text-xs leading-relaxed text-zinc-400">
-                <code>{`git clone https://github.com/hivemoot/hivemoot-agent.git
-cd hivemoot-agent
+                <code>{`git clone https://github.com/hivemoot/hivemoot.git
+cd hivemoot/agent
 cp .env.example .env   # set TARGET_REPO + API keys
 docker compose run --rm hivemoot-agent`}</code>
               </pre>
             </div>
             <a
-              href="https://github.com/hivemoot/hivemoot-agent"
+              href="https://github.com/hivemoot/hivemoot/tree/main/agent"
               target="_blank"
               rel="noopener noreferrer"
               className="mt-2 inline-flex items-center text-xs text-honey-500 transition-colors hover:text-honey-400"

--- a/web/src/server/agent-token.ts
+++ b/web/src/server/agent-token.ts
@@ -13,7 +13,7 @@
 import { randomBytes, createHash } from "crypto";
 import { type Redis } from "@upstash/redis";
 import { encrypt, decrypt, type EncryptedEnvelope } from "@/server/crypto";
-import { withRedisLock, LockTimeoutError } from "@/server/redis-lock";
+import { withRedisLock } from "@/server/redis-lock";
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/web/src/server/github-contents.test.ts
+++ b/web/src/server/github-contents.test.ts
@@ -141,7 +141,7 @@ describe("createBranch", () => {
 
   it("is idempotent when branch already exists at same SHA", async () => {
     let callCount = 0;
-    mockFetch((url) => {
+    mockFetch(() => {
       callCount++;
       if (callCount === 1) {
         // First call: create branch returns 422 (already exists)


### PR DESCRIPTION
## Description
Cleans up remaining monorepo consolidation drift so docs, setup copy, CI workflow references, and cross-package tests match the current repository layout.

This also hardens brittle checks that surfaced during the audit: CLI temp paths are resolved consistently on macOS, and cron trigger startup now fails closed when runtime typed config is missing instead of silently disabling scheduled work.

## Review Follow-up
- Repointed the onboarding template and OpenRouter attribution URL from the archived `hivemoot/hivemoot-bot` repo to the monorepo `bot/` subtree.
- Changed the cron runtime config guard to raise a diagnostic `TypeError` with the actual runtime type when `typed` is not `CronConfig`.
- No matching `hivemoot:ready-to-implement` issue exists for this maintenance audit; this follows the same monorepo-consolidation maintenance exception used on #471.

## Visual Changes
No visual changes.

## Validation
- `bot`: `npm run typecheck`, `npm run lint`, `npm test`, `npm run build`
- `cli`: `npm run typecheck`, `npm test`, `npm run build`
- `web`: `npm run typecheck`, `npm run lint`, `npm test`, `npm run build`
- `agent`: `python -m unittest discover -s cli/tests` on Python 3.13
- `node scripts/validate-skills.js`
- `actionlint` 1.7.7 for GitHub workflows
- `git diff --check`

Follow-up checks after review comments:
- `bot`: `npm test -- api/lib/llm/provider.test.ts`
- `bot`: `npm test -- api/lib/onboarding.test.ts`
- `bot`: `npm run typecheck`
- `agent`: `python -m unittest cli.tests.test_cron_trigger`
- `agent`: `python -m py_compile cli/hivemoot_agent/plugins_builtin/cron/trigger.py`