### PR TITLE
Refine apiarist DESIGN §12.3 client-integration to activity-gated FSM

### DIFF
--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -902,47 +902,81 @@ or privileged flag is needed.
 
 ### 12.3 Agent runtime change (monorepo, not apiary)
 
-An activity-gated FSM lives in a **shared module** at
-`agent/cli/hivemoot_agent/lib/github_auth_fsm.py`, instantiated as a
-process-singleton, **driven by both** `plugins_builtin/github/` and
-`plugins_builtin/hivemoot/` (and any future plugin that triggers
-GitHub-touching work).
+An activity-gated FSM lives **inside the hivemoot plugin** at
+`agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/`. Internal
+implementation detail of the hivemoot plugin; not imported by any
+other plugin.
 
-**Engine constraint that shapes this design**: daemon-mode
+**Why hivemoot owns it (not github plugin, not a shared module, not
+the engine):** apiarist-brokered token minting is a hivemoot-
+architecture-specific feature. The agent_token bearer credential,
+the per-installation policy on the backend, the UDS protocol to
+apiarist, the `AGENT_SERVICE` binding — none of these exist in a
+generic GitHub workflow. They're all hivemoot-architecture concepts.
+So the plugin that owns hivemoot-architecture concerns owns them.
+
+The github plugin remains a **tool provider** — it ships
+`gh`/`octokit`/git wrappers that read `GITHUB_TOKEN` from env.
+That contract doesn't change between the static-PAT path and the
+apiarist-minted path; only who populates the env changes. The
+github plugin doesn't import hivemoot, doesn't import apiarist,
+doesn't know auth exists. Putting hivemoot-specific behavior into
+a tool plugin would invert the dependency direction (hivemoot
+architecture forcing tool changes); keeping the boundary clean
+preserves the rule "tools depend on infrastructure, not the other
+way around."
+
+**V1 scope coverage:** the hivemoot plugin's lifecycle hooks fire
+for **fleet-member agents** (`hivemoot-builder`, `hivemoot-guard`,
+`hivemoot-queen`, `hivemoot-drone`, `hivemoot-forager`, etc. —
+anything triggered by hivemoot.tasks). That's the entire V1 target
+population for apiarist. Per-repo agents triggered by the github
+plugin's PR-watcher (e.g. `foxstoria-builder` watching one repo)
+**stay on the existing static-PAT path** in V1; their auth comes
+from `apiary.secrets.yaml.github_tokens.<agent>` populating
+`GITHUB_TOKEN` at deploy time, unchanged from today. Migrating
+per-repo agents to apiarist is deferred — V1 doesn't need it (the
+drone pilot is a fleet member), and when it does become a need,
+the right answer is either to unify trigger paths through
+hivemoot.tasks or to ship an engine-level AuthManager that doesn't
+depend on plugin ownership.
+
+**Hard precondition: repo must have the Hivemoot Bot GitHub App
+installed.** Apiarist mints **installation access tokens** (the
+`ghs_`-prefixed kind), which by definition only exist where the
+App is installed. A mint request for a repo without the bot
+installed returns `BACKEND_FORBIDDEN` from the daemon (mapped from
+the backend's HTTP 403 — "repo X not covered by the token's
+installation"). This fail-closes correctly: the job that triggered
+the mint sees the error, fails, and the agent runtime escalates
+per its retry policy. It does **not** silently fall back to any
+other credential path.
+
+Operationally this means **before flagging a repo for apiarist
+auth, the operator must verify the Hivemoot Bot is installed on
+it** (via the App admin UI at `https://github.com/apps/<bot>` →
+Configure → Repository access). Repos without the bot installed
+are not eligible for apiarist auth and must stay on the static-PAT
+path. The fleet-member targets for V1 (`hivemoot/hivemoot`,
+`hivemoot/colony`, `hivemoot/apiary`, etc.) all have the bot
+installed today — verified during the §13 shadow-deploy phase by
+hitting the apiarist socket from a fleet-member container against
+each repo and observing successful mints.
+
+**Engine constraint** (verified at
+`agent/cli/hivemoot_agent/engine.py:1208,1316`): daemon-mode
 `run_agent` fires lifecycle hooks only on the *triggering* plugin,
-not on every enabled plugin broadcast-style (verified at
-`agent/cli/hivemoot_agent/engine.py:1208` and `:1316`). Two distinct
-trigger sources need to drive the auth state:
+not on every enabled plugin broadcast-style. Hivemoot.tasks-
+triggered jobs fire **only** the hivemoot plugin's hooks, which is
+exactly what we want for fleet-member auth — the FSM lives where
+the hooks fire, with no broadcast and no cross-plugin wiring.
 
-1. **`plugins_builtin/github/`** triggers per-repo agents (e.g.
-   `foxstoria-builder` watching one repo for PR events) via its own
-   PR-watcher work. Its hooks fire for these jobs.
-2. **`plugins_builtin/hivemoot/`** (hivemoot.tasks) triggers
-   fleet-member agents (`hivemoot-builder`, `hivemoot-guard`,
-   `hivemoot-queen`, `hivemoot-drone` — the bulk of the apiarist
-   target population) via task-claim work. *Its* hooks fire for
-   these jobs, and the github plugin's hooks **do not** fire even
-   though the github plugin is enabled (it's a hard requirement of
-   `hivemoot.github_workflows`, validated at
-   `plugins_builtin/hivemoot/__init__.py:233-238`).
-
-Putting the FSM inside *either* plugin would only cover its own
-work source, breaking auth for the other. A shared-singleton FSM
-that both plugins import and drive via their respective hooks
-covers both trigger paths without needing engine-level broadcast.
-(Engine-level broadcast — moving the FSM into `engine.run_agent`
-itself, options 1 vs 2 in the PR #486 review — is cleaner
-architecturally but a much bigger change touching the engine for
-all plugins; deferred to a future engine refactor when more plugins
-need active/idle awareness.)
-
-States: ACTIVE (count of in-flight GitHub-touching work units ≥ 1)
-or IDLE (count = 0). The shared FSM keeps a reference counter that
-each driving plugin increments on its own work-start hook and
-decrements on its own work-end hook. Only the 0↔1 boundary
-triggers a state transition; intermediate counter movements (and
-all interleavings of github-plugin hooks with hivemoot-plugin
-hooks) are no-ops.
+States: ACTIVE (count of in-flight fleet-member jobs ≥ 1) or IDLE
+(count = 0). The hivemoot plugin's FSM keeps a reference counter
+incremented on the plugin's own `on_job_started` hook and
+decremented on its own `on_job_finished` hook. Only the 0↔1
+boundary triggers a state transition; intermediate counter
+movements are no-ops.
 
 - **IDLE → ACTIVE** (counter goes 0→1, first work unit started):
   mint `GITHUB_TOKEN`, set env, start a background refresh loop
@@ -999,20 +1033,21 @@ not always-on):**
   types can all overlap arbitrarily; the FSM only transitions when
   all of them have released the wake lock.
 
-**The shared FSM** (Phase L′, lives at
-`agent/cli/hivemoot_agent/lib/github_auth_fsm.py`):
+**The FSM** (Phase L′, lives at
+`agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/fsm.py`,
+internal to the hivemoot plugin):
 
 ```python
 # pseudocode — final implementation lands in Phase L′. This shape
-# satisfies the four invariants the prose claims:
+# satisfies five invariants the prose claims:
 #   I1. While ACTIVE, GITHUB_TOKEN is always populated by the time
-#       any work unit's start-hook returns.
+#       any job-start hook returns.
 #   I2. While IDLE, GITHUB_TOKEN is not in env and no refresh runs.
 #   I3. A failed wake-up leaves the counter at 0 so the next
-#       work-start retries cleanly (not stuck at count > 0 with no
+#       job-start retries cleanly (not stuck at count > 0 with no
 #       token).
 #   I4. A refresh-loop crash drives an idle transition + log so the
-#       next work-start re-mints from scratch.
+#       next job-start re-mints from scratch.
 #   I5. Every asyncio.create_task gets add_done_callback so unhandled
 #       exceptions surface instead of being silently swallowed.
 import asyncio
@@ -1022,26 +1057,26 @@ from datetime import UTC, datetime
 
 REFRESH_SAFETY_MARGIN_SECONDS = 300
 
-class GitHubAuthFSM:
-    """Activity-gated reference-counted FSM. Process singleton.
+class HivemootAgentAuthFSM:
+    """Activity-gated reference-counted FSM owned by the hivemoot plugin.
 
-    Driven by ANY plugin whose hooks correspond to GitHub-touching
-    work — currently github/ (per-repo) and hivemoot/ (fleet tasks).
-    Each driving plugin's on_job_started/on_job_finished translates
-    to fsm.on_work_start(plugin_name) / on_work_end(plugin_name).
-    The plugin name is opaque — the FSM only needs the start/end
-    pairing to maintain the counter.
+    Drives GITHUB_TOKEN env management around fleet-member jobs
+    (anything triggered by hivemoot.tasks). The hivemoot plugin
+    instantiates this once at startup and routes its own
+    on_job_started/on_job_finished into on_work_start/on_work_end.
+    Internal to the hivemoot plugin — not imported by github plugin
+    or any other plugin.
     """
 
     def __init__(self, apiarist_client, repo: str):
         self._apiarist = apiarist_client
         self._repo = repo
-        # Counter of GitHub-touching work units in flight, summed
-        # across ALL driving plugins. github/ contributes its own
-        # PR-watcher work, hivemoot/ contributes fleet tasks; both
-        # increments target the same counter. Multi-repo single-
-        # process agents are out of scope V1 (process-global env
-        # discussion above) — bound to a single repo at construction.
+        # Counter of in-flight fleet-member jobs. Only incremented
+        # by the hivemoot plugin's own lifecycle hooks (see wiring
+        # below); per-repo agents triggered by other plugins are on
+        # the static-PAT path in V1 and don't drive this FSM.
+        # Multi-repo single-process agents out of scope V1 — bound
+        # to a single repo at construction.
         self._active = 0
         self._refresh_task: asyncio.Task | None = None
         # Transition lock: serializes IDLE↔ACTIVE state changes so a
@@ -1135,43 +1170,44 @@ class GitHubAuthFSM:
             self._active = 0
 ```
 
-**Plugin drivers** (Phase L′) — each plugin hooks its own
-lifecycle events into the shared FSM:
-
-```python
-# In agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
-from hivemoot_agent.lib.github_auth_fsm import get_fsm
-
-class GithubPlugin:
-    async def on_job_started(self, job) -> None:
-        if _is_github_touching(job):
-            await get_fsm().on_work_start("github")
-
-    async def on_job_finished(self, job) -> None:
-        if _is_github_touching(job):
-            await get_fsm().on_work_end("github")
-```
+**Plugin wiring** (Phase L′) — only the hivemoot plugin touches
+the FSM. The github plugin remains completely unchanged.
 
 ```python
 # In agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
-from hivemoot_agent.lib.github_auth_fsm import get_fsm
+from .auth.fsm import HivemootAgentAuthFSM
+from .auth.apiarist_client import ApiaristClient
 
 class HivemootPlugin:
+    async def setup(self, ctx) -> None:
+        # Instantiated once per agent process at plugin setup.
+        # Bound to one repo via AGENT_SERVICE → repo lookup (apiary
+        # deploy populates this). The apiarist UDS path comes from
+        # the deploy-staged config (default /run/apiarist.sock
+        # inside the container, bind-mounted from the host).
+        self._auth = HivemootAgentAuthFSM(
+            apiarist_client=ApiaristClient(
+                socket_path=ctx.config.apiarist_socket_path,
+            ),
+            repo=ctx.config.agent_repo,
+        )
+
     async def on_job_started(self, job) -> None:
         # All hivemoot.tasks-triggered jobs are GitHub-touching by
         # nature (the agent will use gh/git for PR review, commit,
-        # etc.) — drive the FSM unconditionally for these jobs.
-        await get_fsm().on_work_start("hivemoot.tasks")
+        # etc.). Drive the FSM unconditionally — the FSM tolerates
+        # extra start/end pairs gracefully via the reference counter.
+        await self._auth.on_work_start("hivemoot.tasks")
 
     async def on_job_finished(self, job) -> None:
-        await get_fsm().on_work_end("hivemoot.tasks")
+        await self._auth.on_work_end("hivemoot.tasks")
 ```
 
-`get_fsm()` returns the process-singleton FSM instance, lazily
-initialized on first call from the active plugin's wiring (it
-needs the apiarist client and repo binding from `AGENT_SERVICE`).
-Both plugins import the same module, so both increments target the
-same counter; the FSM lock serializes interleavings between them.
+The github plugin (`plugins_builtin/github/`) is untouched —
+`gh`/`octokit`/git wrappers continue to read `GITHUB_TOKEN` from
+env. Whether the env value comes from a static PAT (deploy-staged,
+non-bot repos) or from the hivemoot plugin's FSM (apiarist-minted,
+bot-installed repos) is invisible to the github plugin.
 
 **Lifecycle (showing overlapping mixed work types):**
 
@@ -1221,6 +1257,14 @@ rotation, etc. would all benefit).
   stays at 0 (invariant I3). Agent runtime treats it as a transient
   failure and retries per its existing policy. The next work-start
   re-attempts the wake-up cleanly.
+- *Repo not covered by an installation* (`BACKEND_FORBIDDEN` from
+  the daemon, mapped from backend HTTP 403) → `_wake_up` raises
+  the same way as the unreachable case; the job fails, runtime
+  escalates. This is the operationally-most-likely failure mode
+  for a misconfigured repo (operator forgot to install the bot
+  before flagging the agent for `auth: github-app`). The error
+  message includes the repo name so the operator sees immediately
+  what to fix; no silent fallback to a stale token or static PAT.
 - *Refresh fails mid-active* → `_on_refresh_died` callback fires,
   logs the exception loudly, schedules `_reset_after_refresh_crash`
   which clears env + zeroes the counter. Any work units still
@@ -1290,6 +1334,19 @@ reach them.
 
 ## 13. Migration plan
 
+**Pre-flight (every phase, every repo):**
+
+Before flagging ANY repo for apiarist auth, **verify the Hivemoot
+Bot GitHub App is installed on it**. Apiarist mints installation
+access tokens; without an installation, the mint returns
+`BACKEND_FORBIDDEN` and the affected agent jobs fail immediately.
+Check via the App admin UI (`https://github.com/apps/<bot-name>`
+→ Configure → Repository access). For org-wide installs, "All
+repositories" covers everything; for per-repo installs, each repo
+needs to be added explicitly. Repos without the bot installed must
+remain on the static-PAT path. Skipping this check is the single
+most common failure mode for an apiarist rollout.
+
 **Phase 0 — Build and shadow** (week 1)
 
 - Implement V1 daemon (token brokering only).
@@ -1299,14 +1356,30 @@ reach them.
 - Verify backend `/api/github/installation-tokens` endpoint deployed to
   hivemoot.dev (separate but coordinated piece).
 
-**Phase 1 — Foxstoria first** (week 2)
+**Phase 1 — Drone pilot** (week 2)
 
-- Install Hivemoot Bot App on `dkjazz/the-storytimes-firebase`.
-- Verify a *separate* agent token is generated for that installation
-  (requires multi-installation apiary schema, §9 future bullet).
-- Flag `foxstoria` repo block with `auth: github-app`.
-- Deploy and observe one full review cycle. Audit logs show exactly one
-  token mint per agent run, ≤1h TTL, scoped to `dkjazz/the-storytimes-firebase`.
+Drone is the V1 pilot target (its existing PAT is already invalid
+as of 2026-04-25, so it's broken anyway and migration won't
+regress anything). Drone runs on `hivemoot/hivemoot`, which has
+the Hivemoot Bot installed already.
+
+- Confirm Hivemoot Bot is installed on `hivemoot/hivemoot` (should
+  be — check via App admin UI).
+- Wire the hivemoot plugin's auth FSM (Phase L′ — see §12.3).
+- Flag drone's repo block in `apiary.yaml` with `auth: github-app`.
+- Deploy and observe one full review cycle. Audit logs should show
+  exactly one token mint per ACTIVE period, ≤1h TTL, scoped to
+  `hivemoot/hivemoot`.
+
+**Phase 1.5 — Foxstoria** (week 2-3)
+
+Foxstoria is a per-repo agent (triggered by github plugin, not
+hivemoot.tasks), so under the V1 architecture it stays on the
+static-PAT path (see §12.3). Migrating per-repo agents to apiarist
+is deferred — see the V1.1 considerations note below. For now:
+keep foxstoria on static PAT in `apiary.secrets.yaml` until
+either (a) we ship the engine-level AuthManager option, or
+(b) per-repo agents are unified into hivemoot.tasks triggers.
 
 **Phase 2 — Validate, document, train** (week 3)
 
@@ -1346,7 +1419,7 @@ reach them.
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `auth: github-app`, skip static token, bind-mount `/run/apiarist.sock`, set `AGENT_SERVICE` + `AGENT_TOKEN_SLOT` env. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). | 0.5d | — (parallel) |
-| **L′.** Agent runtime — activity-gated GitHub auth | New shared FSM module at `agent/cli/hivemoot_agent/lib/github_auth_fsm.py` implementing the activity-gated state machine (§12.3) — reference-counted IDLE/ACTIVE state, mint+set `GITHUB_TOKEN` on 0→1 transition with proactive refresh loop, clear env on 1→0 transition. Wired into both `plugins_builtin/github/` (per-repo agents) and `plugins_builtin/hivemoot/` (fleet members) — both plugins drive the same singleton FSM via their respective `on_job_started`/`on_job_finished` hooks because the engine fires lifecycle hooks only on the triggering plugin (per `engine.py:1208,1316`), and these are the two trigger sources covering apiarist's full target population. Tiny apiarist Python client lib (~50 lines) lives alongside for the UDS round-trip. | 1.5d | D, E |
+| **L′.** Hivemoot plugin — activity-gated GitHub auth | New `agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/` submodule containing the FSM (`fsm.py`, the activity-gated state machine from §12.3) and the apiarist UDS client (`apiarist_client.py`, ~50 LOC). The hivemoot plugin instantiates one FSM at startup and routes its own `on_job_started`/`on_job_finished` hooks into the FSM. Apiarist auth is a hivemoot-architecture-specific feature (apiarist itself, agent_token bearers, per-installation policy), so it lives where hivemoot architecture lives. The github plugin is **not touched** — it remains a tool provider, reading `GITHUB_TOKEN` from env regardless of whether the value is a static PAT or apiarist-minted token. **Hard precondition: target repo must have the Hivemoot Bot GitHub App installed** — apiarist mints installation tokens, which only exist where the App is installed; non-installed repos stay on the static-PAT path forever (or until the operator installs the bot). | 1.5d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Foxstoria pilot | flag foxstoria's repo block with `auth: github-app` + `agent_token: foxstoria-builder`, deploy, observe one full agent run cycle. Verify ghs_ token reaches GitHub successfully and zero token files appear on disk. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -899,31 +899,183 @@ or privileged flag is needed.
 
 ### 12.3 Agent runtime change (monorepo, not apiary)
 
