### PR TITLE
Add AGENTS.md and LICENSE to web/ and cli/

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -61,12 +61,20 @@ The CLI exposes these top-level commands:
 
 ## Authentication
 
-The CLI delegates to `gh` for GitHub API access. Authenticate via:
+The CLI calls `gh` for GitHub API access. Use one of these auth modes:
 
 ```bash
-export GITHUB_TOKEN="$(gh auth token)"
-# or pass --github-token to any command
+# Interactive use
+gh auth login
+gh auth status
+
+# CI / automated agents
+export GITHUB_TOKEN="ghp_yourPersonalAccessToken"
 ```
+
+Do not use `export GITHUB_TOKEN="$(gh auth token)"` as a setup step; it
+requires `gh` to already be authenticated and fails for token-only flows.
+You can also pass `--github-token` to any command.
 
 ## Security boundaries
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+Technical briefing for AI coding agents working in `cli/` inside `hivemoot/hivemoot`.
+
+## Project overview
+
+`@hivemoot-dev/cli` is the CLI tool for Hivemoot agents. It provides role instructions, repo work summaries, PR/issue workflow helpers, and notification management. Published on npm, built with TypeScript and Commander.js, and bundled with tsup.
+
+## Build and verify
+
+```bash
+npm install
+npm test
+npm run typecheck
+npm run build
+```
+
+Run all checks before opening or updating a PR.
+
+## Architecture entry points
+
+- `src/index.ts`: Commander program definition, all command registrations, global error handler.
+- `src/commands/`: Individual command implementations (`buzz.ts`, `roles.ts`, `role.ts`, `init.ts`, `watch.ts`, `ack.ts`, `pr-*.ts`, `issue-*.ts`, `notifications-pull.ts`).
+- `src/config/`: Config loading from `.github/hivemoot.yml` (`loader.ts`, `types.ts`).
+- `src/github/`: GitHub API client and per-command API helpers (`client.ts`, `fetch-notifications.ts`, `issues.ts`, `publish.ts`, etc.).
+- `src/output/`: Output formatting (terminal, JSON).
+- `src/summary/`: Repo work summary generation for `buzz`.
+- `src/watch/`: Long-running mention watch support.
+
+## Conventions
+
+- Keep TypeScript strict (`strict: true` in `tsconfig.json`).
+- ESM throughout (`"type": "module"` in `package.json`).
+- Use explicit `.js` import suffixes in TypeScript source files (NodeNext resolution).
+- Co-locate tests as `*.test.ts` next to implementation files.
+- Build with tsup (`tsup.config.ts`) — outputs to `dist/`.
+- CLI entry point: `./dist/index.js` (shebang handled by tsup).
+- Node.js `>=20` required.
+
+## Testing
+
+- Test framework: Vitest (config in `vitest.config.ts`).
+- Environment: Node.js.
+- Pattern: `src/**/*.test.ts`.
+- Coverage via v8 provider (configured in `vitest.config.ts`).
+- Run targeted tests with `npm test -- src/commands/buzz.test.ts`.
+
+## Commands
+
+The CLI exposes these top-level commands:
+
+- `hivemoot buzz` — role instructions + repo work summary
+- `hivemoot roles` — list available roles from team config
+- `hivemoot role <role>` — show one role definition
+- `hivemoot init` — print sample `.github/hivemoot.yml` template
+- `hivemoot watch` — long-running @mention watcher
+- `hivemoot ack <key>` — acknowledge a processed notification
+- `hivemoot issue snapshot|vote|post-comment` — issue workflow helpers
+- `hivemoot pr snapshot|preflight|post-review` — PR workflow helpers
+- `hivemoot notifications pull` — fetch unread notifications
+
+## Authentication
+
+The CLI delegates to `gh` for GitHub API access. Authenticate via:
+
+```bash
+export GITHUB_TOKEN="$(gh auth token)"
+# or pass --github-token to any command
+```
+
+## Security boundaries
+
+- Do not log or expose GitHub tokens in output.
+- `--dry-run` flags on mutation commands allow preflight without side effects.
+- JSON output mode (`--json`) is deterministic and schema-stable for automation.
+
+## Practical gotchas
+
+- Missing `.js` import suffixes can pass editing but fail at runtime under NodeNext ESM.
+- The `lint` script is `tsc --noEmit` — there is no separate ESLint config for this subproject.
+- `tsup` bundles everything into a single file; ensure all dependencies are listed in `package.json`.
+- The `watch` command uses polling (not webhooks) with a configurable interval.
+
+## Governance and PR conventions
+
+Follow the monorepo conventions in the root `AGENTS.md` and `CONTRIBUTING.md`:
+
+- Fork-first publishing.
+- PR descriptions follow `.github/PULL_REQUEST_TEMPLATE.md`.
+- Issue linking via `Fixes #N` / `Closes #N` / `Resolves #N`.
+- Only implement issues labeled `hivemoot:ready-to-implement`.

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -26,7 +26,7 @@ Run all checks before opening or updating a PR.
 - `src/app/api/byok/`: BYOK (Bring Your Own Key) management — config, rotate, revoke, re-encrypt, status.
 - `src/app/api/tasks/`: Task lifecycle — create, claim, execute, follow-up, retry, stream.
 - `src/app/api/agent-health/`: Agent health check ingestion.
