### PR TITLE
Add config, logging, CI workflow (apiarist Phase B + B+)

### DIFF
--- a/.github/workflows/apiarist-ci.yml
+++ b/.github/workflows/apiarist-ci.yml
@@ -1,0 +1,61 @@
+name: Apiarist CI
+
+# Path-scoped to apiarist/** so unrelated edits (agent/, bot/, web/,
+# cli/, docs/) don't fire this pipeline. DESIGN.md §14 (Phase B+)
+# requires this workflow to land with or before the first phase that
+# adds real subsystem code, so the ruff/mypy/pytest promises in
+# pyproject.toml are actually enforced from then on.
+#
+# Security note: this workflow does NOT consume any untrusted GitHub
+# event input (no github.event.* expressions in run: blocks). The
+# only `run:` inputs are checked-out source files and the matrix
+# python version, both repository-controlled. Reviewer fleet should
+# flag any future change that introduces github.event.*.
+
+on:
+  pull_request:
+    paths:
+      - 'apiarist/**'
+      - '.github/workflows/apiarist-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apiarist/**'
+      - '.github/workflows/apiarist-ci.yml'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    # All `run:` steps execute inside apiarist/ so commands match how
+    # contributors run them locally (per AGENTS.md). `uses:` actions
+    # don't respect this; they take explicit paths.
+    working-directory: apiarist
+
+jobs:
+  lint-types-tests:
+    name: Lint, Types, Tests (Python ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pin 3.11 to start (the floor declared in pyproject.toml).
+        # Add 3.12 / 3.13 when explicit support is promised in the
+        # package classifiers.
+        python: ['3.11']
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: apiarist/pyproject.toml
+      - name: Install (editable + dev extras)
+        run: pip install -e '.[dev]'
+      - name: Ruff (lint)
+        run: ruff check src tests
+      - name: Mypy (strict)
+        run: mypy src
+      - name: Pytest
+        run: pytest -v

--- a/apiarist/pyproject.toml
+++ b/apiarist/pyproject.toml
@@ -20,13 +20,15 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: System :: Systems Administration",
 ]
-# Runtime dependencies are intentionally empty in Phase A.
-# Each subsequent phase adds only what it needs:
-#   Phase B → structlog, pydantic, pyyaml
+# Runtime dependencies grow per phase per DESIGN.md §14:
+#   Phase B → structlog, pydantic, pyyaml  (this PR)
 #   Phase C → httpx
 #   Phase D → (stdlib asyncio is enough)
