### PR TITLE
docs(apiarist): update phase status after B/C merge

### DIFF
--- a/apiarist/AGENTS.md
+++ b/apiarist/AGENTS.md
@@ -50,8 +50,7 @@ ruff check src tests        # style + simplification rules
 mypy src                    # strict mode; configured in pyproject.toml
 ```
 
-All three checks must pass on every PR. CI integration (`.github/workflows/apiarist-ci.yml`)
-lands with **Phase B** per `DESIGN.md` §14 — until then, run them locally.
+All three checks must pass on every PR. CI is enforced on every push via `.github/workflows/apiarist-ci.yml` (landed in Phase B+).
 
 ## Layout & Conventions
 
@@ -136,7 +135,7 @@ A-O (in this directory) do not modify the runtime.
 
 V1 requires one new endpoint on hivemoot.dev:
 `POST /api/github/installation-tokens` (see `DESIGN.md` §11). The route
-ships in this PR (Phase C) as a 501 stub with real auth + body
+shipped in Phase C as a 501 stub with real auth + body
 validation, paired with the apiarist client. The actual GitHub App
 handoff (sign JWT with `.pem`, exchange at api.github.com, return
 `ghs_`) is a follow-up PR — Phase N (foxstoria pilot) is what

--- a/apiarist/README.md
+++ b/apiarist/README.md
@@ -1,6 +1,6 @@
 # apiarist
 
-> **Status:** Phase A — project skeleton only. The daemon does not yet
+> **Status:** Phases A–C landed (scaffold, config/logging/CI, backend client). The daemon does not yet
 > do anything useful. See [DESIGN.md](./DESIGN.md) for the full V1
 > architecture and phase plan.
 
@@ -31,9 +31,9 @@ See [DESIGN.md](./DESIGN.md) for:
 - §10 Security model (threats and mitigations)
 - §11 Backend dependencies (the new `/api/installation-token` endpoint)
 - §12 Integration with existing apiary (cross-repo touch points)
-- §14 Implementation phases (this skeleton is Phase A)
+- §14 Implementation phases (Phases A–C landed)
 
-## Try it (Phase A)
+## Try it
 
 ```bash
 # From the apiarist/ directory


### PR DESCRIPTION
## What changed

Four small doc fixes in `apiarist/` to bring AGENTS.md and README.md in sync with `main` after Phases B+ and C landed.

### `apiarist/README.md`
- Status line: "Phase A — project skeleton only" → "Phases A–C landed (scaffold, config/logging/CI, backend client)"
- Architecture §14 bullet: "this skeleton is Phase A" → "Phases A–C landed"
- Try it heading: dropped "(Phase A)" qualifier

### `apiarist/AGENTS.md`
- CI paragraph: "lands with Phase B — until then, run them locally" → "enforced on every push (landed in Phase B+)"
- Backend Dependency: "ships in this PR (Phase C)" → "shipped in Phase C" (merged, no longer a PR)

## Why

These files were written during Phase A and still said "Phase A only" / "CI not yet live" / "this PR". Phase B+ merged CI in #479, Phase C merged the backend client in #483. The docs should reflect current state so agents and contributors get accurate context.

Closes #507.

## Validation

Docs-only change, no code affected. Verified the diff renders correctly.