### PR TITLE
Extract INSTALL_APP_URL into shared constant

### DIFF
--- a/web/src/app/dashboard/credentials/page.tsx
+++ b/web/src/app/dashboard/credentials/page.tsx
@@ -1,3 +1,4 @@
+import { INSTALL_APP_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
@@ -15,7 +16,6 @@ export const metadata: Metadata = {
   description: "Manage LLM API keys and agent tokens.",
 };
 
-const INSTALL_APP_URL = "https://github.com/apps/hivemoot/installations/new";
 
 export default async function CredentialsPage() {
   const cookieStore = await cookies();

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { INSTALL_APP_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
@@ -11,7 +12,6 @@ export const metadata: Metadata = {
   description: "Monitor your autonomous agent fleet.",
 };
 
-const INSTALL_APP_URL = "https://github.com/apps/hivemoot/installations/new";
 
 async function sessionHasInstallation(): Promise<boolean> {
   // Default true so transient infra errors (Redis down, env unreadable) still

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { INSTALL_APP_URL } from "@/lib/constants";
 import Link from "next/link";
 import { cookies } from "next/headers";
 import SetupWizard from "./SetupWizard";
@@ -352,7 +353,7 @@ export default async function SetupPage({
                 ) : (
                   <>
                     <Link
-                      href="https://github.com/apps/hivemoot/installations/new"
+                      href={INSTALL_APP_URL}
                       className="flex w-full items-center justify-center gap-2.5 rounded-lg bg-honey-500 px-5 py-3 text-sm font-semibold text-[#111114] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
                     >
                       <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const INSTALL_APP_URL =
+  "https://github.com/apps/hivemoot/installations/new";


### PR DESCRIPTION
The GitHub App install URL was hardcoded in three places (`dashboard/page.tsx`, `credentials/page.tsx`, `setup/page.tsx`). Extracts it into `web/src/lib/constants.ts` so there's one source of truth.

Spotted during the architectural review on #475 — the `INSTALL_APP_URL` constant was duplicated as a local `const` in two dashboard pages and inlined as a string in setup. If the URL ever changes (different GitHub App name, environment-specific path), all three need updating independently. Now they don't.

Follow-up to #475.


Closes #667