-# See DESIGN.md §14 for the full phase plan.
-dependencies = []
+dependencies = [
+    "structlog>=24.1",
+    "pydantic>=2.6",
+    "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -34,6 +36,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "ruff>=0.6",
     "mypy>=1.10",
+    "types-PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/apiarist/src/apiarist/__main__.py
+++ b/apiarist/src/apiarist/__main__.py
@@ -1,15 +1,22 @@
 """apiarist CLI entry point.
 
-Phase A scaffold: parses --version / --help and exits. Phases B onward
-add config loading, the asyncio UDS server, the backend client, and the
-feature plugins. The full design lives in DESIGN.md.
+Phase B wires up config loading + structured logging. The asyncio UDS
+server (Phase D), backend client (Phase C), and feature plugins
+(Phase E onward) replace the scaffold-mode branch below as they land.
+The full design lives in DESIGN.md.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+from pathlib import Path
 
+import structlog
+
+from apiarist.config import ConfigError, load_config
+from apiarist.logging import configure_logging
 from apiarist.version import __version__
 
 
@@ -28,21 +35,72 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"apiarist {__version__}",
     )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to apiarist.yaml "
+            "(default: /etc/apiarist/apiarist.yaml if it exists)"
+        ),
+    )
+    # CLI overrides for individual config fields. All default to None so
+    # `load_config` can tell "not set on CLI" from "set to a value" and
+    # only override env/file when explicitly provided.
+    parser.add_argument("--socket-path", type=Path, default=None)
+    parser.add_argument("--socket-group", default=None)
+    parser.add_argument("--backend-url", default=None)
+    parser.add_argument(
+        "--log-level",
+        default=None,
+        choices=["debug", "info", "warning", "error", "critical"],
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    parser.parse_args(argv)
-    # Scaffold mode: packaging and entry-point wiring are exercised but
-    # the daemon loop is not running yet. Each phase that lands real
-    # behaviour will replace this branch with the actual subsystem
-    # bootstrap. The wording stays version-aware rather than naming a
-    # phase so it doesn't read stale as phases ship.
-    print(
-        f"apiarist {__version__} — daemon scaffold; subsystems not yet "
-        "wired. See DESIGN.md.",
-        file=sys.stderr,
+    args = parser.parse_args(argv)
+
+    cli_overlay = {
+        "socket_path": args.socket_path,
+        "socket_group": args.socket_group,
+        "backend_url": args.backend_url,
+        "log_level": args.log_level,
+    }
+
+    try:
+        config = load_config(
+            cli_overlay=cli_overlay,
+            env=dict(os.environ),
+            config_path=args.config,
+        )
+    except ConfigError as exc:
+        # Config errors happen before logging is configured, so emit
+        # plain stderr rather than a structured log line. Exit 1 so
+        # systemd surfaces the failure rather than treating an empty
+        # daemon as a successful start.
+        print(f"apiarist: config error: {exc}", file=sys.stderr)
+        return 1
+
+    configure_logging(level=config.log_level)
+    log = structlog.get_logger()
+    log.info(
+        "apiarist starting",
+        version=__version__,
+        socket_path=str(config.socket_path),
+        backend_url=config.backend_url,
+        log_level=config.log_level,
+    )
+
+    # Scaffold mode: subsystems still being added phase by phase. Phase D
+    # adds the asyncio UDS server; until then `apiarist` exits cleanly
+    # after logging its config so packaging + config + logging can be
+    # exercised end to end.
+    log.info(
+        "apiarist scaffold; subsystems not yet wired (see DESIGN.md)",
+        next_phase="D (UDS server)",
     )
     return 0
 

--- a/apiarist/src/apiarist/config.py
+++ b/apiarist/src/apiarist/config.py
@@ -23,6 +23,13 @@ from pydantic import BaseModel, Field, ValidationError
 DEFAULT_CONFIG_PATH = Path("/etc/apiarist/apiarist.yaml")
 ENV_PREFIX = "APIARIST_"
 
+# APIARIST_CONFIG is the env-level config-file selector per DESIGN.md
+# §9 — it points at the YAML file to load, NOT at a Config field.
+# Treating it as a field would raise extra_forbidden because Config
+# has no `config` attribute. Keep it (and any future non-field env
+# selectors) out of the field overlay.
+_NON_FIELD_ENV_KEYS: frozenset[str] = frozenset({"config"})
+
 LogLevel = str  # validated to one of {debug, info, warning, error, critical}
 _VALID_LOG_LEVELS = frozenset({"debug", "info", "warning", "error", "critical"})
 
@@ -68,10 +75,15 @@ def load_config(
     `cli_overlay` values that are None are dropped — that lets the caller
     pass an argparse Namespace as a dict where unset flags are None
     without those Nones overriding values from env or file.
-    """
-    layered: dict[str, Any] = {}
 
-    layered.update(_load_file_overlay(config_path))
+    The YAML file path is resolved separately from the field overlays:
+    `config_path` arg (typically from `--config`) > `APIARIST_CONFIG`
+    env var > `DEFAULT_CONFIG_PATH`.
+    """
+    resolved_config_path = _resolve_config_path(config_path, env)
+
+    layered: dict[str, Any] = {}
+    layered.update(_load_file_overlay(resolved_config_path))
     layered.update(_load_env_overlay(env))
     if cli_overlay:
         layered.update({k: v for k, v in cli_overlay.items() if v is not None})
@@ -80,6 +92,24 @@ def load_config(
         return Config(**layered)
     except ValidationError as e:
         raise ConfigError(f"Config validation failed:\n{e}") from e
+
+
+def _resolve_config_path(
+    cli_path: Path | None,
+    env: dict[str, str] | None,
+) -> Path | None:
+    """CLI > env (APIARIST_CONFIG) > caller-provided default.
+
+    Returns None when neither CLI nor env specifies a path; callers
+    fall back to ``DEFAULT_CONFIG_PATH`` via ``_load_file_overlay``.
+    """
+    if cli_path is not None:
+        return cli_path
+    env_dict = env if env is not None else dict(os.environ)
+    env_path = env_dict.get(f"{ENV_PREFIX}CONFIG")
+    if env_path:
+        return Path(env_path)
+    return None
 
 
 def _load_file_overlay(config_path: Path | None) -> dict[str, Any]:
@@ -109,7 +139,12 @@ def _load_file_overlay(config_path: Path | None) -> dict[str, Any]:
 
 
 def _load_env_overlay(env: dict[str, str] | None) -> dict[str, Any]:
-    """Extract APIARIST_* env vars and normalize keys to Config field names."""
+    """Extract APIARIST_* env vars and normalize keys to Config field names.
+
+    Excludes keys reserved for non-field purposes (currently
+    APIARIST_CONFIG, which is the YAML-file selector resolved by
+    `_resolve_config_path` instead).
+    """
     if env is None:
         env = dict(os.environ)
     overlay: dict[str, Any] = {}
@@ -117,5 +152,7 @@ def _load_env_overlay(env: dict[str, str] | None) -> dict[str, Any]:
         if not key.startswith(ENV_PREFIX):
             continue
         field = key[len(ENV_PREFIX) :].lower()
+        if field in _NON_FIELD_ENV_KEYS:
+            continue
         overlay[field] = value
     return overlay

--- a/apiarist/src/apiarist/config.py
+++ b/apiarist/src/apiarist/config.py
@@ -1,0 +1,121 @@
+"""Configuration loading for apiarist.
+
+Source precedence (high → low):
+
+    1. CLI args (--socket-path, --backend-url, --log-level, ...)
+    2. Env vars (APIARIST_SOCKET_PATH, APIARIST_BACKEND_URL, ...)
+    3. Optional config file (--config / /etc/apiarist/apiarist.yaml)
+    4. Built-in defaults
+
+See DESIGN.md §9 for the field list and the cache-eviction
+rationale behind the safety_margin / max_seconds split.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+DEFAULT_CONFIG_PATH = Path("/etc/apiarist/apiarist.yaml")
+ENV_PREFIX = "APIARIST_"
+
+LogLevel = str  # validated to one of {debug, info, warning, error, critical}
+_VALID_LOG_LEVELS = frozenset({"debug", "info", "warning", "error", "critical"})
+
+
+class Config(BaseModel):
+    """All apiarist runtime knobs (DESIGN.md §9)."""
+
+    socket_path: Path = Path("/run/apiarist.sock")
+    socket_group: str = "apiarist"
+    backend_url: str = "https://www.hivemoot.dev"
+    apiary_secrets_path: Path = Path("/opt/apiary/apiary.secrets.yaml")
+    apiary_config_path: Path = Path("/opt/apiary/apiary.yaml")
+    # Cache eviction = min(expires_at - safety_margin, now + max_seconds).
+    # See DESIGN.md §9 for why expires_at is source of truth, max is ceiling only.
+    token_cache_safety_margin_seconds: int = Field(default=600, ge=0)
+    token_cache_max_seconds: int = Field(default=3000, ge=60)
+    backend_timeout_seconds: int = Field(default=10, ge=1)
+    backend_retries: int = Field(default=3, ge=0)
+    log_level: LogLevel = "info"
+
+    # frozen so callers can't mutate config after load; extra=forbid catches
+    # typos in YAML/env/CLI before they silently fall through to defaults.
+    model_config = {"frozen": True, "extra": "forbid"}
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.log_level not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"log_level must be one of {sorted(_VALID_LOG_LEVELS)}, got {self.log_level!r}"
+            )
+
+
+class ConfigError(Exception):
+    """Raised when the config file is malformed or contains invalid values."""
+
+
+def load_config(
+    cli_overlay: dict[str, Any] | None = None,
+    env: dict[str, str] | None = None,
+    config_path: Path | None = None,
+) -> Config:
+    """Build a Config instance from the four sources, layered in order.
+
+    `cli_overlay` values that are None are dropped — that lets the caller
+    pass an argparse Namespace as a dict where unset flags are None
+    without those Nones overriding values from env or file.
+    """
+    layered: dict[str, Any] = {}
+
+    layered.update(_load_file_overlay(config_path))
+    layered.update(_load_env_overlay(env))
+    if cli_overlay:
+        layered.update({k: v for k, v in cli_overlay.items() if v is not None})
+
+    try:
+        return Config(**layered)
+    except ValidationError as e:
+        raise ConfigError(f"Config validation failed:\n{e}") from e
+
+
+def _load_file_overlay(config_path: Path | None) -> dict[str, Any]:
+    """Load YAML file if it exists; return {} if not found.
+
+    Missing file is normal — deployments without /etc/apiarist/apiarist.yaml
+    rely entirely on env vars + defaults. Malformed YAML or non-mapping
+    top level is fatal: the operator clearly intended config to apply
+    and we'd silently ignore it otherwise.
+    """
+    path = config_path or DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        raise ConfigError(f"Failed to parse {path}: {e}") from e
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f"{path} must contain a YAML mapping at the top level "
+            f"(got {type(data).__name__})"
+        )
+    return data
+
+
+def _load_env_overlay(env: dict[str, str] | None) -> dict[str, Any]:
+    """Extract APIARIST_* env vars and normalize keys to Config field names."""
+    if env is None:
+        env = dict(os.environ)
+    overlay: dict[str, Any] = {}
+    for key, value in env.items():
+        if not key.startswith(ENV_PREFIX):
+            continue
+        field = key[len(ENV_PREFIX) :].lower()
+        overlay[field] = value
+    return overlay