-In `agent/cli/hivemoot_agent/plugins_builtin/.../github` (Phase L′
-PR against `hivemoot/hivemoot`): wherever the agent currently reads
-`GH_TOKEN` from env or a file, branch on the presence of
-`AGENT_SERVICE` (set by apiary deploy when App auth is on). When
-present, replace the static token read with a UDS round-trip to
-`/run/apiarist.sock`:
+A small auth plugin in `agent/cli/hivemoot_agent/plugins_builtin/github_auth/`
+(Phase L′ PR against `hivemoot/hivemoot`) implementing a two-state
+machine driven by **whether the agent has any active work**.
+
+States: ACTIVE (count of in-flight work units ≥ 1) or IDLE (count = 0).
+The plugin keeps a generic reference counter that any work source in
+the runtime can increment — provider runs, task executions, scheduled
+jobs, future work types — they all contribute uniformly. Only the
+0↔1 boundary triggers a state transition; intermediate counter
+movements are no-ops.
+
+- **IDLE → ACTIVE** (counter goes 0→1, first work unit started):
+  mint `GITHUB_TOKEN`, start a background refresh loop that re-mints
+  at `expires_at - 5min`.
+- **ACTIVE → IDLE** (counter goes 1→0, **last** work unit ended —
+  i.e., all overlapping/chained work is fully drained): cancel the
+  refresh loop, clear `GITHUB_TOKEN` from env.
+
+The "fully idle" definition is critical: a single task ending is just
+a decrement (`count--`); the state only transitions to IDLE when
+**every** work source has released the wake lock. This matters for
+chained or overlapping work — task A ending while scheduled job B is
+still running does NOT trigger cleanup, because the agent is still
+busy from B's perspective.
+
+While ACTIVE, all the agent's existing tooling (`gh`, `git` via
+askpass, `octokit`, `PyGithub`) reads `GITHUB_TOKEN` from env and
+just works. While IDLE, no token is minted, no token sits in env,
+no refresh runs.
+
+**Why activity-gated refresh (not container-startup, not per-trigger,
+not always-on):**
+
+- *Container-startup mint is wrong*: a standing-agent container can
+  boot at 09:00 and sit idle until the first trigger arrives at
+  11:00 — the boot-minted token would have expired before any work
+  began.
+- *Always-on refresh is wasteful*: a periodic agent that runs once
+  a day would burn a refresh mint every ~55 min, 24 mints per
+  idle day, all unused.
+- *Per-trigger mint is needlessly chatty*: rapid-fire chained tasks
+  (one trigger spawns another) would each mint, even though they
+  could share the env value.
+- *Activity-gated FSM is the right shape*: token exists only while
+  work is happening. Cost (mint + env exposure) is exactly aligned
+  to actual work activity, not to wall-clock or trigger volume.
+- *Reference counting + "fully idle" definition handles overlapping
+  and chained work cleanly*: the counter abstracts away "what kind of
+  work is happening." Provider run + scheduled job + future work
+  types can all overlap arbitrarily; the FSM only transitions when
+  all of them have released the wake lock.
+
+**The whole plugin** (Phase L′):
 
 ```python
-# pseudocode — actual implementation lands in Phase L′
-def get_github_token(repo: str) -> str:
-    if os.environ.get("AGENT_SERVICE"):
-        return apiarist_client.mint_token(
-            service=os.environ["AGENT_SERVICE"],
-            repo=repo,
-        ).token
-    return os.environ["GH_TOKEN"]  # legacy PAT path
+# pseudocode — ~30 LOC final shape
+import asyncio
+import os
+from datetime import UTC, datetime
+
+REFRESH_SAFETY_MARGIN_SECONDS = 300
+
+class GitHubAuthPlugin:
+    def __init__(self, apiarist_client, repo: str):
+        self._apiarist = apiarist_client
+        self._repo = repo
+        # Generic active-work counter. Anything that represents
+        # in-flight work (provider runs, tasks, scheduled jobs,
+        # future work types) increments this. The plugin doesn't
+        # care WHAT kind of work; only whether the agent has
+        # anything active right now.
+        self._active = 0
+        self._refresh_task: asyncio.Task | None = None
+
+    async def on_work_start(self, _source) -> None:
+        self._active += 1
+        if self._active == 1:
+            await self._wake_up()  # IDLE → ACTIVE (first work in)
+
+    async def on_work_end(self, _source) -> None:
+        self._active -= 1
+        if self._active == 0:
+            await self._go_idle()  # ACTIVE → IDLE (fully drained)
+
+    async def _wake_up(self) -> None:
+        token = await self._apiarist.mint_token(repo=self._repo)
+        os.environ["GITHUB_TOKEN"] = token.value
+        self._refresh_task = asyncio.create_task(
+            self._refresh_loop(token.expires_at)
+        )
+
+    async def _go_idle(self) -> None:
+        if self._refresh_task:
+            self._refresh_task.cancel()
+            self._refresh_task = None
+        os.environ.pop("GITHUB_TOKEN", None)
+
+    async def _refresh_loop(self, expires_at: datetime) -> None:
+        while True:
+            sleep_s = (
+                expires_at - datetime.now(UTC)
+            ).total_seconds() - REFRESH_SAFETY_MARGIN_SECONDS
+            if sleep_s > 0:
+                await asyncio.sleep(sleep_s)
+            new = await self._apiarist.mint_token(repo=self._repo)
+            os.environ["GITHUB_TOKEN"] = new.value
+            expires_at = new.expires_at
 ```
 
