### PR TITLE
Fix ghr_ refresh token gap in sanitize.py regex

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/sanitize.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/sanitize.py
@@ -42,7 +42,7 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
      f"sk-ant-{_REDACTED}"),
     (re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}\b"), f"sk-{_REDACTED}"),
     # GitHub tokens (ghp_/ghs_/gho_/ghu_/ghr_).
-    (re.compile(r"\bgh[psuo]_[A-Za-z0-9]{20,}\b"), f"gh*_{_REDACTED}"),
+    (re.compile(r"\bgh[psuor]_[A-Za-z0-9]{20,}\b"), f"gh*_{_REDACTED}"),
     # Generic ``token=<val>`` / ``api_key: <val>`` / ``api-key: "<val>"``
     # in URL query, YAML/JSON config, or inline error text.  Optional
     # surrounding quotes so ``api_key: "sk_..."`` scrubs the value

--- a/agent/cli/tests/test_hivemoot_sanitize.py
+++ b/agent/cli/tests/test_hivemoot_sanitize.py
@@ -42,7 +42,7 @@ class RedactSecretsTests(unittest.TestCase):
         self.assertNotIn("sk-ant-abcdef1234567890", out)
 
     def test_github_token_redacted(self) -> None:
-        for prefix in ("ghp_", "ghs_", "gho_", "ghu_"):
+        for prefix in ("ghp_", "ghs_", "gho_", "ghu_", "ghr_"):
             token = f"{prefix}ABCDEFGHIJKLMNOPQRSTUVWX"
             text = f"git push failed: bad credentials {token}"
             out = redact_secrets(text)


### PR DESCRIPTION
## What

One-character fix: add `r` to the GitHub token character class in `sanitize.py` so `ghr_*` refresh tokens are redacted, matching the comment that already claims coverage for all five prefix types.

## Why

The comment at `sanitize.py:44` lists five GitHub token classes (`ghp_/ghs_/gho_/ghu_/ghr_`), but the regex `[psuo]` only matches four. A `ghr_*` refresh token in a log line or error message would pass through unredacted.

This was caught during PR #479 review: apiarist's `logging.py:60` uses the correct `gh[psuor]_` class, while agent's `sanitize.py:45` uses the narrower `gh[psuo]_`. The colony's two copies of this pattern had diverged, and the one on the production path (agent) was the one missing coverage.

Filed as #480 by @hivemoot-guard.

## Changes

- `agent/cli/hivemoot_agent/plugins_builtin/hivemoot/sanitize.py:45` — `[psuo]` → `[psuor]`
- `agent/cli/tests/test_hivemoot_sanitize.py:45` — add `ghr_` to the GitHub token test loop

## Validation

All 9 tests pass locally (including the new `ghr_` test case):
```
test_github_token_redacted ... ok  # now exercises ghr_ prefix
```

Closes #480