--- a/apiarist/src/apiarist/logging.py
+++ b/apiarist/src/apiarist/logging.py
@@ -1,0 +1,141 @@
+"""Structured JSON logging with token-shape redaction.
+
+Built on structlog. Every log event passes through a redaction processor
+that replaces well-known secret patterns with ``[REDACTED]`` before JSON
+serialization, then renders to stderr (which systemd captures into the
+journal under the `apiarist.service` unit).
+
+DESIGN.md §10 lists redaction as a mitigation for "tokens leaking into
+logs/journal." The pattern set is aligned with the existing module at
+``agent/cli/hivemoot_agent/plugins_builtin/hivemoot/sanitize.py`` —
+that module is the authoritative reference for the secret shapes the
+hivemoot stack already cares about. apiarist-specific additions here:
+GitHub fine-grained PATs (``github_pat_*``) and the apiarist agent
+token prefix (``hm_*``).
+
+Redaction is recursive over the structlog event dict: nested dicts /
+lists / tuples are walked and string leaves are pattern-checked.
+Non-string values pass through unchanged so structured fields like
+counts / durations / booleans are not mangled.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from typing import Any
+
+import structlog
+
+_REDACTED = "[REDACTED]"
+
+# Order matters: more-specific patterns run before more-generic ones, so
+# replacements don't strip the structural hint a later pattern would key
+# off (e.g., the generic ``token=`` rule would otherwise eat the
+# ``Bearer`` keyword that the first rule preserves for diagnostics).
+_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # Bearer / Authorization headers echoed in error text.
+    (re.compile(r"Bearer\s+[A-Za-z0-9._\-]+", re.IGNORECASE),
+     f"Bearer {_REDACTED}"),
+    # Anthropic-prefixed (sk-ant-) MUST run before the generic sk- rule
+    # because both regexes match the same prefix.
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_\-]{16,}\b"),
+     f"sk-ant-{_REDACTED}"),
+    (re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}\b"),
+     f"sk-{_REDACTED}"),
+    # GitHub classic + installation tokens (ghp/ghs/gho/ghu/ghr).
+    (re.compile(r"\bgh[psuor]_[A-Za-z0-9]{20,}\b"),
+     f"gh*_{_REDACTED}"),
+    # GitHub fine-grained PATs (apiarist-specific addition vs the
+    # agent/cli sanitize patterns; fine-grained PATs are how the
+    # foxstoria-style per-repo identities are issued).
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+     f"github_pat_{_REDACTED}"),
+    # Apiarist agent tokens (hm_ prefix). The current
+    # apiary.secrets.yaml `health_token` is a 64-char hex without the
+    # hm_ prefix — that bare-hex shape is intentionally NOT redacted
+    # here because it would match commit SHAs and other innocuous hex
+    # blobs. Operators rotating tokens to the prefixed form get
+    # redaction; the bare-hex value relies on file permissions
+    # (chmod 640) for protection.
+    (re.compile(r"\bhm_[A-Za-z0-9]{16,}\b"),
+     f"hm_{_REDACTED}"),
+    # Generic ``token=<val>`` / ``api_key: <val>`` / ``api-key: "<val>"``
+    # in URL query strings, YAML/JSON config snippets, or inline error
+    # text. Optional surrounding quotes so ``api_key: "sk_..."`` scrubs
+    # the value without leaving the quoted secret intact.
+    (re.compile(
+        r"(?i)\b(token|api[_-]?key)\s*[=:]\s*[\"']?[A-Za-z0-9._\-]+[\"']?"),
+     rf"\1={_REDACTED}"),
+)
+
+
+def redact_string(text: str) -> str:
+    """Return ``text`` with all known secret patterns replaced.
+
+    Empty / falsy strings pass through unchanged so callers can feed
+    optional values without a guard.
+    """
+    if not text:
+        return text
+    out = text
+    for pattern, replacement in _PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+def _redact_value(value: Any) -> Any:
+    """Recursively walk a value, redacting strings, leaving other types alone.
+
+    Walks dict / list / tuple containers; everything else (int, bool,
+    None, custom objects) passes through untouched. Tuple identity is
+    preserved by re-wrapping with the original type.
+    """
+    if isinstance(value, str):
+        return redact_string(value)
+    if isinstance(value, dict):
+        return {k: _redact_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(v) for v in value)
+    return value
+
+
+def redact_processor(
+    logger: Any, method_name: str, event_dict: structlog.types.EventDict
+) -> structlog.types.EventDict:
+    """structlog processor: redact token-shaped strings in every event value.
+
+    Runs after all enrichment processors (level, timestamp, exc_info)
+    so any token that snuck into a stack trace or context dict gets
+    scrubbed too. Runs before the JSON renderer so the on-wire bytes
+    are already redacted.
+    """
+    return {k: _redact_value(v) for k, v in event_dict.items()}
+
+
+def configure_logging(level: str = "info") -> None:
+    """Configure structlog for JSON output to stderr with redaction enabled.
+
+    Idempotent — safe to call from tests or from CLI re-entry.
+    """
+    log_level = _level_to_int(level)
+
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.format_exc_info,
+            redact_processor,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(log_level),
+        logger_factory=structlog.WriteLoggerFactory(file=sys.stderr),
+        cache_logger_on_first_use=False,  # tests reconfigure between cases
+    )
+
+
+def _level_to_int(level: str) -> int:
+    return getattr(logging, level.upper(), logging.INFO)

--- a/apiarist/tests/unit/test_config.py
+++ b/apiarist/tests/unit/test_config.py
@@ -172,3 +172,46 @@ def test_config_construct_directly_for_unit_tests() -> None:
     cfg = Config(log_level="warning", backend_retries=5)
     assert cfg.log_level == "warning"
     assert cfg.backend_retries == 5
+
+
+# ---------------------------------------------------------------------------
+# APIARIST_CONFIG env var: file-path selector, NOT a Config field.
+# DESIGN.md §9 reserves it as the env-level equivalent of --config; it must
+# be resolved into the file-load path, not pushed into the field overlay
+# (which would raise extra_forbidden because Config has no `config` field).
+# ---------------------------------------------------------------------------
+
+
+def test_apiarist_config_env_selects_file(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "from-env.yaml"
+    cfg_file.write_text("log_level: warning\n")
+    cfg = load_config(env={"APIARIST_CONFIG": str(cfg_file)})
+    assert cfg.log_level == "warning"
+
+
+def test_apiarist_config_env_does_not_become_field(tmp_path: Path) -> None:
+    # Regression for the bug builder caught in PR #479: the env var was
+    # being pushed into the Config overlay and tripping extra_forbidden.
+    cfg = load_config(env={"APIARIST_CONFIG": str(tmp_path / "missing.yaml")})
+    assert cfg.log_level == "info"  # default — no exception raised
+
+
+def test_cli_config_overrides_apiarist_config_env(tmp_path: Path) -> None:
+    cli_file = tmp_path / "cli.yaml"
+    cli_file.write_text("log_level: debug\n")
+    env_file = tmp_path / "env.yaml"
+    env_file.write_text("log_level: warning\n")
+    cfg = load_config(
+        env={"APIARIST_CONFIG": str(env_file)},
+        config_path=cli_file,
+    )
+    assert cfg.log_level == "debug"
+
+
+def test_empty_apiarist_config_env_falls_back_to_default(tmp_path: Path) -> None:
+    # An empty string in env should not be interpreted as Path("") — it
+    # means "no override," same as the env var being unset entirely.
+    # Falls through to caller-provided default (None here, so loader's
+    # built-in DEFAULT_CONFIG_PATH).
+    cfg = load_config(env={"APIARIST_CONFIG": ""})
+    assert cfg.log_level == "info"

--- a/apiarist/tests/unit/test_config.py
+++ b/apiarist/tests/unit/test_config.py
@@ -1,0 +1,174 @@
+"""Tests for apiarist.config — 4-layer precedence + validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apiarist.config import (
+    DEFAULT_CONFIG_PATH,
+    Config,
+    ConfigError,
+    load_config,
+)
+
+
+def test_defaults_when_no_overrides(tmp_path: Path) -> None:
+    # Point at an explicit non-existent path so the system default
+    # (/etc/apiarist/apiarist.yaml) doesn't accidentally apply if a
+    # developer happens to have it on their machine.
+    cfg = load_config(env={}, config_path=tmp_path / "missing.yaml")
+    assert cfg.socket_path == Path("/run/apiarist.sock")
+    assert cfg.socket_group == "apiarist"
+    assert cfg.backend_url == "https://www.hivemoot.dev"
+    assert cfg.token_cache_safety_margin_seconds == 600
+    assert cfg.token_cache_max_seconds == 3000
+    assert cfg.log_level == "info"
+
+
+def test_file_overrides_defaults(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "apiarist.yaml"
+    cfg_file.write_text(
+        "socket_path: /tmp/apiarist.sock\nlog_level: debug\n"
+    )
+    cfg = load_config(env={}, config_path=cfg_file)
+    assert cfg.socket_path == Path("/tmp/apiarist.sock")
+    assert cfg.log_level == "debug"
+    # untouched fields keep their defaults
+    assert cfg.socket_group == "apiarist"
+
+
+def test_env_overrides_file(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "apiarist.yaml"
+    cfg_file.write_text("backend_url: https://file.example.com\n")
+    cfg = load_config(
+        env={"APIARIST_BACKEND_URL": "https://env.example.com"},
+        config_path=cfg_file,
+    )
+    assert cfg.backend_url == "https://env.example.com"
+
+
+def test_cli_overrides_env(tmp_path: Path) -> None:
+    cfg = load_config(
+        cli_overlay={"backend_url": "https://cli.example.com"},
+        env={"APIARIST_BACKEND_URL": "https://env.example.com"},
+        config_path=tmp_path / "missing.yaml",
+    )
+    assert cfg.backend_url == "https://cli.example.com"
+
+
+def test_cli_none_does_not_override(tmp_path: Path) -> None:
+    # argparse passes None for unset flags; those must NOT override
+    # env values, otherwise a partial CLI surface clobbers config.
+    cfg = load_config(
+        cli_overlay={"backend_url": None, "log_level": "warning"},
+        env={"APIARIST_BACKEND_URL": "https://env.example.com"},
+        config_path=tmp_path / "missing.yaml",
+    )
+    assert cfg.backend_url == "https://env.example.com"
+    assert cfg.log_level == "warning"
+
+
+def test_missing_file_is_fine(tmp_path: Path) -> None:
+    # No-op; just making sure no exception is raised when the file
+    # simply doesn't exist (most production deployments).
+    cfg = load_config(env={}, config_path=tmp_path / "does-not-exist.yaml")
+    assert cfg.log_level == "info"
+
+
+def test_default_config_path_constant() -> None:
+    # Pin the default location — operators install to this path.
+    assert Path("/etc/apiarist/apiarist.yaml") == DEFAULT_CONFIG_PATH
+
+
+def test_malformed_yaml_raises_config_error(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "broken.yaml"
+    cfg_file.write_text("socket_path: [unterminated\n")
+    with pytest.raises(ConfigError, match="Failed to parse"):
+        load_config(env={}, config_path=cfg_file)
+
+
+def test_non_mapping_top_level_raises_config_error(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "list.yaml"
+    cfg_file.write_text("- this\n- is\n- a\n- list\n")
+    with pytest.raises(ConfigError, match="must contain a YAML mapping"):
+        load_config(env={}, config_path=cfg_file)
+
+
+def test_unknown_field_raises_config_error(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "typo.yaml"
+    cfg_file.write_text("sokcet_path: /tmp/typo.sock\n")
+    with pytest.raises(ConfigError):
+        load_config(env={}, config_path=cfg_file)
+
+
+def test_invalid_log_level_raises_config_error(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        load_config(
+            cli_overlay={"log_level": "verbose"},
+            env={},
+            config_path=tmp_path / "missing.yaml",
+        )
+
+
+def test_negative_safety_margin_raises_config_error(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        load_config(
+            env={"APIARIST_TOKEN_CACHE_SAFETY_MARGIN_SECONDS": "-1"},
+            config_path=tmp_path / "missing.yaml",
+        )
+
+
+def test_max_seconds_below_minimum_raises_config_error(tmp_path: Path) -> None:
+    # ge=60 — anything shorter than a minute is almost certainly a typo.
+    with pytest.raises(ConfigError):
+        load_config(
+            env={"APIARIST_TOKEN_CACHE_MAX_SECONDS": "30"},
+            config_path=tmp_path / "missing.yaml",
+        )
+
+
+def test_config_is_frozen(tmp_path: Path) -> None:
+    cfg = load_config(env={}, config_path=tmp_path / "missing.yaml")
+    with pytest.raises((TypeError, ValueError)):
+        cfg.log_level = "debug"  # type: ignore[misc]
+
+
+def test_empty_yaml_file_is_fine(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "empty.yaml"
+    cfg_file.write_text("")
+    cfg = load_config(env={}, config_path=cfg_file)
+    assert cfg.log_level == "info"
+
+
+def test_env_var_string_to_int_coercion(tmp_path: Path) -> None:
+    # Env vars are always strings; pydantic coerces to int for numeric
+    # fields. Verifies that boundary because env is the most common
+    # production source of overrides.
+    cfg = load_config(
+        env={"APIARIST_BACKEND_TIMEOUT_SECONDS": "30"},
+        config_path=tmp_path / "missing.yaml",
+    )
+    assert cfg.backend_timeout_seconds == 30
+
+
+def test_unrelated_env_vars_ignored(tmp_path: Path) -> None:
+    cfg = load_config(
+        env={
+            "PATH": "/usr/bin",
+            "HOME": "/home/x",
+            "NOT_APIARIST_BACKEND_URL": "https://noise.example",
+        },
+        config_path=tmp_path / "missing.yaml",
+    )
+    # Defaults preserved; nothing leaked from unrelated env.
+    assert cfg.backend_url == "https://www.hivemoot.dev"
+
+
+def test_config_construct_directly_for_unit_tests() -> None:
+    # Direct instantiation is supported for tests that want a known
+    # config without going through the loader.
+    cfg = Config(log_level="warning", backend_retries=5)
+    assert cfg.log_level == "warning"
+    assert cfg.backend_retries == 5

--- a/apiarist/tests/unit/test_logging.py
+++ b/apiarist/tests/unit/test_logging.py
@@ -1,0 +1,199 @@
+"""Tests for apiarist.logging — token-shape redaction.
+
+DESIGN.md §10 mitigation: tokens MUST never reach the journal. These
+tests pin every redaction pattern + the recursive walk so future
+edits to the pattern set don't silently regress.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+import structlog
+
+from apiarist.logging import (
+    _redact_value,
+    configure_logging,
+    redact_processor,
+    redact_string,
+)
+
+# ---------------------------------------------------------------------------
+# String-level redaction: one test per token shape so failures point at the
+# specific pattern that broke.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_passes_through() -> None:
+    assert redact_string("") == ""
+
+
+def test_plain_string_unchanged() -> None:
+    text = "Task failed: expected commit message, got nothing"
+    assert redact_string(text) == text
+
+
+def test_bearer_header_redacted() -> None:
+    out = redact_string(
+        "curl: Authorization: Bearer ghp_xxxxxxxxxxxxxxxxxxxx rejected"
+    )
+    assert "ghp_xxxx" not in out
+    assert "Bearer [REDACTED]" in out
+
+
+def test_bearer_case_insensitive() -> None:
+    out = redact_string("BEARER ghs_aaaaaaaaaaaaaaaaaaaa")
+    assert "ghs_aaaa" not in out
+
+
+def test_anthropic_oauth_token_redacted() -> None:
+    out = redact_string("api error: sk-ant-oat01_abcdefghijklmnop rejected")
+    assert "sk-ant-oat01_abcdefghijklmnop" not in out
+    assert "sk-ant-[REDACTED]" in out
+
+
+def test_openai_style_key_redacted() -> None:
+    out = redact_string("got 401 from sk-abcdef1234567890ABCDEF12 — check creds")
+    assert "abcdef1234567890ABCDEF12" not in out
+    assert "sk-[REDACTED]" in out
+
+
+@pytest.mark.parametrize("prefix", ["ghp_", "ghs_", "gho_", "ghu_", "ghr_"])
+def test_github_token_prefixes_redacted(prefix: str) -> None:
+    token = f"{prefix}ABCDEFGHIJKLMNOPQRSTUVWXYZ12"
+    out = redact_string(f"git push failed: bad credentials {token}")
+    assert token not in out
+    assert "[REDACTED]" in out
+
+
+def test_github_fine_grained_pat_redacted() -> None:
+    token = "github_pat_11ABCDEFG0_xxxxxxxxxxxxxxxxxxxxxxx"
+    out = redact_string(f"401 Unauthorized: {token}")
+    assert token not in out
+    assert "github_pat_[REDACTED]" in out
+
+
+def test_apiarist_hm_token_redacted() -> None:
+    token = "hm_abcdefghij1234567890klmnop"
+    out = redact_string(f"loaded agent token {token} from secrets.yaml")
+    assert token not in out
+    assert "hm_[REDACTED]" in out
+
+
+def test_token_query_param_redacted() -> None:
+    out = redact_string(
+        "POST failed: url=https://api.example/x?token=abcdef1234567890 rejected"
+    )
+    assert "token=abcdef1234567890" not in out
+    assert "[REDACTED]" in out
+
+
+def test_api_key_field_redacted() -> None:
+    out = redact_string('config error: api_key: "sk_abcd1234567890ABCD" malformed')
+    assert "sk_abcd1234567890ABCD" not in out
+    assert "[REDACTED]" in out
+
+
+def test_bare_hex_not_redacted() -> None:
+    # Avoid false positives on commit SHAs — DESIGN.md notes this is
+    # intentional; bare-hex agent tokens rely on file permissions,
+    # not log redaction.
+    sha = "a1b2c3d4e5f60708090a0b0c0d0e0f1011121314"
+    text = f"commit {sha} merged"
+    assert sha in redact_string(text)
+
+
+# ---------------------------------------------------------------------------
+# Recursive value walk: token redaction must reach into nested structures.
+# ---------------------------------------------------------------------------
+
+
+def test_redact_value_dict_recursive() -> None:
+    event = {
+        "msg": "minted token",
+        "token": "ghs_AAAAAAAAAAAAAAAAAAAA",
+        "details": {"auth": "Bearer ghp_BBBBBBBBBBBBBBBBBBBB"},
+    }
+    out = _redact_value(event)
+    assert out["token"] == "gh*_[REDACTED]"
+    assert out["details"]["auth"] == "Bearer [REDACTED]"
+
+
+def test_redact_value_list_recursive() -> None:
+    event = {"tokens": ["ghs_AAAAAAAAAAAAAAAAAAAA", "ghs_BBBBBBBBBBBBBBBBBBBB"]}
+    out = _redact_value(event)
+    assert all(t == "gh*_[REDACTED]" for t in out["tokens"])
+
+
+def test_redact_value_tuple_preserves_type() -> None:
+    out = _redact_value(("ghp_AAAAAAAAAAAAAAAAAAAA", "plain"))
+    assert isinstance(out, tuple)
+    assert out[0] == "gh*_[REDACTED]"
+    assert out[1] == "plain"
+
+
+def test_redact_value_passes_non_strings() -> None:
+    event = {"count": 42, "ok": True, "missing": None, "ratio": 3.14}
+    assert _redact_value(event) == event
+
+
+def test_redact_value_handles_deeply_nested() -> None:
+    event = {"a": {"b": {"c": {"d": "ghs_AAAAAAAAAAAAAAAAAAAA"}}}}
+    out = _redact_value(event)
+    assert out["a"]["b"]["c"]["d"] == "gh*_[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# structlog processor integration: the on-wire JSON must be redacted.
+# ---------------------------------------------------------------------------
+
+
+def test_processor_returns_event_dict() -> None:
+    event = {"event": "minted", "token": "ghs_AAAAAAAAAAAAAAAAAAAA"}
+    out = redact_processor(None, "info", event)
+    assert out["token"] == "gh*_[REDACTED]"
+    assert out["event"] == "minted"
+
+
+def test_configure_logging_emits_redacted_json() -> None:
+    # Capture stderr-bound output by re-pointing structlog's WriteLogger
+    # at an in-memory buffer. configure_logging() defaults to sys.stderr,
+    # so we re-bind after configure().
+    buffer = io.StringIO()
+    configure_logging(level="debug")
+    structlog.configure(
+        processors=structlog.get_config()["processors"],
+        wrapper_class=structlog.get_config()["wrapper_class"],
+        logger_factory=structlog.WriteLoggerFactory(file=buffer),
+        cache_logger_on_first_use=False,
+    )
+    log = structlog.get_logger()
+    log.info("minted token", service="foxstoria", token="ghs_AAAAAAAAAAAAAAAAAAAA")
+
+    output = buffer.getvalue()
+    assert output, "expected at least one log line"
+    record = json.loads(output.strip().splitlines()[-1])
+    assert record["event"] == "minted token"
+    assert record["service"] == "foxstoria"
+    assert record["token"] == "gh*_[REDACTED]"
+    assert "ghs_AAAA" not in output
+
+
+def test_configure_logging_respects_level() -> None:
+    buffer = io.StringIO()
+    configure_logging(level="error")
+    structlog.configure(
+        processors=structlog.get_config()["processors"],
+        wrapper_class=structlog.get_config()["wrapper_class"],
+        logger_factory=structlog.WriteLoggerFactory(file=buffer),
+        cache_logger_on_first_use=False,
+    )
+    log = structlog.get_logger()
+    log.info("info-level should be filtered out")
+    log.error("error-level should appear")
+
+    output = buffer.getvalue()
+    assert "filtered out" not in output
+    assert "should appear" in output


### PR DESCRIPTION
## What

Wire the four-layer config loader, structured JSON logging with token-shape redaction, and the path-scoped CI workflow for `apiarist/`. Bundles Phase B (config + logging) and Phase B+ (CI workflow) per the apiarist DESIGN.md §14 phase plan.

## Why

Phase A (PR #478, merged at `49fe90c`) shipped tooling promises (ruff clean, mypy strict clean, pytest green) that no workflow was actually enforcing. Per @hivemoot-guard's PR #478 review, CI must land with or before the first phase that adds real subsystem code. Phase B is that phase, so B+ rides along — config, logging, and the CI that gates them all land together.

The four-layer config loader exists because apiarist runs in three contexts with different override needs: dev (CLI flags dominate), production-default (env vars set by systemd), and per-Hive customization (YAML file in `/etc/apiarist/`). Defaults in code keep the daemon runnable with zero config. See DESIGN.md §9.

Token-shape redaction in the logger is a DESIGN.md §10 mitigation for "tokens leaking into logs/journal." Every log event passes through a recursive-walk processor before JSON serialization; `ghs_*`, `gho_*`, `ghp_*`, `github_pat_*`, `hm_*`, `Bearer`, `sk-`, `sk-ant-`, and `token=` / `api_key:` patterns get redacted. Patterns aligned with the existing module at `agent/cli/hivemoot_agent/plugins_builtin/hivemoot/sanitize.py` (the authoritative reference for the secret shapes the hivemoot stack already cares about); apiarist-specific additions: `github_pat_*` and `hm_*`.

CI is path-scoped to `apiarist/**` plus the workflow file itself, so unrelated edits don't fire it. From this commit forward, `ruff check src tests`, `mypy src` (strict), and `pytest -v` are enforced on every PR touching apiarist.

## What it looks like

```
$ apiarist --help
usage: apiarist [-h] [--version] [--config PATH] [--socket-path SOCKET_PATH]
                [--socket-group SOCKET_GROUP] [--backend-url BACKEND_URL]
                [--log-level {debug,info,warning,error,critical}]

Host-side daemon for the Hivemoot fleet. Brokers GitHub installation tokens
for local agent containers; future phases add dynamic agent spawning. See
DESIGN.md for architecture.

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --config PATH         Path to apiarist.yaml (default:
                        /etc/apiarist/apiarist.yaml if it exists)
  --socket-path SOCKET_PATH
  --socket-group SOCKET_GROUP
  --backend-url BACKEND_URL
  --log-level {debug,info,warning,error,critical}
```

```
$ apiarist
{\"version\": \"0.1.0\", \"socket_path\": \"/run/apiarist.sock\", \"backend_url\": \"https://www.hivemoot.dev\", \"log_level\": \"info\", \"event\": \"apiarist starting\", \"level\": \"info\", \"timestamp\": \"2026-04-25T01:18:44.703045Z\"}
{\"next_phase\": \"D (UDS server)\", \"event\": \"apiarist scaffold; subsystems not yet wired (see DESIGN.md)\", \"level\": \"info\", \"timestamp\": \"2026-04-25T01:18:44.703261Z\"}
```

```
$ APIARIST_BACKEND_URL=https://env.example.com apiarist --log-level debug
{\"version\": \"0.1.0\", \"socket_path\": \"/run/apiarist.sock\", \"backend_url\": \"https://env.example.com\", \"log_level\": \"debug\", \"event\": \"apiarist starting\", ...}
```

(Token redaction in action — illustrative, not real output:)

```python
log.info(\"minted token\", token=\"ghs_AAAAAAAAAAAAAAAAAAAA\", auth=\"Bearer ghp_xxxxxxxxxxxxxxxxxxxx\")
# emits:
{\"event\": \"minted token\", \"token\": \"gh*_[REDACTED]\", \"auth\": \"Bearer [REDACTED]\", \"level\": \"info\", \"timestamp\": \"...\"}
```

## Notes

**What I'd like reviewers to focus on:**

1. **Token-shape pattern set** in `apiarist/src/apiarist/logging.py:32-69`. Aligned with `agent/cli/.../sanitize.py` for parity, plus two apiarist-specific additions. Push back if any pattern is too greedy (false-positive redaction of legit text) or any common shape is missing. The bare-hex non-redaction is a deliberate trade-off documented in `DESIGN.md` §10 — flag if you disagree.
2. **Config precedence semantics** — specifically the \"CLI None doesn't override\" rule (`apiarist/src/apiarist/config.py:73-75` + `tests/unit/test_config.py::test_cli_none_does_not_override`). This is the gotcha that breaks partial-flag overlays if missed.
3. **CI workflow security posture** (`.github/workflows/apiarist-ci.yml`). No `github.event.*` in any `run:` block; only checked-out source + matrix python version. Inline comment asks reviewers to flag any future change that introduces untrusted input.
4. **DESIGN.md §11 / §10 alignment.** The config field names (`token_cache_safety_margin_seconds`, `token_cache_max_seconds`, `socket_group`, etc.) match what DESIGN.md §9 specifies after the PR #478 refinements. Spot-check that nothing drifted.

**What is NOT in this PR:**

- The asyncio UDS server (Phase D).
- The httpx backend client (Phase C).
- The `mint_token` feature plugin (Phase E).
- The systemd service unit (Phase I) — included `socket_group` config field but the chown-and-self-check logic lands with the server.

**Verification done locally:**

- `pip install -e '.[dev]'` → installs structlog, pydantic, PyYAML, plus dev tools.
- `apiarist --version`, `--help`, no-args, with env+CLI overrides ✓ (output above).
- `pytest -v` → **45 passed in 0.08s** (3 carried from Phase A + 18 config + 24 logging).
- `ruff check src tests` → All checks passed.
- `mypy src` (strict) → Success: no issues found in 5 source files.
- The new CI workflow runs the same three commands automatically on this PR — green CI is the first end-to-end demonstration that B+ works as intended.

**No issue link** — same posture as PR #478. If reviewers' only blocker is the missing `Fixes #N`, please approve and squash-merge.