-The token returned is held in agent process memory only for the
-duration of the immediate API call(s); no caching at the agent
-layer (apiarist's cache is the right place for that).
+**Lifecycle (showing overlapping mixed work types):**
 
-Failure modes (apiarist unreachable, mint rejected, token expired
-mid-job): fail-closed — surface the error to the trigger and
-abort the job rather than fall back to a stale or wrong-scope token.
+| Event | Count | State | Action |
+|---|---|---|---|
+| Container boot | 0 | IDLE | nothing |
+| Task A starts | 0→1 | IDLE→ACTIVE | mint, set env, start refresh loop |
+| Task B starts (overlapping, different work source) | 1→2 | ACTIVE | no-op (loop already running) |
+| Task A ends | 2→1 | ACTIVE | no-op (B still running, agent not idle) |
+| Scheduled job C starts (chained from B) | 1→2 | ACTIVE | no-op |
+| Refresh loop fires (~55 min in) | 2 | ACTIVE | re-mint, update env |
+| Task B ends | 2→1 | ACTIVE | no-op (C still running) |
+| Job C ends (last work unit) | 1→0 | ACTIVE→**IDLE** | cancel refresh, clear env |
+| Long idle (e.g. 5h) | 0 | IDLE | zero mints, zero env |
+| New task arrives | 0→1 | IDLE→ACTIVE | mint fresh, set env, start refresh |
+| Container exits (eventually) | — | — | process dies, env evaporates |
+
+The "Task A ends" and "Task B ends" rows in the middle are critical:
+neither triggers a state change because the counter is still ≥ 1.
+Only the **last** ending — Job C, where count finally reaches 0 —
+triggers the IDLE transition. This is the "fully idle" definition.
+
+**What the agent runtime needs to expose:**
+
+Generic hooks: `on_work_start(source)` and `on_work_end(source)`,
+fired around every work unit (provider run, scheduled task, future
+work types). The plugin doesn't introspect `source` — it just
+maintains the counter. If the runtime already exposes per-task or
+per-provider lifecycle events (most plugin systems do), this is a
+thin adapter; if not, adding generic work-lifecycle hooks is a
+one-time investment that pays off across all plugins that need
+active/idle tracking (metrics, logging, secret rotation, etc.).
+
+**Failure modes:**
+
+- *Apiarist unreachable when waking up* → `_wake_up` raises,
+  the work unit that triggered the 0→1 transition fails to start.
+  Agent runtime treats it as a transient failure and retries per
+  its existing policy. The next work-start re-attempts the wake-up.
+  Counter stays at 0 since the failed start never incremented it.
+- *Refresh fails mid-active* → exception in the background task;
+  agent runtime should treat unhandled task exceptions as fatal to
+  the active period (trigger an idle transition + restart). The
+  next work-start mints fresh.
+- *401 mid-work* (clock skew, manual revocation via App admin UI)
+  → agent's current GitHub call fails with normal HTTP error,
+  surfaces as a work-unit failure. Agent runtime retries; the retry
+  hits the still-active state, re-uses the env value (or the refresh
+  loop has already updated it, depending on timing).
+
+**Escape hatch for tasks that genuinely span >1h with no provider
+boundaries:** the task can call `apiarist_client.mint_token(repo)`
+inline at the point it knows the env token may have aged out.
+Opt-in, no plugin change required. Rare in practice — the refresh
+loop covers steady-state ACTIVE periods regardless of duration.
+
+**What this design does NOT do** (intentionally):
+
+- Mint at container startup. Wrong moment — work hasn't arrived.
+- Run a perpetual background refresh loop. The loop only runs
+  during ACTIVE periods; idle = zero burn.
+- Reactively re-mint on 401. The refresh loop covers steady-state
+  expiry; if a 401 still slips through (clock skew, revocation),
+  the task fails loud and the runtime retry path kicks in.
+- Restrict in-process token lifetime during ACTIVE. Once
+  `GITHUB_TOKEN` is in env, agent code and subprocesses can read
+  it. Strong enforcement of "no token in agent memory" would
+  require the V3+ HTTPS proxy model (§11 future hardening). V1
+  enforcement is `(time + scope + audit)` per §10.
 
 ## 13. Migration plan
 

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -967,9 +967,13 @@ knows exactly what it should know and nothing more.
 
 The github plugin (`plugins_builtin/github/`) remains a **tool
 provider** — it ships `gh`/`octokit`/git wrappers that read
-`GITHUB_TOKEN` from env. That contract doesn't change between the
-static-PAT path and the apiarist-refresh path; only who populates
-the env changes. The github plugin is **not modified** by Phase L′.
+`GITHUB_TOKEN` from env. That env-var contract doesn't change between
+the static-PAT path and the apiarist-refresh path; only who
+populates the env changes. The github plugin's runtime tooling is
+**unchanged**. Phase L′ DOES include a small *plugin-setup* refactor
+in the github plugin to handle the setup-time clone work that
+currently requires a token at plugin-load time — see §12.3.5a for
+the contract change.
 
 #### 12.3.1 Per-repo opt-in config
 
@@ -1095,8 +1099,28 @@ class ContainerLifecycle:
     def subscribe(self, sub: "LifecycleSubscriber") -> None:
         """Register a subscriber.
 
-        CONTRACT: called once per subscriber during plugin setup, before
-        the engine starts dispatching jobs. NOT thread/async-safe — V1
+        CONTRACT — registration order is load-bearing:
+        - on_active fires subscribers in REGISTRATION order (so a
+          subscriber that depends on a prior subscriber's setup —
+          e.g., github clone needs hivemoot auth's env var — must
+          register AFTER its dependency).
+        - Rollback on partial-success failure runs subscribers in
+          REVERSE registration order (so a later subscriber's
+          cleanup runs before an earlier subscriber's cleanup,
+          mirroring teardown of dependencies).
+        - on_idle (full drain) runs in PARALLEL via gather() — see
+          on_job_finished for the rationale.
+
+        Plugins control registration order by registering during
+        their setup() call. Plugins are loaded in YAML insertion
+        order under ADR-003, so the operator-visible plugin order in
+        hivemoot.yaml is the subscriber order. deploy-apiary.sh's
+        write_standing_hivemoot_yaml emits hivemoot before github
+        for exactly this reason — auth subscriber must populate env
+        before github subscriber's clone work runs.
+
+        CALLED ONCE per subscriber during plugin setup, before the
+        engine starts dispatching jobs. NOT thread/async-safe — V1
         relies on plugin setup being single-threaded and pre-dispatch.
         Future hot-reload of subscribers would require switching to
         a copy-on-write subscribers list or wrapping append in the
@@ -1106,12 +1130,22 @@ class ContainerLifecycle:
 
     async def on_job_starting(self, job) -> None:
         """Engine calls before dispatching the job. On the 0→1
-        transition, runs all subscribers' on_active sequentially.
+        transition, runs all subscribers' on_active.
+
+        Asymmetric ordering vs on_idle:
+        - on_active is SEQUENTIAL (registration order) because
+          subscribers may have setup-time dependencies (one
+          subscriber's effects must be visible to the next). E.g.,
+          hivemoot auth subscriber writes env → github subscriber's
+          clone reads it.
+        - on_idle is PARALLEL (gather, see on_job_finished) because
+          cleanup is best-effort and order-independent — env clears,
+          file handles close, etc., don't depend on each other.
 
         Subscriber failure semantics (invariant I3 + atomicity):
         if any subscriber raises in on_active, every PRIOR successful
-        subscriber's on_idle is awaited (best-effort cleanup) so the
-        engine doesn't leave half-set-up state behind, then the
+        subscriber's on_idle is awaited in REVERSE registration order
+        (best-effort cleanup mirroring dependency teardown), then the
         counter is rolled back and the original exception bubbles to
         the engine's job-dispatch loop which fails the triggering
         job. The runtime's normal retry path then re-attempts the
@@ -1191,12 +1225,16 @@ class LifecycleSubscriber:
     ContainerLifecycle.subscribe() at plugin setup.
 
     Implementers should:
-    - Be idempotent (subscribe might be called multiple times in
-      future plugin reconfig scenarios, though not in V1).
-    - Raise on critical setup failure in on_active — the engine
-      cancels other subscribers in the same gather and fails the
-      lifecycle transition (the triggering job fails to start, the
-      runtime retries, the next attempt re-runs setup cleanly).
+    - Be idempotent (on_active may run multiple times across the
+      process lifetime — once per IDLE→ACTIVE transition).
+    - Raise on critical setup failure in on_active. The engine runs
+      subscribers SEQUENTIALLY in registration order; a raise stops
+      the chain, awaits on_idle on every prior successful subscriber
+      in REVERSE registration order (best-effort cleanup, each
+      wrapped so one bad cleanup doesn't mask the original error),
+      rolls the active-job counter back, and re-raises. The
+      triggering job fails to start; the runtime's normal retry
+      path re-attempts the full chain cleanly.
     - Tolerate own-errors in on_idle — best-effort cleanup; engine
       logs but doesn't propagate.
     """
@@ -1354,40 +1392,97 @@ class HivemootPlugin:
         ctx.engine.lifecycle.subscribe(subscriber)
 ```
 
-#### 12.3.5a Required github plugin change for `refresh_token: true` repos
+#### 12.3.5a Required github plugin refactor for `refresh_token: true` repos
 
-The github plugin's current `validate()`
-(`agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py:131-145`)
-requires a non-empty `plugins.github.token_file`, and `setup()`
-(`:177-196`) reads that file and writes `GH_TOKEN`/`GITHUB_TOKEN` at
-plugin-setup time. Under the static-PAT path that's exactly what we
-want. Under `refresh_token: true` it's a problem: deploy-apiary.sh
-omits the `token_file:` line (no static file exists), `validate()`
-fails, and the agent never reaches the lifecycle subscriber that
-would have populated the env.
+The github plugin's current `setup()` does materially more than env
+population. Verified at `agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py`:
 
-Phase L′ MUST include a small github-plugin change to short-circuit
-both `validate()` and `setup()` when the hivemoot plugin's apiarist
-subsystem is enabled. Two options, in order of preference:
+- `:131-145` `validate()` — requires non-empty `plugins.github.token_file`
+- `:177` reads the token from that file
+- `:196` writes `GH_TOKEN` / `GITHUB_TOKEN` to env (the part the
+  subscriber would also do)
+- `:205-206` `_validate_repo_access(repo, token)` — fails closed if
+  the token doesn't grant repo access (needs token at setup time)
+- `:211-214` `clone_or_sync(repo, workspace, token, ...)` — clones
+  or fetches the repo into the workspace (needs token at setup time)
 
-1. **(preferred)** github plugin's `validate()` accepts an absent
-   `token_file:` if a sibling `hivemoot.apiarist.enabled: true` is
-   present in the same `hivemoot.yaml`. `setup()` then becomes a
-   no-op for token population (the subscriber handles env at
-   on_active time). This is a one-function change.
-2. **(fallback)** github plugin gets a new `token_source: subscriber`
-   typed config option that explicitly opts out of the file-based
-   read. deploy-apiary.sh emits this when refresh_token: true.
+Plugin `setup()` runs once at engine boot, **before any job is
+dispatched**. The lifecycle subscriber's `on_active` hook fires only
+when the engine starts dispatching the first job. So the naive
+short-circuit ("setup() becomes a no-op") leaves `_validate_repo_access`
+and `clone_or_sync` un-run, and the workspace isn't ready when the
+first job actually starts.
 
-Phase L′'s scope therefore includes: engine `ContainerLifecycle`
-+ `LifecycleSubscriber`; new hivemoot plugin `auth/` submodule with
-the subscriber + apiarist client; **a small github plugin change
-per the above**. The "github plugin is not modified" framing from
-earlier rounds was wrong — there's a small but necessary tweak.
-The framing's intent — that the github plugin's tooling-provider
-role is unchanged, and the env-var contract `gh`/`git` etc. read
-from doesn't change — still holds. Only the validate+setup
-short-circuit is added.
+Phase L′ therefore includes a real refactor of github plugin's
+`setup()` (not just an env-population short-circuit). Two pieces:
+
+**1. Split `setup()` into auth-free + auth-required halves.**
+
+- *auth-free* (always runs at engine boot): typed-config validation,
+  workspace-directory bootstrap, `gh` CLI binary discovery, etc.
+  Anything that doesn't need a token to complete.
+- *auth-required* (deferred to first ACTIVE): `_validate_repo_access`,
+  `clone_or_sync`. These move into a NEW github plugin lifecycle
+  subscriber (the github plugin becomes its OWN `LifecycleSubscriber`
+  in addition to a tool provider) whose `on_active` runs them
+  exactly once per ACTIVE period — guarded by an idempotency check
+  so subsequent on_active calls (from later ACTIVE periods) re-sync
+  if the workspace exists, or full-clone if not.
+
+**2. Subscriber registration order matters.**
+
+The hivemoot auth subscriber must run BEFORE the github subscriber
+in `on_active` so `GITHUB_TOKEN` is in env when github's clone work
+fires. Subscribers run in **registration order** (see
+`ContainerLifecycle.subscribe()` contract below), and plugin setup
+runs in YAML insertion order under ADR-003. So the hivemoot plugin
+(which registers the auth subscriber) must be loaded before the
+github plugin (which registers the clone subscriber). The existing
+deploy-apiary.sh emits hivemoot first then github in the
+hivemoot.yaml plugins block — this ordering is now a load-bearing
+contract, not just stylistic. Document with a comment in
+`write_standing_hivemoot_yaml`.
+
+**3. `validate()` change.**
+
+When `refresh_token: true` is in the deploy contract,
+deploy-apiary.sh omits the `token_file:` line in the github plugin's
+config (already implemented in Phase K). github plugin's `validate()`
+needs to permit absent `token_file:` if either:
+
+- The plugin's own typed config has `token_source: subscriber`
+  (preferred — explicit, plugin-local, no cross-plugin config peek
+  needed) — deploy-apiary.sh emits this flag for `refresh_token: true`
+  repos
+- *or* the plugin can auto-detect by inspecting whether any
+  registered subscriber owns the env-var the plugin would populate
+
+Option 1 (`token_source: subscriber`) is preferred because it's a
+one-function change in the github plugin's typed config schema and
+doesn't require cross-plugin awareness. (Earlier rounds suggested
+peeking at sibling `hivemoot.apiarist.enabled` config — guard's R6
+review correctly noted that's harder to implement than option 1
+because the current Plugin protocol's `validate()` only sees its
+own typed config; cross-plugin peek would need a registry helper or
+a file-level YAML re-read.)
+
+**Phase L′ scope therefore includes:**
+
+- engine `ContainerLifecycle` + `LifecycleSubscriber` (new)
+- hivemoot plugin's `auth/` submodule (new): subscriber + apiarist client
+- github plugin: split `setup()` into auth-free + auth-required;
+  the auth-required half moves to a github-plugin-owned lifecycle
+  subscriber; `validate()` grows the `token_source: subscriber` opt
+- deploy-apiary.sh emits `token_source: subscriber` in the github
+  plugin's typed config when `refresh_token: true` (small Phase K
+  follow-up — could ship as part of L′ or as a separate hivemoot/apiary PR)
+
+This is bigger than "small github tweak" wording from earlier
+rounds. Honest scope: the github plugin's startup model changes
+shape (split into two halves with different timing) — the tooling-
+provider runtime contract is unchanged, but the plugin-load contract
+is meaningfully different. Phase L′'s effort estimate (§14) bumps
+from 2d to 2.5d to reflect the additional refactor.
 
 #### 12.3.6 Lifecycle (showing overlapping work)
 
@@ -1412,13 +1507,16 @@ etc.) don't trigger subscriber events.
 
 - *Apiarist unreachable when waking up* (or *repo not covered by an
   installation* — `BACKEND_FORBIDDEN`) → auth subscriber's
-  `on_active` raises. ContainerLifecycle's gather propagates;
-  `on_job_starting` rolls the counter back to 0; the triggering job
-  fails to start. Runtime treats as transient and retries; next job
-  triggers a fresh `on_job_starting` and re-runs the whole
-  subscriber-setup phase cleanly. The most-common operational
-  failure here is a misconfigured repo (operator set
-  `refresh_token: true` without installing the bot); the daemon's
+  `on_active` raises. `on_job_starting` halts the sequential
+  subscriber chain at this point, awaits `on_idle` on every prior
+  successful subscriber in reverse registration order (best-effort
+  cleanup), rolls the counter back to 0, and re-raises. The
+  triggering job fails to start. Runtime treats it as transient
+  and retries; the next job triggers a fresh `on_job_starting`
+  and re-runs the whole subscriber-setup phase cleanly. The
+  most-common operational failure here is a misconfigured repo
+  (operator set `refresh_token: true` without installing the bot);
+  the daemon's
   error message includes the repo name so the cause is visible
   immediately.
 - *Refresh fails mid-active* → auth subscriber's `_on_refresh_died`
@@ -1577,7 +1675,7 @@ in `apiary.secrets.yaml`.
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `refresh_token: true`, skip static token staging, bind-mount `/run/apiarist/apiarist.sock` (host) → `/run/apiarist.sock` (container), emit `APIARIST_TOKEN_ENV=<env_var>`, omit github plugin's `token_file:` line, emit a new `hivemoot.apiarist:` block (enabled, socket_path, repo, env_var) for Phase L′ to consume. Two new validating helpers (`get_repo_refresh_token`, `get_repo_token_env`) reject malformed inputs at parse time. Fail-fast deploy if the host apiarist socket isn't present. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). **Shipped** in `hivemoot/apiary` PR #67. | 0.5d | — (parallel) |
-| **L′.** Engine lifecycle FSM + hivemoot auth subscriber | Three layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber. Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. github plugin is **not touched**. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2d | D, E |
+| **L′.** Engine lifecycle FSM + hivemoot auth subscriber + github plugin refactor | Four layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber; (d) **github plugin refactor**: split `setup()` into auth-free (workspace bootstrap, `gh` CLI discovery) + auth-required (`_validate_repo_access`, `clone_or_sync`); the auth-required half moves to a github-plugin-owned `LifecycleSubscriber` whose `on_active` runs after the hivemoot auth subscriber has populated env. `validate()` grows a `token_source: subscriber` opt that permits absent `token_file:` (deploy-apiary.sh emits this for `refresh_token: true`). Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. Github plugin's tooling-provider runtime contract is unchanged; only its plugin-load model splits. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2.5d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Drone pilot | The V1 pilot is **drone**, not foxstoria — drone is a fleet member on `hivemoot/hivemoot` (which already has the bot installed) AND its existing PAT is invalid as of 2026-04-25 so migrating it can't regress anything. Flag drone's repo block (`hivemoot:` in `apiary.yaml`) with `refresh_token: true`, deploy, observe one full review cycle. Verify a `ghs_` token reaches GitHub successfully and zero token files appear on disk. Foxstoria opt-in is deferred to Phase 1.5 (see §13) — it works under the engine-lifecycle architecture but is shipped after the drone pilot validates the path. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -100,7 +100,7 @@ all of the above without restructuring.**
   `/run/apiarist.sock` into agent containers and sets `AGENT_SERVICE` in
   their env. Container runtime change (Phase L′) replaces static GH_TOKEN
   reads with mint-via-UDS calls. Containers using the existing PAT path
-  (no `auth: github-app` flag in their repo block) are unaffected.
+  (no `refresh_token: true` flag in their repo block) are unaffected.
 - Structured JSON logging to stderr (captured by journald), with token-
   shape redaction per §10.
 - Health check operation (`health` op over the socket) returning daemon
@@ -184,14 +184,23 @@ all of the above without restructuring.**
   that the host cannot observe. There is no controller pre-spawn hook
   to mediate token requests. The agent is the trigger source, so the
   agent makes the request.
-- **Tokens NEVER touch disk.** Apiarist holds them in process memory
-  for a short cache window (default 5 min); the agent receives them
-  over the socket and exposes them to its tooling via the
-  `GITHUB_TOKEN` env var for the duration of the agent's ACTIVE
-  period (any GitHub-touching work in flight). When the agent
-  becomes fully idle, the env var is cleared. See §12.3 for the
-  activity-gated FSM and what "ACTIVE period" means in practice.
-  No on-disk file at any layer.
+- **Tokens NEVER touch disk** (for repos that have opted in to
+  apiarist auth via `refresh_token: true` in `apiary.yaml`). Apiarist
+  holds them in process memory for a short cache window (default
+  5 min); the agent receives them over the socket and exposes them
+  to its tooling via the `GITHUB_TOKEN` env var for the duration of
+  the agent's ACTIVE period (any GitHub-touching work in flight).
+  When the agent becomes fully idle, the env var is cleared. See
+  §12.3 for the activity-gated FSM and what "ACTIVE period" means
+  in practice.
+
+  Repos that have NOT opted in (the default `refresh_token: false`)
+  retain today's static-PAT model: the token comes from
+  `apiary.secrets.yaml`, is staged on disk at deploy time inside the
+  per-service secrets dir, and stays in env from container boot
+  until container exit. The "no disk + ACTIVE-period env" property
+  is the V1 apiarist contract for opt-in repos, not a global
+  fleet-wide guarantee until every repo is migrated.
 - Filesystem permissions on `/run/apiarist.sock` (chmod 660, group
   `agent`) gate which processes can request mints. Apiary deploy adds
   the agent container's user to the `agent` group.
@@ -460,7 +469,8 @@ agent_tokens:
 repos:
   foxstoria:
     repo: dkjazz/the-storytimes-firebase
-    auth: github-app
+    refresh_token: true     # opt in to apiarist-managed token refresh
+    token_env: GITHUB_TOKEN  # env var the auth subscriber populates
     agents:
       - foxstoria-dev
     overrides:
@@ -468,12 +478,18 @@ repos:
         agent_token: foxstoria-builder   # which slot from secrets
 ```
 
-`apiary/deploy-apiary.sh` resolves `service → token_slot` at deploy
-time and stages the mapping in the per-service env so apiarist can
-look it up by `AGENT_SERVICE` on each mint request. Phase A-B's
-single-token assumption stays compatible: if an `agent_token`
-selector is absent, apiarist falls through to the `default` slot
-(which the existing `health_token` value can populate).
+The `refresh_token` flag is the single opt-in switch (Phase K — see
+`hivemoot/apiary` PR #67 for the deploy-side schema and §12.3 for the
+agent-side subscriber that consumes it). When true, the deploy script
+stages no static token, mounts the apiarist socket, and the agent's
+auth subscriber populates `${token_env}` from apiarist on each ACTIVE
+period. When absent or false, the existing static-PAT path runs
+unchanged. `apiary/deploy-apiary.sh` resolves `service → token_slot`
+at deploy time and stages the mapping in the per-service env so
+apiarist can look it up by `AGENT_SERVICE` on each mint request.
+Phase A-B's single-token assumption stays compatible: if an
+`agent_token` selector is absent, apiarist falls through to the
+`default` slot (which the existing `health_token` value can populate).
 
 ## 10. Security model
 
@@ -492,7 +508,10 @@ selector is absent, apiarist falls through to the `default` slot
 
 | Threat | Defense |
 |---|---|
-| Container compromise | Token in container is short-lived (1h max from GitHub) and resident in `os.environ["GITHUB_TOKEN"]` only during the agent's ACTIVE period (any GitHub-touching work in flight; see §12.3). When the agent goes IDLE, the env var is cleared. Realistic ACTIVE periods are minutes to a few hours; never the container's full uptime. GitHub-side narrowing via `repository_ids` + `permissions` means even a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into all containers using App auth) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. **Subprocess caveat:** subprocesses spawned during ACTIVE inherit the env at fork time and retain `GITHUB_TOKEN` until they exit; the parent's IDLE-time cleanup doesn't reach them. Short-lived `gh`/`git` invocations (the common case) are fine. Long-running spawned processes inheriting the env need to be explicitly bounded by the caller. |
+| Container compromise (`refresh_token: true` repos) | Token in container is short-lived (1h max from GitHub) and resident in `os.environ["GITHUB_TOKEN"]` only during the agent's ACTIVE period (any GitHub-touching work in flight; see §12.3). When the agent goes IDLE, the env var is cleared. Realistic ACTIVE periods are minutes to a few hours; never the container's full uptime. GitHub-side narrowing via `permissions` (and, in V1.5+, `repository_ids` — see V1 caveat row below) means a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into refresh_token containers) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. **Subprocess caveat:** subprocesses spawned during ACTIVE inherit the env at fork time and retain `GITHUB_TOKEN` until they exit; the parent's IDLE-time cleanup doesn't reach them. Short-lived `gh`/`git` invocations (the common case) are fine. Long-running spawned processes inheriting the env need to be explicitly bounded by the caller. |
+| Container compromise (static-PAT repos, default until migration) | Token comes from `apiary.secrets.yaml`, is staged on disk at deploy time, and is resident in env from container boot until container exit. A compromised container leaks the static PAT in full; the only TTL bound is when the operator manually rotates the PAT (months in practice). This is today's posture for every repo without `refresh_token: true`. The apiarist migration shrinks this exposure to the ACTIVE-period model row above; until a repo is flagged, that row's defenses don't apply. |
+| V1 token-policy gap (both paths, until V1.5) | The agent_token envelope in V1 doesn't carry an `allowed_repos` / `allowed_permissions` policy — `resolveTokenToInstallation` returns the installation_id only. So a leaked or cross-service agent token can mint for any repo covered by that App installation (within the V1 hard-coded permission set in `web/src/server/github-installation-token.ts`). The DESIGN.md §11 token-policy scoping model (`(request) ⊆ (token policy) ⊆ (installation grant)`) is the V1.5 target; until then the second containment ⊆ collapses to `(request) ⊆ (installation grant)`. Mitigation in V1: keep agent tokens tightly scoped to one service, audit-log every mint via the backend's `[installation-tokens] minted` log line, alert on anomalous patterns. |
+| V1 short-name narrowing gap (until V1.5) | The mint endpoint passes `repositories: [<short-name>]` to GitHub rather than `repository_ids: [<numeric-id>]`. Short names are mutable (rename / transfer); a stale `apiary.yaml` requesting an old name could mint for a new repo at the same short-name slot if the installation covers all repos. V1.5 target: stand up a Redis-backed `installation:<id>:repos` cache populated by the bot's `installation.repositories.added/removed` webhooks, resolve `owner/name` → numeric `id` before the GitHub call, and fail-closed on rename (the old ID either still resolves to the renamed repo or returns a clear protocol error). Tracked in §16. |
 | Cross-service token theft | An agent claiming `service: builder-claude` in its UDS request still authenticates against the **builder-claude token's policy** server-side. Apiarist trusts `AGENT_SERVICE` env (set by deploy, not by container code), and the broker→backend flow uses the bearer keyed off that. A compromised builder container cannot trick apiarist into minting against guard's token by lying about its service — apiarist's per-service policy lookup is the gate. (This does mean a fully-compromised container can mint within its OWN policy without bound — which is exactly the policy-shrink mitigation: don't grant a token broader scope than the agent legitimately needs.) |
 | Apiarist process memory dump | Disable core dumps via systemd `LimitCORE=0`. Lock pages with `mlock`-equivalent (`MemoryDenyWriteExecute=true`). Restart-on-crash is already systemd's default, so a transient crash doesn't leak the cache to disk via core file. Cache TTL of 5 min (default) bounds the in-memory residency window. |
 | Local user escalation | Socket is `chmod 660`, owned by `apiarist:agent`. Only members of group `agent` (the unprivileged uid the apiary docker-run gives containers) can connect. Other local users get EACCES. The daemon `chown`s the socket and asserts the configured `socket_group` exists at startup; mismatch logs loudly to stderr and refuses to start. asyncio's `start_unix_server` does NOT set group ownership automatically — explicit chown is required after bind. |
@@ -851,7 +870,8 @@ GitHub tokens to disk.
 repos:
   foxstoria:
     repo: dkjazz/the-storytimes-firebase
-    auth: github-app          # NEW — opts into apiarist-brokered tokens
+    refresh_token: true       # NEW — opts into apiarist-managed token (Phase K)
+    token_env: GITHUB_TOKEN   # NEW — which env var the auth subscriber populates
     agents: [foxstoria-dev]
     overrides:
       foxstoria-dev:
@@ -862,32 +882,45 @@ repos:
       # ...
 ```
 
-When `auth: github-app` is set, `deploy-apiary.sh` skips writing the
+When `refresh_token: true` is set, `deploy-apiary.sh` skips writing the
 static PAT into the container, bind-mounts the apiarist UDS, and sets
-the `AGENT_SERVICE` + `AGENT_TOKEN_SLOT` env vars so the agent runtime
-knows its identity and apiarist knows which agent-token to use.
+`APIARIST_TOKEN_ENV` so the agent runtime knows which env var to
+populate. The hivemoot plugin's auth subscriber (Phase L′) reads the
+hivemoot.yaml `apiarist:` block emitted by deploy-apiary.sh and registers
+with the engine's container lifecycle on every job.
 
-When `auth:` is unset (default `pat`), behavior is unchanged.
-**Existing fleet services keep working without modification during
-rollout.**
+When `refresh_token` is unset or false (the default), behavior is
+unchanged. **Existing fleet services keep working without modification
+during rollout.** (See `hivemoot/apiary` PR #67 for the deploy-side
+schema implementation; the fields are documented in the per-repo block
+schema comment at the top of `apiary.yaml`.)
 
 ### 12.2 `deploy-apiary.sh`: skip static token, bind-mount socket, set env
 
-In the per-service docker-run construction (around line 890 of
-`stage_standing_secrets` and around line 1295 of `build_standing_docker_run`):
+Implemented in `hivemoot/apiary` PR #67. Key behavior in
+`stage_standing_secrets`, `write_standing_env_file`,
+`write_standing_hivemoot_yaml`, and `build_standing_docker_run`:
 
 ```bash
-local repo_auth
-repo_auth=$(yq ".repos.${repo_key}.auth // \"pat\"" "$CONFIG_FILE")
-if [[ "$repo_auth" == "github-app" ]]; then
-  # Apiarist brokers tokens — no static file, no env. Mount the
-  # socket and tell the agent its identity.
+# get_repo_refresh_token / get_repo_token_env are validating helpers
+# (reject non-bool / invalid env var name) added by Phase K.
+local refresh_token token_env
+refresh_token="$(get_repo_refresh_token "$repo_key")"
+token_env="$(get_repo_token_env "$repo_key")"
+
+if [[ "$refresh_token" == "true" ]]; then
+  # Apiarist brokers tokens — no static file, no AGENT_GITHUB_TOKEN_FILE.
+  # Mount the socket; emit APIARIST_TOKEN_ENV so the runtime knows which
+  # env var to populate. Fail-fast if the host socket isn't present.
   rm -f "$secrets_dir/github-token"
+  if [[ ! -S /run/apiarist/apiarist.sock ]]; then
+    echo "Error: refresh_token: true but apiarist daemon not running" >&2
+    exit 1
+  fi
   # Host-side socket lives in /run/apiarist/ (created by systemd's
   # RuntimeDirectory directive); container sees it as /run/apiarist.sock.
   docker_run="${docker_run} -v /run/apiarist/apiarist.sock:/run/apiarist.sock"
-  docker_run="${docker_run} -e AGENT_SERVICE=${service_name}"
-  docker_run="${docker_run} -e AGENT_TOKEN_SLOT=${agent_token_slot}"
+  echo "APIARIST_TOKEN_ENV=${token_env}" >> "$env_file"
 else
   # Existing PAT staging path — unchanged.
   agent_github_token="$(yq ".github_tokens.\"${agent}\" // \"\"" "$SECRETS_FILE")"
@@ -1060,24 +1093,59 @@ class ContainerLifecycle:
         self._lock = asyncio.Lock()
 
     def subscribe(self, sub: "LifecycleSubscriber") -> None:
-        """Register a subscriber. Called at plugin setup, once."""
+        """Register a subscriber.
+
+        CONTRACT: called once per subscriber during plugin setup, before
+        the engine starts dispatching jobs. NOT thread/async-safe — V1
+        relies on plugin setup being single-threaded and pre-dispatch.
+        Future hot-reload of subscribers would require switching to
+        a copy-on-write subscribers list or wrapping append in the
+        lock.
+        """
         self._subscribers.append(sub)
 
     async def on_job_starting(self, job) -> None:
         """Engine calls before dispatching the job. On the 0→1
-        transition, awaits all subscribers' on_active. A subscriber
-        raising fails the lifecycle transition and rolls back the
-        counter so the next job-start retries cleanly (invariant I3)."""
+        transition, runs all subscribers' on_active sequentially.
+
+        Subscriber failure semantics (invariant I3 + atomicity):
+        if any subscriber raises in on_active, every PRIOR successful
+        subscriber's on_idle is awaited (best-effort cleanup) so the
+        engine doesn't leave half-set-up state behind, then the
+        counter is rolled back and the original exception bubbles to
+        the engine's job-dispatch loop which fails the triggering
+        job. The runtime's normal retry path then re-attempts the
+        full subscriber chain cleanly."""
         async with self._lock:
             self._active_jobs += 1
             if self._active_jobs == 1:
                 # IDLE → ACTIVE — block on subscribers (invariant I1).
+                # Sequential not gather() so partial-success cleanup is
+                # ordered (cleanup runs in setup-order, ensures earlier
+                # subscribers' state is torn down BEFORE later ones'
+                # failure error is re-raised).
+                completed: list[LifecycleSubscriber] = []
                 try:
-                    await asyncio.gather(
-                        *(s.on_active() for s in self._subscribers)
-                    )
+                    for sub in self._subscribers:
+                        await sub.on_active()
+                        completed.append(sub)
                 except Exception:
-                    self._active_jobs -= 1  # roll back (I3)
+                    # Tear down successful subscribers in reverse
+                    # setup order. Each cleanup wrapped in
+                    # return_exceptions equivalent so one bad cleanup
+                    # doesn't mask the original setup failure.
+                    for done_sub in reversed(completed):
+                        try:
+                            await done_sub.on_idle()
+                        except Exception as cleanup_exc:
+                            log.error(
+                                "subscriber on_idle raised during rollback",
+                                subscriber=type(done_sub).__name__,
+                                exc_info=cleanup_exc,
+                            )
+                    # Roll back counter so next job-start retries
+                    # the full chain cleanly (I3).
+                    self._active_jobs -= 1
                     raise
 
     async def on_job_finished(self, job) -> None:
@@ -1263,7 +1331,11 @@ from .auth.subscriber import HivemootGithubAuthSubscriber, RefreshConfig
 from .auth.apiarist_client import ApiaristClient
 
 class HivemootPlugin:
-    async def setup(self, ctx) -> None:
+    # setup is SYNCHRONOUS — matches the existing plugin contract at
+    # plugins/interfaces.py:137 and engine.py:280. The body has no
+    # awaitable work (the subscriber's actual mint happens in its
+    # on_active, which IS async and runs at job-start time).
+    def setup(self, ctx) -> None:
         if not ctx.repo_config.refresh_token:
             # Static PAT path; nothing to do. The github plugin's
             # tooling will read whatever GITHUB_TOKEN was put in env
@@ -1282,9 +1354,40 @@ class HivemootPlugin:
         ctx.engine.lifecycle.subscribe(subscriber)
 ```
 
-The github plugin (`plugins_builtin/github/`) is **not modified**.
-`gh`/`octokit`/git wrappers continue to read `GITHUB_TOKEN` from env;
-whether the value is a static PAT or apiarist-minted is invisible.
+#### 12.3.5a Required github plugin change for `refresh_token: true` repos
+
+The github plugin's current `validate()`
+(`agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py:131-145`)
+requires a non-empty `plugins.github.token_file`, and `setup()`
+(`:177-196`) reads that file and writes `GH_TOKEN`/`GITHUB_TOKEN` at
+plugin-setup time. Under the static-PAT path that's exactly what we
+want. Under `refresh_token: true` it's a problem: deploy-apiary.sh
+omits the `token_file:` line (no static file exists), `validate()`
+fails, and the agent never reaches the lifecycle subscriber that
+would have populated the env.
+
+Phase L′ MUST include a small github-plugin change to short-circuit
+both `validate()` and `setup()` when the hivemoot plugin's apiarist
+subsystem is enabled. Two options, in order of preference:
+
+1. **(preferred)** github plugin's `validate()` accepts an absent
+   `token_file:` if a sibling `hivemoot.apiarist.enabled: true` is
+   present in the same `hivemoot.yaml`. `setup()` then becomes a
+   no-op for token population (the subscriber handles env at
+   on_active time). This is a one-function change.
+2. **(fallback)** github plugin gets a new `token_source: subscriber`
+   typed config option that explicitly opts out of the file-based
+   read. deploy-apiary.sh emits this when refresh_token: true.
+
+Phase L′'s scope therefore includes: engine `ContainerLifecycle`
++ `LifecycleSubscriber`; new hivemoot plugin `auth/` submodule with
+the subscriber + apiarist client; **a small github plugin change
+per the above**. The "github plugin is not modified" framing from
+earlier rounds was wrong — there's a small but necessary tweak.
+The framing's intent — that the github plugin's tooling-provider
+role is unchanged, and the env-var contract `gh`/`git` etc. read
+from doesn't change — still holds. Only the validate+setup
+short-circuit is added.
 
 #### 12.3.6 Lifecycle (showing overlapping work)
 
@@ -1399,7 +1502,7 @@ most common failure mode for an apiarist rollout.
 
 - Implement V1 daemon (token brokering only).
 - Deploy on Hive in shadow mode: daemon runs but **no service is flagged
-  `auth: github-app` yet**. Validates startup, socket creation, backend
+  `refresh_token: true` yet**. Validates startup, socket creation, backend
   reachability without touching production credential flow.
 - Verify backend `/api/github/installation-tokens` endpoint deployed to
   hivemoot.dev (separate but coordinated piece).
@@ -1413,21 +1516,28 @@ the Hivemoot Bot installed already.
 
 - Confirm Hivemoot Bot is installed on `hivemoot/hivemoot` (should
   be — check via App admin UI).
-- Wire the hivemoot plugin's auth FSM (Phase L′ — see §12.3).
-- Flag drone's repo block in `apiary.yaml` with `auth: github-app`.
+- Land Phase L′: engine `ContainerLifecycle` + `LifecycleSubscriber`
+  interface in `engine.py`; `HivemootGithubAuthSubscriber` in the
+  hivemoot plugin's `auth/` submodule (see §12.3 for the full
+  contract). The engine change adds the generic primitive future
+  cross-cutting concerns reuse; the subscriber implements the
+  apiarist-specific logic.
+- Flag drone's repo block in `apiary.yaml` with `refresh_token: true`.
 - Deploy and observe one full review cycle. Audit logs should show
   exactly one token mint per ACTIVE period, ≤1h TTL, scoped to
   `hivemoot/hivemoot`.
 
 **Phase 1.5 — Foxstoria** (week 2-3)
 
-Foxstoria is a per-repo agent (triggered by github plugin, not
-hivemoot.tasks), so under the V1 architecture it stays on the
-static-PAT path (see §12.3). Migrating per-repo agents to apiarist
-is deferred — see the V1.1 considerations note below. For now:
-keep foxstoria on static PAT in `apiary.secrets.yaml` until
-either (a) we ship the engine-level AuthManager option, or
-(b) per-repo agents are unified into hivemoot.tasks triggers.
+Foxstoria is a per-repo agent (triggered by github plugin's
+PR-watcher, not hivemoot.tasks). Under the V1 engine-lifecycle +
+hivemoot-subscriber architecture, foxstoria works exactly the same
+way fleet members do: any work the engine dispatches (whether the
+github plugin's PR-watcher or hivemoot.tasks) calls
+`on_job_starting` → subscribers run. So foxstoria can opt in to
+`refresh_token: true` once Phase L′ ships, with no additional
+runtime work. Until Phase L′ lands, keep foxstoria on static PAT
+in `apiary.secrets.yaml`.
 
 **Phase 2 — Validate, document, train** (week 3)
 
@@ -1438,8 +1548,8 @@ either (a) we ship the engine-level AuthManager option, or
 
 **Phase 3 — Migrate fleet** (week 4+)
 
-- One service at a time, flag `auth: github-app`. Observe for one full
-  cron cycle before moving to the next.
+- One repo at a time, flag `refresh_token: true` in apiary.yaml. Observe
+  for one full cron cycle before moving to the next.
 - After all services migrated, the corresponding `github_tokens.<agent>`
   classic PATs in `apiary.secrets.yaml` can be revoked. **Don't delete
   the YAML field until backend has accepted token-less requests for at
@@ -1466,10 +1576,10 @@ either (a) we ship the engine-level AuthManager option, or
 | **H.** Tests — integration | fake backend + real socket, full mint flow | 1d | E, G |
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
-| **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `auth: github-app`, skip static token, bind-mount `/run/apiarist.sock`, set `AGENT_SERVICE` + `AGENT_TOKEN_SLOT` env. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). | 0.5d | — (parallel) |
+| **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `refresh_token: true`, skip static token staging, bind-mount `/run/apiarist/apiarist.sock` (host) → `/run/apiarist.sock` (container), emit `APIARIST_TOKEN_ENV=<env_var>`, omit github plugin's `token_file:` line, emit a new `hivemoot.apiarist:` block (enabled, socket_path, repo, env_var) for Phase L′ to consume. Two new validating helpers (`get_repo_refresh_token`, `get_repo_token_env`) reject malformed inputs at parse time. Fail-fast deploy if the host apiarist socket isn't present. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). **Shipped** in `hivemoot/apiary` PR #67. | 0.5d | — (parallel) |
 | **L′.** Engine lifecycle FSM + hivemoot auth subscriber | Three layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber. Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. github plugin is **not touched**. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
-| **N.** Foxstoria pilot | flag foxstoria's repo block with `auth: github-app` + `agent_token: foxstoria-builder`, deploy, observe one full agent run cycle. Verify ghs_ token reaches GitHub successfully and zero token files appear on disk. | 0.5d | M, **backend endpoint live** |
+| **N.** Drone pilot | The V1 pilot is **drone**, not foxstoria — drone is a fleet member on `hivemoot/hivemoot` (which already has the bot installed) AND its existing PAT is invalid as of 2026-04-25 so migrating it can't regress anything. Flag drone's repo block (`hivemoot:` in `apiary.yaml`) with `refresh_token: true`, deploy, observe one full review cycle. Verify a `ghs_` token reaches GitHub successfully and zero token files appear on disk. Foxstoria opt-in is deferred to Phase 1.5 (see §13) — it works under the engine-lifecycle architecture but is shipped after the drone pilot validates the path. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |
 
 **Total V1 estimate:** ~8 days of focused work, plus ~2 days for the
@@ -1562,6 +1672,34 @@ on Hive (Phase 0).
 6. **Telemetry.** Emit logs only in V1. Add Prometheus metrics endpoint
    when (a) we deploy multiple Hives and want fleet-wide visibility, or
    (b) we have a Prometheus scraper anywhere. **Neither today.**
+7. **Subscriber-requested-reset hook in `ContainerLifecycle`.** §12.3.4
+   notes that the hivemoot auth subscriber's `_reset_after_refresh_crash`
+   path doesn't trigger an engine IDLE transition — that would require
+   a callback from subscriber → engine which V1 doesn't have. If
+   401-storms are observed in production after refresh-task crashes
+   (subscriber clears env but engine still thinks it's ACTIVE so no
+   re-wake on next job-start), V1.1 adds a `subscriber.request_reset()`
+   API that triggers a forced ACTIVE→IDLE→ACTIVE cycle. Defer until
+   we have telemetry evidence the gap matters in practice.
+8. **Token-policy scoping in agent-token envelope.** §10's "V1
+   token-policy gap" row tracks this: the envelope today carries only
+   the installation_id, so a leaked token can mint for any repo in the
+   installation grant. V1.5 target: extend the agent-token envelope
+   with `allowed_repos: string[]` and `allowed_permissions: Record<string, string>`,
+   enforce `(request) ⊆ (token policy) ⊆ (installation grant)` in the
+   mint endpoint, and surface the policy in the dashboard's token
+   creation UI. Required before broader fleet rollout (drone pilot
+   acceptable risk because it's a single agent on one repo).
+9. **`repository_ids` narrowing + install-repos cache.** §10's "V1
+   short-name narrowing gap" row tracks this: we pass repo short names
+   to GitHub rather than numeric IDs, so a rename + recreate at the
+   same slot inside an "all repositories" installation could mint for
+   the new repo. V1.5 target: stand up a Redis-backed
+   `installation:<id>:repos` cache populated by the bot's webhook
+   handlers (`installation.repositories.added/removed`), resolve
+   `owner/name` → numeric `id` in the mint endpoint, narrow with
+   `repository_ids: [<id>]`. Pairs with #8 because the
+   policy-enforcement check uses the same lookup.
 
 ## 17. Anti-goals
 

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -902,20 +902,47 @@ or privileged flag is needed.
 
 ### 12.3 Agent runtime change (monorepo, not apiary)
 
-An activity-gated FSM lives **inside the existing GitHub plugin** at
-`agent/cli/hivemoot_agent/plugins_builtin/.../github` (not a new
-plugin). Engine constraint: daemon-mode `run_agent` fires lifecycle
-hooks only on the *triggering* plugin, not on every enabled plugin
-broadcast-style. Putting the FSM inside the existing plugin avoids
-needing to change the engine first; the plugin's hooks already fire
-exactly when its own GitHub-touching work runs, which is the only
-time `GITHUB_TOKEN` actually needs to be in env.
+An activity-gated FSM lives in a **shared module** at
+`agent/cli/hivemoot_agent/lib/github_auth_fsm.py`, instantiated as a
+process-singleton, **driven by both** `plugins_builtin/github/` and
+`plugins_builtin/hivemoot/` (and any future plugin that triggers
+GitHub-touching work).
+
+**Engine constraint that shapes this design**: daemon-mode
+`run_agent` fires lifecycle hooks only on the *triggering* plugin,
+not on every enabled plugin broadcast-style (verified at
+`agent/cli/hivemoot_agent/engine.py:1208` and `:1316`). Two distinct
+trigger sources need to drive the auth state:
+
+1. **`plugins_builtin/github/`** triggers per-repo agents (e.g.
+   `foxstoria-builder` watching one repo for PR events) via its own
+   PR-watcher work. Its hooks fire for these jobs.
+2. **`plugins_builtin/hivemoot/`** (hivemoot.tasks) triggers
+   fleet-member agents (`hivemoot-builder`, `hivemoot-guard`,
+   `hivemoot-queen`, `hivemoot-drone` — the bulk of the apiarist
+   target population) via task-claim work. *Its* hooks fire for
+   these jobs, and the github plugin's hooks **do not** fire even
+   though the github plugin is enabled (it's a hard requirement of
+   `hivemoot.github_workflows`, validated at
+   `plugins_builtin/hivemoot/__init__.py:233-238`).
+
+Putting the FSM inside *either* plugin would only cover its own
+work source, breaking auth for the other. A shared-singleton FSM
+that both plugins import and drive via their respective hooks
+covers both trigger paths without needing engine-level broadcast.
+(Engine-level broadcast — moving the FSM into `engine.run_agent`
+itself, options 1 vs 2 in the PR #486 review — is cleaner
+architecturally but a much bigger change touching the engine for
+all plugins; deferred to a future engine refactor when more plugins
+need active/idle awareness.)
 
 States: ACTIVE (count of in-flight GitHub-touching work units ≥ 1)
-or IDLE (count = 0). The plugin keeps a reference counter that
-increments on every work-start hook the engine fires and decrements
-on every work-end hook. Only the 0↔1 boundary triggers a state
-transition; intermediate counter movements are no-ops.
+or IDLE (count = 0). The shared FSM keeps a reference counter that
+each driving plugin increments on its own work-start hook and
+decrements on its own work-end hook. Only the 0↔1 boundary
+triggers a state transition; intermediate counter movements (and
+all interleavings of github-plugin hooks with hivemoot-plugin
+hooks) are no-ops.
 
 - **IDLE → ACTIVE** (counter goes 0→1, first work unit started):
   mint `GITHUB_TOKEN`, set env, start a background refresh loop
@@ -972,7 +999,8 @@ not always-on):**
   types can all overlap arbitrarily; the FSM only transitions when
   all of them have released the wake lock.
 
-**The whole plugin** (Phase L′):
+**The shared FSM** (Phase L′, lives at
+`agent/cli/hivemoot_agent/lib/github_auth_fsm.py`):
 
 ```python
 # pseudocode — final implementation lands in Phase L′. This shape
@@ -985,6 +1013,8 @@ not always-on):**
 #       token).
 #   I4. A refresh-loop crash drives an idle transition + log so the
 #       next work-start re-mints from scratch.
+#   I5. Every asyncio.create_task gets add_done_callback so unhandled
+#       exceptions surface instead of being silently swallowed.
 import asyncio
 import contextlib
 import os
@@ -992,15 +1022,26 @@ from datetime import UTC, datetime
 
 REFRESH_SAFETY_MARGIN_SECONDS = 300
 
-class GitHubAuthPlugin:
+class GitHubAuthFSM:
+    """Activity-gated reference-counted FSM. Process singleton.
+
+    Driven by ANY plugin whose hooks correspond to GitHub-touching
+    work — currently github/ (per-repo) and hivemoot/ (fleet tasks).
+    Each driving plugin's on_job_started/on_job_finished translates
+    to fsm.on_work_start(plugin_name) / on_work_end(plugin_name).
+    The plugin name is opaque — the FSM only needs the start/end
+    pairing to maintain the counter.
+    """
+
     def __init__(self, apiarist_client, repo: str):
         self._apiarist = apiarist_client
         self._repo = repo
-        # Counter of GitHub-touching work units in flight. Incremented
-        # by on_work_start, decremented by on_work_end. Multi-repo
-        # agents are out of scope for V1 (see process-global env
-        # discussion above), so this is per-process and counts only
-        # this plugin's hook firings.
+        # Counter of GitHub-touching work units in flight, summed
+        # across ALL driving plugins. github/ contributes its own
+        # PR-watcher work, hivemoot/ contributes fleet tasks; both
+        # increments target the same counter. Multi-repo single-
+        # process agents are out of scope V1 (process-global env
+        # discussion above) — bound to a single repo at construction.
         self._active = 0
         self._refresh_task: asyncio.Task | None = None
         # Transition lock: serializes IDLE↔ACTIVE state changes so a
@@ -1010,24 +1051,21 @@ class GitHubAuthPlugin:
         # path is also serialized against new work arrivals.
         self._lock = asyncio.Lock()
 
-    async def on_work_start(self, _source) -> None:
+    async def on_work_start(self, _source: str) -> None:
         async with self._lock:
             if self._active == 0:
                 # IDLE → ACTIVE: wake-up MUST complete before
                 # incrementing. If wake-up raises, counter stays at 0
                 # so the runtime's retry of this work-start re-attempts
                 # cleanly rather than stranding count > 0 with no token
-                # (invariant I3 — addresses builder's gap and aligns
-                # with the failure-mode prose below).
+                # (invariant I3).
                 await self._wake_up()
             self._active += 1
 
-    async def on_work_end(self, _source) -> None:
+    async def on_work_end(self, _source: str) -> None:
         async with self._lock:
             # max(0, ...) clamp defends against a buggy work source
             # that fires on_work_end without a matching on_work_start.
-            # Without this, _active goes negative and the 0→1
-            # transition never re-fires; the agent stops minting.
             self._active = max(0, self._active - 1)
             if self._active == 0:
                 await self._go_idle()  # ACTIVE → IDLE (fully drained)
@@ -1035,24 +1073,19 @@ class GitHubAuthPlugin:
     async def _wake_up(self) -> None:
         token = await self._apiarist.mint_token(repo=self._repo)
         os.environ["GITHUB_TOKEN"] = token.value
+        # Every create_task gets add_done_callback (invariant I5).
         task = asyncio.create_task(self._refresh_loop(token.expires_at))
-        # Surface refresh-loop crashes as state transitions instead
-        # of letting asyncio's default exception handler swallow them
-        # silently (invariant I4). Without add_done_callback the
-        # refresh chain dies invisibly and tokens stop being renewed.
         task.add_done_callback(self._on_refresh_died)
         self._refresh_task = task
 
     async def _go_idle(self) -> None:
         if self._refresh_task is not None:
             self._refresh_task.cancel()
-            # AWAIT the cancelled task before popping env so a refresh
-            # in flight can't write env AFTER our pop (invariant I2).
-            # Task.cancel() is synchronous — only requests cancellation
-            # at the next checkpoint. If the loop is mid-await on
-            # mint_token, the mint return + os.environ assignment
-            # both run before cancellation reaches it; we'd lose the
-            # race and leave a token in env post-IDLE.
+            # AWAIT the cancelled task before popping env (invariant
+            # I2). Task.cancel() is synchronous — only requests
+            # cancellation at the next checkpoint. If the loop is
+            # mid-await on mint_token, the mint return + os.environ
+            # assignment both run before cancellation reaches it.
             with contextlib.suppress(asyncio.CancelledError):
                 await self._refresh_task
             self._refresh_task = None
@@ -1070,16 +1103,25 @@ class GitHubAuthPlugin:
             expires_at = new.expires_at
 
     def _on_refresh_died(self, task: asyncio.Task) -> None:
-        # Cancellation = normal _go_idle path, no-op.
         if task.cancelled():
-            return
+            return  # normal _go_idle path
         exc = task.exception()
         if exc is None:
-            return  # refresh_loop is infinite, won't reach here normally
+            return  # refresh_loop is infinite; won't reach here normally
         log.error("refresh loop crashed", exc_info=exc)
-        # Schedule the idle transition asynchronously (the callback
-        # is a sync context). The next on_work_start will re-wake.
-        asyncio.create_task(self._reset_after_refresh_crash())
+        # Schedule the reset asynchronously (callback is sync). New
+        # task gets its own add_done_callback (invariant I5) so any
+        # exception in the reset path surfaces too — without it, an
+        # unexpected error during cleanup would silently disappear,
+        # leaving the FSM stuck in an inconsistent state.
+        reset_task = asyncio.create_task(self._reset_after_refresh_crash())
+        reset_task.add_done_callback(self._log_reset_failure)
+
+    @staticmethod
+    def _log_reset_failure(task: asyncio.Task) -> None:
+        if task.cancelled() or task.exception() is None:
+            return
+        log.error("FSM reset path itself raised", exc_info=task.exception())
 
     async def _reset_after_refresh_crash(self) -> None:
         async with self._lock:
@@ -1092,6 +1134,44 @@ class GitHubAuthPlugin:
             # fresh.
             self._active = 0
 ```
+
+**Plugin drivers** (Phase L′) — each plugin hooks its own
+lifecycle events into the shared FSM:
+
+```python
+# In agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
+from hivemoot_agent.lib.github_auth_fsm import get_fsm
+
+class GithubPlugin:
+    async def on_job_started(self, job) -> None:
+        if _is_github_touching(job):
+            await get_fsm().on_work_start("github")
+
+    async def on_job_finished(self, job) -> None:
+        if _is_github_touching(job):
+            await get_fsm().on_work_end("github")
+```
+
+```python
+# In agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+from hivemoot_agent.lib.github_auth_fsm import get_fsm
+
+class HivemootPlugin:
+    async def on_job_started(self, job) -> None:
+        # All hivemoot.tasks-triggered jobs are GitHub-touching by
+        # nature (the agent will use gh/git for PR review, commit,
+        # etc.) — drive the FSM unconditionally for these jobs.
+        await get_fsm().on_work_start("hivemoot.tasks")
+
+    async def on_job_finished(self, job) -> None:
+        await get_fsm().on_work_end("hivemoot.tasks")
+```
+
+`get_fsm()` returns the process-singleton FSM instance, lazily
+initialized on first call from the active plugin's wiring (it
+needs the apiarist client and repo binding from `AGENT_SERVICE`).
+Both plugins import the same module, so both increments target the
+same counter; the FSM lock serializes interleavings between them.
 
 **Lifecycle (showing overlapping mixed work types):**
 
@@ -1116,22 +1196,22 @@ triggers the IDLE transition. This is the "fully idle" definition.
 
 **What the agent runtime needs to expose:**
 
-Per-plugin lifecycle hooks: `on_work_start(source)` and
-`on_work_end(source)`, fired on this plugin around every work unit
-the plugin is involved in. The hooks are called **only on the
-triggering plugin** (the existing `run_agent` daemon-mode behavior),
-not broadcast to every enabled plugin. That's why the FSM lives
-inside the existing GitHub plugin: the plugin's own hook firings
-correspond exactly to GitHub-touching work, which is the only time
-`GITHUB_TOKEN` actually needs to be in env.
+Existing per-plugin lifecycle hooks: `on_job_started(job)` and
+`on_job_finished(job)` on each plugin (the standard plugin contract
+that `run_agent` already calls). No new engine surface required.
 
-This means the plugin doesn't track *all* agent work — only its own.
-A non-GitHub work unit running concurrently with GitHub work doesn't
-contribute to the counter, which is fine: it doesn't need
-`GITHUB_TOKEN` either. Future engine change (broadcast hooks) would
-allow splitting the FSM into a dedicated `github_auth` plugin and
-narrowing the GitHub plugin's responsibilities, but isn't needed for
-V1 correctness.
+The hooks fire **only on the triggering plugin** (verified at
+`engine.py:1208,1316`). That's why the FSM is a shared module
+imported by multiple plugins instead of a singleton owned by any
+one plugin — both `github/` and `hivemoot/` need to drive the
+same auth state, but neither receives the other's lifecycle events.
+
+Future engine change (broadcast hooks across all enabled plugins)
+would allow extracting the FSM call into a single engine-level
+hook and removing the per-plugin wiring. Not needed for V1
+correctness; called out in §16 open questions for revisit when
+more plugins need active/idle awareness (metrics, logging, secret
+rotation, etc. would all benefit).
 
 **Failure modes:**
 
@@ -1196,9 +1276,17 @@ reach them.
   inheritance note above. Token leaves the parent's control at
   fork time; the parent's IDLE cleanup doesn't reach already-running
   subprocesses.
-- Track non-GitHub work. The FSM increments only on this plugin's
-  own hooks. Non-GitHub work running concurrently doesn't
-  contribute to the counter and doesn't need `GITHUB_TOKEN` either.
+- Track non-GitHub work. Each driving plugin gates its own
+  contribution to the counter — github/ via `_is_github_touching(job)`,
+  hivemoot/ unconditionally (since hivemoot.tasks jobs are all
+  GitHub-touching by design). Non-GitHub work in any other plugin
+  doesn't contribute and doesn't need `GITHUB_TOKEN` either.
+- Use bare `asyncio.create_task` anywhere in the FSM. Every
+  task gets `add_done_callback` so unhandled exceptions surface
+  via the structured logger instead of being silently swallowed
+  by asyncio's default exception handler (invariant I5). This
+  applies uniformly to the refresh loop AND to the
+  `_reset_after_refresh_crash` reset path.
 
 ## 13. Migration plan
 
@@ -1258,7 +1346,7 @@ reach them.
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `auth: github-app`, skip static token, bind-mount `/run/apiarist.sock`, set `AGENT_SERVICE` + `AGENT_TOKEN_SLOT` env. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). | 0.5d | — (parallel) |
-| **L′.** Agent runtime — activity-gated GitHub auth | In the existing `agent/cli/hivemoot_agent/plugins_builtin/.../github` plugin (monorepo, opened as separate PR against `hivemoot/hivemoot`, fleet-reviewed): add the activity-gated FSM described in §12.3 — reference-counted IDLE/ACTIVE state, mint+set `GITHUB_TOKEN` on 0→1 transition with proactive refresh loop, clear env on 1→0 transition. The FSM lives inside the existing plugin (not a new one) because the agent engine fires lifecycle hooks only on the triggering plugin. Tiny apiarist Python client lib (~50 lines) lives alongside it for the UDS round-trip. | 1.5d | D, E |
+| **L′.** Agent runtime — activity-gated GitHub auth | New shared FSM module at `agent/cli/hivemoot_agent/lib/github_auth_fsm.py` implementing the activity-gated state machine (§12.3) — reference-counted IDLE/ACTIVE state, mint+set `GITHUB_TOKEN` on 0→1 transition with proactive refresh loop, clear env on 1→0 transition. Wired into both `plugins_builtin/github/` (per-repo agents) and `plugins_builtin/hivemoot/` (fleet members) — both plugins drive the same singleton FSM via their respective `on_job_started`/`on_job_finished` hooks because the engine fires lifecycle hooks only on the triggering plugin (per `engine.py:1208,1316`), and these are the two trigger sources covering apiarist's full target population. Tiny apiarist Python client lib (~50 lines) lives alongside for the UDS round-trip. | 1.5d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Foxstoria pilot | flag foxstoria's repo block with `auth: github-app` + `agent_token: foxstoria-builder`, deploy, observe one full agent run cycle. Verify ghs_ token reaches GitHub successfully and zero token files appear on disk. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -1453,12 +1453,18 @@ Phase L′ therefore includes a real refactor of github plugin's
 
   All five move into a NEW github plugin lifecycle subscriber (the
   github plugin becomes its OWN `LifecycleSubscriber` in addition to
-  a tool provider) whose `on_active` runs them in that order. An
-  idempotency guard at the subscriber level skips the work after
-  the first successful on_active per process — subsequent
-  IDLE→ACTIVE cycles re-mint the token but don't re-clone (clone
-  output is process-stable, only the env value cycles per
-  ACTIVE/IDLE).
+  a tool provider) whose `on_active` runs them in that order.
+  **Token source: the subscriber reads the token from
+  `os.environ[token_env]` at on_active entry** — the hivemoot auth
+  subscriber registered before us (per the load-bearing
+  registration-order contract in §12.3.2's `subscribe()` docstring)
+  has populated env by the time our `on_active` fires. The github
+  subscriber doesn't take a token in its constructor; it's an
+  ambient-env read inside on_active. An idempotency guard at the
+  subscriber level skips the clone work after the first successful
+  on_active per process — subsequent IDLE→ACTIVE cycles re-mint the
+  token but don't re-clone (clone output is process-stable, only
+  the env value cycles per ACTIVE/IDLE).
 
 **2. Subscriber registration order matters.**
 
@@ -1706,7 +1712,7 @@ in `apiary.secrets.yaml`.
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `refresh_token: true`, skip static token staging, bind-mount `/run/apiarist/apiarist.sock` (host) → `/run/apiarist.sock` (container), emit `APIARIST_TOKEN_ENV=<env_var>`, omit github plugin's `token_file:` line, emit a new `hivemoot.apiarist:` block (enabled, socket_path, repo, env_var) for Phase L′ to consume. Two new validating helpers (`get_repo_refresh_token`, `get_repo_token_env`) reject malformed inputs at parse time. Fail-fast deploy if the host apiarist socket isn't present. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). **Shipped** in `hivemoot/apiary` PR #67. | 0.5d | — (parallel) |
-| **L′.** Engine lifecycle FSM + hivemoot auth subscriber + github plugin refactor | Four layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber; (d) **github plugin refactor**: split `setup()` into auth-free (workspace bootstrap, `gh` CLI discovery) + auth-required (`_validate_repo_access`, `clone_or_sync`); the auth-required half moves to a github-plugin-owned `LifecycleSubscriber` whose `on_active` runs after the hivemoot auth subscriber has populated env. `validate()` grows a `token_source: subscriber` opt that permits absent `token_file:` (deploy-apiary.sh emits this for `refresh_token: true`). Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. Github plugin's tooling-provider runtime contract is unchanged; only its plugin-load model splits. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2.5d | D, E |
+| **L′.** Engine lifecycle FSM + hivemoot auth subscriber + github plugin refactor | Four layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber; (d) **github plugin refactor**: split `setup()` into auth-free (workspace bootstrap, `gh` CLI discovery) + the **full auth-required sequence per §12.3.5a** — `resolve_github_user`, `_configure_git_auth`, `_validate_repo_access`, `clone_or_sync`, `configure_git_user` (in that exact order; see §12.3.5a for file:line references). The auth-required half moves to a github-plugin-owned `LifecycleSubscriber` whose `on_active` reads the token from `os.environ[token_env]` (populated by the hivemoot subscriber that registered before us per the load-bearing registration-order contract) and runs the five operations idempotently — clone happens once per process, env reads cycle per ACTIVE/IDLE. `validate()` grows a `token_source: subscriber` opt that permits absent `token_file:` (deploy-apiary.sh emits this for `refresh_token: true`). Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. Github plugin's tooling-provider runtime contract is unchanged; only its plugin-load model splits. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2.5d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Drone pilot | The V1 pilot is **drone**, not foxstoria — drone is a fleet member on `hivemoot/hivemoot` (which already has the bot installed) AND its existing PAT is invalid as of 2026-04-25 so migrating it can't regress anything. Flag drone's repo block (`hivemoot:` in `apiary.yaml`) with `refresh_token: true`, deploy, observe one full review cycle. Verify a `ghs_` token reaches GitHub successfully and zero token files appear on disk. Foxstoria opt-in is deferred to Phase 1.5 (see §13) — it works under the engine-lifecycle architecture but is shipped after the drone pilot validates the path. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -902,117 +902,123 @@ or privileged flag is needed.
 
 ### 12.3 Agent runtime change (monorepo, not apiary)
 
-An activity-gated FSM lives **inside the hivemoot plugin** at
-`agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/`. Internal
-implementation detail of the hivemoot plugin; not imported by any
-other plugin.
+The agent runtime grows three layered pieces, with strict separation
+of concerns:
 
-**Why hivemoot owns it (not github plugin, not a shared module, not
-the engine):** apiarist-brokered token minting is a hivemoot-
-architecture-specific feature. The agent_token bearer credential,
-the per-installation policy on the backend, the UDS protocol to
-apiarist, the `AGENT_SERVICE` binding — none of these exist in a
-generic GitHub workflow. They're all hivemoot-architecture concepts.
-So the plugin that owns hivemoot-architecture concerns owns them.
+1. **Engine layer**: a generic container-lifecycle FSM with a
+   subscriber/event-bus pattern. Lives in `engine.py`. Knows IDLE
+   and ACTIVE states. Doesn't know about auth.
+2. **Subscriber interface**: a small abstract class plugins
+   implement to receive lifecycle events. Generic, plugin-agnostic.
+3. **Hivemoot github-auth subscriber**: implements the subscriber
+   interface, owns GitHub token mint/refresh/env management.
+   Lives inside the hivemoot plugin. Registers with the engine
+   only for repos that opt in via per-repo config.
 
-The github plugin remains a **tool provider** — it ships
-`gh`/`octokit`/git wrappers that read `GITHUB_TOKEN` from env.
-That contract doesn't change between the static-PAT path and the
-apiarist-minted path; only who populates the env changes. The
-github plugin doesn't import hivemoot, doesn't import apiarist,
-doesn't know auth exists. Putting hivemoot-specific behavior into
-a tool plugin would invert the dependency direction (hivemoot
-architecture forcing tool changes); keeping the boundary clean
-preserves the rule "tools depend on infrastructure, not the other
-way around."
+This separation means: the engine knows when the container is busy
+or idle but nothing about auth; plugins know about the concerns
+they own (auth, metrics, logging, ...) but nothing about lifecycle
+internals — they just receive events and react. Auth is the first
+user of this pattern; future plugins (metrics on idle/active
+transitions, secret rotation, audit logging, etc.) reuse the same
+subscriber surface.
 
-**V1 scope coverage:** the hivemoot plugin's lifecycle hooks fire
-for **fleet-member agents** (`hivemoot-builder`, `hivemoot-guard`,
-`hivemoot-queen`, `hivemoot-drone`, `hivemoot-forager`, etc. —
-anything triggered by hivemoot.tasks). That's the entire V1 target
-population for apiarist. Per-repo agents triggered by the github
-plugin's PR-watcher (e.g. `foxstoria-builder` watching one repo)
-**stay on the existing static-PAT path** in V1; their auth comes
-from `apiary.secrets.yaml.github_tokens.<agent>` populating
-`GITHUB_TOKEN` at deploy time, unchanged from today. Migrating
-per-repo agents to apiarist is deferred — V1 doesn't need it (the
-drone pilot is a fleet member), and when it does become a need,
-the right answer is either to unify trigger paths through
-hivemoot.tasks or to ship an engine-level AuthManager that doesn't
-depend on plugin ownership.
+**Why this layered split:** auth is a hivemoot-architecture-specific
+feature (apiarist itself, the agent_token bearer, per-installation
+policy on the backend, the UDS protocol). It belongs in the hivemoot
+plugin. But the *trigger* for auth setup — "container is now busy,
+get ready" — is a generic engine concern, not a plugin one. So the
+engine owns the lifecycle FSM and emits events; the hivemoot plugin
+subscribes to those events and runs its auth logic. Each layer
+knows exactly what it should know and nothing more.
 
-**Hard precondition: repo must have the Hivemoot Bot GitHub App
-installed.** Apiarist mints **installation access tokens** (the
-`ghs_`-prefixed kind), which by definition only exist where the
-App is installed. A mint request for a repo without the bot
-installed returns `BACKEND_FORBIDDEN` from the daemon (mapped from
-the backend's HTTP 403 — "repo X not covered by the token's
-installation"). This fail-closes correctly: the job that triggered
-the mint sees the error, fails, and the agent runtime escalates
-per its retry policy. It does **not** silently fall back to any
-other credential path.
+The github plugin (`plugins_builtin/github/`) remains a **tool
+provider** — it ships `gh`/`octokit`/git wrappers that read
+`GITHUB_TOKEN` from env. That contract doesn't change between the
+static-PAT path and the apiarist-refresh path; only who populates
+the env changes. The github plugin is **not modified** by Phase L′.
 
-Operationally this means **before flagging a repo for apiarist
-auth, the operator must verify the Hivemoot Bot is installed on
-it** (via the App admin UI at `https://github.com/apps/<bot>` →
-Configure → Repository access). Repos without the bot installed
-are not eligible for apiarist auth and must stay on the static-PAT
-path. The fleet-member targets for V1 (`hivemoot/hivemoot`,
-`hivemoot/colony`, `hivemoot/apiary`, etc.) all have the bot
-installed today — verified during the §13 shadow-deploy phase by
-hitting the apiarist socket from a fleet-member container against
-each repo and observing successful mints.
+#### 12.3.1 Per-repo opt-in config
 
-**Engine constraint** (verified at
-`agent/cli/hivemoot_agent/engine.py:1208,1316`): daemon-mode
-`run_agent` fires lifecycle hooks only on the *triggering* plugin,
-not on every enabled plugin broadcast-style. Hivemoot.tasks-
-triggered jobs fire **only** the hivemoot plugin's hooks, which is
-exactly what we want for fleet-member auth — the FSM lives where
-the hooks fire, with no broadcast and no cross-plugin wiring.
+Token refresh is **opt-in per repo**, extending the existing per-repo
+prefetch feature surface in `apiary.yaml`:
 
-States: ACTIVE (count of in-flight fleet-member jobs ≥ 1) or IDLE
-(count = 0). The hivemoot plugin's FSM keeps a reference counter
-incremented on the plugin's own `on_job_started` hook and
-decremented on its own `on_job_finished` hook. Only the 0↔1
-boundary triggers a state transition; intermediate counter
-movements are no-ops.
+```yaml
+repos:
+  hivemoot/hivemoot:
+    prefetch: true              # existing feature — unchanged
+    refresh_token: true         # NEW: opt in to apiarist-managed token
+    token_env: GITHUB_TOKEN     # NEW: which env var (default: GITHUB_TOKEN)
 
-- **IDLE → ACTIVE** (counter goes 0→1, first work unit started):
-  mint `GITHUB_TOKEN`, set env, start a background refresh loop
-  that re-mints at `expires_at - 5min`.
-- **ACTIVE → IDLE** (counter goes 1→0, **last** work unit ended —
-  i.e., all overlapping/chained GitHub work is fully drained):
-  cancel the refresh loop (and await it to drain), clear
-  `GITHUB_TOKEN` from env.
+  some-non-bot-repo:
+    prefetch: false
+    # refresh_token absent → static PAT path; nothing changes
+```
 
-The "fully idle" definition is critical: a single task ending is just
-a decrement (`count--`); the state only transitions to IDLE when
-**every** GitHub-touching work source has released the wake lock.
-This matters for chained or overlapping work — task A ending while
-task B is still running does NOT trigger cleanup, because the agent
-is still busy from B's perspective.
+Two valid configurations for any repo:
 
-While ACTIVE, all the agent's existing tooling (`gh`, `git` via
-askpass, `octokit`, `PyGithub`) reads `GITHUB_TOKEN` from env and
-just works. While IDLE, no token is minted, no token sits in env,
-no refresh runs.
+| Config | What happens | When to use |
+|---|---|---|
+| `refresh_token: false` (or absent) | Static PAT path. Env populated at deploy from `apiary.secrets.yaml`. Never changes during the agent run. Subscriber not registered. | Default. Repos without the bot installed. Backwards compat. |
+| `refresh_token: true` | Subscriber registered. On each ACTIVE period: mint via apiarist, set env, refresh in background, clear on IDLE. | Repos where the bot is installed and the operator has explicitly opted in. |
 
