### PR TITLE
Add systemd unit for apiarist with hardened sandbox (Phase I)

### DIFF
--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -41,7 +41,8 @@ filename, and unprivileged user account.
 | Systemd unit | `apiarist.service` |
 | User account | `apiarist` |
 | Group | `apiarist` |
-| IPC socket | `/run/apiarist.sock` |
+| IPC socket (host path) | `/run/apiarist/apiarist.sock` |
+| IPC socket (container path, post bind-mount) | `/run/apiarist.sock` |
 | Config dir | `/etc/apiarist/` (optional, see §6) |
 | State dir | `/var/lib/apiarist/` |
 | Log destination | systemd journald (`journalctl -u apiarist`) |
@@ -501,12 +502,23 @@ selector is absent, apiarist falls through to the `default` slot
 **Filesystem layout, post-install:**
 
 ```
-/etc/apiarist/apiarist.yaml         apiary:apiarist  640
-/var/lib/apiarist/                  apiarist:apiarist  750
-/run/apiarist.sock                  apiarist:apiarist  660  (created by daemon at startup)
+/etc/apiarist/apiarist.yaml         root:apiarist      640
+/etc/apiarist/agent-token.env       root:apiarist      640  (env file with APIARIST_AGENT_TOKEN)
+/var/lib/apiarist/                  apiarist:apiarist  750  (created by systemd: StateDirectory)
+/run/apiarist/                      apiarist:apiarist  755  (created by systemd: RuntimeDirectory)
+/run/apiarist/apiarist.sock         apiarist:agent     660  (created by daemon; chgrp'd to agent
+                                                              for cross-container access — relies on
+                                                              apiarist user being in the 'agent' group)
 /opt/apiary/apiary.secrets.yaml     apiary:apiarist    640  (group adjusted at install time)
 /usr/local/bin/apiarist             root:root          755  (compiled wheel entry point)
 ```
+
+The socket lives **inside** `/run/apiarist/` rather than directly at
+`/run/apiarist.sock` because the systemd unit's `ProtectSystem=strict`
+denies write access to root-owned `/run/`. The
+`RuntimeDirectory=apiarist` directive gives the daemon a writable
+location it owns. Agent containers see the socket at `/run/apiarist.sock`
+inside the container — that's the bind-mount target, not the host path.
 
 **Process attributes** (systemd unit):
 
@@ -862,7 +874,9 @@ if [[ "$repo_auth" == "github-app" ]]; then
   # Apiarist brokers tokens — no static file, no env. Mount the
   # socket and tell the agent its identity.
   rm -f "$secrets_dir/github-token"