-- `src/app/api/agent-token/`: Installation token brokering for agent containers.
+- `src/app/api/agent-tokens/`: Installation token brokering for agent containers.
 - `src/app/dashboard/`: Frontend dashboard pages (fleet, tasks, credentials).
 - `src/server/`: Server-side business logic (auth, BYOK crypto, Redis store, task store).
 - `src/lib/`: Shared client/server utilities (cookies).

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+Technical briefing for AI coding agents working in `web/` inside `hivemoot/hivemoot`.
+
+## Project overview
+
+Hivemoot Web is the frontend dashboard and API backend for hivemoot.dev. It's a Next.js 16 application (App Router) deploying to Vercel serverless functions, with an Upstash Redis backing store for sessions, BYOK key management, task state, and agent health reporting.
+
+## Build and verify
+
+```bash
+npm install
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Run all checks before opening or updating a PR.
+
+## Architecture entry points
+
+- `src/app/`: Next.js App Router pages and API routes.
+- `src/app/api/`: REST API route handlers (`route.ts` per endpoint).
+- `src/app/api/auth/github/`: GitHub App OAuth flow (start, callback, start-discover).
+- `src/app/api/byok/`: BYOK (Bring Your Own Key) management — config, rotate, revoke, re-encrypt, status.
+- `src/app/api/tasks/`: Task lifecycle — create, claim, execute, follow-up, retry, stream.
+- `src/app/api/agent-health/`: Agent health check ingestion.
+- `src/app/api/agent-token/`: Installation token brokering for agent containers.
+- `src/app/dashboard/`: Frontend dashboard pages (fleet, tasks, credentials).
+- `src/server/`: Server-side business logic (auth, BYOK crypto, Redis store, task store).
+- `src/lib/`: Shared client/server utilities (cookies).
+- `src/constants/`: Shared constants (BYOK error codes, cookie names).
+- `src/middleware.ts`: Next.js middleware (auth guards, session handling).
+
+## Conventions
+
+- Keep TypeScript strict (`strict: true` in `tsconfig.json`).
+- Use the `@/` path alias for imports from `src/`.
+- Co-locate tests as `*.test.ts` next to implementation files.
+- API routes use Next.js App Router conventions (`route.ts` exports named `GET`, `POST`, etc.).
+- ESLint uses `eslint-config-next` (core-web-vitals + typescript presets).
+- Tailwind CSS for styling (`tailwind.config.ts`).
+
+## Testing
+
+- Test framework: Vitest (config in `vitest.config.ts`).
+- Environment: Node.js (not jsdom).
+- Pattern: `src/**/*.test.{ts,tsx}`.
+- Run targeted tests with `npm test -- src/app/api/health/route.test.ts`.
+
+## API contracts
+
+- `AGENT_HEALTH_CONTRACT.md`: Agent health check API contract.
+- `BYOK_CONTRACT.md`: BYOK key management contract (encryption, rotation, limits).
+
+## Environment variables
+
+Required env vars are documented in `.env.example`. Key categories:
+
+- Redis: `HIVEMOOT_REDIS_REST_URL`, `HIVEMOOT_REDIS_REST_TOKEN`
+- GitHub App: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
+- BYOK: `BYOK_ACTIVE_KEY_VERSION`, `BYOK_MASTER_KEYS`
+- Site: `NEXT_PUBLIC_SITE_URL`
+
+## Deployment
+
+- Vercel serverless deployment (config in `vercel.json`).
+- `deploymentEnabled: false` — deploys are triggered explicitly, not on push.
+
+## Security boundaries
+
+- Do not leak internal errors, stack traces, or secrets in API responses.
+- BYOK keys are encrypted at rest with versioned master keys. Never log or expose key material.
+- Redis interactions must handle connection errors gracefully (see `redis.ts`).
+- GitHub OAuth secrets and App private key must stay in environment variables only.
+- API routes that require installation context must use `require-installation.ts`.
+
+## Practical gotchas
+
+- Missing `@/` alias imports will pass editing but fail at build time.
+- Vercel functions have execution-time limits based on deployment settings.
+- Redis errors in BYOK and task routes must be caught explicitly — they don't auto-propagate as HTTP errors.
+- The `BYOK_CONTRACT.md` defines a 4 KB payload limit for BYOK config and rotate endpoints.
+
+## Governance and PR conventions
+
+Follow the monorepo conventions in the root `AGENTS.md` and `CONTRIBUTING.md`:
+
+- Fork-first publishing.
+- PR descriptions follow `.github/PULL_REQUEST_TEMPLATE.md`.
+- Issue linking via `Fixes #N` / `Closes #N` / `Resolves #N`.
+- Only implement issues labeled `hivemoot:ready-to-implement`.

--- a/web/LICENSE
+++ b/web/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## What

Adds `AGENTS.md` and `LICENSE` to `web/` and `cli/`, bringing them to parity with `agent/`, `bot/`, and `apiarist/`.

## Why

Every subproject in the monorepo should have its own:
- **AGENTS.md** — agent onboarding context (build commands, architecture entry points, conventions, testing, security boundaries, gotchas). The reviewer fleet relies on these files for per-subproject context.
- **LICENSE** — Apache-2.0 matching the repo root. Subprojects can be consumed independently (e.g., `cli/` is published on npm), so each should carry its own license.

`web/` and `cli/` were the only subprojects missing both files.

## Scope

Four new files, no existing files changed:

| File | Description |
|------|-------------|
| `web/AGENTS.md` | Next.js App Router architecture, build/test commands, API route structure, BYOK/Redis security boundaries |
| `cli/AGENTS.md` | Commander.js CLI architecture, build/test commands, command reference, ESM conventions |
| `web/LICENSE` | Apache-2.0 (identical to root) |
| `cli/LICENSE` | Apache-2.0 (identical to root) |

## Verification

- LICENSE files verified identical to root via `diff`.
- AGENTS.md content cross-referenced with existing `package.json`, `tsconfig.json`, `vitest.config.ts`, and source structure for accuracy.


Closes #666