-**Single-instance, single-repo invariant (V1):** one plugin instance
-per agent process, bound to one repo via `AGENT_SERVICE` lookup.
-`os.environ["GITHUB_TOKEN"]` is process-global — there is one slot,
-not one per repo — so an agent process running concurrent work for
-two different repos would have the two repo's tokens stomp each
-other in env, last-writer-wins. Multi-repo agents in a single
-process are out of scope for V1 and the runtime should refuse to
-register a second plugin instance. (Multi-repo agents today already
-run as separate containers per the apiary model, so this constraint
-matches existing reality.) Future V2+ option: per-work-unit env
-injection via `subprocess.run(env=...)` rather than process-global
-mutation, when/if multi-repo single-process agents become a need.
+**Hard precondition for `refresh_token: true`:** the Hivemoot Bot
+GitHub App must be installed on the target repo. Apiarist mints
+installation access tokens, which by definition only exist where the
+App is installed. A mint for a non-installed repo returns
+`BACKEND_FORBIDDEN` (mapped from backend HTTP 403 — "repo X not
+covered by the token's installation"). This fail-closes correctly
+inside the subscriber's `on_active`: the lifecycle transition fails,
+the triggering job fails, the runtime escalates per its retry policy.
+No silent fallback to a stale token or static PAT.
 
-**Why activity-gated refresh (not container-startup, not per-trigger,
-not always-on):**
+Operator pre-flight: check `https://github.com/apps/<bot>` →
+Configure → Repository access before flagging any repo for
+`refresh_token: true`. Skipping this is the most common operational
+footgun for an apiarist rollout (covered in §13 migration plan).
+
+**V1 scope coverage:** repos that opt in get apiarist refresh; repos
+that don't keep the static-PAT path. The drone pilot (V1's gate) is
+a fleet-member agent on `hivemoot/hivemoot`, which has the bot
+installed; flag drone's repo block with `refresh_token: true` and
+the subscriber wires up automatically. Per-repo agents like
+`foxstoria-builder` can opt in too if their repos have the bot
+installed; nothing forces them to.
+
+**Single-repo invariant (V1):** one subscriber per agent process,
+bound to one repo. `os.environ["GITHUB_TOKEN"]` (or whatever
+`token_env` names) is process-global; an agent running concurrent
+work for two different repos would have the two repos' tokens stomp
+each other in env, last-writer-wins. The runtime should refuse to
+register a second subscriber. (Today multi-repo agents already run
+as separate containers per the apiary model, so this matches
+existing reality.) Future V2+ option: per-work-unit env injection
+via `subprocess.run(env=...)` rather than process-global mutation.
+
+#### 12.3.2 Engine layer — ContainerLifecycle
+
+Lives in `agent/cli/hivemoot_agent/engine.py`. New class with five
+invariants the engine guarantees:
+
+- **I1.** When the engine dispatches a job to its plugin, every
+  subscriber's `on_active` has completed and any state setup
+  (env vars, network connections, etc.) is in place.
+- **I2.** On full drain (last job ends), every subscriber's
+  `on_idle` is awaited before the engine returns to the next idle
+  iteration.
+- **I3.** A subscriber raising in `on_active` rolls the active-job
+  counter back to its prior value so the next job-start retries
+  cleanly (no stuck count > 0 with no setup).
+- **I4.** A subscriber raising in `on_idle` is logged but doesn't
+  block other subscribers' cleanup; the lifecycle transition
+  completes regardless.
+- **I5.** Every `asyncio.create_task` in the engine and in
+  subscribers uses `add_done_callback` so unhandled exceptions
+  surface via the structured logger instead of being swallowed by
+  asyncio's default exception handler.
+
+**Why activity-gated (not container-startup, not per-trigger, not
+always-on):**
 
 - *Container-startup mint is wrong*: a standing-agent container can
   boot at 09:00 and sit idle until the first trigger arrives at
