### PR TITLE
Chown /workspace to node so agents can write cwd

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -211,7 +211,15 @@ COPY --chown=node:node cli /opt/hivemoot-agent/cli
 RUN chmod +x /opt/hivemoot-agent/cli/hivemoot-agent
 
 USER root
-RUN ln -sf /opt/hivemoot-agent/cli/hivemoot-agent /usr/local/bin/hivemoot-agent
+# WORKDIR /workspace above creates the dir owned by root even though
+# USER=node was active at that point — on this Docker engine WORKDIR
+# ignores the current USER and always uses root.  Chown it explicitly
+# so agents running as node can write to cwd.  Without this,
+# engine.py's _stage_workspace_agents_skills() raises PermissionError
+# when it creates /workspace/.agents for workqueue-dispatched runs
+# (github-mention / github-review-request / workqueue drain paths).
+RUN ln -sf /opt/hivemoot-agent/cli/hivemoot-agent /usr/local/bin/hivemoot-agent \
+  && chown node:node /workspace
 USER node
 
 # tini owns PID 1 and forwards signals to the CLI.  Default CMD is


### PR DESCRIPTION
## Summary

Fix a latent permission bug that blocks workqueue-dispatched agent runs (github-mention, github-review-request, workqueue drain).

The Dockerfile declares `WORKDIR /workspace` after `USER node`, but on this Docker engine version WORKDIR ignores the current USER and creates new dirs as root. Agents then run as node (uid 1000) and hit `PermissionError: [Errno 13] Permission denied: '/workspace/.agents'` when `engine.py`'s `_stage_workspace_agents_skills()` tries to create a \`.agents\` subdir under cwd.

Fix: chown `/workspace` to node:node inside the existing root RUN that already symlinks the hivemoot-agent cli. Zero new layers.

## Why this hasn't been caught earlier

A direct `github-new-pr` dispatch cds into the cloned repo dir (`/data/workspace/owner/repo`) which is bind-mounted from host and already node-owned — it sidesteps `/workspace` entirely. Only the *workqueue* drain path runs from `Path.cwd()` = `/workspace`. So PR reviews looked intermittent rather than systemically broken.

## Verified live

The same fix was applied inside the four running containers via `docker exec -u root chown node:node /workspace`. Confirmed:

```
=== hivemoot-drone ===
  chown OK
drwxr-xr-x 1 node node 4096 Apr 24 01:08 /workspace
writable-by-node
```

After the live chown, pending mentions drained on the next 90s poll instead of raising `PermissionError` every cycle.

This PR bakes the same fix into the image so redeploys, container restarts, and new services don't re-introduce the bug.

## Test plan

- [x] Dockerfile syntax: diff is minimal, one added comment + one `&& chown` in an existing RUN
- [ ] CI agent-docker-publish builds the image (the RUN line changes so the cache invalidates from line 215 onwards)
- [ ] Post-rebuild: `docker run --rm --entrypoint sh hivemoot-agent:latest -c 'ls -ld /workspace'` shows `node:node`
- [ ] Post-rebuild redeploy: pending agent @mention runs without `PermissionError`