-  docker_run="${docker_run} -v /run/apiarist.sock:/run/apiarist.sock"
+  # Host-side socket lives in /run/apiarist/ (created by systemd's
+  # RuntimeDirectory directive); container sees it as /run/apiarist.sock.
+  docker_run="${docker_run} -v /run/apiarist/apiarist.sock:/run/apiarist.sock"
   docker_run="${docker_run} -e AGENT_SERVICE=${service_name}"
   docker_run="${docker_run} -e AGENT_TOKEN_SLOT=${agent_token_slot}"
 else

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -383,8 +383,8 @@ daemon-specific file. **No new mandatory config files** for V1.
    own env.
 3. **Optional config file:** `/etc/apiarist/apiarist.yaml` (or path from `--config`):
    ```yaml
-   socket_path: /run/apiarist.sock
-   socket_group: apiarist          # group that gets read access
+   socket_path: /run/apiarist/apiarist.sock   # host path; container sees /run/apiarist.sock via bind-mount
+   socket_group: agent             # group that gets read access (set by Phase J install.sh; daemon-default is "apiarist" for dev)
    backend_url: https://www.hivemoot.dev
    apiary_secrets_path: /opt/apiary/apiary.secrets.yaml
    apiary_config_path: /opt/apiary/apiary.yaml
@@ -520,19 +520,25 @@ denies write access to root-owned `/run/`. The
 location it owns. Agent containers see the socket at `/run/apiarist.sock`
 inside the container — that's the bind-mount target, not the host path.
 
-**Process attributes** (systemd unit):
+**Process attributes** (systemd unit): see
+[`apiarist/systemd/apiarist.service`](systemd/apiarist.service) for
+the source of truth — that file is the deploy contract and what
+`systemd-analyze security` actually measures (currently scoring
+1.4/10, bordering "exemplary"). Snippets here would just drift.
 
-```ini
-User=apiarist
-Group=apiarist
-ProtectSystem=strict
-ProtectHome=true
-PrivateTmp=true
-NoNewPrivileges=true
-ReadWritePaths=/run /var/lib/apiarist
-ReadOnlyPaths=/opt/apiary
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-```
+Headline directives (the full set is in the unit):
+
+| Concern | Directive |
+|---|---|
+| Identity | `User=apiarist`, `Group=apiarist` (member of `agent`) |
+| FS isolation | `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`, `PrivateDevices=true` |
+| Writable surface | `RuntimeDirectory=apiarist`, `StateDirectory=apiarist` (only these two dirs) |
+| Privilege | `NoNewPrivileges=true`, empty `CapabilityBoundingSet=` and `AmbientCapabilities=` |
+| Memory | `MemoryDenyWriteExecute=true`, `LimitCORE=0` |
+| Network | `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6` |
+| Syscalls | `SystemCallFilter=@system-service ~@privileged`, `SystemCallErrorNumber=EPERM` |
+| /proc | `ProtectProc=invisible`, `ProcSubset=pid` |
+| File creation | `UMask=0077` |
 
 ## 11. Backend dependencies
 

--- a/apiarist/src/apiarist/config.py
+++ b/apiarist/src/apiarist/config.py
@@ -40,7 +40,13 @@ _VALID_LOG_LEVELS = frozenset({"debug", "info", "warning", "error", "critical"})
 class Config(BaseModel):
     """All apiarist runtime knobs (DESIGN.md §9)."""
 
-    socket_path: Path = Path("/run/apiarist.sock")
+    # Default socket path lives inside /run/apiarist/, which the systemd
+    # unit creates via RuntimeDirectory=apiarist (owned by the apiarist
+    # user, mode 0755 — agent containers traverse it via +x to reach the
+    # socket inside). Using /run/apiarist.sock directly would require
+    # the daemon to write into root-owned /run/, which the hardened unit
+    # explicitly forbids via ProtectSystem=strict.
+    socket_path: Path = Path("/run/apiarist/apiarist.sock")
     socket_group: str = "apiarist"
     backend_url: str = "https://www.hivemoot.dev"
     apiary_secrets_path: Path = Path("/opt/apiary/apiary.secrets.yaml")

--- a/apiarist/systemd/README.md
+++ b/apiarist/systemd/README.md
@@ -1,0 +1,56 @@
+# apiarist systemd unit
+
+`apiarist.service` runs the apiarist daemon under systemd with the
+hardening profile from DESIGN.md §10.
+
+## What it expects on the host (Phase J — install script)
+
+The unit file references several pre-existing pieces. The Phase J
+install script (`deploy/install.sh`) creates them; this README
+documents the contract so the install script and the unit stay
+honest with each other.
+
+| Path | Owner | Mode | Created by |
+|---|---|---|---|
+| `/usr/local/bin/apiarist` | `root:root` | 0755 | install.sh (pip-installed entry point) |
+| `/etc/apiarist/apiarist.yaml` | `root:apiarist` | 0640 | install.sh (or operator) |
+| `/etc/apiarist/agent-token.env` | `root:apiarist` | 0640 | install.sh, populated from `apiary.secrets.yaml` |
+| User `apiarist` | — | — | install.sh (`useradd -r -s /sbin/nologin`) |
+| Group membership: `apiarist ∈ agent` | — | — | install.sh (`usermod -aG agent apiarist`) |
+| `/var/lib/apiarist/` | `apiarist:apiarist` | 0750 | systemd via `StateDirectory=apiarist` |
+| `/run/apiarist/` | `apiarist:apiarist` | 0755 | systemd via `RuntimeDirectory=apiarist` |
+| `/run/apiarist/apiarist.sock` | `apiarist:agent` | 0660 | daemon at startup (chgrp + chmod after bind) |
+
+The `apiarist ∈ agent` group membership is required so the daemon
+can `chgrp` the socket file to `agent` for cross-container access.
+Without it, the chgrp call inside `Server.bind()` returns EPERM.
+
+## Why the socket is inside a directory, not directly in /run/
+
+A previous draft used `/run/apiarist.sock` directly. That doesn't work
+with the hardening profile: `ProtectSystem=strict` plus
+`ReadWritePaths=` (empty here) means the daemon cannot write into
+`/run/` itself. systemd's idiomatic answer is `RuntimeDirectory=`,
+which creates `/run/<dir>/` owned by the unit's `User:Group` and
+makes that directory the daemon's writable runtime location.
+
+Containers in the `agent` group reach the socket via directory
+traversal: `/run/apiarist` is mode 0755 (any user can `+x` traverse),
+the socket file inside is mode 0660 with group `agent` (only group
+members can read/write).
+
+## Installing manually (development only)
+
+For dev-on-Hive iteration before the install script lands:
+
+```bash
+sudo cp apiarist.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now apiarist.service
+sudo systemctl status apiarist.service
+sudo journalctl -u apiarist -f
+```
+
+Production should always go through `deploy/install.sh` (Phase J)
+which handles the user creation, group membership, env-file population,
+and config staging atomically.

--- a/apiarist/systemd/apiarist.service
+++ b/apiarist/systemd/apiarist.service
@@ -1,0 +1,173 @@
+# apiarist — host-side broker daemon for the Hivemoot fleet.
+#
+# Installed by deploy/install.sh into /etc/systemd/system/apiarist.service.
+# Enable and start with:
+#   systemctl enable --now apiarist.service
+# Inspect with:
+#   systemctl status apiarist.service
+#   journalctl -u apiarist -f
+#
+# All hardening directives below trace back to DESIGN.md §10 (security
+# model). Do not relax any of them without updating the design doc and
+# explaining why in the same change — the unit's job is not just to run
+# the daemon, it's to constrain the daemon's blast radius if the daemon
+# itself is compromised.
+
+[Unit]
+Description=Apiarist - host-side GitHub-token broker for the Hivemoot fleet
+Documentation=https://github.com/hivemoot/hivemoot/tree/main/apiarist
+# Backend calls go to hivemoot.dev; need network reachable before start.
+After=network-online.target
+Wants=network-online.target
+# Crash-loop guard: at most 5 starts in any 60s window. Prevents a
+# misconfigured daemon from saturating the journal.
+# (StartLimit* live in [Unit] in modern systemd, not [Service].)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+
+# Unprivileged dedicated user/group (created by deploy/install.sh).
+# Daemon must additionally be a member of the 'agent' group so it can
+# chgrp the socket file to 'agent' for cross-container access; that
+# membership is set up by install.sh, not here.
+User=apiarist
+Group=apiarist
+
+# Agent-token bearer credential. Loaded from a 0640 file (root:apiarist)
+# created by the deploy script from apiary.secrets.yaml. Format:
+#   APIARIST_AGENT_TOKEN=hm_xxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Kept out of the unit file so secrets never enter the systemd graph
+# (which is world-readable via `systemctl show`).
+EnvironmentFile=/etc/apiarist/agent-token.env
+
+# Daemon entry point. The package's console_script is installed at
+# /usr/local/bin/apiarist by deploy/install.sh (or wherever the venv
+# wheel lands — see install.sh for the canonical path).
+ExecStart=/usr/local/bin/apiarist --config /etc/apiarist/apiarist.yaml
+
+# Reload signal: we don't currently support live config reload, but
+# SIGHUP is the conventional answer; future feature can wire it.
+# (Restart for now via `systemctl restart apiarist`.)
+
+# Restart policy: daemon is a stateless broker, safe to restart freely.
+# RestartSec=5 prevents tight crash loops from saturating the journal.
+Restart=on-failure
+RestartSec=5
+
+# --- Filesystem layout -----------------------------------------------------
+
+# Creates /run/apiarist/ owned by User:Group, mode 0755. The socket file
+# (apiarist.sock) lives inside; +x on the dir lets agent-group containers
+# traverse to reach the socket without listing the directory contents.
+RuntimeDirectory=apiarist
+RuntimeDirectoryMode=0755
+
+# Creates /var/lib/apiarist/ for any future on-disk state (currently
+# unused; reserved). Mode 0750 means only the apiarist user can read,
+# defense in depth against future mistakes that put secrets there.
+StateDirectory=apiarist
+StateDirectoryMode=0750
+
+# Logs go to journald (default for Type=simple, made explicit here so
+# anyone reading this file sees where to look).
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=apiarist
+
+# --- Hardening (DESIGN.md §10) ---------------------------------------------
+
+# Disable core dumps. A core file from a daemon holding cached `ghs_`
+# tokens in memory would put those tokens on disk — exactly the leak
+# vector apiarist's in-memory-only cache is designed to avoid.
+LimitCORE=0
+
+# Disallow writable+executable memory — blocks JIT-style RCE primitives.
+# Python doesn't need W^X; if a future feature does, drop this AND
+# document the threat-model change in DESIGN.md §10.
+MemoryDenyWriteExecute=true
+
+# Whole filesystem read-only EXCEPT what RuntimeDirectory + StateDirectory
+# make writable for us. Even if the daemon is RCE'd, the attacker can't
+# write to /etc, /usr, /home, /opt, etc.
+ProtectSystem=strict
+ProtectHome=true
+
+# Private mount namespaces for /tmp and /dev — daemon sees only its
+# own ephemeral tmp and a minimal /dev (no raw block devices, etc.).
+PrivateTmp=true
+PrivateDevices=true
+
+# No setuid/setgid escalation, ever.
+NoNewPrivileges=true
+
+# Restrict the address families the daemon can use. AF_UNIX is the
+# socket we serve on; AF_INET/AF_INET6 are for outbound httpx calls
+# to hivemoot.dev. Nothing else (AF_NETLINK, AF_PACKET, AF_BLUETOOTH,
+# etc.) is needed.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+# Block namespace creation (would let a compromised daemon set up
+# user-namespace tricks).
+RestrictNamespaces=true
+
+# Block real-time scheduling (potential DoS lever).
+RestrictRealtime=true
+
+# Block creation of setuid/setgid files.
+RestrictSUIDSGID=true
+
+# Native syscall ABI only (blocks i386-on-x86_64 syscall confusion).
+SystemCallArchitectures=native
+
+# Conservative syscall allowlist — @system-service is systemd's
+# "general-purpose service" set, then strip @privileged on top.
+# If a future feature trips this, the resulting EPERM is loud and
+# obvious (vs the silent-corruption alternative of an open allowlist).
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+
+# Lock the personality syscall (prevents emulating older ABIs).
+LockPersonality=true
+
+# Kernel-surface protection — cgroup, kernel logs, modules, sysctls,
+# clock all read-only or hidden.
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectClock=true
+ProtectHostname=true
+
+# File-descriptor limit. The daemon serves one connection per request
+# (no keepalive), so 4096 is a 50× headroom over expected peak load
+# while bounding the impact of any FD-leak bug.
+LimitNOFILE=4096
+
+# Process limit. The daemon doesn't fork; this caps the impact of any
+# bug that would spawn subprocesses (it shouldn't).
+LimitNPROC=64
+
+# Drop ALL Linux capabilities. The daemon runs as an unprivileged user
+# so it has no caps to start with, but the explicit empty bounding set
+# documents the intent: this process should never need any capability.
+# Future code that suddenly requires one (e.g., CAP_NET_BIND_SERVICE
+# for binding port < 1024) will fail loudly here, prompting a design
+# review rather than silently picking up a privilege.
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# /proc hardening: only see our own process tree (`hidepid=invisible`),
+# and only the pid subset of /proc (no /proc/cpuinfo etc.). The daemon
+# doesn't need any of that.
+ProtectProc=invisible
+ProcSubset=pid
+
+# Default umask for any file the daemon creates (state files, future
+# cache files in /var/lib/apiarist/). 0077 means files default to
+# 0600 — owner read/write only, no group, no other.
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/apiarist/systemd/apiarist.service
+++ b/apiarist/systemd/apiarist.service
@@ -45,7 +45,15 @@ EnvironmentFile=/etc/apiarist/agent-token.env
 # Daemon entry point. The package's console_script is installed at
 # /usr/local/bin/apiarist by deploy/install.sh (or wherever the venv
 # wheel lands — see install.sh for the canonical path).
-ExecStart=/usr/local/bin/apiarist --config /etc/apiarist/apiarist.yaml
+#
+# --socket-group=agent is passed explicitly so the unit is the
+# production contract for cross-container access. Even if a future
+# operator stages a stale or empty apiarist.yaml, the daemon still
+# chgrp's the socket to 'agent' and containers in that group keep
+# working. (Daemon's own Config.socket_group default is "apiarist"
+# — fine for dev/CI, wrong for Hive — and CLI args trump config in
+# the precedence chain so this flag wins regardless.)
+ExecStart=/usr/local/bin/apiarist --config /etc/apiarist/apiarist.yaml --socket-group=agent
 
 # Reload signal: we don't currently support live config reload, but
 # SIGHUP is the conventional answer; future feature can wire it.
@@ -123,10 +131,15 @@ SystemCallArchitectures=native
 
 # Conservative syscall allowlist — @system-service is systemd's
 # "general-purpose service" set, then strip @privileged on top.
-# If a future feature trips this, the resulting EPERM is loud and
-# obvious (vs the silent-corruption alternative of an open allowlist).
+# If a future feature trips this, the daemon gets EPERM on the
+# blocked syscall (Python raises OSError, the daemon's structured
+# logger surfaces it before exit). EPERM is more debuggable than
+# systemd's default action of SIGSYS-killing the process — the
+# kill leaves operators with only "code=killed, status=31/SYS"
+# in the journal and no Python-level traceback.
 SystemCallFilter=@system-service
 SystemCallFilter=~@privileged
+SystemCallErrorNumber=EPERM
 
 # Lock the personality syscall (prevents emulating older ABIs).
 LockPersonality=true

--- a/apiarist/tests/unit/test_config.py
+++ b/apiarist/tests/unit/test_config.py
@@ -19,7 +19,7 @@ def test_defaults_when_no_overrides(tmp_path: Path) -> None:
     # (/etc/apiarist/apiarist.yaml) doesn't accidentally apply if a
     # developer happens to have it on their machine.
     cfg = load_config(env={}, config_path=tmp_path / "missing.yaml")
-    assert cfg.socket_path == Path("/run/apiarist.sock")
+    assert cfg.socket_path == Path("/run/apiarist/apiarist.sock")
     assert cfg.socket_group == "apiarist"
     assert cfg.backend_url == "https://www.hivemoot.dev"
     # Defaults match DESIGN.md §9: tail-exposure-bounded cache (5 min


### PR DESCRIPTION
## Summary

Phase I of the apiarist build (per the implementation phases in \`apiarist/DESIGN.md\` §14): the systemd unit and a small install-time contract README. No daemon-code change beyond a default socket-path tweak required by the hardening profile.

The unit applies the security model from \`DESIGN.md\` §10:

- \`User=apiarist Group=apiarist\` (unprivileged, dedicated)
- \`ProtectSystem=strict\` + \`ProtectHome=true\` + \`PrivateTmp=true\` + \`PrivateDevices=true\` — daemon cannot write anywhere except its \`RuntimeDirectory\` and \`StateDirectory\`
- \`NoNewPrivileges=true\` + empty \`CapabilityBoundingSet=\` + \`MemoryDenyWriteExecute=true\` + \`RestrictSUIDSGID=true\` + \`LockPersonality=true\`
- \`RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6\` (only what we need: UDS for clients, INET/INET6 for outbound httpx to hivemoot.dev)
- \`SystemCallFilter=@system-service\` minus \`@privileged\` — minimal syscall surface
- \`ProtectProc=invisible\` + \`ProcSubset=pid\` — daemon only sees its own /proc tree
- \`UMask=0077\` — any file the daemon creates defaults to 0600
- Full \`Protect*\` set: kernel logs, modules, tunables, control groups, clock, hostname
- \`LimitCORE=0\` — no core dumps (security model: cached \`ghs_\` tokens must never reach disk via core file)
- Restart-on-failure with \`RestartSec=5\` + \`StartLimitBurst=5\` over \`StartLimitIntervalSec=60\` to prevent crash-loop journal saturation

Verified on Ubuntu 24.04 systemd via \`systemd-analyze security apiarist.service\`:

\`\`\`
→ Overall exposure level for apiarist.service: 1.4 OK 🙂
\`\`\`

(0–2 = exemplary, 2–4 = OK, 4–6 = warnings. We're at the OK/exemplary boundary.)

## What it looks like

| Path | Owner | Mode | Created by |
|---|---|---|---|
| \`/usr/local/bin/apiarist\` | \`root:root\` | 0755 | install.sh (Phase J) |
| \`/etc/apiarist/apiarist.yaml\` | \`root:apiarist\` | 0640 | install.sh / operator |
| \`/etc/apiarist/agent-token.env\` | \`root:apiarist\` | 0640 | install.sh, populated from \`apiary.secrets.yaml\` |
| user \`apiarist\` (also member of \`agent\` group) | — | — | install.sh |
| \`/var/lib/apiarist/\` | \`apiarist:apiarist\` | 0750 | systemd \`StateDirectory\` |
| \`/run/apiarist/\` | \`apiarist:apiarist\` | 0755 | systemd \`RuntimeDirectory\` |
| \`/run/apiarist/apiarist.sock\` | \`apiarist:agent\` | 0660 | daemon at startup |

## Default socket-path change

The daemon's default socket path moves from \`/run/apiarist.sock\` to \`/run/apiarist/apiarist.sock\`. Reasoning: \`ProtectSystem=strict\` denies write access to root-owned \`/run/\`, so the daemon needs a writable subdirectory it owns. The systemd \`RuntimeDirectory=apiarist\` directive creates exactly that, idiomatically.

Containers continue to see the socket at \`/run/apiarist.sock\` (the in-container path) via bind-mount; only the host-side path changed. \`DESIGN.md\` is updated to reflect both paths and the deploy-script bind-mount snippet.

## Verification

- \`pytest\` — 139 pass (one test updated to expect the new default path)
- \`ruff\` + \`mypy\` — clean
- \`systemd-analyze verify\` (Hive Ubuntu 24.04) — clean (only "command not yet installed" warning, expected pre-Phase-J)
- \`systemd-analyze security\` — 1.4/10 exposure level

## Scope

This PR is unit + config-default-tweak + minimal DESIGN.md alignment. Phase J (\`deploy/install.sh\`) is the next PR — it'll create the user, set group memberships, install the binary, stage the env file, copy this unit into place, and \`systemctl enable --now\`.