@@ -1021,35 +1027,132 @@ not always-on):**
 - *Always-on refresh is wasteful*: a periodic agent that runs once
   a day would burn a refresh mint every ~55 min, 24 mints per
   idle day, all unused.
-- *Per-trigger mint is needlessly chatty*: rapid-fire chained tasks
+- *Per-trigger mint is needlessly chatty*: rapid-fire chained jobs
   (one trigger spawns another) would each mint, even though they
   could share the env value.
-- *Activity-gated FSM is the right shape*: token exists only while
-  work is happening. Cost (mint + env exposure) is exactly aligned
-  to actual work activity, not to wall-clock or trigger volume.
-- *Reference counting + "fully idle" definition handles overlapping
-  and chained work cleanly*: the counter abstracts away "what kind of
-  work is happening." Provider run + scheduled job + future work
-  types can all overlap arbitrarily; the FSM only transitions when
-  all of them have released the wake lock.
+- *Engine-driven activity gating is the right shape*: token exists
+  only while work is happening. Cost (mint + env exposure) is
+  exactly aligned to actual activity. The engine is the natural
+  owner of "container is busy/idle" signals; subscribers react.
 
-**The FSM** (Phase L′, lives at
-`agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/fsm.py`,
-internal to the hivemoot plugin):
+**The engine class:**
 
 ```python
-# pseudocode — final implementation lands in Phase L′. This shape
-# satisfies five invariants the prose claims:
-#   I1. While ACTIVE, GITHUB_TOKEN is always populated by the time
-#       any job-start hook returns.
-#   I2. While IDLE, GITHUB_TOKEN is not in env and no refresh runs.
-#   I3. A failed wake-up leaves the counter at 0 so the next
-#       job-start retries cleanly (not stuck at count > 0 with no
-#       token).
-#   I4. A refresh-loop crash drives an idle transition + log so the
-#       next job-start re-mints from scratch.
-#   I5. Every asyncio.create_task gets add_done_callback so unhandled
-#       exceptions surface instead of being silently swallowed.
+# Lives in agent/cli/hivemoot_agent/engine.py
+import asyncio
+import contextlib
+
+class ContainerLifecycle:
+    """Container-wide IDLE/ACTIVE state with subscriber events.
+
+    The engine wires this around its job-dispatch loop: on_job_starting
+    runs before the engine hands a job to its plugin, on_job_finished
+    runs after. Subscribers register once at process setup and receive
+    on_active/on_idle on the 0↔1 active-job-counter boundary. The
+    engine awaits subscribers, so they can do async setup (e.g. mint a
+    token, set env, open a connection) and the engine doesn't proceed
+    until they're done.
+    """
+
+    def __init__(self) -> None:
+        self._active_jobs = 0
+        self._subscribers: list[LifecycleSubscriber] = []
+        self._lock = asyncio.Lock()
+
+    def subscribe(self, sub: "LifecycleSubscriber") -> None:
+        """Register a subscriber. Called at plugin setup, once."""
+        self._subscribers.append(sub)
+
+    async def on_job_starting(self, job) -> None:
+        """Engine calls before dispatching the job. On the 0→1
+        transition, awaits all subscribers' on_active. A subscriber
+        raising fails the lifecycle transition and rolls back the
+        counter so the next job-start retries cleanly (invariant I3)."""
+        async with self._lock:
+            self._active_jobs += 1
+            if self._active_jobs == 1:
+                # IDLE → ACTIVE — block on subscribers (invariant I1).
+                try:
+                    await asyncio.gather(
+                        *(s.on_active() for s in self._subscribers)
+                    )
+                except Exception:
+                    self._active_jobs -= 1  # roll back (I3)
+                    raise
+
+    async def on_job_finished(self, job) -> None:
+        """Engine calls after the job completes. On the 1→0
+        transition, awaits all subscribers' on_idle for cleanup.
+        Subscriber errors here are logged but don't propagate
+        (invariant I4) — the job is done, cleanup should be
+        best-effort across all subscribers."""
+        async with self._lock:
+            self._active_jobs = max(0, self._active_jobs - 1)
+            if self._active_jobs == 0:
+                # ACTIVE → IDLE — all subscribers' cleanup runs (I2, I4).
+                results = await asyncio.gather(
+                    *(s.on_idle() for s in self._subscribers),
+                    return_exceptions=True,
+                )
+                for sub, result in zip(self._subscribers, results):
+                    if isinstance(result, Exception):
+                        log.error(
+                            "subscriber on_idle raised",
+                            subscriber=type(sub).__name__,
+                            exc_info=result,
+                        )
+
+
+# Engine's job-dispatch loop becomes:
+async def _run_one_job(self, job) -> None:
+    await self._lifecycle.on_job_starting(job)  # awaits subscribers
+    try:
+        await self._dispatch_to_plugin(job)
+    finally:
+        await self._lifecycle.on_job_finished(job)  # awaits subscribers
+```
+
+#### 12.3.3 Subscriber interface (generic)
+
+Lives next to `ContainerLifecycle`:
+
+```python
+class LifecycleSubscriber:
+    """Plugin-agnostic contract for receiving container lifecycle
+    events. Plugins implementing this register via
+    ContainerLifecycle.subscribe() at plugin setup.
+
+    Implementers should:
+    - Be idempotent (subscribe might be called multiple times in
+      future plugin reconfig scenarios, though not in V1).
+    - Raise on critical setup failure in on_active — the engine
+      cancels other subscribers in the same gather and fails the
+      lifecycle transition (the triggering job fails to start, the
+      runtime retries, the next attempt re-runs setup cleanly).
+    - Tolerate own-errors in on_idle — best-effort cleanup; engine
+      logs but doesn't propagate.
+    """
+
+    async def on_active(self) -> None:
+        """Container transitioned IDLE → ACTIVE. Setup phase.
+        Engine awaits this before running the triggering job."""
+
+    async def on_idle(self) -> None:
+        """Container transitioned ACTIVE → IDLE. Cleanup phase.
+        Engine awaits this after the last job completes."""
+```
+
+This interface is the **only** thing the engine knows about
+subscribers. Generic, reusable for future cross-cutting concerns
+(metrics, logging, secret rotation, audit hooks).
+
+#### 12.3.4 Hivemoot github-auth subscriber
+
+Lives in `agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/`.
+Internal to the hivemoot plugin; not imported by any other plugin.
+
+```python
+# In plugins_builtin/hivemoot/auth/subscriber.py
 import asyncio
 import contextlib
 import os
@@ -1057,74 +1160,45 @@ from datetime import UTC, datetime
 
 REFRESH_SAFETY_MARGIN_SECONDS = 300
 
-class HivemootAgentAuthFSM:
-    """Activity-gated reference-counted FSM owned by the hivemoot plugin.
+class HivemootGithubAuthSubscriber(LifecycleSubscriber):
+    """Subscribes to ContainerLifecycle to keep GITHUB_TOKEN fresh
+    via apiarist for opt-in repos.
 
-    Drives GITHUB_TOKEN env management around fleet-member jobs
-    (anything triggered by hivemoot.tasks). The hivemoot plugin
-    instantiates this once at startup and routes its own
-    on_job_started/on_job_finished into on_work_start/on_work_end.
-    Internal to the hivemoot plugin — not imported by github plugin
-    or any other plugin.
+    Bound to a single repo at construction (V1 single-repo invariant).
+    Configured per repo in apiary.yaml — plugin only registers this
+    subscriber when the repo's `refresh_token: true` flag is set.
     """
 
-    def __init__(self, apiarist_client, repo: str):
+    def __init__(self, config: "RefreshConfig", apiarist_client) -> None:
+        self._config = config            # repo, env_var
         self._apiarist = apiarist_client
-        self._repo = repo
-        # Counter of in-flight fleet-member jobs. Only incremented
-        # by the hivemoot plugin's own lifecycle hooks (see wiring
-        # below); per-repo agents triggered by other plugins are on
-        # the static-PAT path in V1 and don't drive this FSM.
-        # Multi-repo single-process agents out of scope V1 — bound
-        # to a single repo at construction.
-        self._active = 0
         self._refresh_task: asyncio.Task | None = None
-        # Transition lock: serializes IDLE↔ACTIVE state changes so a
-        # second on_work_start arriving during wake-up cannot return
-        # to its caller before GITHUB_TOKEN is set (invariant I1).
-        # Wraps both on_work_start and on_work_end so the cleanup
-        # path is also serialized against new work arrivals.
-        self._lock = asyncio.Lock()
 
-    async def on_work_start(self, _source: str) -> None:
-        async with self._lock:
-            if self._active == 0:
-                # IDLE → ACTIVE: wake-up MUST complete before
-                # incrementing. If wake-up raises, counter stays at 0
-                # so the runtime's retry of this work-start re-attempts
-                # cleanly rather than stranding count > 0 with no token
-                # (invariant I3).
-                await self._wake_up()
-            self._active += 1
-
-    async def on_work_end(self, _source: str) -> None:
-        async with self._lock:
-            # max(0, ...) clamp defends against a buggy work source
-            # that fires on_work_end without a matching on_work_start.
-            self._active = max(0, self._active - 1)
-            if self._active == 0:
-                await self._go_idle()  # ACTIVE → IDLE (fully drained)
-
-    async def _wake_up(self) -> None:
-        token = await self._apiarist.mint_token(repo=self._repo)
-        os.environ["GITHUB_TOKEN"] = token.value
-        # Every create_task gets add_done_callback (invariant I5).
+    async def on_active(self) -> None:
+        # Engine awaits this before running the job. When this returns,
+        # env is populated and the triggering job sees a valid token
+        # (invariant I1). A raise here fails the transition; the engine
+        # rolls the counter back and the runtime retries the job.
+        token = await self._apiarist.mint_token(repo=self._config.repo)
+        os.environ[self._config.env_var] = token.value
+        # Background refresh: re-mint at expires_at - 5min so an ACTIVE
+        # period spanning >1h doesn't hit a stale token.
         task = asyncio.create_task(self._refresh_loop(token.expires_at))
-        task.add_done_callback(self._on_refresh_died)
+        task.add_done_callback(self._on_refresh_died)  # invariant I5
         self._refresh_task = task
 
-    async def _go_idle(self) -> None:
+    async def on_idle(self) -> None:
         if self._refresh_task is not None:
             self._refresh_task.cancel()
-            # AWAIT the cancelled task before popping env (invariant
-            # I2). Task.cancel() is synchronous — only requests
-            # cancellation at the next checkpoint. If the loop is
+            # Await drain BEFORE clearing env — Task.cancel() is
+            # synchronous, only requests cancellation. If the loop is
             # mid-await on mint_token, the mint return + os.environ
-            # assignment both run before cancellation reaches it.
+            # assignment both run before cancellation reaches it,
+            # leaving a token in env post-IDLE without the await.
             with contextlib.suppress(asyncio.CancelledError):
                 await self._refresh_task
             self._refresh_task = None
-        os.environ.pop("GITHUB_TOKEN", None)
+        os.environ.pop(self._config.env_var, None)
 
     async def _refresh_loop(self, expires_at: datetime) -> None:
         while True:
@@ -1133,22 +1207,20 @@ class HivemootAgentAuthFSM:
             ).total_seconds() - REFRESH_SAFETY_MARGIN_SECONDS
             if sleep_s > 0:
                 await asyncio.sleep(sleep_s)
-            new = await self._apiarist.mint_token(repo=self._repo)
-            os.environ["GITHUB_TOKEN"] = new.value
+            new = await self._apiarist.mint_token(repo=self._config.repo)
+            os.environ[self._config.env_var] = new.value
             expires_at = new.expires_at
 
     def _on_refresh_died(self, task: asyncio.Task) -> None:
+        # Cancellation = normal on_idle path, no-op.
         if task.cancelled():
-            return  # normal _go_idle path
+            return
         exc = task.exception()
         if exc is None:
             return  # refresh_loop is infinite; won't reach here normally
         log.error("refresh loop crashed", exc_info=exc)
-        # Schedule the reset asynchronously (callback is sync). New
-        # task gets its own add_done_callback (invariant I5) so any
-        # exception in the reset path surfaces too — without it, an
-        # unexpected error during cleanup would silently disappear,
-        # leaving the FSM stuck in an inconsistent state.
+        # Schedule cleanup asynchronously (callback is sync). New task
+        # also gets add_done_callback (invariant I5).
         reset_task = asyncio.create_task(self._reset_after_refresh_crash())
         reset_task.add_done_callback(self._log_reset_failure)
 
@@ -1156,181 +1228,157 @@ class HivemootAgentAuthFSM:
     def _log_reset_failure(task: asyncio.Task) -> None:
         if task.cancelled() or task.exception() is None:
             return
-        log.error("FSM reset path itself raised", exc_info=task.exception())
+        log.error(
+            "auth subscriber reset path itself raised",
+            exc_info=task.exception(),
+        )
 
     async def _reset_after_refresh_crash(self) -> None:
-        async with self._lock:
-            os.environ.pop("GITHUB_TOKEN", None)
-            self._refresh_task = None
-            # Force the next on_work_start to re-wake even if work
-            # units are still nominally in flight. They'll see env
-            # cleared, fail with 401, runtime retries them — and
-            # the retry's on_work_start finds _active = 0 and mints
-            # fresh.
-            self._active = 0
+        # Refresh died unexpectedly: clear env so any in-flight job's
+        # next GitHub call gets 401 and the runtime retries it. The
+        # retry will go through on_job_starting → on_active again
+        # (since the engine doesn't know about our internal failure;
+        # it sees the lifecycle as still ACTIVE). The fresh on_active
+        # mints a new token and restarts the refresh loop.
+        #
+        # NOTE: this reset path doesn't currently trigger an engine
+        # IDLE transition — that would require a callback from
+        # subscriber → engine which V1 doesn't have. If a 401 storm
+        # is observed in production after refresh deaths, the right
+        # fix is a "subscriber-requested reset" hook in the engine.
+        # Track in §16 open questions.
+        self._refresh_task = None
+        os.environ.pop(self._config.env_var, None)
 ```
 
