### PR TITLE
Allow dashboard login without installing the GitHub App

### DIFF
--- a/web/src/app/api/agent-health/route.ts
+++ b/web/src/app/api/agent-health/route.ts
@@ -214,11 +214,22 @@ export async function GET(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
 
+  const installationId = auth.session.installationId;
+
   const { searchParams } = new URL(request.url);
   const agentId = searchParams.get("agent_id");
   const repo = searchParams.get("repo");
   const historyFlag = searchParams.get("history");
   const wantsHistory = historyFlag === "true";
+
+  // Null-installation sessions have no agents reporting. Return the same
+  // empty shape the dashboard already renders gracefully.
+  if (installationId === null) {
+    if (wantsHistory || agentId || repo) {
+      return NextResponse.json({ agent_id: agentId ?? "", repo: repo ?? "", history: [], runs: [] });
+    }
+    return NextResponse.json({ agents: [] });
+  }
 
   if (wantsHistory && (!agentId || !repo)) {
     return agentHealthError(
@@ -246,7 +257,7 @@ export async function GET(request: NextRequest) {
 
     try {
       const history = await getHistory(
-        auth.session.installationId,
+        installationId,
         agentId,
         repo,
         auth.redis,
@@ -260,7 +271,7 @@ export async function GET(request: NextRequest) {
       });
     } catch (err) {
       console.error("[agent-health] Failed to fetch history", {
-        installationId: auth.session.installationId,
+        installationId,
         agentId,
         repo,
         error: err,
@@ -282,11 +293,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const overview = await getOverview(auth.session.installationId, auth.redis);
+    const overview = await getOverview(installationId, auth.redis);
     return NextResponse.json({ agents: overview });
   } catch (err) {
     console.error("[agent-health] Failed to fetch overview", {
-      installationId: auth.session.installationId,
+      installationId,
       error: err,
     });
     return agentHealthError(

--- a/web/src/app/api/agent-token/route.ts
+++ b/web/src/app/api/agent-token/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import {
   generateAgentToken,
   getAgentToken,
@@ -23,9 +24,13 @@ export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   try {
     const token = await generateAgentToken(
-      auth.session.installationId,
+      installationId,
       auth.session.userLogin,
       auth.activeKeyVersion,
       auth.keyring,
@@ -46,7 +51,7 @@ export async function POST(request: NextRequest) {
       );
     }
     console.error("[agent-token] Failed to generate token", {
-      installationId: auth.session.installationId,
+      installationId,
       error: err,
     });
     return agentHealthError(
@@ -61,8 +66,12 @@ export async function GET(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   try {
-    const record = await getAgentToken(auth.session.installationId, auth.keyring, auth.redis);
+    const record = await getAgentToken(installationId, auth.keyring, auth.redis);
     if (!record) {
       return agentHealthError(
         AGENT_HEALTH_ERROR.TOKEN_NOT_FOUND,
@@ -74,7 +83,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(record);
   } catch (err) {
     console.error("[agent-token] Failed to retrieve token", {
-      installationId: auth.session.installationId,
+      installationId,
       error: err,
     });
     return agentHealthError(
@@ -89,8 +98,12 @@ export async function DELETE(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   try {
-    const revoked = await revokeAgentToken(auth.session.installationId, auth.redis);
+    const revoked = await revokeAgentToken(installationId, auth.redis);
     if (!revoked) {
       return agentHealthError(
         AGENT_HEALTH_ERROR.TOKEN_NOT_FOUND,
@@ -109,7 +122,7 @@ export async function DELETE(request: NextRequest) {
       );
     }
     console.error("[agent-token] Failed to revoke token", {
-      installationId: auth.session.installationId,
+      installationId,
       error: err,
     });
     return agentHealthError(

--- a/web/src/app/api/auth/github/callback/route.test.ts
+++ b/web/src/app/api/auth/github/callback/route.test.ts
@@ -407,7 +407,7 @@ describe("GET /api/auth/github/callback — discovery flow", () => {
     expect(res.status).toBe(307);
     const location = new URL(res.headers.get("location")!);
     expect(location.pathname).toBe("/dashboard");
-    expect(location.searchParams.get("no_install")).toBe("1");
+    expect(location.searchParams.has("installation_id")).toBe(false);
 
     // Installation-specific calls must not have run.
     expect(getInstallation).not.toHaveBeenCalled();

--- a/web/src/app/api/auth/github/callback/route.test.ts
+++ b/web/src/app/api/auth/github/callback/route.test.ts
@@ -390,6 +390,62 @@ describe("GET /api/auth/github/callback — discovery flow", () => {
     expect(location).not.toContain("installation_id=");
   });
 
+  it("issues a null-installation session and redirects to dashboard when allowEmpty is set and user has no installations", async () => {
+    vi.mocked(validateOAuthState).mockImplementation(async (_state, stateBinding) => (
+      stateBinding === "binding-cookie"
+        ? { installationId: "discover", allowEmpty: true }
+        : null
+    ));
+    vi.mocked(getUserInstallations).mockResolvedValue([]);
+
+    const req = makeRequestWithCookie(
+      { code: "gh-code", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = new URL(res.headers.get("location")!);
+    expect(location.pathname).toBe("/dashboard");
+    expect(location.searchParams.get("no_install")).toBe("1");
+
+    // Installation-specific calls must not have run.
+    expect(getInstallation).not.toHaveBeenCalled();
+    expect(checkOrgAdmin).not.toHaveBeenCalled();
+
+    // Session is created with a null installationId.
+    expect(createSetupSession).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: null, userLogin: "alice" }),
+      expect.anything(),
+    );
+  });
+
+  it("still picks the first installation when allowEmpty is set but the user has installations", async () => {
+    vi.mocked(validateOAuthState).mockImplementation(async (_state, stateBinding) => (
+      stateBinding === "binding-cookie"
+        ? { installationId: "discover", allowEmpty: true }
+        : null
+    ));
+    vi.mocked(getUserInstallations).mockResolvedValue([
+      { id: 4242, app_id: 99, account: { login: "alice", type: "User" } },
+    ]);
+    vi.mocked(getInstallation).mockResolvedValue({
+      account: { login: "alice", type: "User" },
+    });
+
+    const req = makeRequestWithCookie(
+      { code: "gh-code", state: "valid-state" },
+      "binding-cookie",
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(createSetupSession).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "4242" }),
+      expect.anything(),
+    );
+  });
+
   it("uses the first installation when multiple exist", async () => {
     vi.mocked(getUserInstallations).mockResolvedValue([
       { id: 111, app_id: 99, account: { login: "alice", type: "User" } },

--- a/web/src/app/api/auth/github/callback/route.ts
+++ b/web/src/app/api/auth/github/callback/route.ts
@@ -128,6 +128,7 @@ export async function GET(request: NextRequest) {
   // --- Step 1: Validate state (CSRF check) ---
   let installationId: string;
   let oauthNext: string | undefined;
+  let allowEmpty = false;
   try {
     const stateResult = await validateOAuthState(state, oauthStateBinding, redis);
     if (!stateResult) {
@@ -139,6 +140,7 @@ export async function GET(request: NextRequest) {
     }
     installationId = stateResult.installationId;
     oauthNext = stateResult.next;
+    allowEmpty = stateResult.allowEmpty === true;
   } catch (err) {
     console.error("[oauth-callback] Failed to validate OAuth state", { error: err });
     const errResponse = setupErrorRedirect(siteUrl, "oauth_state_read_failed");
@@ -158,17 +160,25 @@ export async function GET(request: NextRequest) {
   }
 
   // --- Step 2b: Discover installation if the user started from the "already installed" flow ---
+  // After this block, `resolvedInstallationId` is either a real GitHub
+  // installation id or null (when the user signed in via the "skip install"
+  // path and has no installations yet — gated on `allowEmpty`).
+  let resolvedInstallationId: string | null = installationId;
   if (installationId === DISCOVER_SENTINEL) {
     try {
       const installations = await getUserInstallations(userToken, githubAppId!);
       if (installations.length === 0) {
-        const notInstalledUrl = new URL(`${siteUrl}/setup`);
-        notInstalledUrl.searchParams.set("auth", "not_installed");
-        const response = NextResponse.redirect(notInstalledUrl.toString());
-        clearOAuthStateBindingCookie(response);
-        return response;
+        if (!allowEmpty) {
+          const notInstalledUrl = new URL(`${siteUrl}/setup`);
+          notInstalledUrl.searchParams.set("auth", "not_installed");
+          const response = NextResponse.redirect(notInstalledUrl.toString());
+          clearOAuthStateBindingCookie(response);
+          return response;
+        }
+        resolvedInstallationId = null;
+      } else {
+        resolvedInstallationId = String(installations[0].id);
       }
-      installationId = String(installations[0].id);
     } catch (err) {
       console.error("[oauth-callback] Failed to discover user installations", { error: err });
       const errResponse = setupErrorRedirect(siteUrl, "server_error");
@@ -178,56 +188,65 @@ export async function GET(request: NextRequest) {
   }
 
   let user: { login: string; id: number };
-  let installation: { account: { login: string; type: string } };
+  let installation: { account: { login: string; type: string } } | null = null;
 
   try {
-    // --- Step 3 & 4: Fetch user identity and installation in parallel ---
-    const appJwt = generateAppJwt(githubAppId!, githubAppPrivateKey!);
-    [user, installation] = await Promise.all([
-      getAuthenticatedUser(userToken),
-      getInstallation(installationId, appJwt),
-    ]);
+    // --- Step 3 & 4: Fetch user identity, and installation metadata when attached ---
+    if (resolvedInstallationId !== null) {
+      const appJwt = generateAppJwt(githubAppId!, githubAppPrivateKey!);
+      [user, installation] = await Promise.all([
+        getAuthenticatedUser(userToken),
+        getInstallation(resolvedInstallationId, appJwt),
+      ]);
+    } else {
+      user = await getAuthenticatedUser(userToken);
+    }
   } catch (err) {
-    console.error("[oauth-callback] Failed to fetch user/installation", { installationId, error: err });
-    const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
+    console.error("[oauth-callback] Failed to fetch user/installation", {
+      installationId: resolvedInstallationId,
+      error: err,
+    });
+    const errResponse = setupErrorRedirect(siteUrl, "server_error", resolvedInstallationId);
     clearOAuthStateBindingCookie(errResponse);
     return errResponse;
   }
 
-  // --- Step 5: Authorization check ---
-  const accountType = installation.account.type;
-  const accountLogin = installation.account.login;
+  // --- Step 5: Authorization check (only when the session is tied to an installation) ---
+  if (installation !== null && resolvedInstallationId !== null) {
+    const accountType = installation.account.type;
+    const accountLogin = installation.account.login;
 
-  if (accountType === "Organization") {
-    // Org installation: caller must be an org admin
-    let isAdmin: boolean;
-    try {
-      isAdmin = await checkOrgAdmin(userToken, accountLogin);
-    } catch (err) {
-      console.error("[oauth-callback] Failed to check org admin status", { accountLogin, error: err });
-      const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
-      clearOAuthStateBindingCookie(errResponse);
-      return errResponse;
-    }
-    if (!isAdmin) {
-      const forbiddenUrl = new URL(`${siteUrl}/setup`);
-      forbiddenUrl.searchParams.set("installation_id", installationId);
-      forbiddenUrl.searchParams.set("auth", "forbidden");
-      forbiddenUrl.searchParams.set("reason", "not_org_admin");
-      const response = NextResponse.redirect(forbiddenUrl.toString());
-      clearOAuthStateBindingCookie(response);
-      return response;
-    }
-  } else {
-    // User installation: authenticated user must be the installer
-    if (user.login.toLowerCase() !== accountLogin.toLowerCase()) {
-      const forbiddenUrl = new URL(`${siteUrl}/setup`);
-      forbiddenUrl.searchParams.set("installation_id", installationId);
-      forbiddenUrl.searchParams.set("auth", "forbidden");
-      forbiddenUrl.searchParams.set("reason", "user_mismatch");
-      const response = NextResponse.redirect(forbiddenUrl.toString());
-      clearOAuthStateBindingCookie(response);
-      return response;
+    if (accountType === "Organization") {
+      // Org installation: caller must be an org admin
+      let isAdmin: boolean;
+      try {
+        isAdmin = await checkOrgAdmin(userToken, accountLogin);
+      } catch (err) {
+        console.error("[oauth-callback] Failed to check org admin status", { accountLogin, error: err });
+        const errResponse = setupErrorRedirect(siteUrl, "server_error", resolvedInstallationId);
+        clearOAuthStateBindingCookie(errResponse);
+        return errResponse;
+      }
+      if (!isAdmin) {
+        const forbiddenUrl = new URL(`${siteUrl}/setup`);
+        forbiddenUrl.searchParams.set("installation_id", resolvedInstallationId);
+        forbiddenUrl.searchParams.set("auth", "forbidden");
+        forbiddenUrl.searchParams.set("reason", "not_org_admin");
+        const response = NextResponse.redirect(forbiddenUrl.toString());
+        clearOAuthStateBindingCookie(response);
+        return response;
+      }
+    } else {
+      // User installation: authenticated user must be the installer
+      if (user.login.toLowerCase() !== accountLogin.toLowerCase()) {
+        const forbiddenUrl = new URL(`${siteUrl}/setup`);
+        forbiddenUrl.searchParams.set("installation_id", resolvedInstallationId);
+        forbiddenUrl.searchParams.set("auth", "forbidden");
+        forbiddenUrl.searchParams.set("reason", "user_mismatch");
+        const response = NextResponse.redirect(forbiddenUrl.toString());
+        clearOAuthStateBindingCookie(response);
+        return response;
+      }
     }
   }
 
@@ -235,37 +254,46 @@ export async function GET(request: NextRequest) {
   let token: string;
   try {
     token = await createSetupSession(
-      { installationId, userId: user.id, userLogin: user.login },
+      { installationId: resolvedInstallationId, userId: user.id, userLogin: user.login },
       redis,
     );
   } catch (err) {
-    console.error("[oauth-callback] Failed to create setup session", { installationId, error: err });
-    const errResponse = setupErrorRedirect(siteUrl, "setup_session_create_failed", installationId);
+    console.error("[oauth-callback] Failed to create setup session", {
+      installationId: resolvedInstallationId,
+      error: err,
+    });
+    const errResponse = setupErrorRedirect(siteUrl, "setup_session_create_failed", resolvedInstallationId);
     clearOAuthStateBindingCookie(errResponse);
     return errResponse;
   }
 
   // --- Step 7: Smart redirect based on setup completion ---
-  // Returning users who already configured BYOK go straight to the dashboard
-  // (or the `next` URL from OAuth state if present and safe).
-  // New users (or failed checks) go to the setup wizard.
+  // No-installation sessions go straight to the dashboard, which renders a
+  // "Connect a repo" CTA. Returning users who already configured BYOK go
+  // straight to the dashboard (or the `next` URL from OAuth state if present
+  // and safe). New users go to the setup wizard.
   let setupComplete = false;
-  try {
-    setupComplete = await hasByokEnvelope(installationId, redis);
-  } catch (err) {
-    console.warn("[oauth-callback] BYOK check failed, defaulting to setup wizard", {
-      installationId,
-      error: err,
-    });
+  if (resolvedInstallationId !== null) {
+    try {
+      setupComplete = await hasByokEnvelope(resolvedInstallationId, redis);
+    } catch (err) {
+      console.warn("[oauth-callback] BYOK check failed, defaulting to setup wizard", {
+        installationId: resolvedInstallationId,
+        error: err,
+      });
+    }
   }
 
   let successUrl: URL;
-  if (setupComplete) {
+  if (resolvedInstallationId === null) {
+    successUrl = new URL(`${siteUrl}/dashboard`);
+    successUrl.searchParams.set("no_install", "1");
+  } else if (setupComplete) {
     const destination = oauthNext ?? "/dashboard";
     successUrl = new URL(`${siteUrl}${destination}`);
   } else {
     successUrl = new URL(`${siteUrl}/setup`);
-    successUrl.searchParams.set("installation_id", installationId);
+    successUrl.searchParams.set("installation_id", resolvedInstallationId);
     successUrl.searchParams.set("auth", "ok");
   }
   const response = NextResponse.redirect(successUrl.toString());

--- a/web/src/app/api/auth/github/callback/route.ts
+++ b/web/src/app/api/auth/github/callback/route.ts
@@ -287,7 +287,6 @@ export async function GET(request: NextRequest) {
   let successUrl: URL;
   if (resolvedInstallationId === null) {
     successUrl = new URL(`${siteUrl}/dashboard`);
-    successUrl.searchParams.set("no_install", "1");
   } else if (setupComplete) {
     const destination = oauthNext ?? "/dashboard";
     successUrl = new URL(`${siteUrl}${destination}`);

--- a/web/src/app/api/auth/github/start-discover/route.test.ts
+++ b/web/src/app/api/auth/github/start-discover/route.test.ts
@@ -149,25 +149,56 @@ describe("GET /api/auth/github/start-discover", () => {
   it("passes the discover sentinel as installationId to createOAuthState", async () => {
     const req = makeRequest();
     await GET(req);
-    expect(createOAuthState).toHaveBeenCalledWith("discover", expect.anything(), undefined);
+    expect(createOAuthState).toHaveBeenCalledWith(
+      "discover",
+      expect.anything(),
+      undefined,
+      { allowEmpty: false },
+    );
   });
 
   it("passes safeNext to createOAuthState when next param is provided", async () => {
     const req = makeRequest("?next=/dashboard/credentials");
     await GET(req);
-    expect(createOAuthState).toHaveBeenCalledWith("discover", expect.anything(), "/dashboard/credentials");
+    expect(createOAuthState).toHaveBeenCalledWith(
+      "discover",
+      expect.anything(),
+      "/dashboard/credentials",
+      { allowEmpty: false },
+    );
   });
 
   it("ignores unsafe next params (protocol-relative URLs)", async () => {
     const req = makeRequest("?next=//evil.com/steal");
     await GET(req);
-    expect(createOAuthState).toHaveBeenCalledWith("discover", expect.anything(), undefined);
+    expect(createOAuthState).toHaveBeenCalledWith(
+      "discover",
+      expect.anything(),
+      undefined,
+      { allowEmpty: false },
+    );
   });
 
   it("ignores unsafe next params (backslash-relative URLs)", async () => {
     const req = makeRequest("?next=/\\evil.com/steal");
     await GET(req);
-    expect(createOAuthState).toHaveBeenCalledWith("discover", expect.anything(), undefined);
+    expect(createOAuthState).toHaveBeenCalledWith(
+      "discover",
+      expect.anything(),
+      undefined,
+      { allowEmpty: false },
+    );
+  });
+
+  it("passes allowEmpty=true when allow_empty=1 is set", async () => {
+    const req = makeRequest("?allow_empty=1");
+    await GET(req);
+    expect(createOAuthState).toHaveBeenCalledWith(
+      "discover",
+      expect.anything(),
+      undefined,
+      { allowEmpty: true },
+    );
   });
 });
 
@@ -234,5 +265,17 @@ describe("GET /api/auth/github/start-discover — fast-path (valid session)", ()
 
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("github.com/login/oauth/authorize");
+  });
+
+  it("redirects null-installation sessions straight to /dashboard without a BYOK check", async () => {
+    vi.mocked(getSetupSession).mockResolvedValue({ ...VALID_SESSION, installationId: null });
+
+    const req = makeRequestWithCookie("setup_session=valid-token");
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/dashboard");
+    expect(createOAuthState).not.toHaveBeenCalled();
+    expect(hasByokEnvelope).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/api/auth/github/start-discover/route.ts
+++ b/web/src/app/api/auth/github/start-discover/route.ts
@@ -7,6 +7,12 @@
  * It stores a "discover" sentinel in the OAuth state. After the user authorizes,
  * the callback detects the sentinel and resolves the real installation_id via
  * GET /user/installations.
+ *
+ * When called with `?allow_empty=1`, this is the "skip install, just sign in"
+ * path: if the user has zero installations, the callback issues a session with
+ * `installationId: null` (rather than redirecting with auth=not_installed).
+ * That session lets the user browse the dashboard; governance features stay
+ * gated with a "Connect a repo" CTA until the user installs the App.
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -47,6 +53,7 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const force = searchParams.get("force");
+  const allowEmpty = searchParams.get("allow_empty") === "1";
   const nextParam = searchParams.get("next");
   const safeNext = nextParam && isSafeNextPath(nextParam) ? nextParam : undefined;
 
@@ -61,8 +68,10 @@ export async function GET(request: NextRequest) {
         const session = await getSetupSession(existingToken, redis);
         if (session) {
           let destination = safeNext ?? "/dashboard";
-          if (destination === "/dashboard") {
-            // Verify BYOK to determine correct landing page.
+          if (destination === "/dashboard" && session.installationId !== null) {
+            // Verify BYOK to determine correct landing page (only when an
+            // installation is attached — null-installation sessions land on
+            // the dashboard's "Connect a repo" CTA).
             let setupComplete = false;
             try {
               setupComplete = await hasByokEnvelope(session.installationId, redis);
@@ -83,7 +92,7 @@ export async function GET(request: NextRequest) {
 
   let stateRecord: { state: string; stateBinding: string };
   try {
-    stateRecord = await createOAuthState(DISCOVER_SENTINEL, redis, safeNext);
+    stateRecord = await createOAuthState(DISCOVER_SENTINEL, redis, safeNext, { allowEmpty });
   } catch {
     return NextResponse.json(
       { error: "Failed to store OAuth state", code: OAUTH_STATE_STORE_FAILED_CODE },

--- a/web/src/app/api/byok/config/route.ts
+++ b/web/src/app/api/byok/config/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { encrypt } from "@/server/crypto";
 import { setByokEnvelope } from "@/server/byok-store";
 import { validateProviderKey } from "@/server/provider-validation";
@@ -23,6 +24,10 @@ export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   let body: ConfigRequestBody;
   try {
     body = (await request.json()) as ConfigRequestBody;
@@ -31,7 +36,6 @@ export async function POST(request: NextRequest) {
   }
 
   const { provider, model, apiKey } = body;
-  const installationId = auth.session.installationId;
 
   if (!provider || !model || !apiKey) {
     return byokError(

--- a/web/src/app/api/byok/re-encrypt/route.ts
+++ b/web/src/app/api/byok/re-encrypt/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { encrypt, decrypt } from "@/server/crypto";
 import { getByokEnvelope, setByokEnvelope } from "@/server/byok-store";
 
@@ -18,7 +19,9 @@ export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
-  const installationId = auth.session.installationId;
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   let reEncrypted = 0;
   let skipped = 0;

--- a/web/src/app/api/byok/revoke/route.ts
+++ b/web/src/app/api/byok/revoke/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { getByokEnvelope, setByokEnvelope } from "@/server/byok-store";
 import { BYOK_ERROR, byokError } from "@/server/byok-error";
 
@@ -14,7 +15,9 @@ export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
-  const installationId = auth.session.installationId;
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   const existing = await getByokEnvelope(installationId, auth.redis);
   if (!existing) {

--- a/web/src/app/api/byok/rotate/route.ts
+++ b/web/src/app/api/byok/rotate/route.ts
@@ -8,6 +8,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { encrypt } from "@/server/crypto";
 import { setByokEnvelope } from "@/server/byok-store";
 import { validateProviderKey } from "@/server/provider-validation";
@@ -24,6 +25,10 @@ export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   let body: RotateRequestBody;
   try {
     body = (await request.json()) as RotateRequestBody;
@@ -32,7 +37,6 @@ export async function POST(request: NextRequest) {
   }
 
   const { provider, model, apiKey } = body;
-  const installationId = auth.session.installationId;
 
   if (!provider || !model || !apiKey) {
     return byokError(

--- a/web/src/app/api/byok/status/route.ts
+++ b/web/src/app/api/byok/status/route.ts
@@ -16,6 +16,12 @@ export async function GET(request: NextRequest) {
 
   const installationId = auth.session.installationId;
 
+  // Null-installation sessions never have a BYOK envelope: surface the same
+  // "not configured" response the client already handles, rather than 409ing.
+  if (installationId === null) {
+    return byokError(BYOK_ERROR.NOT_CONFIGURED, "BYOK is not configured", 404);
+  }
+
   const envelope = await getByokEnvelope(installationId, auth.redis);
   if (!envelope) {
     return byokError(

--- a/web/src/app/api/repos/[owner]/[repo]/roles/route.ts
+++ b/web/src/app/api/repos/[owner]/[repo]/roles/route.ts
@@ -18,6 +18,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { parse as parseYaml, parseDocument } from "yaml";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { validateEnv } from "@/server/env";
 import { generateAppJwt, generateInstallationToken } from "@/server/github-auth";
 import {
@@ -146,6 +147,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   const { pathname } = new URL(request.url);
   const parsed = extractOwnerRepo(pathname);
   if (!parsed) {
@@ -166,7 +171,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const appJwt = generateAppJwt(githubAppId, githubAppPrivateKey);
     const installationToken = await generateInstallationToken(
-      auth.session.installationId,
+      installationId,
       appJwt,
     );
 
@@ -199,7 +204,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json(body);
   } catch (error) {
     console.error("[repos/roles] Failed to fetch roles", {
-      installationId: auth.session.installationId,
+      installationId,
       owner,
       repo,
       error,
@@ -211,6 +216,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 export async function PUT(request: NextRequest): Promise<NextResponse> {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   const { pathname } = new URL(request.url);
   const parsed = extractOwnerRepo(pathname);
@@ -257,7 +266,7 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
   try {
     const appJwt = generateAppJwt(githubAppId, githubAppPrivateKey);
     const installationToken = await generateInstallationToken(
-      auth.session.installationId,
+      installationId,
       appJwt,
     );
 
@@ -360,7 +369,7 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json(responseBody, { status: editPR ? 200 : 201 });
   } catch (error) {
     console.error("[repos/roles] Failed to write role edit", {
-      installationId: auth.session.installationId,
+      installationId,
       owner,
       repo,
       roleName,

--- a/web/src/app/api/tasks/[taskId]/follow-up/route.ts
+++ b/web/src/app/api/tasks/[taskId]/follow-up/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { parseContentLength } from "@/server/request-utils";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import { extractTaskId } from "@/server/task-route-utils";
@@ -11,6 +12,10 @@ const textEncoder = new TextEncoder();
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   const { pathname } = new URL(request.url);
   const taskId = extractTaskId(pathname);
@@ -52,7 +57,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const result = await resumeTaskWithFollowUp(
-      auth.session.installationId,
+      installationId,
       taskId,
       obj.message.trim(),
       auth.redis,
@@ -79,7 +84,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ task: result.task });
   } catch (error) {
     console.error("[tasks] Failed to resume task with follow-up", {
-      installationId: auth.session.installationId,
+      installationId,
       taskId,
       error,
     });

--- a/web/src/app/api/tasks/[taskId]/messages/route.ts
+++ b/web/src/app/api/tasks/[taskId]/messages/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { parseContentLength } from "@/server/request-utils";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import { extractTaskId } from "@/server/task-route-utils";
@@ -12,6 +13,10 @@ export async function GET(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   try {
     const { pathname } = new URL(request.url);
     const taskId = extractTaskId(pathname);
@@ -19,13 +24,13 @@ export async function GET(request: NextRequest) {
       return taskError(TASK_ERROR.INVALID_TASK_ID, "Invalid task id", 400);
     }
 
-    const task = await getTask(auth.session.installationId, taskId, auth.redis);
+    const task = await getTask(installationId, taskId, auth.redis);
     if (!task) {
       return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
     }
 
     const messages = await getTaskMessages(
-      auth.session.installationId,
+      installationId,
       taskId,
       auth.redis,
     );
@@ -33,7 +38,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ messages });
   } catch (error) {
     console.error("[tasks] Failed to fetch task messages", {
-      installationId: auth.session.installationId,
+      installationId,
       error,
     });
     return taskError(
@@ -47,6 +52,10 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   try {
     const { pathname } = new URL(request.url);
@@ -88,7 +97,7 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await addUserMessage(
-      auth.session.installationId,
+      installationId,
       taskId,
       obj.message.trim(),
       auth.redis,
@@ -115,7 +124,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ task: result.task });
   } catch (error) {
     console.error("[tasks] Failed to add user message", {
-      installationId: auth.session.installationId,
+      installationId,
       error,
     });
     return taskError(

--- a/web/src/app/api/tasks/[taskId]/retry/route.ts
+++ b/web/src/app/api/tasks/[taskId]/retry/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import { extractTaskId } from "@/server/task-route-utils";
 import { checkTaskCreateRateLimit, retryTask, TASK_ID_PATTERN } from "@/server/task-store";
@@ -7,6 +8,10 @@ import { checkTaskCreateRateLimit, retryTask, TASK_ID_PATTERN } from "@/server/t
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   const { pathname } = new URL(request.url);
   const taskId = extractTaskId(pathname);
@@ -17,7 +22,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const rateLimit = await checkTaskCreateRateLimit(
-      auth.session.installationId,
+      installationId,
       auth.session.userId,
       auth.redis,
     );
@@ -31,7 +36,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await retryTask(auth.session.installationId, taskId, auth.redis);
+    const result = await retryTask(installationId, taskId, auth.redis);
 
     if (!result.ok) {
       if (result.reason === "not_found") {
@@ -63,7 +68,7 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     console.error("[tasks] Failed to retry task", {
-      installationId: auth.session.installationId,
+      installationId,
       taskId,
       error,
     });

--- a/web/src/app/api/tasks/[taskId]/route.ts
+++ b/web/src/app/api/tasks/[taskId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import { extractTaskId } from "@/server/task-route-utils";
 import { deleteTask, getTask, TASK_ID_PATTERN } from "@/server/task-store";
@@ -7,6 +8,10 @@ import { deleteTask, getTask, TASK_ID_PATTERN } from "@/server/task-store";
 export async function GET(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   const { pathname } = new URL(request.url);
   const taskId = extractTaskId(pathname);
@@ -16,14 +21,14 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const task = await getTask(auth.session.installationId, taskId, auth.redis);
+    const task = await getTask(installationId, taskId, auth.redis);
     if (!task) {
       return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
     }
     return NextResponse.json({ task });
   } catch (error) {
     console.error("[tasks] Failed to fetch task", {
-      installationId: auth.session.installationId,
+      installationId,
       taskId,
       error,
     });
@@ -36,6 +41,10 @@ export async function DELETE(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   const { pathname } = new URL(request.url);
   const taskId = extractTaskId(pathname);
 
@@ -44,7 +53,7 @@ export async function DELETE(request: NextRequest) {
   }
 
   try {
-    const result = await deleteTask(auth.session.installationId, taskId, auth.redis);
+    const result = await deleteTask(installationId, taskId, auth.redis);
 
     if (!result.ok) {
       if (result.reason === "not_found") {
@@ -60,7 +69,7 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ deleted: true });
   } catch (error) {
     console.error("[tasks] Failed to delete task", {
-      installationId: auth.session.installationId,
+      installationId,
       taskId,
       error,
     });

--- a/web/src/app/api/tasks/[taskId]/stream/route.ts
+++ b/web/src/app/api/tasks/[taskId]/stream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import { extractTaskId } from "@/server/task-route-utils";
 import { getTask, TASK_ID_PATTERN, type TaskStatus } from "@/server/task-store";
@@ -26,6 +27,10 @@ export async function GET(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
 
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
   const { pathname } = new URL(request.url);
   const taskId = extractTaskId(pathname);
 
@@ -33,12 +38,11 @@ export async function GET(request: NextRequest) {
     return taskError(TASK_ERROR.INVALID_TASK_ID, "Invalid task id", 400);
   }
 
-  const initialTask = await getTask(auth.session.installationId, taskId, auth.redis);
+  const initialTask = await getTask(installationId, taskId, auth.redis);
   if (!initialTask) {
     return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
   }
 
-  const installationId = auth.session.installationId;
   const redis = auth.redis;
   const encoder = new TextEncoder();
 

--- a/web/src/app/api/tasks/create/route.ts
+++ b/web/src/app/api/tasks/create/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
 import { parseContentLength } from "@/server/request-utils";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 import {
@@ -28,6 +29,10 @@ function isSameOriginRequest(request: NextRequest): boolean {
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
 
   if (!isSameOriginRequest(request)) {
     return taskError(
@@ -67,7 +72,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const rateLimit = await checkTaskCreateRateLimit(
-      auth.session.installationId,
+      installationId,
       auth.session.userId,
       auth.redis,
     );
@@ -82,7 +87,7 @@ export async function POST(request: NextRequest) {
     }
 
     const created = await createTask(
-      auth.session.installationId,
+      installationId,
       auth.session.userLogin,
       validation.request,
       auth.redis,
@@ -108,7 +113,7 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     console.error("[tasks] Failed to create task", {
-      installationId: auth.session.installationId,
+      installationId,
       error,
     });
 

--- a/web/src/app/api/tasks/route.ts
+++ b/web/src/app/api/tasks/route.ts
@@ -19,15 +19,23 @@ export async function GET(request: NextRequest) {
   const auth = await authenticateByokRequest(request);
   if (!auth.ok) return auth.response;
 
+  const installationId = auth.session.installationId;
+
+  // Null-installation sessions never own tasks — return an empty list so the
+  // dashboard renders its "no tasks yet" state instead of an error.
+  if (installationId === null) {
+    return NextResponse.json({ tasks: [] });
+  }
+
   const { searchParams } = new URL(request.url);
   const limit = parseLimit(searchParams.get("limit"));
 
   try {
-    const tasks = await listRecentTasks(auth.session.installationId, limit, auth.redis);
+    const tasks = await listRecentTasks(installationId, limit, auth.redis);
     return NextResponse.json({ tasks });
   } catch (error) {
     console.error("[tasks] Failed to list tasks", {
-      installationId: auth.session.installationId,
+      installationId,
       error,
     });
     return taskError(

--- a/web/src/app/dashboard/credentials/page.tsx
+++ b/web/src/app/dashboard/credentials/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { cookies } from "next/headers";
 import { getRedisClient } from "@/server/redis";
 import { validateEnv } from "@/server/env";
@@ -14,11 +15,14 @@ export const metadata: Metadata = {
   description: "Manage LLM API keys and agent tokens.",
 };
 
+const INSTALL_APP_URL = "https://github.com/apps/hivemoot/installations/new";
+
 export default async function CredentialsPage() {
   const cookieStore = await cookies();
   const token = cookieStore.get(SETUP_SESSION_COOKIE)?.value;
 
   let fresh = false;
+  let hasInstallation = true;
   let reAuthUrl = "/api/auth/github/start-discover?force=1&next=/dashboard/credentials";
   if (token) {
     const env = validateEnv();
@@ -28,16 +32,48 @@ export default async function CredentialsPage() {
         const session = await getSetupSession(token, redis);
         if (session) {
           fresh = isSessionFresh(session);
-          // Route re-auth through /start with the known installationId so the
-          // callback skips discovery and stays pinned to the current installation.
-          // Using start-discover would pick installations[0], silently switching
-          // multi-install users to the wrong installation.
-          reAuthUrl = `/api/auth/github/start?installation_id=${encodeURIComponent(session.installationId)}&next=/dashboard/credentials`;
+          hasInstallation = session.installationId !== null;
+          if (session.installationId !== null) {
+            // Route re-auth through /start with the known installationId so the
+            // callback skips discovery and stays pinned to the current installation.
+            // Using start-discover would pick installations[0], silently switching
+            // multi-install users to the wrong installation.
+            reAuthUrl = `/api/auth/github/start?installation_id=${encodeURIComponent(session.installationId)}&next=/dashboard/credentials`;
+          }
         }
       } catch {
         // Treat as stale on Redis error. Fall back to the discovery path.
       }
     }
+  }
+
+  if (!hasInstallation) {
+    return (
+      <>
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
+            Credentials
+          </h1>
+          <p className="mt-2 text-sm text-zinc-400">
+            Manage your LLM API key and agent authentication token.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-honey-500/20 bg-honey-500/5 p-8 text-center">
+          <p className="mb-4 text-sm text-zinc-300">
+            Connect the Hivemoot Bot to a repo to manage credentials. Credentials
+            are scoped per-installation, so there&apos;s nothing to configure until
+            you install the App.
+          </p>
+          <Link
+            href={INSTALL_APP_URL}
+            className="inline-flex items-center gap-2 rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-colors hover:bg-honey-400"
+          >
+            Install on a repo
+          </Link>
+        </div>
+      </>
+    );
   }
 
   if (!fresh) {

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
 const INSTALL_APP_URL = "https://github.com/apps/hivemoot/installations/new";
 
 async function sessionHasInstallation(): Promise<boolean> {
+  // Default true so transient infra errors (Redis down, env unreadable) still
+  // render the normal dashboard shell. Client-side API calls surface the real
+  // error instead of the server component crashing the page.
   const cookieStore = await cookies();
   const token = cookieStore.get(SETUP_SESSION_COOKIE)?.value;
   if (!token) return true;
@@ -23,10 +26,15 @@ async function sessionHasInstallation(): Promise<boolean> {
     return true;
   }
 
-  const redis = getRedisClient(env.config.redisRestUrl, env.config.redisRestToken);
-  const session = await getSetupSession(token, redis);
-  if (!session) return true;
-  return session.installationId !== null;
+  try {
+    const redis = getRedisClient(env.config.redisRestUrl, env.config.redisRestToken);
+    const session = await getSetupSession(token, redis);
+    if (!session) return true;
+    return session.installationId !== null;
+  } catch (err) {
+    console.warn("[dashboard] Failed to resolve session; rendering normal shell", { error: err });
+    return true;
+  }
 }
 
 function ConnectRepoCta() {

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,12 +1,115 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { cookies } from "next/headers";
 import AgentHealthDashboard from "./AgentHealthDashboard";
+import { SETUP_SESSION_COOKIE, getSetupSession } from "@/server/setup-session";
+import { getRedisClient } from "@/server/redis";
+import { validateEnv } from "@/server/env";
 
 export const metadata: Metadata = {
   title: "Dashboard — Hivemoot",
   description: "Monitor your autonomous agent fleet.",
 };
 
-export default function DashboardPage() {
+const INSTALL_APP_URL = "https://github.com/apps/hivemoot/installations/new";
+
+async function sessionHasInstallation(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SETUP_SESSION_COOKIE)?.value;
+  if (!token) return true;
+
+  const env = validateEnv();
+  if (!env.ok || !env.config.redisRestUrl || !env.config.redisRestToken) {
+    return true;
+  }
+
+  const redis = getRedisClient(env.config.redisRestUrl, env.config.redisRestToken);
+  const session = await getSetupSession(token, redis);
+  if (!session) return true;
+  return session.installationId !== null;
+}
+
+function ConnectRepoCta() {
+  return (
+    <div className="rounded-2xl border border-honey-500/20 bg-honey-500/5 p-8 sm:p-10">
+      <div className="flex flex-col items-start gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-honey-500/10 text-honey-400">
+          <svg
+            className="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 2L2 7l10 5 10-5-10-5z" />
+            <path d="M2 17l10 5 10-5" />
+            <path d="M2 12l10 5 10-5" />
+          </svg>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[#fafafa]">
+            Connect the Queen to a repo
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-zinc-400">
+            You&apos;re signed in, but the Hivemoot Bot isn&apos;t installed on
+            any of your repos yet. Install it on a repo to unlock governance
+            features — agent roles, task dispatch, BYOK, and the full
+            dashboard.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Link
+            href={INSTALL_APP_URL}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-2.5 text-sm font-semibold text-[#111114] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
+            </svg>
+            Install on a repo
+          </Link>
+          <Link
+            href="https://github.com/hivemoot/hivemoot#readme"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center rounded-lg border border-white/10 px-5 py-2.5 text-sm text-zinc-300 transition-colors hover:border-white/20 hover:text-[#fafafa]"
+          >
+            Read the docs
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default async function DashboardPage() {
+  const hasInstallation = await sessionHasInstallation();
+
+  if (!hasInstallation) {
+    return (
+      <>
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
+            Welcome to Hivemoot
+          </h1>
+          <p className="mt-2 text-sm text-zinc-400">
+            One step to unlock the dashboard.
+          </p>
+        </div>
+
+        <ConnectRepoCta />
+      </>
+    );
+  }
+
   return (
     <>
       <div className="mb-8">

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -367,6 +367,13 @@ export default async function SetupPage({
                     >
                       Already installed? Authorize to continue
                     </Link>
+
+                    <Link
+                      href="/api/auth/github/start-discover?allow_empty=1"
+                      className="mt-1 flex w-full items-center justify-center rounded-lg px-5 py-2 text-xs text-zinc-600 transition-colors hover:text-zinc-400"
+                    >
+                      Skip for now — just sign me in
+                    </Link>
                   </>
                 )}
 

--- a/web/src/server/require-installation.ts
+++ b/web/src/server/require-installation.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import type { SetupSessionPayload } from "@/server/setup-session";
+
+export const INSTALLATION_REQUIRED_CODE = "installation_required";
+
+export type RequireInstallationResult =
+  | { ok: true; installationId: string }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Narrows `session.installationId` from `string | null` to `string`.
+ *
+ * Sessions with a null installation id come from the "skip install, just sign
+ * me in" path. Reads that only surface shared UI state can return empty or
+ * "not configured" responses without calling this helper. Endpoints that
+ * write per-installation data (BYOK, tasks, roles, agent tokens) must reject
+ * null-installation sessions so the client can prompt the user to install
+ * the GitHub App on a repo.
+ */
+export function requireInstallation(
+  session: SetupSessionPayload,
+): RequireInstallationResult {
+  if (session.installationId !== null) {
+    return { ok: true, installationId: session.installationId };
+  }
+  return {
+    ok: false,
+    response: NextResponse.json(
+      {
+        error: "Connect the Hivemoot Bot to a repo to use this feature.",
+        code: INSTALLATION_REQUIRED_CODE,
+      },
+      { status: 409 },
+    ),
+  };
+}

--- a/web/src/server/setup-session.test.ts
+++ b/web/src/server/setup-session.test.ts
@@ -226,6 +226,19 @@ describe("getSetupSession", () => {
     expect(session!.iat).toBeGreaterThanOrEqual(before);
   });
 
+  it("round-trips a null installationId (user signed in without installing the app)", async () => {
+    const redis = makeMockRedis();
+    const token = await createSetupSession(
+      { installationId: null, userId: 55, userLogin: "no-install" },
+      redis,
+    );
+    const session = await getSetupSession(token, redis);
+    expect(session).not.toBeNull();
+    expect(session!.installationId).toBeNull();
+    expect(session!.userId).toBe(55);
+    expect(session!.userLogin).toBe("no-install");
+  });
+
   it("returns null for an unknown token", async () => {
     const redis = makeMockRedis();
     const session = await getSetupSession("x".repeat(64), redis);

--- a/web/src/server/setup-session.ts
+++ b/web/src/server/setup-session.ts
@@ -35,6 +35,13 @@ interface OAuthStatePayload {
   installationId: string;
   stateBinding: string;
   next?: string;
+  /**
+   * When true, paired with the DISCOVER_SENTINEL installationId, the callback
+   * tolerates "user has zero installations" and issues a session with
+   * `installationId: null` instead of redirecting with auth=not_installed.
+   * Used by the "skip install, just sign in" entry point.
+   */
+  allowEmpty?: boolean;
 }
 
 export interface OAuthStateRecord {
@@ -45,17 +52,20 @@ export interface OAuthStateRecord {
 export interface OAuthStateValidationResult {
   installationId: string;
   next?: string;
+  allowEmpty?: boolean;
 }
 
 export async function createOAuthState(
   installationId: string,
   redis: Redis,
   next?: string,
+  options?: { allowEmpty?: boolean },
 ): Promise<OAuthStateRecord> {
   const state = randomBytes(32).toString("hex");
   const stateBinding = randomBytes(32).toString("hex");
   const payload: OAuthStatePayload = { installationId, stateBinding };
   if (next) payload.next = next;
+  if (options?.allowEmpty) payload.allowEmpty = true;
   await redis.set(
     `${STATE_KEY_PREFIX}${state}`,
     payload,
@@ -86,11 +96,18 @@ export async function validateOAuthState(
   if (payload.stateBinding !== stateBinding) return null;
   const result: OAuthStateValidationResult = { installationId: payload.installationId };
   if (payload.next) result.next = payload.next;
+  if (payload.allowEmpty === true) result.allowEmpty = true;
   return result;
 }
 
 export interface SetupSessionPayload {
-  installationId: string;
+  /**
+   * null when the user signed in via OAuth without having the GitHub App
+   * installed on any repo. Governance features that require repo access
+   * (BYOK config, roles editing, task dispatch) should return
+   * "installation_required" until the user installs the app.
+   */
+  installationId: string | null;
   userId: number;
   userLogin: string;
 }


### PR DESCRIPTION
## Summary

- The setup flow required installing the Hivemoot Bot on at least one repo before OAuth could complete, so new users couldn't explore the dashboard before committing to an install.
- Adds a **"Skip for now — just sign me in"** entry on the setup page that runs OAuth via `start-discover?allow_empty=1`. When the authorized user has zero installations, the callback issues a setup session with `installationId: null` and redirects to `/dashboard`.
- The dashboard root renders a **"Connect the Queen to a repo"** CTA card for null-installation sessions. Mutating API endpoints reject those sessions with 409 via a new `requireInstallation` helper; read endpoints return empty / "not configured" responses so the UI renders cleanly.

## Why

The user-visible behavior before this change: the setup screen that follows GitHub auth felt like it was forcing Probot onto the user. In reality, the GitHub App install is only load-bearing for governance features (agent roles, task dispatch, BYOK). Dashboard monitoring and sign-in only need OAuth. This PR makes that distinction visible by separating "log in" from "connect a repo."

The scope was kept narrow: the data model stays per-installation (BYOK, tasks, health reports keyed by `installationId`). Null-installation sessions just render empty UI with a clear CTA until the user completes the install. No existing session shape or per-installation data was migrated.

## What it looks like

**Setup page (Step 1), new tertiary link below the existing two:**

```
[Install GitHub App]          ← primary
Already installed? Authorize to continue
Skip for now — just sign me in   ← NEW
```

**Dashboard (null-installation session):**

```
Welcome to Hivemoot
One step to unlock the dashboard.

┌──────────────────────────────────────────────────────┐
│ ⬡  Connect the Queen to a repo                       │
│                                                      │
│    You're signed in, but the Hivemoot Bot isn't      │
│    installed on any of your repos yet. Install it    │
│    on a repo to unlock governance features — agent   │
│    roles, task dispatch, BYOK, and the full          │
│    dashboard.                                        │
│                                                      │
│    [ ⬡ Install on a repo ]   [ Read the docs ]       │
└──────────────────────────────────────────────────────┘
```

**Credentials page (null-installation session):**

Same pattern — "Connect the Hivemoot Bot to a repo to manage credentials" + install CTA.

**Mutating API responses (null-installation session):**

```json
HTTP/1.1 409 Conflict
{
  "error": "Connect the Hivemoot Bot to a repo to use this feature.",
  "code": "installation_required"
}
```

**Read API responses (null-installation session):**

- `GET /api/tasks` → `{ "tasks": [] }`
- `GET /api/agent-health` → `{ "agents": [] }`
- `GET /api/byok/status` → `404 not_configured` (same shape the client already handles)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 618 passing, 1 skipped (added new cases for null-installation session, `allowEmpty` flag, callback 0-installations-with-allowEmpty branch)
- [ ] Manual: click "Skip for now — just sign me in" on /setup as a user with zero installations → land on /dashboard → see the "Connect a repo" CTA
- [ ] Manual: same flow as a user who *does* have an installation → normal dashboard renders (falls back to picking the first installation, same as the existing "Already installed? Authorize" path)
- [ ] Manual: from a null-installation session, hit /dashboard/credentials → see the "Connect to manage credentials" CTA
- [ ] Manual: from a null-installation session, curl `POST /api/tasks/create` → 409 with `installation_required`