-**Plugin wiring** (Phase L′) — only the hivemoot plugin touches
-the FSM. The github plugin remains completely unchanged.
+#### 12.3.5 Hivemoot plugin wiring
+
+The hivemoot plugin reads per-repo config and conditionally registers
+the subscriber:
 
 ```python
-# In agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
-from .auth.fsm import HivemootAgentAuthFSM
+# In plugins_builtin/hivemoot/__init__.py
+from hivemoot_agent.engine import ContainerLifecycle, LifecycleSubscriber
+from .auth.subscriber import HivemootGithubAuthSubscriber, RefreshConfig
 from .auth.apiarist_client import ApiaristClient
 
 class HivemootPlugin:
     async def setup(self, ctx) -> None:
-        # Instantiated once per agent process at plugin setup.
-        # Bound to one repo via AGENT_SERVICE → repo lookup (apiary
-        # deploy populates this). The apiarist UDS path comes from
-        # the deploy-staged config (default /run/apiarist.sock
-        # inside the container, bind-mounted from the host).
-        self._auth = HivemootAgentAuthFSM(
+        if not ctx.repo_config.refresh_token:
+            # Static PAT path; nothing to do. The github plugin's
+            # tooling will read whatever GITHUB_TOKEN was put in env
+            # at deploy time from apiary.secrets.yaml.
+            return
+
+        subscriber = HivemootGithubAuthSubscriber(
+            config=RefreshConfig(
+                repo=ctx.repo_config.repo,
+                env_var=ctx.repo_config.token_env or "GITHUB_TOKEN",
+            ),
             apiarist_client=ApiaristClient(
                 socket_path=ctx.config.apiarist_socket_path,
             ),
-            repo=ctx.config.agent_repo,
         )
-
-    async def on_job_started(self, job) -> None:
-        # All hivemoot.tasks-triggered jobs are GitHub-touching by
-        # nature (the agent will use gh/git for PR review, commit,
-        # etc.). Drive the FSM unconditionally — the FSM tolerates
-        # extra start/end pairs gracefully via the reference counter.
-        await self._auth.on_work_start("hivemoot.tasks")
-
-    async def on_job_finished(self, job) -> None:
-        await self._auth.on_work_end("hivemoot.tasks")
+        ctx.engine.lifecycle.subscribe(subscriber)
 ```
 
-The github plugin (`plugins_builtin/github/`) is untouched —
-`gh`/`octokit`/git wrappers continue to read `GITHUB_TOKEN` from
-env. Whether the env value comes from a static PAT (deploy-staged,
-non-bot repos) or from the hivemoot plugin's FSM (apiarist-minted,
-bot-installed repos) is invisible to the github plugin.
+The github plugin (`plugins_builtin/github/`) is **not modified**.
+`gh`/`octokit`/git wrappers continue to read `GITHUB_TOKEN` from env;
+whether the value is a static PAT or apiarist-minted is invisible.
 
-**Lifecycle (showing overlapping mixed work types):**
+#### 12.3.6 Lifecycle (showing overlapping work)
 
-| Event | Count | State | Action |
+| Event | Count | State | Engine action |
 |---|---|---|---|
 | Container boot | 0 | IDLE | nothing |
-| Task A starts | 0→1 | IDLE→ACTIVE | mint, set env, start refresh loop |
-| Task B starts (overlapping, different work source) | 1→2 | ACTIVE | no-op (loop already running) |
-| Task A ends | 2→1 | ACTIVE | no-op (B still running, agent not idle) |
-| Scheduled job C starts (chained from B) | 1→2 | ACTIVE | no-op |
-| Refresh loop fires (~55 min in) | 2 | ACTIVE | re-mint, update env |
-| Task B ends | 2→1 | ACTIVE | no-op (C still running) |
-| Job C ends (last work unit) | 1→0 | ACTIVE→**IDLE** | cancel refresh, clear env |
-| Long idle (e.g. 5h) | 0 | IDLE | zero mints, zero env |
-| New task arrives | 0→1 | IDLE→ACTIVE | mint fresh, set env, start refresh |
+| Job A starts (engine `on_job_starting`) | 0→1 | IDLE→ACTIVE | await all subscribers' `on_active`; auth subscriber mints, sets env, starts refresh loop |
+| Engine dispatches Job A to plugin | 1 | ACTIVE | env populated; job sees valid token |
+| Job B starts (overlapping) | 1→2 | ACTIVE | no transition; subscribers not called |
+| Job A finishes | 2→1 | ACTIVE | no transition |
+| Refresh loop fires (~55 min in) | 2 | ACTIVE | auth subscriber's loop re-mints, updates env transparently |
+| Job B finishes (last) | 1→0 | ACTIVE→IDLE | await all subscribers' `on_idle`; auth subscriber cancels refresh, awaits drain, clears env |
+| Long idle (5h) | 0 | IDLE | zero mints, zero env |
+| Job C starts (next trigger, hours later) | 0→1 | IDLE→ACTIVE | full wake-up cycle again |
 | Container exits (eventually) | — | — | process dies, env evaporates |
 
-The "Task A ends" and "Task B ends" rows in the middle are critical:
-neither triggers a state change because the counter is still ≥ 1.
-Only the **last** ending — Job C, where count finally reaches 0 —
-triggers the IDLE transition. This is the "fully idle" definition.
+The "fully idle" definition is critical: the IDLE transition only
+fires when the counter reaches 0. Intermediate decrements (2→1, 1→2,
+etc.) don't trigger subscriber events.
 
-**What the agent runtime needs to expose:**
+#### 12.3.7 Failure modes
 
-Existing per-plugin lifecycle hooks: `on_job_started(job)` and
-`on_job_finished(job)` on each plugin (the standard plugin contract
-that `run_agent` already calls). No new engine surface required.
+- *Apiarist unreachable when waking up* (or *repo not covered by an
+  installation* — `BACKEND_FORBIDDEN`) → auth subscriber's
+  `on_active` raises. ContainerLifecycle's gather propagates;
+  `on_job_starting` rolls the counter back to 0; the triggering job
+  fails to start. Runtime treats as transient and retries; next job
+  triggers a fresh `on_job_starting` and re-runs the whole
+  subscriber-setup phase cleanly. The most-common operational
+  failure here is a misconfigured repo (operator set
+  `refresh_token: true` without installing the bot); the daemon's
+  error message includes the repo name so the cause is visible
+  immediately.
+- *Refresh fails mid-active* → auth subscriber's `_on_refresh_died`
+  callback fires, logs loudly, schedules
+  `_reset_after_refresh_crash` which clears env. Any in-flight job
+  will see env cleared on its next GitHub call, fail with 401, and
+  the runtime retries the job; the retry doesn't trigger a new
+  `on_job_starting` (engine still sees us as ACTIVE), so the auth
+  subscriber doesn't re-run setup automatically — the
+  `_reset_after_refresh_crash` path is best-effort. If 401 storms
+  are observed in production after refresh deaths, the right fix is
+  a "subscriber-requested reset" hook in the engine; tracked in §16
+  open questions.
+- *401 mid-job* (clock skew, manual revocation via App admin UI) →
+  job fails with normal HTTP error, runtime retries; refresh loop
+  may have already updated env on the retry. If 401 recurs the job
+  fails permanently and the runtime escalates per its retry policy.
+- *Subscriber `on_idle` raises* → engine logs the error but
+  continues with other subscribers' cleanup (invariant I4). The
+  lifecycle transition to IDLE completes; the engine returns to its
+  next idle iteration. A leaked refresh task or env from a
+  partial-cleanup will be visible to operators in the journal.
 
-The hooks fire **only on the triggering plugin** (verified at
-`engine.py:1208,1316`). That's why the FSM is a shared module
-imported by multiple plugins instead of a singleton owned by any
-one plugin — both `github/` and `hivemoot/` need to drive the
-same auth state, but neither receives the other's lifecycle events.
-
-Future engine change (broadcast hooks across all enabled plugins)
-would allow extracting the FSM call into a single engine-level
-hook and removing the per-plugin wiring. Not needed for V1
-correctness; called out in §16 open questions for revisit when
-more plugins need active/idle awareness (metrics, logging, secret
-rotation, etc. would all benefit).
-
-**Failure modes:**
-
-- *Apiarist unreachable when waking up* → `_wake_up` raises inside
-  the lock held by `on_work_start`; the work unit that triggered
-  the 0→1 transition fails to start. The lock is released, counter
-  stays at 0 (invariant I3). Agent runtime treats it as a transient
-  failure and retries per its existing policy. The next work-start
-  re-attempts the wake-up cleanly.
-- *Repo not covered by an installation* (`BACKEND_FORBIDDEN` from
-  the daemon, mapped from backend HTTP 403) → `_wake_up` raises
-  the same way as the unreachable case; the job fails, runtime
-  escalates. This is the operationally-most-likely failure mode
-  for a misconfigured repo (operator forgot to install the bot
-  before flagging the agent for `auth: github-app`). The error
-  message includes the repo name so the operator sees immediately
-  what to fix; no silent fallback to a stale token or static PAT.
-- *Refresh fails mid-active* → `_on_refresh_died` callback fires,
-  logs the exception loudly, schedules `_reset_after_refresh_crash`
-  which clears env + zeroes the counter. Any work units still
-  nominally in flight will see env cleared on their next GitHub
-  call, fail with 401, and the runtime retries them. The retry's
-  `on_work_start` finds `_active = 0` and mints fresh (invariant I4).
-- *401 mid-work* (clock skew, manual revocation via App admin UI)
-  → agent's current GitHub call fails with normal HTTP error,
-  surfaces as a work-unit failure. Agent runtime retries; the retry
-  hits the still-active state, re-uses the env value (or the refresh
-  loop has already updated it, depending on timing). If the 401
-  recurs the work unit fails permanently and the runtime escalates
-  per its retry policy.
-
-**Escape hatch for tasks that genuinely span >1h with no work-unit
-boundaries:** the task can call `apiarist_client.mint_token(repo)`
+**Escape hatch for jobs that genuinely span >1h** with no work-unit
+boundaries: the job can call `apiarist_client.mint_token(repo)`
 inline at the point it knows the env token may have aged out. The
-inline mint call should also update `os.environ["GITHUB_TOKEN"]` if
-the task expects sibling tooling (subprocesses, other libraries
-reading env) to see the fresh value. Opt-in, no plugin change
-required. Rare in practice — the refresh loop covers steady-state
-ACTIVE periods regardless of duration.
+inline mint should also update `os.environ[token_env]` if the job
+expects sibling tooling (subprocesses, other libraries reading env)
+to see the fresh value. Opt-in, no subscriber change required. Rare
+in practice — the refresh loop covers steady-state ACTIVE periods
+regardless of duration.
 
 **Subprocess env inheritance** (V1 trust model honesty): when the
-agent spawns subprocesses during ACTIVE — `gh`, `git` (via
-askpass), anything else exec'd — those subprocesses receive a
-fork-time copy of env including `GITHUB_TOKEN`. The token persists
-in the subprocess until **the subprocess** exits, not until the
-parent transitions to IDLE. Short-lived `gh`/`git` invocations
-(the common case) are fine. Long-running spawned processes (a
-watch loop, a wrapper that never exits) need to be explicitly
-bounded by the caller; the parent's `os.environ.pop` doesn't
-reach them.
+agent spawns subprocesses during ACTIVE — `gh`, `git` (via askpass),
+anything else exec'd — those subprocesses receive a fork-time copy
+of env including `GITHUB_TOKEN`. The token persists in the
+subprocess until **the subprocess** exits, not until the parent
+transitions to IDLE. Short-lived `gh`/`git` invocations are fine.
+Long-running spawned processes (a watch loop, a wrapper that never
+exits) need to be explicitly bounded by the caller; the parent's
+`os.environ.pop` doesn't reach them.
 
-**What this design does NOT do** (intentionally):
+#### 12.3.8 What this design does NOT do (intentionally)
 
-- Mint at container startup. Wrong moment — work hasn't arrived.
-- Run a perpetual background refresh loop. The loop only runs
-  during ACTIVE periods; idle = zero burn.
-- Reactively re-mint on 401. The refresh loop covers steady-state
-  expiry; if a 401 still slips through (clock skew, revocation),
-  the work unit fails loud and the runtime retry path kicks in.
-- Mint per-work-unit. Overlapping/chained work units share the
-  active token via the FSM; per-unit minting would burn redundant
-  mints during chained work and tear down env between rapid-fire
-  triggers.
-- Restrict in-process token lifetime during ACTIVE. Once
-  `GITHUB_TOKEN` is in env, agent code and subprocesses can read
-  it. Strong enforcement of "no token in agent memory" would
-  require the V3+ HTTPS proxy model (§11 future hardening). V1
-  enforcement is `(time + scope + audit)` per §10.
-- Restrict subprocess token lifetime once spawned. See subprocess
-  inheritance note above. Token leaves the parent's control at
-  fork time; the parent's IDLE cleanup doesn't reach already-running
-  subprocesses.
-- Track non-GitHub work. Each driving plugin gates its own
-  contribution to the counter — github/ via `_is_github_touching(job)`,
-  hivemoot/ unconditionally (since hivemoot.tasks jobs are all
-  GitHub-touching by design). Non-GitHub work in any other plugin
-  doesn't contribute and doesn't need `GITHUB_TOKEN` either.
-- Use bare `asyncio.create_task` anywhere in the FSM. Every
-  task gets `add_done_callback` so unhandled exceptions surface
-  via the structured logger instead of being silently swallowed
-  by asyncio's default exception handler (invariant I5). This
-  applies uniformly to the refresh loop AND to the
-  `_reset_after_refresh_crash` reset path.
+- Mint at container startup (wrong moment — work hasn't arrived).
+- Run a perpetual background refresh loop (only runs during ACTIVE).
+- Reactively re-mint on 401 (refresh covers steady-state; 401
+  fails the job; runtime retry path handles recovery).
+- Mint per-job (chained jobs share env via the engine's lifecycle
+  state; per-job mint would burn redundant mints + tear down env
+  between rapid-fire triggers).
+- Restrict in-process token lifetime during ACTIVE (env is
+  process-global; agent code and subprocesses can read it).
+- Restrict subprocess token lifetime once spawned (subprocess
+  inherits env at fork; parent IDLE cleanup doesn't reach it).
+- Drive auth from the github plugin (it's a tool provider, not an
+  identity owner; the dependency direction is auth → tools, not
+  the reverse).
+- Use bare `asyncio.create_task` anywhere in the engine or auth
+  subscriber (every task gets `add_done_callback`; invariant I5).
+- Couple plugins to each other through auth concerns (every plugin
+  that subscribes to lifecycle does so directly with the engine; no
+  cross-plugin imports).
 
 ## 13. Migration plan
 
@@ -1419,7 +1467,7 @@ either (a) we ship the engine-level AuthManager option, or
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `auth: github-app`, skip static token, bind-mount `/run/apiarist.sock`, set `AGENT_SERVICE` + `AGENT_TOKEN_SLOT` env. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). | 0.5d | — (parallel) |
-| **L′.** Hivemoot plugin — activity-gated GitHub auth | New `agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth/` submodule containing the FSM (`fsm.py`, the activity-gated state machine from §12.3) and the apiarist UDS client (`apiarist_client.py`, ~50 LOC). The hivemoot plugin instantiates one FSM at startup and routes its own `on_job_started`/`on_job_finished` hooks into the FSM. Apiarist auth is a hivemoot-architecture-specific feature (apiarist itself, agent_token bearers, per-installation policy), so it lives where hivemoot architecture lives. The github plugin is **not touched** — it remains a tool provider, reading `GITHUB_TOKEN` from env regardless of whether the value is a static PAT or apiarist-minted token. **Hard precondition: target repo must have the Hivemoot Bot GitHub App installed** — apiarist mints installation tokens, which only exist where the App is installed; non-installed repos stay on the static-PAT path forever (or until the operator installs the bot). | 1.5d | D, E |
+| **L′.** Engine lifecycle FSM + hivemoot auth subscriber | Three layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber. Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. github plugin is **not touched**. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Foxstoria pilot | flag foxstoria's repo block with `auth: github-app` + `agent_token: foxstoria-builder`, deploy, observe one full agent run cycle. Verify ghs_ token reaches GitHub successfully and zero token files appear on disk. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -1155,9 +1155,10 @@ class ContainerLifecycle:
             if self._active_jobs == 1:
                 # IDLE → ACTIVE — block on subscribers (invariant I1).
                 # Sequential not gather() so partial-success cleanup is
-                # ordered (cleanup runs in setup-order, ensures earlier
-                # subscribers' state is torn down BEFORE later ones'
-                # failure error is re-raised).
+                # ordered: rollback uses `reversed(completed)` (reverse
+                # setup order) so a later subscriber's state is torn
+                # down BEFORE the earlier subscriber it depends on —
+                # mirrors typical setup-time dependency direction.
                 completed: list[LifecycleSubscriber] = []
                 try:
                     for sub in self._subscribers:
@@ -1395,23 +1396,37 @@ class HivemootPlugin:
 #### 12.3.5a Required github plugin refactor for `refresh_token: true` repos
 
 The github plugin's current `setup()` does materially more than env
-population. Verified at `agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py`:
+population. Full audit of token-dependent operations in
+`agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py` and
+the `repo_manager.py` it calls into:
 
-- `:131-145` `validate()` — requires non-empty `plugins.github.token_file`
-- `:177` reads the token from that file
-- `:196` writes `GH_TOKEN` / `GITHUB_TOKEN` to env (the part the
-  subscriber would also do)
-- `:205-206` `_validate_repo_access(repo, token)` — fails closed if
-  the token doesn't grant repo access (needs token at setup time)
-- `:211-214` `clone_or_sync(repo, workspace, token, ...)` — clones
-  or fetches the repo into the workspace (needs token at setup time)
+- `__init__.py:131-145` `validate()` — requires non-empty `plugins.github.token_file`
+- `__init__.py:177` reads the token from that file
+- `__init__.py:185-186` `resolve_github_user(token)` (in
+  `repo_manager.py:230-249`) — runs `gh api user` with the token
+  in env to derive git identity (`name`, `email`). Skipped if
+  `cfg.git_name` is set, but the lookup itself needs a token.
+- `__init__.py:196` writes `GH_TOKEN` / `GITHUB_TOKEN` to env
+- `__init__.py:198-199` `_configure_git_auth()` (at `:38-60`) —
+  runs `gh auth setup-git` as a subprocess to register `gh` as
+  git's credential helper. Subprocess needs `GH_TOKEN` /
+  `GITHUB_TOKEN` populated when it runs (otherwise `gh` exits
+  unauthenticated).
+- `__init__.py:205-206` `_validate_repo_access(repo, token)` — fails
+  closed if the token doesn't grant repo access
+- `__init__.py:211-214` `clone_or_sync(repo, workspace, token, ...)`
+  — clones or fetches the repo into the workspace
+- `__init__.py:217` `configure_git_user(info.path, git_name, git_email)`
+  (in `repo_manager.py:218-227`) — sets git config in the cloned
+  workspace. Doesn't itself need a token but logically follows the
+  clone (depends on the cloned `info.path` existing).
 
 Plugin `setup()` runs once at engine boot, **before any job is
 dispatched**. The lifecycle subscriber's `on_active` hook fires only
-when the engine starts dispatching the first job. So the naive
-short-circuit ("setup() becomes a no-op") leaves `_validate_repo_access`
-and `clone_or_sync` un-run, and the workspace isn't ready when the
-first job actually starts.
+when the engine starts dispatching the first job. So everything
+that needs a token (lookup, env-set, gh-auth-setup, repo-access
+validation, clone/sync) and everything that depends on the clone
+output (configure_git_user) must defer to `on_active`.
 
 Phase L′ therefore includes a real refactor of github plugin's
 `setup()` (not just an env-population short-circuit). Two pieces:
@@ -1419,15 +1434,31 @@ Phase L′ therefore includes a real refactor of github plugin's
 **1. Split `setup()` into auth-free + auth-required halves.**
 
 - *auth-free* (always runs at engine boot): typed-config validation,
-  workspace-directory bootstrap, `gh` CLI binary discovery, etc.
-  Anything that doesn't need a token to complete.
-- *auth-required* (deferred to first ACTIVE): `_validate_repo_access`,
-  `clone_or_sync`. These move into a NEW github plugin lifecycle
-  subscriber (the github plugin becomes its OWN `LifecycleSubscriber`
-  in addition to a tool provider) whose `on_active` runs them
-  exactly once per ACTIVE period — guarded by an idempotency check
-  so subsequent on_active calls (from later ACTIVE periods) re-sync
-  if the workspace exists, or full-clone if not.
+  workspace-directory bootstrap (`mkdir -p`), `gh` CLI binary
+  discovery (which path), reading the typed config. Anything that
+  doesn't need a token to complete.
+- *auth-required* (deferred to first ACTIVE, runs in this exact
+  order):
+  1. `resolve_github_user(token)` — derive git identity (skip if
+     `cfg.git_name` set)
+  2. `_configure_git_auth()` — `gh auth setup-git`, needs env
+     populated (which the hivemoot auth subscriber's prior
+     on_active has done — see registration order)
+  3. `_validate_repo_access(repo, token)` — fail-closed access
+     check
+  4. `clone_or_sync(repo, workspace, token, ...)` — clone or fetch
+     into the workspace
+  5. `configure_git_user(info.path, git_name, git_email)` — git
+     config in the cloned workspace
+
+  All five move into a NEW github plugin lifecycle subscriber (the
+  github plugin becomes its OWN `LifecycleSubscriber` in addition to
+  a tool provider) whose `on_active` runs them in that order. An
+  idempotency guard at the subscriber level skips the work after
+  the first successful on_active per process — subsequent
+  IDLE→ACTIVE cycles re-mint the token but don't re-clone (clone
+  output is process-stable, only the env value cycles per
+  ACTIVE/IDLE).
 
 **2. Subscriber registration order matters.**
 

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -186,8 +186,11 @@ all of the above without restructuring.**
   agent makes the request.
 - **Tokens NEVER touch disk.** Apiarist holds them in process memory
   for a short cache window (default 5 min); the agent receives them
-  over the socket and holds them in process memory for the duration
-  of one or a few GitHub API calls, then they're garbage-collected.
+  over the socket and exposes them to its tooling via the
+  `GITHUB_TOKEN` env var for the duration of the agent's ACTIVE
+  period (any GitHub-touching work in flight). When the agent
+  becomes fully idle, the env var is cleared. See §12.3 for the
+  activity-gated FSM and what "ACTIVE period" means in practice.
   No on-disk file at any layer.
 - Filesystem permissions on `/run/apiarist.sock` (chmod 660, group
   `agent`) gate which processes can request mints. Apiary deploy adds
@@ -489,7 +492,7 @@ selector is absent, apiarist falls through to the `default` slot
 
 | Threat | Defense |
 |---|---|
-| Container compromise | Token in container is short-lived (1h max from GitHub, but only resident in agent process memory while in active use — typically seconds). GitHub-side narrowing via `repository_ids` + `permissions` means even a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into all containers using App auth) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. |
+| Container compromise | Token in container is short-lived (1h max from GitHub) and resident in `os.environ["GITHUB_TOKEN"]` only during the agent's ACTIVE period (any GitHub-touching work in flight; see §12.3). When the agent goes IDLE, the env var is cleared. Realistic ACTIVE periods are minutes to a few hours; never the container's full uptime. GitHub-side narrowing via `repository_ids` + `permissions` means even a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into all containers using App auth) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. **Subprocess caveat:** subprocesses spawned during ACTIVE inherit the env at fork time and retain `GITHUB_TOKEN` until they exit; the parent's IDLE-time cleanup doesn't reach them. Short-lived `gh`/`git` invocations (the common case) are fine. Long-running spawned processes inheriting the env need to be explicitly bounded by the caller. |
 | Cross-service token theft | An agent claiming `service: builder-claude` in its UDS request still authenticates against the **builder-claude token's policy** server-side. Apiarist trusts `AGENT_SERVICE` env (set by deploy, not by container code), and the broker→backend flow uses the bearer keyed off that. A compromised builder container cannot trick apiarist into minting against guard's token by lying about its service — apiarist's per-service policy lookup is the gate. (This does mean a fully-compromised container can mint within its OWN policy without bound — which is exactly the policy-shrink mitigation: don't grant a token broader scope than the agent legitimately needs.) |
 | Apiarist process memory dump | Disable core dumps via systemd `LimitCORE=0`. Lock pages with `mlock`-equivalent (`MemoryDenyWriteExecute=true`). Restart-on-crash is already systemd's default, so a transient crash doesn't leak the cache to disk via core file. Cache TTL of 5 min (default) bounds the in-memory residency window. |
 | Local user escalation | Socket is `chmod 660`, owned by `apiarist:agent`. Only members of group `agent` (the unprivileged uid the apiary docker-run gives containers) can connect. Other local users get EACCES. The daemon `chown`s the socket and asserts the configured `socket_group` exists at startup; mismatch logs loudly to stderr and refuses to start. asyncio's `start_unix_server` does NOT set group ownership automatically — explicit chown is required after bind. |
@@ -899,35 +902,53 @@ or privileged flag is needed.
 
 ### 12.3 Agent runtime change (monorepo, not apiary)
 
-A small auth plugin in `agent/cli/hivemoot_agent/plugins_builtin/github_auth/`
-(Phase L′ PR against `hivemoot/hivemoot`) implementing a two-state
-machine driven by **whether the agent has any active work**.
+An activity-gated FSM lives **inside the existing GitHub plugin** at
+`agent/cli/hivemoot_agent/plugins_builtin/.../github` (not a new
+plugin). Engine constraint: daemon-mode `run_agent` fires lifecycle
+hooks only on the *triggering* plugin, not on every enabled plugin
+broadcast-style. Putting the FSM inside the existing plugin avoids
+needing to change the engine first; the plugin's hooks already fire
+exactly when its own GitHub-touching work runs, which is the only
+time `GITHUB_TOKEN` actually needs to be in env.
 
-States: ACTIVE (count of in-flight work units ≥ 1) or IDLE (count = 0).
-The plugin keeps a generic reference counter that any work source in
-the runtime can increment — provider runs, task executions, scheduled
-jobs, future work types — they all contribute uniformly. Only the
-0↔1 boundary triggers a state transition; intermediate counter
-movements are no-ops.
+States: ACTIVE (count of in-flight GitHub-touching work units ≥ 1)
+or IDLE (count = 0). The plugin keeps a reference counter that
+increments on every work-start hook the engine fires and decrements
+on every work-end hook. Only the 0↔1 boundary triggers a state
+transition; intermediate counter movements are no-ops.
 
 - **IDLE → ACTIVE** (counter goes 0→1, first work unit started):
-  mint `GITHUB_TOKEN`, start a background refresh loop that re-mints
-  at `expires_at - 5min`.
+  mint `GITHUB_TOKEN`, set env, start a background refresh loop
+  that re-mints at `expires_at - 5min`.
 - **ACTIVE → IDLE** (counter goes 1→0, **last** work unit ended —
-  i.e., all overlapping/chained work is fully drained): cancel the
-  refresh loop, clear `GITHUB_TOKEN` from env.
+  i.e., all overlapping/chained GitHub work is fully drained):
+  cancel the refresh loop (and await it to drain), clear
+  `GITHUB_TOKEN` from env.
 
 The "fully idle" definition is critical: a single task ending is just
 a decrement (`count--`); the state only transitions to IDLE when
-**every** work source has released the wake lock. This matters for
-chained or overlapping work — task A ending while scheduled job B is
-still running does NOT trigger cleanup, because the agent is still
-busy from B's perspective.
+**every** GitHub-touching work source has released the wake lock.
+This matters for chained or overlapping work — task A ending while
+task B is still running does NOT trigger cleanup, because the agent
+is still busy from B's perspective.
 
 While ACTIVE, all the agent's existing tooling (`gh`, `git` via
 askpass, `octokit`, `PyGithub`) reads `GITHUB_TOKEN` from env and
 just works. While IDLE, no token is minted, no token sits in env,
 no refresh runs.
+
+**Single-instance, single-repo invariant (V1):** one plugin instance
+per agent process, bound to one repo via `AGENT_SERVICE` lookup.
+`os.environ["GITHUB_TOKEN"]` is process-global — there is one slot,
+not one per repo — so an agent process running concurrent work for
+two different repos would have the two repo's tokens stomp each
+other in env, last-writer-wins. Multi-repo agents in a single
+process are out of scope for V1 and the runtime should refuse to
+register a second plugin instance. (Multi-repo agents today already
+run as separate containers per the apiary model, so this constraint
+matches existing reality.) Future V2+ option: per-work-unit env
+injection via `subprocess.run(env=...)` rather than process-global
+mutation, when/if multi-repo single-process agents become a need.
 
 **Why activity-gated refresh (not container-startup, not per-trigger,
 not always-on):**
@@ -954,8 +975,18 @@ not always-on):**
 **The whole plugin** (Phase L′):
 
 ```python
-# pseudocode — ~30 LOC final shape
+# pseudocode — final implementation lands in Phase L′. This shape
+# satisfies the four invariants the prose claims:
+#   I1. While ACTIVE, GITHUB_TOKEN is always populated by the time
+#       any work unit's start-hook returns.
+#   I2. While IDLE, GITHUB_TOKEN is not in env and no refresh runs.
+#   I3. A failed wake-up leaves the counter at 0 so the next
+#       work-start retries cleanly (not stuck at count > 0 with no
+#       token).
+#   I4. A refresh-loop crash drives an idle transition + log so the
+#       next work-start re-mints from scratch.
 import asyncio
+import contextlib
 import os
 from datetime import UTC, datetime
 
@@ -965,34 +996,65 @@ class GitHubAuthPlugin:
     def __init__(self, apiarist_client, repo: str):
         self._apiarist = apiarist_client
         self._repo = repo
-        # Generic active-work counter. Anything that represents
-        # in-flight work (provider runs, tasks, scheduled jobs,
-        # future work types) increments this. The plugin doesn't
-        # care WHAT kind of work; only whether the agent has
-        # anything active right now.
+        # Counter of GitHub-touching work units in flight. Incremented
+        # by on_work_start, decremented by on_work_end. Multi-repo
+        # agents are out of scope for V1 (see process-global env
+        # discussion above), so this is per-process and counts only
+        # this plugin's hook firings.
         self._active = 0
         self._refresh_task: asyncio.Task | None = None
+        # Transition lock: serializes IDLE↔ACTIVE state changes so a
+        # second on_work_start arriving during wake-up cannot return
+        # to its caller before GITHUB_TOKEN is set (invariant I1).
+        # Wraps both on_work_start and on_work_end so the cleanup
+        # path is also serialized against new work arrivals.
+        self._lock = asyncio.Lock()
 
     async def on_work_start(self, _source) -> None:
-        self._active += 1
-        if self._active == 1:
-            await self._wake_up()  # IDLE → ACTIVE (first work in)
+        async with self._lock:
+            if self._active == 0:
+                # IDLE → ACTIVE: wake-up MUST complete before
+                # incrementing. If wake-up raises, counter stays at 0
+                # so the runtime's retry of this work-start re-attempts
+                # cleanly rather than stranding count > 0 with no token
+                # (invariant I3 — addresses builder's gap and aligns
+                # with the failure-mode prose below).
+                await self._wake_up()
+            self._active += 1
 
     async def on_work_end(self, _source) -> None:
-        self._active -= 1
-        if self._active == 0:
-            await self._go_idle()  # ACTIVE → IDLE (fully drained)
+        async with self._lock:
+            # max(0, ...) clamp defends against a buggy work source
+            # that fires on_work_end without a matching on_work_start.
+            # Without this, _active goes negative and the 0→1
+            # transition never re-fires; the agent stops minting.
+            self._active = max(0, self._active - 1)
+            if self._active == 0:
+                await self._go_idle()  # ACTIVE → IDLE (fully drained)
 
     async def _wake_up(self) -> None:
         token = await self._apiarist.mint_token(repo=self._repo)
         os.environ["GITHUB_TOKEN"] = token.value
-        self._refresh_task = asyncio.create_task(
-            self._refresh_loop(token.expires_at)
-        )
+        task = asyncio.create_task(self._refresh_loop(token.expires_at))
+        # Surface refresh-loop crashes as state transitions instead
+        # of letting asyncio's default exception handler swallow them
+        # silently (invariant I4). Without add_done_callback the
+        # refresh chain dies invisibly and tokens stop being renewed.
+        task.add_done_callback(self._on_refresh_died)
+        self._refresh_task = task
 
     async def _go_idle(self) -> None:
-        if self._refresh_task:
+        if self._refresh_task is not None:
             self._refresh_task.cancel()
+            # AWAIT the cancelled task before popping env so a refresh
+            # in flight can't write env AFTER our pop (invariant I2).
+            # Task.cancel() is synchronous — only requests cancellation
+            # at the next checkpoint. If the loop is mid-await on
+            # mint_token, the mint return + os.environ assignment
+            # both run before cancellation reaches it; we'd lose the
+            # race and leave a token in env post-IDLE.
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._refresh_task
             self._refresh_task = None
         os.environ.pop("GITHUB_TOKEN", None)
 
@@ -1006,6 +1068,29 @@ class GitHubAuthPlugin:
             new = await self._apiarist.mint_token(repo=self._repo)
             os.environ["GITHUB_TOKEN"] = new.value
             expires_at = new.expires_at
+
+    def _on_refresh_died(self, task: asyncio.Task) -> None:
+        # Cancellation = normal _go_idle path, no-op.
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return  # refresh_loop is infinite, won't reach here normally
+        log.error("refresh loop crashed", exc_info=exc)
+        # Schedule the idle transition asynchronously (the callback
+        # is a sync context). The next on_work_start will re-wake.
+        asyncio.create_task(self._reset_after_refresh_crash())
+
+    async def _reset_after_refresh_crash(self) -> None:
+        async with self._lock:
+            os.environ.pop("GITHUB_TOKEN", None)
+            self._refresh_task = None
+            # Force the next on_work_start to re-wake even if work
+            # units are still nominally in flight. They'll see env
+            # cleared, fail with 401, runtime retries them — and
+            # the retry's on_work_start finds _active = 0 and mints
+            # fresh.
+            self._active = 0
 ```
 
 **Lifecycle (showing overlapping mixed work types):**
@@ -1031,37 +1116,64 @@ triggers the IDLE transition. This is the "fully idle" definition.
 
 **What the agent runtime needs to expose:**
 
-Generic hooks: `on_work_start(source)` and `on_work_end(source)`,
-fired around every work unit (provider run, scheduled task, future
-work types). The plugin doesn't introspect `source` — it just
-maintains the counter. If the runtime already exposes per-task or
-per-provider lifecycle events (most plugin systems do), this is a
-thin adapter; if not, adding generic work-lifecycle hooks is a
-one-time investment that pays off across all plugins that need
-active/idle tracking (metrics, logging, secret rotation, etc.).
+Per-plugin lifecycle hooks: `on_work_start(source)` and
+`on_work_end(source)`, fired on this plugin around every work unit
+the plugin is involved in. The hooks are called **only on the
+triggering plugin** (the existing `run_agent` daemon-mode behavior),
+not broadcast to every enabled plugin. That's why the FSM lives
+inside the existing GitHub plugin: the plugin's own hook firings
+correspond exactly to GitHub-touching work, which is the only time
+`GITHUB_TOKEN` actually needs to be in env.
+
+This means the plugin doesn't track *all* agent work — only its own.
+A non-GitHub work unit running concurrently with GitHub work doesn't
+contribute to the counter, which is fine: it doesn't need
+`GITHUB_TOKEN` either. Future engine change (broadcast hooks) would
+allow splitting the FSM into a dedicated `github_auth` plugin and
+narrowing the GitHub plugin's responsibilities, but isn't needed for
+V1 correctness.
 
 **Failure modes:**
 
-- *Apiarist unreachable when waking up* → `_wake_up` raises,
-  the work unit that triggered the 0→1 transition fails to start.
-  Agent runtime treats it as a transient failure and retries per
-  its existing policy. The next work-start re-attempts the wake-up.
-  Counter stays at 0 since the failed start never incremented it.
-- *Refresh fails mid-active* → exception in the background task;
-  agent runtime should treat unhandled task exceptions as fatal to
-  the active period (trigger an idle transition + restart). The
-  next work-start mints fresh.
+- *Apiarist unreachable when waking up* → `_wake_up` raises inside
+  the lock held by `on_work_start`; the work unit that triggered
+  the 0→1 transition fails to start. The lock is released, counter
+  stays at 0 (invariant I3). Agent runtime treats it as a transient
+  failure and retries per its existing policy. The next work-start
+  re-attempts the wake-up cleanly.
+- *Refresh fails mid-active* → `_on_refresh_died` callback fires,
+  logs the exception loudly, schedules `_reset_after_refresh_crash`
+  which clears env + zeroes the counter. Any work units still
+  nominally in flight will see env cleared on their next GitHub
+  call, fail with 401, and the runtime retries them. The retry's
+  `on_work_start` finds `_active = 0` and mints fresh (invariant I4).
 - *401 mid-work* (clock skew, manual revocation via App admin UI)
   → agent's current GitHub call fails with normal HTTP error,
   surfaces as a work-unit failure. Agent runtime retries; the retry
   hits the still-active state, re-uses the env value (or the refresh
-  loop has already updated it, depending on timing).
+  loop has already updated it, depending on timing). If the 401
+  recurs the work unit fails permanently and the runtime escalates
+  per its retry policy.
 
-**Escape hatch for tasks that genuinely span >1h with no provider
+**Escape hatch for tasks that genuinely span >1h with no work-unit
 boundaries:** the task can call `apiarist_client.mint_token(repo)`
-inline at the point it knows the env token may have aged out.
-Opt-in, no plugin change required. Rare in practice — the refresh
-loop covers steady-state ACTIVE periods regardless of duration.
+inline at the point it knows the env token may have aged out. The
+inline mint call should also update `os.environ["GITHUB_TOKEN"]` if
+the task expects sibling tooling (subprocesses, other libraries
+reading env) to see the fresh value. Opt-in, no plugin change
+required. Rare in practice — the refresh loop covers steady-state
+ACTIVE periods regardless of duration.
+
+**Subprocess env inheritance** (V1 trust model honesty): when the
+agent spawns subprocesses during ACTIVE — `gh`, `git` (via
+askpass), anything else exec'd — those subprocesses receive a
+fork-time copy of env including `GITHUB_TOKEN`. The token persists
+in the subprocess until **the subprocess** exits, not until the
+parent transitions to IDLE. Short-lived `gh`/`git` invocations
+(the common case) are fine. Long-running spawned processes (a
+watch loop, a wrapper that never exits) need to be explicitly
+bounded by the caller; the parent's `os.environ.pop` doesn't
+reach them.
 
 **What this design does NOT do** (intentionally):
 
@@ -1070,12 +1182,23 @@ loop covers steady-state ACTIVE periods regardless of duration.
   during ACTIVE periods; idle = zero burn.
 - Reactively re-mint on 401. The refresh loop covers steady-state
   expiry; if a 401 still slips through (clock skew, revocation),
-  the task fails loud and the runtime retry path kicks in.
+  the work unit fails loud and the runtime retry path kicks in.
+- Mint per-work-unit. Overlapping/chained work units share the
+  active token via the FSM; per-unit minting would burn redundant
+  mints during chained work and tear down env between rapid-fire
+  triggers.
 - Restrict in-process token lifetime during ACTIVE. Once
   `GITHUB_TOKEN` is in env, agent code and subprocesses can read
   it. Strong enforcement of "no token in agent memory" would
   require the V3+ HTTPS proxy model (§11 future hardening). V1
   enforcement is `(time + scope + audit)` per §10.
+- Restrict subprocess token lifetime once spawned. See subprocess
+  inheritance note above. Token leaves the parent's control at
+  fork time; the parent's IDLE cleanup doesn't reach already-running
+  subprocesses.
+- Track non-GitHub work. The FSM increments only on this plugin's
+  own hooks. Non-GitHub work running concurrently doesn't
+  contribute to the counter and doesn't need `GITHUB_TOKEN` either.
 
 ## 13. Migration plan
 
@@ -1135,7 +1258,7 @@ loop covers steady-state ACTIVE periods regardless of duration.
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `auth: github-app`, skip static token, bind-mount `/run/apiarist.sock`, set `AGENT_SERVICE` + `AGENT_TOKEN_SLOT` env. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). | 0.5d | — (parallel) |
-| **L′.** Agent runtime — UDS-based mint | In `agent/cli/hivemoot_agent/plugins_builtin/.../github` (monorepo, opened as separate PR against `hivemoot/hivemoot`, fleet-reviewed): branch on `AGENT_SERVICE` env; when present, replace static `GH_TOKEN` reads with mint-via-UDS. Tiny apiarist Python client lib (~50 lines) lives in monorepo so the agent can import it. | 1.5d | D, E |
+| **L′.** Agent runtime — activity-gated GitHub auth | In the existing `agent/cli/hivemoot_agent/plugins_builtin/.../github` plugin (monorepo, opened as separate PR against `hivemoot/hivemoot`, fleet-reviewed): add the activity-gated FSM described in §12.3 — reference-counted IDLE/ACTIVE state, mint+set `GITHUB_TOKEN` on 0→1 transition with proactive refresh loop, clear env on 1→0 transition. The FSM lives inside the existing plugin (not a new one) because the agent engine fires lifecycle hooks only on the triggering plugin. Tiny apiarist Python client lib (~50 lines) lives alongside it for the UDS round-trip. | 1.5d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Foxstoria pilot | flag foxstoria's repo block with `auth: github-app` + `agent_token: foxstoria-builder`, deploy, observe one full agent run cycle. Verify ghs_ token reaches GitHub successfully and zero token files appear on disk. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |


### PR DESCRIPTION
## Summary

Doc-only refinement of \`apiarist/DESIGN.md\` §12.3 capturing the agent-side plugin design we converged on while reviewing the daemon contract during PR #485.

The earlier draft proposed mint-once-at-container-startup with an "in-memory only during the HTTP call" goal. That doesn't survive the realistic case of standing-agent containers that boot, idle for hours, then handle overlapping/chained work units.

## What changed

Replaces the earlier guidance with a two-state machine driven by **whether the agent has any active work**:

- **ACTIVE** (count of in-flight work units ≥ 1) — holds the wake lock; runs a background refresh loop that re-mints at \`expires_at - 5min\`
- **IDLE** (count = 0) — cancels the refresh loop, clears \`GITHUB_TOKEN\` from env

The critical detail: the IDLE transition only fires when **every** work source has released the wake lock. A single task ending while another is still running (or while a scheduled job kicked off mid-stream) is a no-op decrement. Reference counting handles overlapping and chained work cleanly without the plugin needing to know what kind of work is in flight.

Generic \`on_work_start\` / \`on_work_end\` hooks let any future work source (provider runs, scheduled tasks, cron jobs, future work types) contribute uniformly without changing the auth plugin.

## Why this shape (vs alternatives explored)

- *Container-startup mint*: wrong moment — token expires before work arrives
- *Always-on refresh*: burns mints during idle periods for no benefit
- *Per-trigger mint*: needlessly chatty for chained tasks; doesn't share env across overlap
- *Activity-gated FSM*: token exists exactly when work happens; cost aligned to actual activity

## What it looks like

The plugin pseudocode (\`~30 LOC\` final shape) and a lifecycle table showing mixed work types overlapping (task A + task B + scheduled job C, with state transitions only at 0↔1 boundary) are in the diff.

## Scope

Doc-only — no code change, no test change. Captures architectural intent for the upcoming Phase L′ (agent-side \`github_auth\` plugin) so the contract is clear when implementation begins.