### PR TITLE
Wire engine ContainerLifecycle + apiarist auth subscriber chain (Phase L')

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -79,6 +79,16 @@ jobs:
         run: python3 cli/tests/test_engine.py
       - name: Verify engine lifecycle contract tests
         run: python3 cli/tests/test_engine_lifecycle.py
+      - name: Verify container lifecycle FSM (apiarist Phase L' invariants I1-I5)
+        run: python3 cli/tests/test_lifecycle.py
+      - name: Verify apiarist UDS client (framing + transport/protocol/remote errors)
+        run: python3 cli/tests/test_apiarist_client.py
+      - name: Verify hivemoot apiarist auth subscriber (mint, env, fail-closed)
+        run: python3 cli/tests/test_hivemoot_auth_subscriber.py
+      - name: Verify hivemoot setup_lifecycle wiring + two-phase ordering
+        run: python3 cli/tests/test_hivemoot_setup_lifecycle.py
+      - name: Verify github token_source subscriber mode + end-to-end auth chain
+        run: python3 cli/tests/test_github_token_source_subscriber.py
       - name: Verify worker entrypoint tests
         run: python3 cli/tests/test_worker_cli.py
       - name: Verify hivemoot plugin config schema

--- a/agent/cli/hivemoot_agent/apiarist_client.py
+++ b/agent/cli/hivemoot_agent/apiarist_client.py
@@ -1,0 +1,454 @@
+"""Sync Python client for the apiarist Unix-domain-socket protocol.
+
+Mirrors apiarist's wire format (see ``apiarist/src/apiarist/core/ipc.py``):
+
+    | 4 bytes (big-endian uint32, payload length N) | N bytes UTF-8 JSON |
+
+Each method opens a fresh socket, sends one request, reads one
+response, closes. No connection pooling, no streaming — V1 ops are
+infrequent (one mint per IDLE→ACTIVE transition, plus background
+refresh once per token-lifetime) and the cost of a UDS connect is
+trivial. Stateless connect-per-call also means a stale FD can't
+poison subsequent requests.
+
+This module is intentionally pure stdlib (socket + struct + json) so
+it can be imported from any plugin without dragging asyncio runtime
+state into a sync codepath. The engine's lifecycle subscriber pattern
+(see :mod:`hivemoot_agent.lifecycle`) is sync, and so is the bash
+helper that the apiary controller may eventually shell out to.
+
+Error model:
+
+- :class:`ApiaristTransportError` — socket-level failure (connect
+  refused, EOF, timeout, broken pipe). Caller can retry or fail-closed.
+- :class:`ApiaristProtocolError` — wire framing or response shape is
+  malformed (length above cap, invalid JSON, missing envelope keys).
+  Indicates a bug or version skew; retrying won't help.
+- :class:`ApiaristRemoteError` — server returned a typed error envelope
+  with ``code`` + ``message``. Caller inspects ``code`` for retry
+  policy (``BACKEND_RATE_LIMITED`` is retryable;
+  ``BACKEND_UNAUTHORIZED`` is not).
+
+All three derive from :class:`ApiaristError` for callers that just
+want "anything went wrong, fail this job".
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Final
+
+# Wire constants — must match apiarist's ipc.py. If apiarist changes
+# them it's a breaking protocol bump and this client must follow.
+_LENGTH_PREFIX_FORMAT: Final[str] = "!I"
+_LENGTH_PREFIX_BYTES: Final[int] = 4
+_MAX_PAYLOAD_BYTES: Final[int] = 64 * 1024  # 64 KiB
+
+# Conservative default request timeout. The end-to-end mint takes a
+# backend roundtrip (typically <500ms) plus apiarist's local dispatch
+# (<10ms), so 10 seconds covers the long tail without leaving the
+# subscriber wedged on a stuck backend. Callers can tighten via the
+# constructor for hot paths.
+_DEFAULT_TIMEOUT_SECONDS: Final[float] = 10.0
+
+
+# ── Errors ─────────────────────────────────────────────────────────
+
+
+class ApiaristError(Exception):
+    """Base class for all client-side errors talking to apiarist."""
+
+
+class ApiaristTransportError(ApiaristError):
+    """Socket-level failure — connect refused, EOF, timeout, broken pipe.
+
+    Indicates the daemon is unreachable, restarting, or unresponsive.
+    Distinct from :class:`ApiaristProtocolError` so callers can
+    distinguish "service down, may recover" from "version skew, won't".
+    """
+
+
+class ApiaristProtocolError(ApiaristError):
+    """Wire framing or response shape is malformed.
+
+    Includes: length prefix above cap, payload not valid UTF-8 JSON,
+    response envelope missing required keys. Indicates a bug or
+    version skew between client and server; retrying does not help.
+    """
+
+
+class ApiaristRemoteError(ApiaristError):
+    """Server returned a typed error envelope.
+
+    The ``code`` field is the wire-level upper-snake string from
+    apiarist's ``ErrorCode`` (``BACKEND_UNAUTHORIZED``,
+    ``BACKEND_RATE_LIMITED``, ``BACKEND_FORBIDDEN``, ...). Callers
+    branch on it for retry policy. ``message`` is human-readable and
+    safe to log/surface.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code: str = code
+        self.message: str = message
+
+
+# ── Response data shapes ───────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Repository:
+    """One repository entry from a mint_token response."""
+
+    full_name: str
+    id: int
+
+
+@dataclass(frozen=True)
+class MintedToken:
+    """Decoded mint_token response (DESIGN.md §8)."""
+
+    token: str
+    expires_at: datetime  # tz-aware UTC
+    installation_id: str
+    permissions: dict[str, str] = field(default_factory=dict)
+    repositories: list[Repository] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    """Decoded health response.
+
+    Shape is best-effort — apiarist may evolve the health payload
+    without bumping the protocol, so we expose the raw dict for
+    diagnostics-only consumers.
+    """
+
+    raw: dict[str, Any]
+
+
+# ── Client ─────────────────────────────────────────────────────────
+
+
+class ApiaristClient:
+    """Sync UDS client for apiarist.
+
+    Thread-safe by virtue of stateless construction — every call opens
+    a fresh socket. The instance only holds the socket path and the
+    request timeout, both immutable after init.
+    """
+
+    def __init__(
+        self,
+        socket_path: str,
+        *,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        if not socket_path:
+            raise ValueError("socket_path must be non-empty")
+        if timeout_seconds <= 0:
+            raise ValueError(
+                f"timeout_seconds must be positive (got {timeout_seconds!r})"
+            )
+        self._socket_path: str = socket_path
+        self._timeout_seconds: float = timeout_seconds
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    # ── Public ops ─────────────────────────────────────────────────
+
+    def mint_token(
+        self,
+        service: str,
+        repo: str,
+        *,
+        agent_id: str | None = None,
+    ) -> MintedToken:
+        """Request a freshly-minted GitHub installation token.
+
+        Both ``service`` and ``repo`` are required by the apiarist
+        protocol (``service`` for caller identification in logs,
+        ``repo`` for the policy check + per-repo scoping). ``agent_id``
+        is audit-only (DESIGN.md §11) — included in the apiarist log
+        line, ignored for authorization.
+        """
+        if not service:
+            raise ValueError("service must be non-empty")
+        if not repo:
+            raise ValueError("repo must be non-empty")
+
+        params: dict[str, Any] = {"service": service, "repo": repo}
+        if agent_id is not None:
+            params["agent_id"] = agent_id
+
+        data = self._call("mint_token", params)
+        return _parse_minted_token(data)
+
+    def health(self) -> HealthSnapshot:
+        """Liveness + last-call telemetry from the daemon.
+
+        Diagnostics surface; not a control-plane signal. Callers
+        should not gate behavior on health beyond logging.
+        """
+        data = self._call("health", {})
+        return HealthSnapshot(raw=data)
+
+    # ── Internal: framed request/response ──────────────────────────
+
+    def _call(self, op: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send one framed request, return the response ``data`` dict.
+
+        Raises:
+            ApiaristTransportError: socket-level failure.
+            ApiaristProtocolError: wire framing or envelope malformed.
+            ApiaristRemoteError: server returned an error envelope.
+        """
+        request_id = uuid.uuid4().hex
+        payload = {"op": op, "params": params, "request_id": request_id}
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self._timeout_seconds)
+        try:
+            try:
+                sock.connect(self._socket_path)
+            except OSError as exc:
+                raise ApiaristTransportError(
+                    f"connect to {self._socket_path!r} failed: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+
+            try:
+                sock.sendall(_encode_message(payload))
+            except OSError as exc:
+                raise ApiaristTransportError(
+                    f"send to {self._socket_path!r} failed: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+
+            response = _recv_response(sock)
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+        return _validate_response(response, request_id)
+
+
+# ── Helpers (module-level for testability) ─────────────────────────
+
+
+def _encode_message(payload: dict[str, Any]) -> bytes:
+    """Serialize a payload dict into a length-prefixed JSON frame.
+
+    Mirror of apiarist's :func:`apiarist.core.ipc.encode_message`. We
+    can't import that directly (apiarist isn't a dependency of the
+    agent runtime), so the framing is duplicated here. If the format
+    changes both sides must be bumped in lockstep.
+    """
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(body) > _MAX_PAYLOAD_BYTES:
+        raise ApiaristProtocolError(
+            f"encoded request {len(body)} bytes exceeds wire cap "
+            f"{_MAX_PAYLOAD_BYTES}"
+        )
+    return struct.pack(_LENGTH_PREFIX_FORMAT, len(body)) + body
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly ``n`` bytes; raise ApiaristTransportError on short read.
+
+    A short read here means the server closed mid-stream — a transport
+    failure, not a protocol violation, because we have no way to know
+    if the server even framed a complete reply.
+    """
+    chunks: list[bytes] = []
+    remaining = n
+    while remaining:
+        try:
+            chunk = sock.recv(remaining)
+        except OSError as exc:
+            raise ApiaristTransportError(
+                f"recv failed after {n - remaining} of {n} bytes: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        if not chunk:
+            raise ApiaristTransportError(
+                f"connection closed after {n - remaining} of {n} bytes"
+            )
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _recv_response(sock: socket.socket) -> dict[str, Any]:
+    """Read one length-prefixed JSON response from ``sock``."""
+    prefix = _recv_exact(sock, _LENGTH_PREFIX_BYTES)
+    (length,) = struct.unpack(_LENGTH_PREFIX_FORMAT, prefix)
+    if length > _MAX_PAYLOAD_BYTES:
+        raise ApiaristProtocolError(
+            f"response declared length {length} exceeds wire cap "
+            f"{_MAX_PAYLOAD_BYTES}"
+        )
+    body = _recv_exact(sock, length)
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ApiaristProtocolError(
+            f"response body is not valid UTF-8 JSON: {exc}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ApiaristProtocolError(
+            f"response must be a JSON object (got {type(parsed).__name__})"
+        )
+    return parsed
+
+
+def _validate_response(
+    response: dict[str, Any],
+    expected_request_id: str,
+) -> dict[str, Any]:
+    """Validate the response envelope and return the ``data`` payload.
+
+    Echo'd ``request_id`` MUST match what we sent — a mismatch points
+    at a multi-tenant socket bug or a request/response interleave on
+    the server. Treat as protocol error rather than silently accepting
+    cross-talk.
+    """
+    echoed = response.get("request_id")
+    ok = response.get("ok")
+    if not isinstance(ok, bool):
+        raise ApiaristProtocolError(
+            "response missing required boolean field 'ok'"
+        )
+    # Allow a None echoed id ONLY when the server couldn't parse our
+    # request (its envelope echoes null per apiarist DESIGN §8). A
+    # successful response MUST echo the request_id.
+    if ok and echoed != expected_request_id:
+        raise ApiaristProtocolError(
+            f"response request_id {echoed!r} does not match "
+            f"sent {expected_request_id!r}"
+        )
+
+    if ok:
+        data = response.get("data")
+        if not isinstance(data, dict):
+            raise ApiaristProtocolError(
+                "successful response missing required object field 'data'"
+            )
+        return data
+
+    error = response.get("error")
+    if not isinstance(error, dict):
+        raise ApiaristProtocolError(
+            "error response missing required object field 'error'"
+        )
+    code = error.get("code")
+    message = error.get("message")
+    if not isinstance(code, str) or not code:
+        raise ApiaristProtocolError(
+            "error envelope missing required string 'code'"
+        )
+    if not isinstance(message, str):
+        # Accept missing/empty message — server may emit codes only.
+        message = ""
+    raise ApiaristRemoteError(code=code, message=message)
+
+
+def _parse_minted_token(data: dict[str, Any]) -> MintedToken:
+    """Decode a mint_token data payload, raising on shape mismatch."""
+    token = data.get("token")
+    expires_raw = data.get("expires_at")
+    installation_id = data.get("installation_id")
+    if not isinstance(token, str) or not token:
+        raise ApiaristProtocolError(
+            "mint_token response missing required string 'token'"
+        )
+    if not isinstance(expires_raw, str) or not expires_raw:
+        raise ApiaristProtocolError(
+            "mint_token response missing required string 'expires_at'"
+        )
+    if not isinstance(installation_id, str) or not installation_id:
+        raise ApiaristProtocolError(
+            "mint_token response missing required string 'installation_id'"
+        )
+
+    expires_at = _parse_iso8601_utc(expires_raw)
+
+    permissions_raw = data.get("permissions", {})
+    if not isinstance(permissions_raw, dict):
+        raise ApiaristProtocolError(
+            "mint_token response 'permissions' must be an object"
+        )
+    permissions: dict[str, str] = {}
+    for key, value in permissions_raw.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ApiaristProtocolError(
+                f"mint_token response 'permissions' entry "
+                f"{key!r}: {value!r} is not string→string"
+            )
+        permissions[key] = value
+
+    repos_raw = data.get("repositories", [])
+    if not isinstance(repos_raw, list):
+        raise ApiaristProtocolError(
+            "mint_token response 'repositories' must be a list"
+        )
+    repos: list[Repository] = []
+    for entry in repos_raw:
+        if not isinstance(entry, dict):
+            raise ApiaristProtocolError(
+                "mint_token response 'repositories' entry must be an object"
+            )
+        full_name = entry.get("full_name")
+        rid = entry.get("id")
+        if not isinstance(full_name, str) or not full_name:
+            raise ApiaristProtocolError(
+                "repositories entry missing required string 'full_name'"
+            )
+        if not isinstance(rid, int):
+            raise ApiaristProtocolError(
+                "repositories entry missing required int 'id'"
+            )
+        repos.append(Repository(full_name=full_name, id=rid))
+
+    return MintedToken(
+        token=token,
+        expires_at=expires_at,
+        installation_id=installation_id,
+        permissions=permissions,
+        repositories=repos,
+    )
+
+
+def _parse_iso8601_utc(raw: str) -> datetime:
+    """Parse the ISO 8601 timestamp emitted by apiarist into tz-aware UTC.
+
+    apiarist emits ``"YYYY-MM-DDTHH:MM:SSZ"`` (trailing Z). Python's
+    ``datetime.fromisoformat`` accepts ``+00:00`` but not the bare Z
+    suffix until 3.11; since the agent runtime targets 3.11+ this works,
+    but normalizing the suffix first keeps the parser robust to either
+    form (some servers may emit ``+00:00``).
+    """
+    normalized = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ApiaristProtocolError(
+            f"expires_at {raw!r} is not a valid ISO 8601 timestamp: {exc}"
+        ) from exc
+    if parsed.tzinfo is None:
+        # Defensive — a naive timestamp from the server would be a bug
+        # (apiarist always emits UTC). Treat as protocol error rather
+        # than guessing a timezone.
+        raise ApiaristProtocolError(
+            f"expires_at {raw!r} must include a timezone (got naive)"
+        )
+    return parsed

--- a/agent/cli/hivemoot_agent/engine.py
+++ b/agent/cli/hivemoot_agent/engine.py
@@ -25,6 +25,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable
 
+from hivemoot_agent.lifecycle import ContainerLifecycle
 from hivemoot_agent.plugins import registry
 from hivemoot_agent.plugins.interfaces import AgentEvent, AgentResult, Job, PluginConfig
 from hivemoot_agent.providers import get as get_provider
@@ -143,6 +144,14 @@ class Engine:
         # See workqueue.py for the queue semantics.
         self._workqueue: WorkQueue = WorkQueue()
         self._worker_thread: threading.Thread | None = None
+        # Container-wide lifecycle FSM with subscriber/event-bus pattern
+        # (apiarist DESIGN.md §12.3). Plugins register subscribers from
+        # their optional setup_lifecycle() hook; the engine wraps every
+        # job dispatch (oneshot AND daemon-mode) so subscribers see
+        # IDLE↔ACTIVE transitions regardless of which plugin triggered
+        # the job. Public attribute so plugins can call
+        # ``engine.lifecycle.subscribe(...)`` from setup_lifecycle().
+        self.lifecycle: ContainerLifecycle = ContainerLifecycle()
 
     def _resolve_plugins(self) -> dict[str, Any] | None:
         """Discover + activate plugins.
@@ -273,7 +282,31 @@ class Engine:
         return selected
 
     def _setup_plugins(self, plugins: dict[str, Any]) -> bool:
-        """Run one-time plugin setup and fail closed on errors."""
+        """Run one-time plugin setup and fail closed on errors.
+
+        Two-phase setup (apiarist DESIGN.md §12.3):
+
+        1. ``plugin.setup(config)`` — auth-free init (config validation,
+           workspace prep). Existing contract; runs for every plugin in
+           registration order.
+        2. ``plugin.setup_lifecycle(lifecycle, config)`` — OPTIONAL hook
+           for plugins that need to register lifecycle subscribers
+           (auth env injection, secret rotation, etc.). Detected via
+           ``hasattr`` so existing plugins are unaffected.
+
+        Two phases are sequenced — ALL plugins finish phase 1 before any
+        plugin enters phase 2 — so a phase-2 hook can safely assume
+        every other plugin's auth-free init is complete (e.g. the
+        github plugin's subscriber knows the hivemoot plugin has
+        finished resolving its apiarist socket path).
+
+        Subscriber registration order is then driven by the iteration
+        order of ``plugins`` (insertion order under ADR-003: matches
+        ``hivemoot.yaml`` plugin order). Operators control the chain by
+        ordering plugin entries — hivemoot before github so the auth
+        subscriber's env is in place when github's clone subscriber
+        fires.
+        """
         for name, plugin in plugins.items():
             config = registry.config_for(name)
             try:
@@ -281,6 +314,19 @@ class Engine:
             except Exception as exc:
                 print(
                     f"[engine] FATAL: plugin '{name}' setup failed: {exc}",
+                    file=sys.stderr, flush=True,
+                )
+                return False
+        for name, plugin in plugins.items():
+            if not hasattr(plugin, "setup_lifecycle"):
+                continue
+            config = registry.config_for(name)
+            try:
+                plugin.setup_lifecycle(self.lifecycle, config)
+            except Exception as exc:
+                print(
+                    f"[engine] FATAL: plugin '{name}' setup_lifecycle "
+                    f"failed: {exc}",
                     file=sys.stderr, flush=True,
                 )
                 return False
@@ -510,6 +556,27 @@ class Engine:
         if is_resume:
             effective_prompt = f"{prompt}\n\n{_RESUME_STALENESS_NOTE}"
 
+        # Container lifecycle: notify subscribers BEFORE per-plugin
+        # on_job_started so subscriber-set env (e.g. apiarist-minted
+        # GITHUB_TOKEN) is in place when on_job_started, the provider
+        # command builder, AND the agent subprocess all read it. Safe
+        # to call when no plugins are loaded — empty subscriber list
+        # makes both transitions no-ops (covered by lifecycle tests).
+        try:
+            self.lifecycle.on_job_starting(job)
+        except Exception as exc:
+            # Subscriber raised in on_active. Lifecycle has already
+            # rolled back the counter and torn down completed
+            # subscribers. Bail without invoking plugin hooks for
+            # this job (no on_job_started ran → no on_job_finished
+            # to pair with).
+            print(
+                f"[engine] oneshot lifecycle on_active failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr, flush=True,
+            )
+            return 1
+
         # Plugin lifecycle parity with run_agent: every plugin gets a
         # chance to set per-job env (e.g. CODEX_ANSWER_FILE) BEFORE the
         # provider command is built, and on_job_finished is guaranteed
@@ -627,6 +694,20 @@ class Engine:
                             f"{type(exc).__name__}: {exc}",
                             file=sys.stderr, flush=True,
                         )
+            # Lifecycle teardown ALWAYS runs, even when no plugins are
+            # loaded — empty subscriber list makes this a no-op.
+            # Subscriber on_idle errors are swallowed inside
+            # ContainerLifecycle (invariant I4); the defensive try
+            # guards a regression that breaks the invariant.
+            try:
+                self.lifecycle.on_job_finished(job)
+            except Exception as exc:
+                print(
+                    f"[engine] oneshot lifecycle.on_job_finished raised "
+                    f"unexpectedly (broken contract): "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr, flush=True,
+                )
 
     @staticmethod
     def _run_oneshot_subprocess(
@@ -1146,7 +1227,84 @@ class Engine:
         config: PluginConfig,
         plugin_name: str,
     ) -> AgentResult:
-        """Run the agent with MCP tools from the plugin.
+        """Run the agent with MCP tools, wrapped in the container lifecycle.
+
+        Wraps :meth:`_run_agent_inner` with the engine-owned
+        :class:`ContainerLifecycle` so subscribers see IDLE↔ACTIVE
+        transitions on the 0↔1 active-job-counter boundary
+        (apiarist DESIGN.md §12.3).
+
+        Subscriber semantics:
+
+        - On the IDLE→ACTIVE boundary, every subscriber's ``on_active``
+          runs sequentially in registration order BEFORE
+          ``plugin.on_job_started`` so subscriber-set state (env vars,
+          handoffs, metrics) is visible to the triggering plugin AND
+          the agent subprocess.
+        - On the ACTIVE→IDLE boundary, every subscriber's ``on_idle``
+          runs AFTER ``plugin.on_job_finished``. Subscriber errors are
+          logged but don't propagate (best-effort cleanup).
+        - If a subscriber raises in ``on_active``, the lifecycle
+          module rolls back the counter and tears down completed
+          subscribers in reverse order; this method then returns a
+          failed ``AgentResult``. The runtime's normal retry path
+          re-attempts the full chain cleanly.
+
+        Single-threaded contract is unchanged: under daemon mode this
+        runs on the workqueue drain thread; under oneshot it runs on
+        the caller's thread. Lifecycle's ``threading.RLock`` makes the
+        FSM correct under future concurrent dispatch, but other
+        run-time mutations (process env, session store) still need
+        the existing single-caller invariant.
+        """
+        try:
+            self.lifecycle.on_job_starting(job)
+        except Exception as exc:
+            # Subscriber raised in on_active. The lifecycle module has
+            # already rolled back the counter and torn down completed
+            # subscribers; we just need to fail the job so the runtime's
+            # retry path re-attempts the full chain cleanly.
+            print(
+                f"[engine] lifecycle on_active failed for "
+                f"{job.session_key}: {type(exc).__name__}: {exc}",
+                file=sys.stderr, flush=True,
+            )
+            return AgentResult(
+                exit_code=1,
+                response=f"lifecycle setup failed: {exc}",
+            )
+
+        try:
+            return self._run_agent_inner(plugin, job, config, plugin_name)
+        finally:
+            # Subscriber on_idle errors are swallowed inside
+            # ContainerLifecycle.on_job_finished (invariant I4) so this
+            # call cannot raise under contract. Defensive try guards
+            # against a regression that breaks the invariant — if this
+            # ever raises, swallowing it here would silently break the
+            # dispatcher's ability to fire the next 0→1 transition.
+            try:
+                self.lifecycle.on_job_finished(job)
+            except Exception as exc:
+                print(
+                    f"[engine] lifecycle.on_job_finished raised "
+                    f"unexpectedly (broken contract): "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr, flush=True,
+                )
+
+    def _run_agent_inner(
+        self,
+        plugin: Any,
+        job: Job,
+        config: PluginConfig,
+        plugin_name: str,
+    ) -> AgentResult:
+        """Inner body of ``run_agent`` — runs the agent subprocess.
+
+        Always called via :meth:`run_agent`, which wraps this with the
+        container lifecycle FSM. Direct callers in tests can bypass
+        the lifecycle by calling this method directly.
 
         Under daemon operation (``Engine.run``), this is called
         exclusively from the single workqueue drain thread — the

--- a/agent/cli/hivemoot_agent/lifecycle.py
+++ b/agent/cli/hivemoot_agent/lifecycle.py
@@ -14,21 +14,38 @@ the 0↔1 boundary.
 
 The first user is GitHub token auth (apiarist):
 
-- Hivemoot plugin's auth subscriber mints a token via apiarist on
-  ``on_active``, sets ``GITHUB_TOKEN`` in env, and clears it on
-  ``on_idle``.
+- Hivemoot plugin's auth subscriber mints a token via apiarist at
+  ``setup_lifecycle`` time AND keeps ``GH_TOKEN`` / ``GITHUB_TOKEN``
+  populated for the container lifetime via a background refresh
+  thread. ``on_active`` is a defensive proactive-refresh
+  (re-mints when the current token is within the lead-time window);
+  ``on_idle`` is a NO-OP. Watch-driven services (drone) need env
+  populated between jobs so trigger threads can poll — clearing on
+  idle would deadlock those services.
 - Github plugin's clone subscriber runs ``_validate_repo_access``
   and ``clone_or_sync`` on ``on_active`` (after the auth subscriber
   has populated env per registration order — see
   :meth:`ContainerLifecycle.subscribe`).
 
+The "always-on env" model trades one layer of defense-in-depth
+(env-clear-when-idle) for trigger viability between jobs. The
+strong guarantee — short token TTL via apiarist's policy + the
+GitHub App 1h cap — is preserved by the refresh thread. See
+``plugins_builtin/hivemoot/auth_subscriber.py`` module docstring
+for the trade-off rationale in full.
+
 Future cross-cutting concerns reuse the same surface (metrics on
 state changes, secret rotation, audit logging, …).
 
 Synchronicity: this module is **synchronous** to match the existing
-plugin contract in `plugins/interfaces.py`. Subscribers that need
-async work (background refresh threads, etc.) spawn their own threads
-and join them in ``on_idle``. The reference-count invariant remains
+plugin contract in `plugins/interfaces.py`. Subscribers that spawn
+background threads (e.g. the hivemoot apiarist subscriber's
+refresh thread) own their thread lifecycle outside the
+``on_active`` / ``on_idle`` hooks — they may start the thread from
+their plugin's ``setup_lifecycle`` and rely on ``daemon=True``
+exit at process shutdown, OR expose an explicit ``stop()`` for
+clean test teardown. The lifecycle module doesn't track those
+subscriber-internal tasks. The reference-count invariant remains
 correct under sync dispatch because ``on_job_starting`` /
 ``on_job_finished`` calls are serialized by the engine's per-job
 sequential loop.

--- a/agent/cli/hivemoot_agent/lifecycle.py
+++ b/agent/cli/hivemoot_agent/lifecycle.py
@@ -126,10 +126,39 @@ class ContainerLifecycle:
       back to its prior value so the next job-start retries cleanly.
     - **I4**: a subscriber raising in ``on_idle`` is logged but
       doesn't block other subscribers' cleanup.
-    - **I5**: implementers that spawn background threads/tasks must
-      join them in ``on_idle`` and surface unhandled exceptions
-      themselves (this layer doesn't track subscriber-internal
-      tasks).
+    - **I5**: subscribers own the lifecycle of any background
+      threads / tasks they spawn. This module does NOT track
+      subscriber-internal work. Concretely, each implementer must:
+
+      a) **Surface failures themselves.** Unhandled exceptions in a
+         subscriber's background thread won't reach the lifecycle's
+         exception logger — the implementer must wrap their loop
+         and log to stderr (or whatever channel the operator
+         observes).
+      b) **Pick — and document — the lifetime model that fits its
+         job.** Two valid shapes:
+
+         - *Per-cycle* (spawn-and-join inside on_active/on_idle):
+           the subscriber starts the thread in ``on_active`` and
+           joins it in ``on_idle``. Right when the thread's work
+           is conceptually paired with a single ACTIVE period
+           (e.g. a per-job metrics-flush task).
+
+         - *Container-lifetime* (start once, stop on shutdown):
+           the subscriber starts a daemon thread before subscribing
+           (typically from the plugin's ``setup_lifecycle``) and
+           lets process exit handle the join, OR exposes an
+           explicit ``stop()`` for clean test teardown. Right when
+           the subscriber owns state that must persist across
+           ACTIVE/IDLE boundaries (e.g. the apiarist auth
+           subscriber's token-refresh thread, which keeps the env
+           valid for trigger threads polling between jobs).
+
+      Either pattern is fine; the implementer documents the
+      choice in their subscriber's class docstring so future
+      maintainers don't accidentally regress one model into the
+      other. The lifecycle module does not enforce or police the
+      choice.
     """
 
     def __init__(self) -> None:

--- a/agent/cli/hivemoot_agent/lifecycle.py
+++ b/agent/cli/hivemoot_agent/lifecycle.py
@@ -1,0 +1,268 @@
+"""Container-wide lifecycle FSM with subscriber/event-bus pattern.
+
+Per `apiarist/DESIGN.md` §12.3: the engine owns a generic IDLE/ACTIVE
+state machine; plugins (and other cross-cutting concerns) implement
+:class:`LifecycleSubscriber` and register at setup time. Subscribers
+receive ``on_active`` when the container transitions IDLE → ACTIVE
+(first job in flight) and ``on_idle`` when it transitions back
+(last job done).
+
+The engine wraps each job dispatch with ``on_job_starting`` /
+``on_job_finished``. Reference counting handles overlapping jobs:
+intermediate counter changes (1→2, 2→1) don't fire subscribers, only
+the 0↔1 boundary.
+
+The first user is GitHub token auth (apiarist):
+
+- Hivemoot plugin's auth subscriber mints a token via apiarist on
+  ``on_active``, sets ``GITHUB_TOKEN`` in env, and clears it on
+  ``on_idle``.
+- Github plugin's clone subscriber runs ``_validate_repo_access``
+  and ``clone_or_sync`` on ``on_active`` (after the auth subscriber
+  has populated env per registration order — see
+  :meth:`ContainerLifecycle.subscribe`).
+
+Future cross-cutting concerns reuse the same surface (metrics on
+state changes, secret rotation, audit logging, …).
+
+Synchronicity: this module is **synchronous** to match the existing
+plugin contract in `plugins/interfaces.py`. Subscribers that need
+async work (background refresh threads, etc.) spawn their own threads
+and join them in ``on_idle``. The reference-count invariant remains
+correct under sync dispatch because ``on_job_starting`` /
+``on_job_finished`` calls are serialized by the engine's per-job
+sequential loop.
+"""
+
+from __future__ import annotations
+
+import abc
+import sys
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from hivemoot_agent.plugins.interfaces import Job
+
+
+class LifecycleSubscriber(abc.ABC):
+    """Plugin-agnostic contract for receiving container lifecycle events.
+
+    Subscribers register via :meth:`ContainerLifecycle.subscribe` at
+    plugin setup time, before the engine starts dispatching jobs.
+    Implementations should:
+
+    - Be idempotent on ``on_active`` (may run multiple times across
+      the process lifetime — once per IDLE→ACTIVE transition).
+    - Raise on critical setup failure in ``on_active``. The engine
+      runs subscribers SEQUENTIALLY in registration order; a raise
+      stops the chain, then engine awaits ``on_idle`` on every prior
+      successful subscriber in REVERSE registration order
+      (best-effort cleanup, each wrapped so one bad cleanup doesn't
+      mask the original error), rolls the active-job counter back,
+      and re-raises. The triggering job fails to start; the runtime's
+      normal retry path re-attempts the full chain cleanly.
+    - Tolerate own-errors in ``on_idle``. Engine logs and continues
+      with other subscribers' cleanup; the lifecycle transition
+      completes regardless. Best-effort.
+    """
+
+    @abc.abstractmethod
+    def on_active(self) -> None:
+        """Container transitioned IDLE → ACTIVE. Setup phase.
+
+        The engine waits for this to return before dispatching the
+        triggering job. Raise to fail-closed (engine rolls back the
+        counter, the triggering job fails, runtime retries).
+        """
+
+    @abc.abstractmethod
+    def on_idle(self) -> None:
+        """Container transitioned ACTIVE → IDLE. Cleanup phase.
+
+        Best-effort. Engine logs exceptions but continues with other
+        subscribers' cleanup.
+        """
+
+
+class ContainerLifecycle:
+    """Container-wide IDLE/ACTIVE state with subscriber events.
+
+    The engine wires this around its job-dispatch loop:
+    :meth:`on_job_starting` runs before the engine hands a job to its
+    plugin; :meth:`on_job_finished` runs after. Subscribers register
+    once at process setup and receive ``on_active`` / ``on_idle`` on
+    the 0↔1 active-job-counter boundary. The engine waits for
+    subscribers (sequentially in registration order on ``on_active``;
+    sequentially in any order on ``on_idle``), so they can do setup
+    work (e.g., mint a token, set env, open a connection) and the
+    engine doesn't proceed until they're done.
+
+    Five invariants the lifecycle guarantees (DESIGN.md §12.3.2):
+
+    - **I1**: when the engine dispatches a job, every subscriber's
+      ``on_active`` has completed.
+    - **I2**: on full drain (last job ends), every subscriber's
+      ``on_idle`` is invoked before the engine returns to the next
+      idle iteration.
+    - **I3**: a subscriber raising in ``on_active`` rolls the counter
+      back to its prior value so the next job-start retries cleanly.
+    - **I4**: a subscriber raising in ``on_idle`` is logged but
+      doesn't block other subscribers' cleanup.
+    - **I5**: implementers that spawn background threads/tasks must
+      join them in ``on_idle`` and surface unhandled exceptions
+      themselves (this layer doesn't track subscriber-internal
+      tasks).
+    """
+
+    def __init__(self) -> None:
+        self._active_jobs: int = 0
+        self._subscribers: list[LifecycleSubscriber] = []
+        # Reentrant lock because a subscriber's on_active could in
+        # principle call back into the engine, which would in turn
+        # call on_job_starting. RLock prevents the inner call from
+        # deadlocking on the outer call's lock; subscriber-callback
+        # patterns aren't expected in V1 but the cost of RLock vs
+        # Lock is negligible and the safer default avoids a class
+        # of subtle hangs.
+        self._lock = threading.RLock()
+
+    def subscribe(self, sub: LifecycleSubscriber) -> None:
+        """Register a subscriber.
+
+        CONTRACT — registration order is load-bearing:
+
+        - ``on_active`` fires subscribers in REGISTRATION order (so a
+          subscriber that depends on a prior subscriber's setup must
+          register AFTER its dependency — e.g., github clone needs
+          hivemoot auth's env var, so hivemoot registers first).
+        - Rollback on partial-success ``on_active`` failure runs
+          subscribers in REVERSE registration order (mirrors
+          dependency teardown).
+        - ``on_idle`` (full drain) runs sequentially in registration
+          order; cleanup is best-effort and doesn't depend on
+          completion order.
+
+        Plugins control registration order by calling
+        :meth:`subscribe` during their ``setup()``. Plugins are
+        loaded in YAML insertion order under ADR-003, so the
+        operator-visible plugin order in ``hivemoot.yaml`` is the
+        subscriber order.
+
+        Called ONCE per subscriber during plugin setup, before the
+        engine starts dispatching jobs. NOT thread/async-safe — V1
+        relies on plugin setup being single-threaded and pre-dispatch.
+        """
+        self._subscribers.append(sub)
+
+    def on_job_starting(self, job: Job | None = None) -> None:
+        """Engine calls this before dispatching the job.
+
+        On the 0→1 transition, runs all subscribers' ``on_active``.
+
+        Asymmetric ordering vs ``on_idle``:
+
+        - ``on_active`` is **sequential** (registration order)
+          because subscribers may have setup-time dependencies (one
+          subscriber's effects must be visible to the next). E.g.,
+          hivemoot auth subscriber writes env → github subscriber's
+          clone reads it.
+        - ``on_idle`` is **sequential, best-effort** (any-order):
+          cleanup is order-independent and one bad cleanup must not
+          mask the rest.
+
+        Subscriber failure semantics (invariant I3 + atomicity):
+        if any subscriber raises in ``on_active``, every PRIOR
+        successful subscriber's ``on_idle`` is awaited in REVERSE
+        registration order (best-effort cleanup mirroring dependency
+        teardown), then the counter is rolled back and the original
+        exception bubbles to the engine's job-dispatch loop, which
+        fails the triggering job. The runtime's normal retry path
+        then re-attempts the full subscriber chain cleanly.
+        """
+        with self._lock:
+            self._active_jobs += 1
+            if self._active_jobs == 1:
+                # IDLE → ACTIVE — block on subscribers (invariant I1).
+                completed: list[LifecycleSubscriber] = []
+                try:
+                    for sub in self._subscribers:
+                        sub.on_active()
+                        completed.append(sub)
+                except Exception:
+                    # Tear down successful subscribers in reverse
+                    # registration order. Each cleanup wrapped so one
+                    # bad cleanup doesn't mask the original setup
+                    # failure.
+                    for done_sub in reversed(completed):
+                        try:
+                            done_sub.on_idle()
+                        except Exception as cleanup_exc:
+                            print(
+                                f"[lifecycle] subscriber on_idle raised "
+                                f"during rollback: "
+                                f"{type(done_sub).__name__}: "
+                                f"{type(cleanup_exc).__name__}: {cleanup_exc}",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                    # Roll back counter so next job-start retries
+                    # the full chain cleanly (I3).
+                    self._active_jobs -= 1
+                    raise
+
+    def on_job_finished(self, job: Job | None = None) -> None:
+        """Engine calls this after the job completes (success or fail).
+
+        On the 1→0 transition, runs all subscribers' ``on_idle`` for
+        cleanup. Subscriber errors here are logged but don't propagate
+        (invariant I4) — the job is done, cleanup should be
+        best-effort across all subscribers.
+
+        Defensive early-return when counter is already 0: defends
+        against a stray ``on_job_finished`` call (buggy engine path
+        or test setup). Without this, every spurious call would
+        re-fire ``on_idle`` (subscribers tearing down already-torn-
+        down state) AND would be impossible to distinguish from a
+        real 1→0 transition. Returning early keeps the counter
+        non-negative, prevents the next 0→1 transition from being
+        missed, and ensures ``on_idle`` fires exactly once per cycle.
+        """
+        with self._lock:
+            if self._active_jobs == 0:
+                return
+            self._active_jobs -= 1
+            if self._active_jobs == 0:
+                # ACTIVE → IDLE — all subscribers' cleanup runs (I2, I4).
+                for sub in self._subscribers:
+                    try:
+                        sub.on_idle()
+                    except Exception as exc:
+                        print(
+                            f"[lifecycle] subscriber on_idle raised: "
+                            f"{type(sub).__name__}: "
+                            f"{type(exc).__name__}: {exc}",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the container currently has any in-flight jobs.
+
+        Snapshot — not lock-protected; useful for diagnostics and
+        tests, not for control flow (anything depending on this
+        should use the lifecycle's own state-machine semantics
+        instead).
+        """
+        return self._active_jobs > 0
+
+    @property
+    def active_job_count(self) -> int:
+        """Number of in-flight jobs. Snapshot — diagnostics only."""
+        return self._active_jobs
+
+    @property
+    def subscriber_count(self) -> int:
+        """Number of registered subscribers. Diagnostics."""
+        return len(self._subscribers)

--- a/agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
@@ -113,6 +113,10 @@ class GitHubPlugin:
         # protocol) can read cfg.watch_* flags without reaching into
         # the global registry.
         self._cfg: GitHubConfig | None = None
+        # Auth-dependent subscriber populated in setup_lifecycle() when
+        # token_source: subscriber. Cached for diagnostics + tests; the
+        # runtime path goes through engine.lifecycle directly.
+        self._auth_subscriber: Any = None
 
     def validate(self, config: PluginConfig) -> list[str]:
         from hivemoot_agent.plugins_builtin.github.config import GitHubConfig
@@ -128,19 +132,28 @@ class GitHubPlugin:
         errors: list[str] = []
         if not cfg.repos:
             errors.append("plugins.github.repos is required (list of owner/repo)")
-        if cfg.token_file is None:
-            errors.append(
-                "plugins.github.token_file is required "
-                "(typically `!secret github_token`)"
-            )
-        elif not Path(cfg.token_file).is_file():
-            errors.append(
-                f"plugins.github.token_file does not exist: {cfg.token_file}"
-            )
-        elif not _read_token(cfg):
-            errors.append(
-                f"plugins.github.token_file is empty: {cfg.token_file}"
-            )
+
+        # token_file is REQUIRED only when token_source is "file" (the
+        # default — long-lived PAT in a secrets file). Under
+        # token_source: subscriber, the token arrives via env on every
+        # job from another plugin's lifecycle subscriber (apiarist via
+        # hivemoot), so an absent token_file is intentional and not an
+        # error.
+        if cfg.token_source == "file":
+            if cfg.token_file is None:
+                errors.append(
+                    "plugins.github.token_file is required when "
+                    "token_source is 'file' (typically "
+                    "`!secret github_token`)"
+                )
+            elif not Path(cfg.token_file).is_file():
+                errors.append(
+                    f"plugins.github.token_file does not exist: {cfg.token_file}"
+                )
+            elif not _read_token(cfg):
+                errors.append(
+                    f"plugins.github.token_file is empty: {cfg.token_file}"
+                )
         return errors
 
     def triggers(self) -> list[Trigger]:
@@ -163,7 +176,23 @@ class GitHubPlugin:
         return instances
 
     def setup(self, config: PluginConfig) -> None:
-        """Clone all configured repos and authenticate gh CLI."""
+        """One-time plugin setup.
+
+        Two-stage when ``token_source: subscriber`` (apiarist DESIGN.md
+        §12.3):
+
+        - ``token_source: file`` (default): runs both stages here. The
+          token from ``token_file`` is available immediately; clone +
+          validate happen synchronously. Existing PAT-based behavior.
+        - ``token_source: subscriber``: runs ONLY the auth-free stage
+          (cache config, choose git user defaults). The auth-required
+          stage (clone, validate, configure git user) moves into
+          :meth:`setup_lifecycle` which registers a subscriber that
+          runs on every IDLE→ACTIVE boundary AFTER the upstream
+          subscriber has populated env. ``self._repos`` stays empty
+          until the first job; ``system_prompt()`` falls back to the
+          placeholder path (config-derived) for the merged prompt.
+        """
         from hivemoot_agent.plugins_builtin.github.config import GitHubConfig
 
         self._setup_attempted = True
@@ -174,26 +203,59 @@ class GitHubPlugin:
             )
         self._cfg = cfg
 
+        # Auth-free defaults — git_name/email fallbacks. Don't resolve
+        # from token here in subscriber mode; the subscriber's on_active
+        # will refine these once the env is populated.
+        if cfg.git_name:
+            self._git_name = cfg.git_name
+            self._git_email = cfg.git_email
+        else:
+            self._git_name = "hivemoot-agent"
+            self._git_email = "hivemoot-agent@users.noreply.github.com"
+
+        if cfg.token_source == "subscriber":
+            # Auth-required steps deferred to setup_lifecycle / on_active.
+            return
+
+        # Legacy file-token path: auth-required steps run inline.
         token = _read_token(cfg)
+        os.environ["GH_TOKEN"] = token
+        os.environ["GITHUB_TOKEN"] = token
+        self._auth_required_setup(cfg, token)
+
+    def _auth_required_setup(
+        self, cfg: "GitHubConfig", token: str,
+    ) -> None:
+        """Auth-required half of setup.
+
+        Runs in two scenarios:
+
+        - From :meth:`setup` when ``token_source: file`` (token loaded
+          from disk; behavior unchanged from pre-subscriber refactor).
+        - From the github auth-dependent subscriber's ``on_active``
+          when ``token_source: subscriber`` (token loaded from env,
+          populated by the upstream auth subscriber).
+
+        Idempotent: ``clone_or_sync`` fetches an existing checkout
+        instead of re-cloning; ``configure_git_user`` is a no-op when
+        the values match. ``_validate_repo_access`` is one ``gh api``
+        call per repo — the cost is acceptable per-job because it
+        catches a stale/wrong token before the agent runs and burns
+        a job slot on a confusing failure.
+        """
         workspace = str(cfg.workspace)
         clone_depth = cfg.clone_depth
         repo_names = list(cfg.repos)
 
-        # Resolve git user from token for commit authorship.
-        git_name = cfg.git_name
-        git_email = cfg.git_email
-        if not git_name:
+        # Refine git user from the live token if not pinned in config.
+        # Only updates self._git_name/_email when resolve succeeds —
+        # we keep the auth-free defaults when the API call fails (the
+        # agent still gets a sane committer identity for the run).
+        if not cfg.git_name:
             login, email = resolve_github_user(token)
             if login:
-                git_name = login
-                git_email = email
-        if not git_name:
-            git_name = "hivemoot-agent"
-            git_email = "hivemoot-agent@users.noreply.github.com"
-
-        # Set GH_TOKEN so the agent's gh CLI calls are authenticated.
-        os.environ["GH_TOKEN"] = token
-        os.environ["GITHUB_TOKEN"] = token
+                self._git_name = login
+                self._git_email = email
 
         try:
             _configure_git_auth()
@@ -205,13 +267,12 @@ class GitHubPlugin:
         for repo in repo_names:
             _validate_repo_access(repo, token)
 
-        # Clone/sync each repo.
         cloned: list[RepoInfo] = []
         failures: list[str] = []
         for repo in repo_names:
             try:
                 info = clone_or_sync(repo, workspace, token, clone_depth)
-                configure_git_user(info.path, git_name, git_email)
+                configure_git_user(info.path, self._git_name, self._git_email)
                 cloned.append(info)
                 print(
                     f"[github] ready: {info.repo} → {info.path} "
@@ -226,10 +287,49 @@ class GitHubPlugin:
                 )
 
         self._repos = cloned
-        self._git_name = git_name
-        self._git_email = git_email
         if failures:
             raise RuntimeError("; ".join(failures))
+
+    def setup_lifecycle(
+        self, lifecycle: Any, config: PluginConfig,
+    ) -> None:
+        """Optional engine hook: register the auth-dependent subscriber.
+
+        Only registers when ``token_source: subscriber``. The subscriber's
+        ``on_active`` reads ``GH_TOKEN`` from env (populated by the
+        upstream auth subscriber, e.g. hivemoot's apiarist-backed one)
+        and runs :meth:`_auth_required_setup` — clone/validate/configure.
+
+        ``on_idle`` is a no-op for this subscriber: the cloned
+        workspace is intentionally persistent across jobs (next job's
+        on_active just fetches), and the env vars are owned by the
+        upstream subscriber to clear.
+
+        Registration order is load-bearing. The engine calls
+        ``setup_lifecycle`` in plugin iteration order (matching
+        ``hivemoot.yaml`` insertion order under ADR-003), and the
+        operator MUST list the upstream auth subscriber's plugin
+        BEFORE the github plugin so its ``on_active`` fires first
+        (env populated → github sees it).
+        """
+        cfg = config.typed
+        if cfg is None or cfg.token_source != "subscriber":
+            return
+
+        from hivemoot_agent.plugins_builtin.github.auth_subscriber import (
+            GithubAuthDependentSubscriber,
+        )
+
+        subscriber = GithubAuthDependentSubscriber(self, cfg)
+        lifecycle.subscribe(subscriber)
+        # Cache for diagnostics + tests; the engine drives this via
+        # lifecycle directly.
+        self._auth_subscriber = subscriber
+        print(
+            "[github] registered auth-dependent subscriber "
+            "(token_source: subscriber)",
+            file=sys.stderr, flush=True,
+        )
 
     def system_prompt(self, config: PluginConfig) -> str:
         from hivemoot_agent.plugins_builtin.github.config import GitHubConfig

--- a/agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
@@ -89,6 +89,12 @@ def _read_token(cfg: "GitHubConfig") -> str:
     Returns empty string if no token_file is set or the file isn't
     readable — validate() reports the error upstream.  Kept as a tiny
     helper so setup/trigger/ack all resolve the token the same way.
+
+    NOTE: Does NOT consult env. Subscriber-mode callers should use
+    :func:`_read_token_runtime` which falls back to env. We keep this
+    helper file-only because validate-time checks need a deterministic
+    "is the file readable?" answer, separate from "is there a token
+    available right now?".
     """
     if cfg.token_file is None:
         return ""
@@ -96,6 +102,27 @@ def _read_token(cfg: "GitHubConfig") -> str:
         return Path(cfg.token_file).read_text().strip()
     except OSError:
         return ""
+
+
+def _read_token_runtime(cfg: "GitHubConfig") -> str:
+    """Resolve the GitHub token at runtime, file or env per token_source.
+
+    Two-mode resolution (apiarist Phase L'):
+
+    - ``token_source: file`` — read from ``cfg.token_file`` (existing
+      long-lived-PAT path).
+    - ``token_source: subscriber`` — read from ``GH_TOKEN`` /
+      ``GITHUB_TOKEN`` env, populated by the hivemoot apiarist auth
+      subscriber.
+
+    Used by hot paths (notification ack, gh API calls, etc.) that need
+    "the currently valid token, whatever its source." Validate-time
+    checks should keep using :func:`_read_token` because env state at
+    validate time isn't representative of runtime.
+    """
+    if cfg.token_source == "subscriber":
+        return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    return _read_token(cfg)
 
 
 class GitHubPlugin:
@@ -336,6 +363,36 @@ class GitHubPlugin:
 
         cfg: GitHubConfig | None = config.typed or self._cfg
         clone_depth = cfg.clone_depth if cfg else 50
+
+        # Subscriber mode: setup() runs the auth-free half + sets
+        # _setup_attempted, but _repos stays empty until first
+        # IDLE→ACTIVE clones them. Without this branch the gate below
+        # would take the empty-repos path for the first job's prompt
+        # ("No repositories were pre-cloned"), since system_prompt() is
+        # called once after setup() and reused across jobs. Falling
+        # through to the placeholder builder gives the first job a
+        # correct prompt with the deterministic repo paths; subsequent
+        # process restarts (when _repos is populated) use the real
+        # values via the next branch.
+        if (
+            cfg is not None
+            and cfg.token_source == "subscriber"
+            and not self._repos
+        ):
+            workspace = str(cfg.workspace)
+            placeholder_repos = [
+                RepoInfo(
+                    repo=r,
+                    path=repo_checkout_path(workspace, r),
+                    default_branch="main",
+                )
+                for r in cfg.repos
+            ]
+            return build_system_prompt(
+                placeholder_repos, clone_depth,
+                git_user=self._git_name,
+            )
+
         if self._repos or self._setup_attempted:
             return build_system_prompt(
                 self._repos, clone_depth,
@@ -418,7 +475,14 @@ class GitHubPlugin:
 
         try:
             if ack_strategy == "notification":
-                gh_token = _read_token(config.typed) if config.typed else ""
+                # Hot path — use the runtime resolver so subscriber-mode
+                # services read the env-injected token rather than the
+                # absent token_file. Without this, ack_event would skip
+                # on empty token and the notification would replay
+                # forever.
+                gh_token = (
+                    _read_token_runtime(config.typed) if config.typed else ""
+                )
                 ack_module.ack_event(ack_key, state_file, gh_token)
                 return
             if ack_strategy == "new_pr":

--- a/agent/cli/hivemoot_agent/plugins_builtin/github/auth_subscriber.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/auth_subscriber.py
@@ -1,0 +1,112 @@
+"""Lifecycle subscriber that runs the github plugin's auth-required
+setup steps every IDLE→ACTIVE boundary.
+
+Used only when ``plugins.github.token_source: subscriber`` (apiarist
+DESIGN.md §12.3). The token isn't available at process startup under
+that mode — an upstream lifecycle subscriber (e.g. the hivemoot
+plugin's apiarist auth subscriber) populates ``GH_TOKEN`` /
+``GITHUB_TOKEN`` env vars on each on_active. This subscriber runs
+AFTER the upstream one (registration order is load-bearing — the
+operator lists the upstream plugin BEFORE github in
+``hivemoot.yaml``) and consumes the env to perform:
+
+- Resolve the GitHub user from the token (refines git committer
+  identity if not pinned in config).
+- ``gh auth setup-git`` to wire the credential helper.
+- ``gh api repos/<repo>`` for each configured repo (catches a stale
+  or wrong-scope token before the agent runs and burns a job slot
+  on a confusing failure).
+- ``clone_or_sync`` per repo (idempotent — fetches an existing
+  checkout instead of re-cloning).
+- ``configure_git_user`` per cloned repo.
+
+These steps are cheap per-job (~1-2 seconds) compared to the agent
+subprocess runtime; the value of running them per-on_active is
+fail-fast verification + a fresh fetch of upstream changes.
+
+``on_idle`` is intentionally a no-op:
+
+- The cloned workspace is persistent across jobs (next on_active
+  fetches incrementally; clearing it would force a slow re-clone).
+- The env vars are owned by the upstream subscriber to clear on its
+  own ``on_idle``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+from hivemoot_agent.lifecycle import LifecycleSubscriber
+
+if TYPE_CHECKING:
+    from hivemoot_agent.plugins_builtin.github import GitHubPlugin
+    from hivemoot_agent.plugins_builtin.github.config import GitHubConfig
+
+
+class GithubAuthDependentSubscriber(LifecycleSubscriber):
+    """Lifecycle subscriber that performs github auth-required setup
+    steps using a token populated by an upstream subscriber.
+
+    Holds a back-reference to the github plugin instance so it can
+    delegate to :meth:`GitHubPlugin._auth_required_setup` (the same
+    helper that ``token_source: file`` mode runs inline at setup time).
+    Single source of truth for the auth-required steps lives on the
+    plugin; this subscriber is the IDLE→ACTIVE driver.
+    """
+
+    def __init__(
+        self,
+        plugin: "GitHubPlugin",
+        cfg: "GitHubConfig",
+    ) -> None:
+        if plugin is None:
+            raise ValueError("plugin is required")
+        if cfg is None:
+            raise ValueError("cfg is required")
+        self._plugin: "GitHubPlugin" = plugin
+        self._cfg: "GitHubConfig" = cfg
+
+    def on_active(self) -> None:
+        """Read ``GH_TOKEN`` from env and run the auth-required setup.
+
+        Raises ``RuntimeError`` when env is missing the token (upstream
+        subscriber didn't fire, OR fired but failed to populate env).
+        Lifecycle module rolls back the counter and tears down completed
+        subscribers; the triggering job fails and runtime retries.
+
+        Fail-closed is intentional. Anonymous git operations would
+        succeed for public repos with read access but silently fail for
+        anything write-related (push, PR, comment), and the agent would
+        spend its budget on a job it can't complete.
+        """
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+        if not token:
+            raise RuntimeError(
+                "github auth subscriber: GH_TOKEN / GITHUB_TOKEN env "
+                "not set. The upstream auth subscriber (e.g. hivemoot "
+                "with apiarist) must populate the env BEFORE this "
+                "subscriber's on_active fires. Check plugin "
+                "registration order in hivemoot.yaml — the upstream "
+                "plugin must be listed BEFORE 'github'."
+            )
+
+        self._plugin._auth_required_setup(self._cfg, token)
+        print(
+            f"[github] auth-dependent setup completed for "
+            f"{len(self._cfg.repos)} repo(s)",
+            file=sys.stderr, flush=True,
+        )
+
+    def on_idle(self) -> None:
+        """No-op — see module docstring for why.
+
+        The cloned workspace persists across jobs by design (next
+        on_active fetches incrementally), and env-var ownership stays
+        with the upstream auth subscriber.
+        """
+        return None
+
+
+__all__ = ["GithubAuthDependentSubscriber"]

--- a/agent/cli/hivemoot_agent/plugins_builtin/github/auth_subscriber.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/auth_subscriber.py
@@ -2,13 +2,15 @@
 setup steps every IDLE→ACTIVE boundary.
 
 Used only when ``plugins.github.token_source: subscriber`` (apiarist
-DESIGN.md §12.3). The token isn't available at process startup under
+DESIGN.md §12.3, Phase L'). The token isn't read from a file under
 that mode — an upstream lifecycle subscriber (e.g. the hivemoot
 plugin's apiarist auth subscriber) populates ``GH_TOKEN`` /
-``GITHUB_TOKEN`` env vars on each on_active. This subscriber runs
-AFTER the upstream one (registration order is load-bearing — the
-operator lists the upstream plugin BEFORE github in
-``hivemoot.yaml``) and consumes the env to perform:
+``GITHUB_TOKEN`` env vars at ``setup_lifecycle`` time and keeps
+them populated for the container lifetime via a background refresh
+thread. This subscriber registers AFTER the upstream one
+(registration order is load-bearing — the operator lists the
+upstream plugin BEFORE github in ``hivemoot.yaml``) and on each
+on_active reads the current env to perform:
 
 - Resolve the GitHub user from the token (refines git committer
   identity if not pinned in config).
@@ -28,8 +30,11 @@ fail-fast verification + a fresh fetch of upstream changes.
 
 - The cloned workspace is persistent across jobs (next on_active
   fetches incrementally; clearing it would force a slow re-clone).
-- The env vars are owned by the upstream subscriber to clear on its
-  own ``on_idle``.
+- The env vars are NOT cleared by anyone on idle in the always-on
+  contract — the upstream apiarist subscriber keeps them populated
+  for the container lifetime so trigger threads can poll between
+  jobs. See ``hivemoot/auth_subscriber.py`` module docstring for
+  the trade-off rationale.
 """
 
 from __future__ import annotations

--- a/agent/cli/hivemoot_agent/plugins_builtin/github/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 
@@ -23,11 +24,31 @@ class GitHubConfig(StrictPluginConfig):
             "entry IS the canonical 'primary'."
         ),
     )
+    token_source: Literal["file", "subscriber"] = Field(
+        default="file",
+        description=(
+            "Where the GitHub token comes from at runtime:\n"
+            "- ``file`` (default): read once at setup() from "
+            "``token_file``.  Existing long-lived-PAT path.\n"
+            "- ``subscriber``: read from ``GH_TOKEN`` / ``GITHUB_TOKEN`` "
+            "env on every job, populated by another plugin's lifecycle "
+            "subscriber (e.g. apiarist via the hivemoot plugin's "
+            "auth subscriber).  When set to ``subscriber``, the github "
+            "plugin's setup() does NOT run its auth-required steps "
+            "(clone, validate access, configure git user) — those move "
+            "into a github-owned subscriber that fires on every "
+            "IDLE→ACTIVE boundary AFTER the upstream subscriber has "
+            "populated env (registration order is load-bearing; list "
+            "the upstream plugin BEFORE github in plugins:)."
+        ),
+    )
     token_file: Path | None = Field(
         default=None,
         description=(
             "Path to file containing the GitHub token.  Deployer writes "
-            "`!secret github_token` in hivemoot.yaml."
+            "`!secret github_token` in hivemoot.yaml.  Required when "
+            "``token_source`` is ``file`` (default); ignored when "
+            "``token_source`` is ``subscriber``."
         ),
     )
     workspace: Path = Field(

--- a/agent/cli/hivemoot_agent/plugins_builtin/github/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/trigger.py
@@ -73,7 +73,26 @@ def _resolve_state_dir(cfg: "GitHubConfig") -> str:
 
 
 def _resolve_gh_token(cfg: "GitHubConfig") -> str:
-    """Read the token from cfg.token_file (empty string on any failure)."""
+    """Read the token for trigger polls, returning ``""`` on failure.
+
+    Two-mode resolution (apiarist Phase L'):
+
+    - ``token_source: file`` — read once per call from ``cfg.token_file``.
+      Existing long-lived-PAT path; the file is local + cheap to re-read.
+    - ``token_source: subscriber`` — read from ``GH_TOKEN`` /
+      ``GITHUB_TOKEN`` env, populated by the hivemoot apiarist auth
+      subscriber. The subscriber mints a token in ``setup_lifecycle``
+      (so env is populated before triggers' first poll) and refreshes
+      it via a background thread (so env stays populated during long
+      idle periods between jobs — critical for trigger services like
+      drone that have NO work source but the watch triggers).
+
+    Called per-poll-iteration (not just at ``start()``) so a token
+    rotation in either mode takes effect within one poll interval
+    instead of waiting for container restart.
+    """
+    if cfg.token_source == "subscriber":
+        return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
     if cfg.token_file is None:
         return ""
     try:
@@ -154,7 +173,13 @@ class _GitHubWatchTrigger:
                 f"{self.name} requires plugins.github.target_repo or "
                 "plugins.github.repos to select a repo to watch"
             )
-        if not _resolve_gh_token(cfg):
+        # Token validation is mode-dependent:
+        #   - file mode: token must be readable NOW (validate-time fail-fast).
+        #   - subscriber mode: env populated asynchronously by the hivemoot
+        #     auth subscriber after setup_lifecycle; checking at validate()
+        #     time would always fail. The trigger's poll loop re-reads
+        #     each iteration and skips empty-token cycles with a log.
+        if cfg.token_source == "file" and not _resolve_gh_token(cfg):
             errors.append(
                 f"{self.name} requires plugins.github.token_file "
                 "for GitHub API auth"
@@ -170,10 +195,19 @@ class _GitHubWatchTrigger:
             )
             return
         repo = _resolve_target_repo(cfg)
-        gh_token = _resolve_gh_token(cfg)
-        if not repo or not gh_token:
+        if not repo:
             print(
-                f"[{self.name}] disabled: missing repo or token",
+                f"[{self.name}] disabled: missing repo",
+                file=sys.stderr, flush=True,
+            )
+            return
+        # In file mode we can fail fast on missing token here. In
+        # subscriber mode the env token is populated by the hivemoot
+        # auth subscriber asynchronously; the poll loop tolerates
+        # empty-token cycles, so we proceed.
+        if cfg.token_source == "file" and not _resolve_gh_token(cfg):
+            print(
+                f"[{self.name}] disabled: missing token file",
                 file=sys.stderr, flush=True,
             )
             return
@@ -194,11 +228,40 @@ class _GitHubWatchTrigger:
         self._stop_event.clear()
         print(
             f"[{self.name}] watching {repo} every {poll_interval}s "
-            f"(state={state_file})",
+            f"(state={state_file}, token_source={cfg.token_source})",
             file=sys.stderr, flush=True,
         )
 
+        # Rate-limit the "no token this cycle" warning so a long idle
+        # period (subscriber mode, awaiting initial mint) doesn't flood
+        # stderr with one warning per poll. One warning per minute
+        # covers operator visibility without spam.
+        last_no_token_warn = 0.0
+        no_token_warn_interval = 60.0
+
         while not self._stop_event.is_set():
+            # Re-resolve token EACH poll so a rotation in either mode
+            # (file mode: file replaced on disk; subscriber mode:
+            # apiarist auth subscriber re-mints into env) takes effect
+            # within one poll interval instead of waiting for restart.
+            gh_token = _resolve_gh_token(cfg)
+            if not gh_token:
+                # In subscriber mode this happens briefly between
+                # container start and the auth subscriber's initial
+                # mint. Skip this poll cycle and retry next interval.
+                import time as _time
+                now = _time.monotonic()
+                if now - last_no_token_warn >= no_token_warn_interval:
+                    print(
+                        f"[{self.name}] no token this cycle "
+                        f"(token_source={cfg.token_source}); "
+                        "skipping poll, retry next interval",
+                        file=sys.stderr, flush=True,
+                    )
+                    last_no_token_warn = now
+                self._stop_event.wait(poll_interval)
+                continue
+
             try:
                 events = self._poll_events(
                     cfg=cfg,

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -145,6 +145,11 @@ class HivemootPlugin:
         # triggers/system_prompt methods don't re-read from the registry.
         self._cfg: "HivemootConfig | None" = None
 
+        # Apiarist auth subscriber, populated in setup_lifecycle() when
+        # cfg.apiarist.enabled is true. Cached for diagnostics and
+        # tests; runtime path goes through engine.lifecycle directly.
+        self._auth_subscriber: Any = None
+
     # ── Validation / setup ─────────────────────────────────────────
 
     def validate(self, config: PluginConfig) -> list[str]:
@@ -221,31 +226,27 @@ class HivemootPlugin:
     def _validate_github_workflows(self, cfg: "HivemootConfig") -> list[str]:
         """Mirrors the previous hivemoot-github plugin's validation.
 
-        Requires the ``github`` plugin to be activated BEFORE
-        ``hivemoot`` in the YAML so repos are cloned by the time our
-        setup runs.
+        Order-tolerant since apiarist DESIGN.md §12.3 (Phase L'): the
+        github plugin can be listed AFTER hivemoot in plugins: when
+        ``github.token_source: subscriber`` (so hivemoot's auth
+        subscriber registers first and fires before github's auth
+        subscriber). The legacy file-mode order (``github`` first so
+        its setup() clones repos before hivemoot.github_workflows
+        reads them) still works — both orders are accepted.
+
+        We skip the "github already configured" check here because:
+
+        - validate() runs BEFORE the engine calls
+          ``registry.configure(name, config)``, so when hivemoot is
+          listed first, github hasn't been configured yet even though
+          it WILL be configured by the time setup() runs. The check
+          was a sequencing artifact, not a real precondition.
+        - Cross-plugin presence is checked in :meth:`_setup_github_workflows`
+          via ``registry.config_for_or_none("github")`` — by setup
+          time all plugins have been validated and configured, so the
+          check is order-independent.
         """
         errors: list[str] = []
-
-        from hivemoot_agent.plugins import registry as _registry
-        already_configured = _registry.configured_names()
-        if "github" not in already_configured:
-            errors.append(
-                "hivemoot.github_workflows requires the ``github`` plugin "
-                "to be activated AND listed BEFORE ``hivemoot`` in "
-                "plugins: of hivemoot.yaml so repos are cloned before "
-                "this plugin's setup runs.  Currently configured before "
-                f"us: {already_configured or '(none)'}."
-            )
-            return errors
-
-        target_repo = self._resolve_github_target_repo()
-        if not target_repo:
-            errors.append(
-                "hivemoot.github_workflows could not determine the "
-                "target repository from the github plugin's typed config "
-                "(plugins.github.repos is empty)."
-            )
 
         if shutil.which("hivemoot") is None:
             errors.append(
@@ -264,14 +265,104 @@ class HivemootPlugin:
         if cfg.github_workflows.enabled:
             self._setup_github_workflows(cfg)
 
+    def setup_lifecycle(
+        self, lifecycle: Any, config: PluginConfig,
+    ) -> None:
+        """Optional engine hook: register the apiarist auth subscriber.
+
+        Called by the engine after every plugin's ``setup()`` completes
+        (apiarist DESIGN.md §12.3). When ``apiarist.enabled`` is true,
+        this builds the apiarist UDS client and registers a
+        :class:`HivemootGithubAuthSubscriber` on the engine's container
+        lifecycle so every IDLE→ACTIVE transition mints a fresh
+        GitHub installation token into ``GH_TOKEN`` / ``GITHUB_TOKEN``.
+
+        No-op when apiarist is disabled — fleets running on long-lived
+        PATs see this method but it returns silently.
+
+        Subscriber registration ordering is load-bearing: list the
+        hivemoot plugin BEFORE the github plugin in ``hivemoot.yaml``
+        so the env this subscriber populates is in place when the
+        github plugin's clone subscriber fires.
+        """
+        cfg = config.typed
+        if cfg is None or not cfg.apiarist.enabled:
+            return
+
+        from hivemoot_agent.apiarist_client import ApiaristClient
+        from hivemoot_agent.plugins_builtin.hivemoot.auth_subscriber import (
+            HivemootGithubAuthSubscriber,
+        )
+
+        service = cfg.apiarist.service or self.resolved_agent_id()
+        if not service:
+            raise RuntimeError(
+                "plugins.hivemoot.apiarist.service is required (or set "
+                "AGENT_ID env) when apiarist.enabled is true — apiarist "
+                "uses it as the caller-identifier in its audit log."
+            )
+
+        repo = cfg.apiarist.repo or self._resolve_github_target_repo()
+        if not repo:
+            raise RuntimeError(
+                "plugins.hivemoot.apiarist.repo is required (or "
+                "configure plugins.github.repos[0]) when apiarist.enabled "
+                "is true — apiarist's token policy scopes the minted "
+                "token to a single repo."
+            )
+
+        client = ApiaristClient(
+            socket_path=str(cfg.apiarist.socket_path),
+            timeout_seconds=cfg.apiarist.timeout_seconds,
+        )
+        subscriber = HivemootGithubAuthSubscriber(
+            client,
+            service=service,
+            repo=repo,
+            agent_id=self.resolved_agent_id() or None,
+        )
+        lifecycle.subscribe(subscriber)
+        # Cache for diagnostics + tests; not load-bearing for runtime.
+        self._auth_subscriber = subscriber
+        print(
+            f"[hivemoot-auth] registered apiarist auth subscriber "
+            f"(socket={cfg.apiarist.socket_path}, service={service}, "
+            f"repo={repo})",
+            file=sys.stderr, flush=True,
+        )
+
     def _setup_github_workflows(self, cfg: "HivemootConfig") -> None:
-        """Resolve target repo path + optional role prompt block."""
+        """Resolve target repo path + optional role prompt block.
+
+        Order-tolerant per apiarist DESIGN.md §12.3 (Phase L'). When
+        ``github.token_source: subscriber`` the github plugin's
+        setup() runs only the auth-free half — the actual clone
+        happens at first IDLE→ACTIVE in the github auth subscriber.
+        We still resolve target_repo + repo_path deterministically
+        here (the path is computable from cfg.workspace + repo name);
+        we just SKIP the dir-exists check that the file-mode path
+        relies on for fail-fast clone-failure detection.
+
+        Role prompt loading was already best-effort (try/except on
+        RoleLoadError) so it's resilient either way.
+        """
+        from hivemoot_agent.plugins import registry as _registry
         from hivemoot_agent.plugins_builtin.github.repo_manager import (
             repo_checkout_path,
         )
         from hivemoot_agent.plugins_builtin.hivemoot.github_workflows.role_loader import (
             RoleLoadError,
             load_role_prompt_block,
+        )
+
+        gh_cfg = _registry.config_for_or_none("github")
+        if gh_cfg is None or gh_cfg.typed is None:
+            raise RuntimeError(
+                "hivemoot.github_workflows requires the 'github' plugin "
+                "to be enabled in plugins: of hivemoot.yaml."
+            )
+        github_subscriber_mode = (
+            getattr(gh_cfg.typed, "token_source", "file") == "subscriber"
         )
 
         target_repo = self._resolve_github_target_repo()
@@ -285,13 +376,24 @@ class HivemootPlugin:
         repo_path = repo_checkout_path(
             str(cfg.github_workflows.workspace), target_repo,
         )
-        if not repo_path or not os.path.isdir(repo_path):
+        if not repo_path:
             raise RuntimeError(
-                "hivemoot.github_workflows expected the github plugin to "
-                f"clone {target_repo} at "
-                f"{repo_path or '(unknown path)'}"
+                "hivemoot.github_workflows could not derive a checkout "
+                f"path for {target_repo} under "
+                f"{cfg.github_workflows.workspace}"
             )
         self._repo_path = repo_path
+
+        # Dir-exists check is meaningful only in file mode (clone
+        # synchronously runs in github.setup before this). In subscriber
+        # mode the clone happens at first on_active; checking here would
+        # always fail. The deterministic path is still cached so
+        # system_prompt() can reference it.
+        if not github_subscriber_mode and not os.path.isdir(repo_path):
+            raise RuntimeError(
+                "hivemoot.github_workflows expected the github plugin to "
+                f"clone {target_repo} at {repo_path}"
+            )
 
         self._role_name = self._resolve_role_name(cfg)
         self._role_prompt_block = ""

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -321,6 +321,16 @@ class HivemootPlugin:
             repo=repo,
             agent_id=self.resolved_agent_id() or None,
         )
+        # Initial mint + start the background refresh thread BEFORE
+        # subscribing. The subscriber's start() does a synchronous
+        # mint so triggers (whose start() runs after setup_lifecycle)
+        # see env populated on their first poll, AND launches the
+        # refresh thread that keeps env populated during long idle
+        # periods between jobs (critical for watch-driven services
+        # like drone whose only work source is the trigger threads).
+        # If start() raises, the lifecycle subscribe never happens
+        # and plugin setup fails fast — fail-closed.
+        subscriber.start()
         lifecycle.subscribe(subscriber)
         # Cache for diagnostics + tests; not load-bearing for runtime.
         self._auth_subscriber = subscriber

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth_subscriber.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth_subscriber.py
@@ -1,55 +1,72 @@
-"""Lifecycle subscriber that mints a GitHub token via apiarist on
-the IDLE→ACTIVE boundary.
+"""Lifecycle subscriber that brokers GitHub installation tokens via
+the apiarist daemon and keeps the env populated for the lifetime of
+the container.
 
-This is the V1 implementation of the apiarist token broker integration
-(DESIGN.md §12.3). It bridges the engine's container lifecycle FSM to
-the apiarist UDS daemon:
+V1 of the apiarist token broker integration (DESIGN.md §12.3, Phase L').
+The subscriber:
 
-- **on_active** (IDLE→ACTIVE): call ``mint_token`` over the apiarist
-  socket, populate ``GH_TOKEN`` + ``GITHUB_TOKEN`` env vars.
-- **on_idle** (ACTIVE→IDLE): clear those env vars so a stale token
-  doesn't linger if the daemon restarts or the operator stops it.
+- **start()** (called once from the hivemoot plugin's
+  ``setup_lifecycle()`` BEFORE the lifecycle subscribes it):
+  performs an initial synchronous mint and starts a background
+  refresh thread. Triggers running in subscriber mode read
+  ``GH_TOKEN`` / ``GITHUB_TOKEN`` from env; doing the initial mint
+  here guarantees the env is populated before the trigger threads
+  start polling.
+- **Background refresh thread**: re-mints when the current token is
+  within ``refresh_lead_time_secs`` (default 5 minutes) of expiry.
+  Required because trigger services (drone, builder review queue)
+  poll continuously and need a valid token even during long idle
+  periods between jobs that exceed the 1-hour token TTL.
+- **on_active** (IDLE→ACTIVE): proactively refreshes if the current
+  token is within the lead-time window. Normally a no-op (the
+  background thread keeps things fresh) — defensive for the case
+  where the thread is wedged or a job starts during the lead-time
+  window.
+- **on_idle** (ACTIVE→IDLE): NO-OP. The env stays populated between
+  jobs so trigger threads can poll. See §12.3 trade-off discussion.
+- **stop()**: signals the refresh thread to exit. Daemon=True
+  thread also dies with the process, so this is mainly for clean
+  test teardown; not strictly required at container shutdown.
 
-Why mint per IDLE→ACTIVE (not at process startup):
+Why on_idle is a no-op (different from earlier V1 sketch):
 
-- A container can sit IDLE for hours between jobs. Minting upfront
-  burns a 1-hour-TTL token that will have expired by the time a job
-  arrives.
-- Minting per IDLE→ACTIVE means every job sees a freshly-minted
-  token, so the only way the token can expire mid-job is if the job
-  itself runs longer than the token TTL (~55 min effective). V1
-  treats that as out-of-scope; long-running jobs (>50 min) see the
-  edge case and the operator's runbook covers it.
+Watch-driven services (drone with watch_mentions / watch_review_requests
+/ watch_new_prs) have NO work source besides their trigger threads.
+Trigger threads run on the engine event loop, INDEPENDENT of jobs.
+Between jobs they need to poll GitHub to discover new events. If
+on_idle clears the env, the trigger has no token between jobs →
+deadlock (no events → no jobs → no on_active → token stays missing).
 
-Why clear on ACTIVE→IDLE (not just leave the token sitting):
-
-- Defense-in-depth. If the env-var leaks (subprocess dump, log
-  capture, /proc inspection), it's only exposed during active jobs.
-- If a debug shell attaches between jobs, ``env | grep TOKEN`` shows
-  nothing — clear signal that the token broker is wired and working.
-
-The subscriber is NOT registered with a background refresh thread in
-V1. Refresh-during-job (rotating the env mid-flight) does not reach
-already-spawned subprocesses (they snapshot env at exec time), so the
-benefit is marginal vs. the complexity of join-on-idle thread
-lifecycle. A future V1.1 iteration may add it for nested-gh-call
-freshness; see DESIGN.md §12.3.4 "Future variants".
+The defense-in-depth value of "env clear when idle" turned out to
+be marginal anyway: the token is held in process memory by this
+subscriber regardless of whether it's also in env. The hard guarantee
+that DOES matter (~1h max TTL via apiarist's policy) is preserved.
 
 Failure modes:
 
-- Apiarist daemon down → :class:`ApiaristTransportError` propagates
-  from ``on_active``, lifecycle module rolls back the counter, the
-  triggering job fails to start, runtime retries.
+- Apiarist daemon down at start() → :class:`ApiaristTransportError`
+  propagates from start(); plugin setup fails; container exits
+  fail-closed. Operator's runbook covers this (apiarist must be
+  running before the agent container starts; the apiarist install
+  script enables it as a systemd unit).
 - Apiarist returns ``BACKEND_FORBIDDEN`` (e.g. repo not in token
-  policy) → :class:`ApiaristRemoteError` propagates the same way.
-  This is fail-closed: a misconfigured policy never lets a request
-  silently fall back to a long-lived PAT.
+  policy) → same; fail-closed at startup, operator must fix the
+  policy via the set-agent-policy CLI.
+- Mint failure in the refresh loop → logged, retried after
+  ``refresh_backoff_on_error_secs``. The previous token stays in env
+  and may expire → triggers eventually start failing 401 → operator
+  sees it in logs. NOT silent.
+- Mint failure in on_active (defensive refresh) → propagates,
+  lifecycle rolls back the counter, the triggering job fails and
+  retries; same fail-closed semantics as the original design.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+import threading
+from datetime import datetime, timedelta, timezone
 from typing import Final
 
 from hivemoot_agent.apiarist_client import (
@@ -71,22 +88,38 @@ from hivemoot_agent.lifecycle import LifecycleSubscriber
 # tool surface the agent uses (gh, git remote, octokit-bearing tools).
 _TOKEN_ENV_VARS: Final[tuple[str, ...]] = ("GH_TOKEN", "GITHUB_TOKEN")
 
+# Default refresh window: re-mint when within 5 minutes of expiry.
+# Apiarist tokens default to 1h TTL; this gives the refresh thread
+# 55 minutes between routine re-mints. Tightening below ~60 seconds
+# would create contention with on_active's defensive refresh during
+# active job periods; widening beyond ~10 minutes risks expiry mid-poll
+# under clock skew.
+_DEFAULT_REFRESH_LEAD_TIME_SECS: Final[int] = 300
+
+# Default backoff between mint retries when the refresh loop hits
+# an apiarist error (transport / remote / protocol). Short enough to
+# recover quickly from a transient blip; long enough that a sustained
+# outage doesn't burn through a 60-RPM apiarist rate-limit budget.
+_DEFAULT_REFRESH_BACKOFF_SECS: Final[float] = 60.0
+
 
 class HivemootGithubAuthSubscriber(LifecycleSubscriber):
     """Lifecycle subscriber that brokers GitHub installation tokens
-    via the apiarist daemon.
+    via the apiarist daemon and maintains an always-on env populated
+    via a background refresh thread.
 
-    Single-instance per container. Registered by the hivemoot plugin's
-    ``setup_lifecycle()`` hook when the operator opts into apiarist
-    token brokering via the ``apiarist:`` config block.
+    Single-instance per container. Built and started by the hivemoot
+    plugin's ``setup_lifecycle()`` hook when the operator opts into
+    apiarist token brokering via the ``apiarist:`` config block.
 
     Thread-safety: the engine calls ``on_active`` / ``on_idle`` on the
     ContainerLifecycle's serialized boundary (sequential under
-    ``threading.RLock``), so the subscriber's internal state changes
-    don't need their own lock. The env-var reads from other threads
-    (e.g. heartbeat threads in the hivemoot tasks subsystem) see a
-    consistent snapshot — Python's GIL makes a single
-    ``os.environ[k] = v`` assignment atomic.
+    ``threading.RLock``). The background refresh thread also touches
+    ``self._current`` and env. We rely on Python's GIL to make single
+    attribute writes and ``os.environ[k] = v`` atomic; readers
+    (triggers consulting env each poll) see a consistent snapshot.
+    For invariants stronger than "atomic per write", a lock would be
+    needed — none of the current readers care.
     """
 
     def __init__(
@@ -96,6 +129,8 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
         service: str,
         repo: str,
         agent_id: str | None = None,
+        refresh_lead_time_secs: int = _DEFAULT_REFRESH_LEAD_TIME_SECS,
+        refresh_backoff_on_error_secs: float = _DEFAULT_REFRESH_BACKOFF_SECS,
     ) -> None:
         """
         Args:
@@ -110,6 +145,12 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
             agent_id: optional audit-only identifier (``AGENT_ID`` env
                 value, e.g. ``"drone"``). Logged by apiarist; ignored
                 for authorization.
+            refresh_lead_time_secs: re-mint when the current token is
+                within this many seconds of expiry. Default 300 (5 min)
+                gives the refresh thread plenty of margin against a
+                transient apiarist outage at the moment of refresh.
+            refresh_backoff_on_error_secs: how long the refresh thread
+                waits after a mint error before retrying. Default 60s.
         """
         if client is None:
             raise ValueError("client is required")
@@ -117,15 +158,32 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
             raise ValueError("service must be non-empty")
         if not repo:
             raise ValueError("repo must be non-empty")
+        if refresh_lead_time_secs <= 0:
+            raise ValueError(
+                f"refresh_lead_time_secs must be positive "
+                f"(got {refresh_lead_time_secs!r})"
+            )
+        if refresh_backoff_on_error_secs <= 0:
+            raise ValueError(
+                f"refresh_backoff_on_error_secs must be positive "
+                f"(got {refresh_backoff_on_error_secs!r})"
+            )
         self._client: ApiaristClient = client
         self._service: str = service
         self._repo: str = repo
         self._agent_id: str | None = agent_id
-        # Last successfully-minted token, kept for diagnostics and to
-        # short-circuit the env-clear when on_idle fires before the
-        # first on_active (defensive — the lifecycle module shouldn't
-        # do this but the cost of guarding is zero).
+        self._refresh_lead_time_secs: int = refresh_lead_time_secs
+        self._refresh_backoff_on_error_secs: float = refresh_backoff_on_error_secs
+        # Last successfully-minted token. Held in memory for diagnostics
+        # and so on_active can decide whether a defensive refresh is
+        # needed (compare expiry to now + lead-time).
         self._current: MintedToken | None = None
+        # Refresh thread coordination. _started is single-shot: a second
+        # start() call is a no-op so plugin setup_lifecycle is idempotent
+        # under retry.
+        self._stop_event: threading.Event = threading.Event()
+        self._refresh_thread: threading.Thread | None = None
+        self._started: bool = False
 
     # ── Diagnostics ──────────────────────────────────────────────
 
@@ -141,7 +199,7 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
 
     @property
     def current_token(self) -> MintedToken | None:
-        """The last successfully-minted token, or None when idle.
+        """The last successfully-minted token, or None before start().
 
         Diagnostics only — callers must not pluck the raw token out
         of this property to authenticate; they should read
@@ -150,22 +208,109 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
         """
         return self._current
 
-    # ── Lifecycle hooks ──────────────────────────────────────────
+    @property
+    def is_started(self) -> bool:
+        """Whether ``start()`` has run successfully. Diagnostics + tests."""
+        return self._started
+
+    # ── Explicit lifecycle (called by the plugin, not the engine) ─
+
+    def start(self) -> None:
+        """Initial mint + start the background refresh thread.
+
+        Called once by the hivemoot plugin's ``setup_lifecycle()``
+        BEFORE the lifecycle subscribes this instance. The initial
+        mint is synchronous so trigger threads (which start shortly
+        after) see env populated on their first poll.
+
+        Idempotent — a second call is a silent no-op so plugin
+        setup_lifecycle can be retried safely.
+
+        Raises whatever ``client.mint_token`` raises on the initial
+        mint (Transport / Protocol / Remote errors). Plugin setup
+        fails fast; container exits with a clear error pointing the
+        operator at apiarist health.
+        """
+        if self._started:
+            return
+        # Initial mint synchronously so triggers see env populated
+        # immediately — without this they'd skip their first N polls
+        # waiting for the refresh thread to schedule a mint.
+        self._mint_and_set_env()
+        self._refresh_thread = threading.Thread(
+            target=self._refresh_loop,
+            name=f"hivemoot-auth-refresh-{self._service}",
+            daemon=True,
+        )
+        self._refresh_thread.start()
+        self._started = True
+
+    def stop(self) -> None:
+        """Signal the refresh thread to exit and wait for it to finish.
+
+        Daemon thread also exits at process shutdown, so this is mainly
+        for clean test teardown — production code rarely needs to call
+        it. Idempotent; safe to call multiple times or before start().
+        """
+        self._stop_event.set()
+        thread = self._refresh_thread
+        if thread is not None:
+            thread.join(timeout=5)
+        self._refresh_thread = None
+
+    # ── Lifecycle hooks (called by the engine) ───────────────────
 
     def on_active(self) -> None:
-        """Mint a fresh token and populate the GitHub auth env vars.
+        """Defensive refresh on the IDLE→ACTIVE boundary.
 
-        Raises whatever the apiarist client raises (Transport /
-        Protocol / Remote errors). The lifecycle module catches the
-        exception, rolls back the counter, and tears down any prior
-        successful subscribers — the triggering job fails and the
-        runtime retries the full chain cleanly.
+        Normally the background refresh thread keeps the token fresh,
+        so this is a no-op. We re-mint here only when:
 
-        We intentionally do NOT swallow errors here: a missing
-        GITHUB_TOKEN is silently catastrophic (the github plugin's
-        clone subscriber would fail to authenticate, possibly falling
-        back to anonymous and leaking access patterns). Fail-closed
-        keeps the contract crisp.
+        - The thread has somehow not run (bug / hang / not yet
+          started), and we have no current token. Force-mint to
+          fail-closed cleanly.
+        - The current token is within the refresh-lead-time window
+          (about to expire). Refresh proactively so the upcoming job
+          doesn't race the refresh thread on the boundary.
+
+        Raises whatever ``client.mint_token`` raises in either of
+        those branches. The lifecycle module catches and rolls back
+        the counter, the triggering job fails, the runtime retries.
+        """
+        if self._current is None:
+            # No token yet — start() wasn't called, OR the refresh
+            # loop hasn't recovered from a sustained mint outage.
+            # Force a synchronous mint to fail-closed cleanly.
+            self._mint_and_set_env()
+            return
+        now = datetime.now(timezone.utc)
+        seconds_to_expiry = (self._current.expires_at - now).total_seconds()
+        if seconds_to_expiry < self._refresh_lead_time_secs:
+            # Inside the lead-time window — refresh now so the job
+            # doesn't race the refresh thread.
+            self._mint_and_set_env()
+
+    def on_idle(self) -> None:
+        """No-op — env stays populated between jobs.
+
+        Trigger threads (mention / review-request / new-PR watchers)
+        poll continuously and need a valid token between jobs. Clearing
+        env on idle would deadlock watch-driven services that have NO
+        work source besides triggers (drone is the V1 example).
+
+        See module docstring "Why on_idle is a no-op" for the full
+        trade-off rationale.
+        """
+        return None
+
+    # ── Internal: mint + refresh loop ────────────────────────────
+
+    def _mint_and_set_env(self) -> None:
+        """Mint a fresh token via apiarist, atomically replace env.
+
+        Caller is responsible for catching exceptions (the refresh
+        loop wraps + logs; on_active and start() let them propagate
+        for fail-closed behavior).
         """
         token = self._client.mint_token(
             service=self._service,
@@ -175,10 +320,6 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
         for var in _TOKEN_ENV_VARS:
             os.environ[var] = token.token
         self._current = token
-        # Diagnostics only — operator can correlate with apiarist log
-        # via the installation_id and the token's last-12 chars
-        # (sha-prefixed, not the raw secret). Token full value is
-        # never logged.
         print(
             f"[hivemoot-auth] minted token for {self._repo} "
             f"(installation={token.installation_id}, "
@@ -186,25 +327,62 @@ class HivemootGithubAuthSubscriber(LifecycleSubscriber):
             file=sys.stderr, flush=True,
         )
 
-    def on_idle(self) -> None:
-        """Clear the GitHub auth env vars.
+    def _seconds_until_refresh(self) -> float:
+        """How many seconds the refresh loop should sleep before next mint.
 
-        Best-effort by lifecycle contract (I4) — exceptions get
-        logged by the lifecycle module and don't propagate. Clearing
-        env is a few atomic dict ops, so failures here are unlikely;
-        we still wrap defensively because an early ``on_idle`` (no
-        prior ``on_active``) would otherwise leak ``KeyError`` from
-        the lifecycle module's exception logger.
+        Returns ``refresh_backoff_on_error_secs`` when there's no
+        current token (we're recovering from a mint failure and want
+        to retry sooner than the full TTL). Otherwise returns time
+        until ``expires_at - lead_time``, clamped to a minimum of 1s
+        so a clock skew can't yield a tight loop.
         """
-        for var in _TOKEN_ENV_VARS:
-            os.environ.pop(var, None)
-        if self._current is not None:
-            print(
-                f"[hivemoot-auth] cleared token env for {self._repo} "
-                f"(installation={self._current.installation_id})",
-                file=sys.stderr, flush=True,
-            )
-        self._current = None
+        if self._current is None:
+            return self._refresh_backoff_on_error_secs
+        now = datetime.now(timezone.utc)
+        target = self._current.expires_at - timedelta(
+            seconds=self._refresh_lead_time_secs,
+        )
+        delta = (target - now).total_seconds()
+        return max(1.0, delta)
+
+    def _refresh_loop(self) -> None:
+        """Background: re-mint when current token nears expiry.
+
+        Runs in its own daemon thread for the lifetime of the container.
+        Sleeps on the stop_event so a stop() call interrupts the wait
+        immediately instead of running out the full sleep.
+        """
+        while not self._stop_event.is_set():
+            sleep_secs = self._seconds_until_refresh()
+            if self._stop_event.wait(sleep_secs):
+                return
+            try:
+                self._mint_and_set_env()
+            except ApiaristError as exc:
+                # Don't update self._current — keep using the previous
+                # token. If it's already expired, downstream callers
+                # will see 401s; we log here so the operator can
+                # correlate with apiarist health.
+                print(
+                    f"[hivemoot-auth] refresh failed for {self._repo}: "
+                    f"{type(exc).__name__}: {exc}; retrying in "
+                    f"{self._refresh_backoff_on_error_secs}s",
+                    file=sys.stderr, flush=True,
+                )
+                if self._stop_event.wait(self._refresh_backoff_on_error_secs):
+                    return
+            except Exception as exc:
+                # Defensive — unknown exceptions from the client
+                # shouldn't kill the refresh loop. Same backoff +
+                # retry behavior.
+                print(
+                    f"[hivemoot-auth] refresh raised unexpectedly for "
+                    f"{self._repo}: {type(exc).__name__}: {exc}; "
+                    f"retrying in {self._refresh_backoff_on_error_secs}s",
+                    file=sys.stderr, flush=True,
+                )
+                if self._stop_event.wait(self._refresh_backoff_on_error_secs):
+                    return
 
 
 __all__ = ["HivemootGithubAuthSubscriber", "ApiaristError"]

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth_subscriber.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth_subscriber.py
@@ -1,0 +1,210 @@
+"""Lifecycle subscriber that mints a GitHub token via apiarist on
+the IDLE→ACTIVE boundary.
+
+This is the V1 implementation of the apiarist token broker integration
+(DESIGN.md §12.3). It bridges the engine's container lifecycle FSM to
+the apiarist UDS daemon:
+
+- **on_active** (IDLE→ACTIVE): call ``mint_token`` over the apiarist
+  socket, populate ``GH_TOKEN`` + ``GITHUB_TOKEN`` env vars.
+- **on_idle** (ACTIVE→IDLE): clear those env vars so a stale token
+  doesn't linger if the daemon restarts or the operator stops it.
+
+Why mint per IDLE→ACTIVE (not at process startup):
+
+- A container can sit IDLE for hours between jobs. Minting upfront
+  burns a 1-hour-TTL token that will have expired by the time a job
+  arrives.
+- Minting per IDLE→ACTIVE means every job sees a freshly-minted
+  token, so the only way the token can expire mid-job is if the job
+  itself runs longer than the token TTL (~55 min effective). V1
+  treats that as out-of-scope; long-running jobs (>50 min) see the
+  edge case and the operator's runbook covers it.
+
+Why clear on ACTIVE→IDLE (not just leave the token sitting):
+
+- Defense-in-depth. If the env-var leaks (subprocess dump, log
+  capture, /proc inspection), it's only exposed during active jobs.
+- If a debug shell attaches between jobs, ``env | grep TOKEN`` shows
+  nothing — clear signal that the token broker is wired and working.
+
+The subscriber is NOT registered with a background refresh thread in
+V1. Refresh-during-job (rotating the env mid-flight) does not reach
+already-spawned subprocesses (they snapshot env at exec time), so the
+benefit is marginal vs. the complexity of join-on-idle thread
+lifecycle. A future V1.1 iteration may add it for nested-gh-call
+freshness; see DESIGN.md §12.3.4 "Future variants".
+
+Failure modes:
+
+- Apiarist daemon down → :class:`ApiaristTransportError` propagates
+  from ``on_active``, lifecycle module rolls back the counter, the
+  triggering job fails to start, runtime retries.
+- Apiarist returns ``BACKEND_FORBIDDEN`` (e.g. repo not in token
+  policy) → :class:`ApiaristRemoteError` propagates the same way.
+  This is fail-closed: a misconfigured policy never lets a request
+  silently fall back to a long-lived PAT.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Final
+
+from hivemoot_agent.apiarist_client import (
+    ApiaristClient,
+    ApiaristError,
+    MintedToken,
+)
+from hivemoot_agent.lifecycle import LifecycleSubscriber
+
+# Both env vars are exported because GitHub tooling is split-brain
+# about which it reads. Authoritatively:
+#
+# - ``GH_TOKEN`` — what the ``gh`` CLI uses (and prefers over
+#   ``GITHUB_TOKEN`` when both are set).
+# - ``GITHUB_TOKEN`` — what ``actions/checkout`` and most third-party
+#   GitHub libraries (octokit, PyGithub, hub) read first.
+#
+# Setting both eliminates the "which one wins?" question across the
+# tool surface the agent uses (gh, git remote, octokit-bearing tools).
+_TOKEN_ENV_VARS: Final[tuple[str, ...]] = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+class HivemootGithubAuthSubscriber(LifecycleSubscriber):
+    """Lifecycle subscriber that brokers GitHub installation tokens
+    via the apiarist daemon.
+
+    Single-instance per container. Registered by the hivemoot plugin's
+    ``setup_lifecycle()`` hook when the operator opts into apiarist
+    token brokering via the ``apiarist:`` config block.
+
+    Thread-safety: the engine calls ``on_active`` / ``on_idle`` on the
+    ContainerLifecycle's serialized boundary (sequential under
+    ``threading.RLock``), so the subscriber's internal state changes
+    don't need their own lock. The env-var reads from other threads
+    (e.g. heartbeat threads in the hivemoot tasks subsystem) see a
+    consistent snapshot — Python's GIL makes a single
+    ``os.environ[k] = v`` assignment atomic.
+    """
+
+    def __init__(
+        self,
+        client: ApiaristClient,
+        *,
+        service: str,
+        repo: str,
+        agent_id: str | None = None,
+    ) -> None:
+        """
+        Args:
+            client: pre-built apiarist client (caller owns its
+                lifetime; we just hold the reference).
+            service: caller identifier for apiarist's audit log
+                (typically the systemd service / container name like
+                ``"drone-zai"``). Required.
+            repo: ``owner/name`` of the repo this agent works on.
+                Required — apiarist scopes the minted token to this
+                single repo per the token policy.
+            agent_id: optional audit-only identifier (``AGENT_ID`` env
+                value, e.g. ``"drone"``). Logged by apiarist; ignored
+                for authorization.
+        """
+        if client is None:
+            raise ValueError("client is required")
+        if not service:
+            raise ValueError("service must be non-empty")
+        if not repo:
+            raise ValueError("repo must be non-empty")
+        self._client: ApiaristClient = client
+        self._service: str = service
+        self._repo: str = repo
+        self._agent_id: str | None = agent_id
+        # Last successfully-minted token, kept for diagnostics and to
+        # short-circuit the env-clear when on_idle fires before the
+        # first on_active (defensive — the lifecycle module shouldn't
+        # do this but the cost of guarding is zero).
+        self._current: MintedToken | None = None
+
+    # ── Diagnostics ──────────────────────────────────────────────
+
+    @property
+    def repo(self) -> str:
+        """The repo this subscriber mints tokens for. Diagnostics."""
+        return self._repo
+
+    @property
+    def service(self) -> str:
+        """The caller identifier reported to apiarist. Diagnostics."""
+        return self._service
+
+    @property
+    def current_token(self) -> MintedToken | None:
+        """The last successfully-minted token, or None when idle.
+
+        Diagnostics only — callers must not pluck the raw token out
+        of this property to authenticate; they should read
+        ``GH_TOKEN`` / ``GITHUB_TOKEN`` from env so the contract
+        with downstream tools stays uniform.
+        """
+        return self._current
+
+    # ── Lifecycle hooks ──────────────────────────────────────────
+
+    def on_active(self) -> None:
+        """Mint a fresh token and populate the GitHub auth env vars.
+
+        Raises whatever the apiarist client raises (Transport /
+        Protocol / Remote errors). The lifecycle module catches the
+        exception, rolls back the counter, and tears down any prior
+        successful subscribers — the triggering job fails and the
+        runtime retries the full chain cleanly.
+
+        We intentionally do NOT swallow errors here: a missing
+        GITHUB_TOKEN is silently catastrophic (the github plugin's
+        clone subscriber would fail to authenticate, possibly falling
+        back to anonymous and leaking access patterns). Fail-closed
+        keeps the contract crisp.
+        """
+        token = self._client.mint_token(
+            service=self._service,
+            repo=self._repo,
+            agent_id=self._agent_id,
+        )
+        for var in _TOKEN_ENV_VARS:
+            os.environ[var] = token.token
+        self._current = token
+        # Diagnostics only — operator can correlate with apiarist log
+        # via the installation_id and the token's last-12 chars
+        # (sha-prefixed, not the raw secret). Token full value is
+        # never logged.
+        print(
+            f"[hivemoot-auth] minted token for {self._repo} "
+            f"(installation={token.installation_id}, "
+            f"expires_at={token.expires_at.isoformat()})",
+            file=sys.stderr, flush=True,
+        )
+
+    def on_idle(self) -> None:
+        """Clear the GitHub auth env vars.
+
+        Best-effort by lifecycle contract (I4) — exceptions get
+        logged by the lifecycle module and don't propagate. Clearing
+        env is a few atomic dict ops, so failures here are unlikely;
+        we still wrap defensively because an early ``on_idle`` (no
+        prior ``on_active``) would otherwise leak ``KeyError`` from
+        the lifecycle module's exception logger.
+        """
+        for var in _TOKEN_ENV_VARS:
+            os.environ.pop(var, None)
+        if self._current is not None:
+            print(
+                f"[hivemoot-auth] cleared token env for {self._repo} "
+                f"(installation={self._current.installation_id})",
+                file=sys.stderr, flush=True,
+            )
+        self._current = None
+
+
+__all__ = ["HivemootGithubAuthSubscriber", "ApiaristError"]

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -189,6 +189,68 @@ class HivemootGithubWorkflowsConfig(StrictPluginConfig):
     )
 
 
+class HivemootApiaristConfig(StrictPluginConfig):
+    """GitHub installation-token brokering via the apiarist daemon.
+
+    Disabled by default. When enabled, the hivemoot plugin registers a
+    :class:`HivemootGithubAuthSubscriber` on the engine's container
+    lifecycle (apiarist DESIGN.md §12.3): every IDLE→ACTIVE transition
+    mints a fresh ``ghs_*`` token via the apiarist UDS daemon and
+    populates ``GH_TOKEN`` + ``GITHUB_TOKEN``; every ACTIVE→IDLE
+    transition clears them.
+
+    The github plugin must be configured with
+    ``token_source: subscriber`` so its own setup skips reading a
+    static token file. Subscriber registration order matters — list
+    the hivemoot plugin BEFORE the github plugin in
+    ``plugins:`` so the env is populated when the github plugin's
+    own clone subscriber fires.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable apiarist token brokering.  Off by default so the "
+            "feature ships idempotently; fleet YAML opts in per "
+            "container."
+        ),
+    )
+    socket_path: Path = Field(
+        default=Path("/run/apiarist.sock"),
+        description=(
+            "Path to the apiarist Unix-domain socket.  Default matches "
+            "the systemd unit's bind path; override when running "
+            "apiarist out of a non-standard location (dev / staging)."
+        ),
+    )
+    service: str = Field(
+        default="",
+        description=(
+            "Caller identifier reported to apiarist for audit logging "
+            "(typically the systemd service / container name like "
+            "``drone-zai``).  Empty = derive from ``AGENT_ID`` env."
+        ),
+    )
+    repo: str = Field(
+        default="",
+        description=(
+            "owner/name of the repo this agent works on.  apiarist's "
+            "token policy requires it for per-repo scoping.  Empty = "
+            "derive from the github plugin's ``repos[0]``; still empty "
+            "after that is a validation error."
+        ),
+    )
+    timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description=(
+            "Per-call timeout for apiarist UDS round trips.  10s "
+            "covers the long-tail backend roundtrip; tighten for hot "
+            "paths."
+        ),
+    )
+
+
 class HivemootConfig(StrictPluginConfig):
     """Top-level typed config for the consolidated hivemoot plugin."""
 
@@ -213,4 +275,8 @@ class HivemootConfig(StrictPluginConfig):
     github_workflows: HivemootGithubWorkflowsConfig = Field(
         default_factory=HivemootGithubWorkflowsConfig,
         description="Hivemoot-specific GitHub contribution workflow.",
+    )
+    apiarist: HivemootApiaristConfig = Field(
+        default_factory=HivemootApiaristConfig,
+        description="GitHub installation-token brokering via apiarist.",
     )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -192,12 +192,30 @@ class HivemootGithubWorkflowsConfig(StrictPluginConfig):
 class HivemootApiaristConfig(StrictPluginConfig):
     """GitHub installation-token brokering via the apiarist daemon.
 
-    Disabled by default. When enabled, the hivemoot plugin registers a
-    :class:`HivemootGithubAuthSubscriber` on the engine's container
-    lifecycle (apiarist DESIGN.md §12.3): every IDLE→ACTIVE transition
-    mints a fresh ``ghs_*`` token via the apiarist UDS daemon and
-    populates ``GH_TOKEN`` + ``GITHUB_TOKEN``; every ACTIVE→IDLE
-    transition clears them.
+    Disabled by default. When enabled, the hivemoot plugin builds a
+    :class:`HivemootGithubAuthSubscriber`, calls its ``start()`` (which
+    does an initial synchronous mint AND launches a background
+    refresh thread), and registers it with the engine's container
+    lifecycle (apiarist DESIGN.md §12.3, Phase L'):
+
+    - **At setup**: initial mint populates ``GH_TOKEN`` +
+      ``GITHUB_TOKEN`` env so trigger threads (which spin up next)
+      see a valid token on their first poll.
+    - **Background refresh thread**: re-mints when within the
+      configured lead-time window of expiry (default 5 min), keeping
+      env populated for the container lifetime.
+    - **on_active** (IDLE→ACTIVE): proactively refreshes if expiring
+      soon; otherwise no-op (refresh thread handles it).
+    - **on_idle** (ACTIVE→IDLE): NO-OP. Env stays populated between
+      jobs because watch-driven services (drone with watch_mentions
+      etc.) need a valid token to poll between jobs — clearing on
+      idle would deadlock those services (no events → no jobs → no
+      on_active to repopulate).
+
+    The "always-on env" model trades one defense-in-depth layer
+    (env-clear-on-idle) for trigger viability between jobs. The
+    short-TTL guarantee (apiarist policy + GitHub App 1h cap) is
+    preserved by the refresh thread.
 
     The github plugin must be configured with
     ``token_source: subscriber`` so its own setup skips reading a
@@ -237,7 +255,17 @@ class HivemootApiaristConfig(StrictPluginConfig):
             "owner/name of the repo this agent works on.  apiarist's "
             "token policy requires it for per-repo scoping.  Empty = "
             "derive from the github plugin's ``repos[0]``; still empty "
-            "after that is a validation error."
+            "after that is a validation error.\n\n"
+            "**Multi-repo caveat**: this field scopes the minted token "
+            "to a SINGLE repo. ``plugins.github.repos`` accepts a list, "
+            "but the github plugin's auth subscriber will run "
+            "``_validate_repo_access`` and ``clone_or_sync`` for EVERY "
+            "entry against the token scoped here — non-matching repos "
+            "will fail at first IDLE→ACTIVE with a confusing 403/404. "
+            "V1 deploys (drone) are single-repo; multi-repo subscriber-"
+            "mode services need either an apiarist policy that grants "
+            "access to all configured github.repos, or a follow-up "
+            "design that mints per-repo on demand."
         ),
     )
     timeout_seconds: float = Field(

--- a/agent/cli/tests/test_apiarist_client.py
+++ b/agent/cli/tests/test_apiarist_client.py
@@ -1,0 +1,466 @@
+"""Tests for ``hivemoot_agent.apiarist_client.ApiaristClient``.
+
+Uses a real Unix-domain-socket server in a background thread so the
+client exercises actual socket + framing code (no mocks past the
+wire). Each test creates a temp socket path, spins up a fake server
+that returns a scripted response, and asserts the client behavior.
+
+Coverage:
+
+- mint_token success — happy path round trip with full response shape.
+- mint_token error envelope — server returns ok=false → raises
+  ApiaristRemoteError with code+message.
+- mint_token bad shape — missing fields raise ApiaristProtocolError.
+- Connect refused (no server) → ApiaristTransportError.
+- Server EOFs after length prefix → ApiaristTransportError.
+- Server sends oversize length prefix → ApiaristProtocolError.
+- Server sends invalid JSON → ApiaristProtocolError.
+- Response request_id mismatch → ApiaristProtocolError.
+- Health round trip.
+- ISO 8601 'Z' and '+00:00' suffix accepted; naive timestamp rejected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.apiarist_client import (
+    ApiaristClient,
+    ApiaristProtocolError,
+    ApiaristRemoteError,
+    ApiaristTransportError,
+    MintedToken,
+    Repository,
+)
+
+
+# Same wire constants as apiarist_client (mirror to avoid private import).
+_LENGTH_PREFIX_FORMAT = "!I"
+_LENGTH_PREFIX_BYTES = 4
+
+
+# ── Fake server harness ────────────────────────────────────────────
+
+
+class _FakeServer:
+    """Single-shot UDS server that serves one scripted response and exits.
+
+    ``handler(request_dict) -> bytes`` returns the raw bytes to send
+    back. This lets a test fabricate any response (well-formed or
+    malformed) without going through the client's encode helpers.
+    """
+
+    def __init__(
+        self,
+        socket_path: str,
+        handler: Callable[[dict[str, Any]], bytes],
+    ) -> None:
+        self.socket_path = socket_path
+        self.handler = handler
+        self.received: dict[str, Any] | None = None
+        self.error: BaseException | None = None
+        self._thread: threading.Thread | None = None
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+    def __enter__(self) -> _FakeServer:
+        self._sock.bind(self.socket_path)
+        self._sock.listen(1)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        try:
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+
+    def _serve(self) -> None:
+        try:
+            self._sock.settimeout(2)
+            conn, _ = self._sock.accept()
+            try:
+                conn.settimeout(2)
+                prefix = _recv_exact(conn, _LENGTH_PREFIX_BYTES)
+                (length,) = struct.unpack(_LENGTH_PREFIX_FORMAT, prefix)
+                body = _recv_exact(conn, length)
+                self.received = json.loads(body.decode("utf-8"))
+                conn.sendall(self.handler(self.received))
+            finally:
+                conn.close()
+        except BaseException as exc:  # noqa: BLE001 — captured for the test
+            self.error = exc
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly n bytes from the server side."""
+    chunks: list[bytes] = []
+    remaining = n
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise EOFError(f"short read: {n - remaining} of {n}")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _frame(payload: dict[str, Any]) -> bytes:
+    body = json.dumps(payload).encode("utf-8")
+    return struct.pack(_LENGTH_PREFIX_FORMAT, len(body)) + body
+
+
+def _temp_socket_path() -> str:
+    """Generate a fresh temp socket path that hasn't been bound yet."""
+    fd, path = tempfile.mkstemp(prefix="apiarist-client-test-", suffix=".sock")
+    os.close(fd)
+    os.unlink(path)
+    return path
+
+
+# ── Success paths ──────────────────────────────────────────────────
+
+
+class MintTokenSuccessTest(unittest.TestCase):
+    def test_round_trip_returns_minted_token(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": True,
+                    "data": {
+                        "token": "ghs_fake12345",
+                        "expires_at": "2026-04-25T12:34:56Z",
+                        "installation_id": "98765",
+                        "permissions": {
+                            "contents": "read",
+                            "pull_requests": "write",
+                        },
+                        "repositories": [
+                            {"full_name": "hivemoot/colony", "id": 4242},
+                        ],
+                    },
+                }
+            )
+
+        with _FakeServer(sock_path, handler) as server:
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            result = client.mint_token(
+                "colony-codex", "hivemoot/colony", agent_id="codex-1",
+            )
+
+        self.assertIsNone(server.error, f"server raised: {server.error!r}")
+        self.assertIsInstance(result, MintedToken)
+        self.assertEqual(result.token, "ghs_fake12345")
+        self.assertEqual(result.installation_id, "98765")
+        self.assertEqual(
+            result.expires_at,
+            datetime(2026, 4, 25, 12, 34, 56, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            result.permissions, {"contents": "read", "pull_requests": "write"},
+        )
+        self.assertEqual(result.repositories, [Repository("hivemoot/colony", 4242)])
+
+        # Server should have received the well-formed request.
+        self.assertIsNotNone(server.received)
+        assert server.received is not None  # for type-checker
+        self.assertEqual(server.received["op"], "mint_token")
+        self.assertEqual(server.received["params"]["service"], "colony-codex")
+        self.assertEqual(server.received["params"]["repo"], "hivemoot/colony")
+        self.assertEqual(server.received["params"]["agent_id"], "codex-1")
+        self.assertTrue(server.received.get("request_id"))
+
+    def test_omits_agent_id_when_not_supplied(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": True,
+                    "data": {
+                        "token": "ghs_fake",
+                        "expires_at": "2026-04-25T12:34:56+00:00",
+                        "installation_id": "1",
+                    },
+                }
+            )
+
+        with _FakeServer(sock_path, handler) as server:
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            client.mint_token("svc", "owner/name")
+
+        assert server.received is not None
+        self.assertNotIn("agent_id", server.received["params"])
+
+
+class HealthSuccessTest(unittest.TestCase):
+    def test_health_returns_raw_dict(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": True,
+                    "data": {"status": "ok", "uptime_seconds": 1234},
+                }
+            )
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            snap = client.health()
+
+        self.assertEqual(snap.raw, {"status": "ok", "uptime_seconds": 1234})
+
+
+# ── Error envelope handling ────────────────────────────────────────
+
+
+class RemoteErrorTest(unittest.TestCase):
+    def test_error_envelope_raises_remote_error(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": False,
+                    "error": {
+                        "code": "BACKEND_FORBIDDEN",
+                        "message": "repo not in token policy",
+                    },
+                }
+            )
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristRemoteError) as ctx:
+                client.mint_token("svc", "denied/repo")
+
+        self.assertEqual(ctx.exception.code, "BACKEND_FORBIDDEN")
+        self.assertEqual(ctx.exception.message, "repo not in token policy")
+
+    def test_error_envelope_with_missing_message_uses_empty_string(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": False,
+                    "error": {"code": "INTERNAL"},
+                }
+            )
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristRemoteError) as ctx:
+                client.mint_token("svc", "owner/name")
+
+        self.assertEqual(ctx.exception.code, "INTERNAL")
+        self.assertEqual(ctx.exception.message, "")
+
+
+# ── Protocol violations ────────────────────────────────────────────
+
+
+class ProtocolErrorTest(unittest.TestCase):
+    def test_oversize_length_prefix_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+        # MAX_PAYLOAD_BYTES is 64 KiB; declare 1 MiB.
+        oversize_prefix = struct.pack(_LENGTH_PREFIX_FORMAT, 1024 * 1024)
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return oversize_prefix  # client should reject before reading body
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError) as ctx:
+                client.mint_token("svc", "owner/name")
+
+        self.assertIn("exceeds wire cap", str(ctx.exception))
+
+    def test_invalid_json_body_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+        bad_body = b"not valid json {{{"
+        bad_frame = struct.pack(_LENGTH_PREFIX_FORMAT, len(bad_body)) + bad_body
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return bad_frame
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError):
+                client.mint_token("svc", "owner/name")
+
+    def test_response_array_root_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            body = b"[1, 2, 3]"
+            return struct.pack(_LENGTH_PREFIX_FORMAT, len(body)) + body
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError) as ctx:
+                client.mint_token("svc", "owner/name")
+        self.assertIn("must be a JSON object", str(ctx.exception))
+
+    def test_request_id_mismatch_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": "WRONG",  # not what client sent
+                    "ok": True,
+                    "data": {
+                        "token": "ghs_x",
+                        "expires_at": "2026-04-25T12:34:56Z",
+                        "installation_id": "1",
+                    },
+                }
+            )
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError) as ctx:
+                client.mint_token("svc", "owner/name")
+        self.assertIn("does not match", str(ctx.exception))
+
+    def test_missing_ok_field_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame({"request_id": req["request_id"], "data": {}})
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError):
+                client.mint_token("svc", "owner/name")
+
+    def test_missing_token_field_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": True,
+                    "data": {
+                        # No 'token' field
+                        "expires_at": "2026-04-25T12:34:56Z",
+                        "installation_id": "1",
+                    },
+                }
+            )
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError) as ctx:
+                client.mint_token("svc", "owner/name")
+        self.assertIn("'token'", str(ctx.exception))
+
+    def test_naive_expires_at_rejected(self) -> None:
+        sock_path = _temp_socket_path()
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return _frame(
+                {
+                    "request_id": req["request_id"],
+                    "ok": True,
+                    "data": {
+                        "token": "ghs_x",
+                        "expires_at": "2026-04-25T12:34:56",  # no tz
+                        "installation_id": "1",
+                    },
+                }
+            )
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristProtocolError) as ctx:
+                client.mint_token("svc", "owner/name")
+        self.assertIn("timezone", str(ctx.exception))
+
+
+# ── Transport errors ───────────────────────────────────────────────
+
+
+class TransportErrorTest(unittest.TestCase):
+    def test_connect_refused_when_no_server_present(self) -> None:
+        sock_path = _temp_socket_path()  # nothing binds it
+        client = ApiaristClient(sock_path, timeout_seconds=2.0)
+        with self.assertRaises(ApiaristTransportError) as ctx:
+            client.mint_token("svc", "owner/name")
+        self.assertIn("connect", str(ctx.exception))
+
+    def test_server_eof_after_length_prefix(self) -> None:
+        sock_path = _temp_socket_path()
+        # Declare 100 bytes incoming, then close → client reads 0 bytes.
+        partial_frame = struct.pack(_LENGTH_PREFIX_FORMAT, 100)
+
+        def handler(req: dict[str, Any]) -> bytes:
+            return partial_frame
+
+        with _FakeServer(sock_path, handler):
+            client = ApiaristClient(sock_path, timeout_seconds=2.0)
+            with self.assertRaises(ApiaristTransportError) as ctx:
+                client.mint_token("svc", "owner/name")
+        self.assertIn("connection closed", str(ctx.exception))
+
+
+# ── Construction validation ────────────────────────────────────────
+
+
+class ConstructionTest(unittest.TestCase):
+    def test_empty_socket_path_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            ApiaristClient("")
+
+    def test_non_positive_timeout_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            ApiaristClient("/tmp/x.sock", timeout_seconds=0)
+        with self.assertRaises(ValueError):
+            ApiaristClient("/tmp/x.sock", timeout_seconds=-1)
+
+    def test_socket_path_property_exposes_value(self) -> None:
+        c = ApiaristClient("/run/apiarist.sock")
+        self.assertEqual(c.socket_path, "/run/apiarist.sock")
+
+
+class CallParamValidationTest(unittest.TestCase):
+    def test_empty_service_rejected(self) -> None:
+        c = ApiaristClient("/run/apiarist.sock")
+        with self.assertRaises(ValueError):
+            c.mint_token("", "owner/name")
+
+    def test_empty_repo_rejected(self) -> None:
+        c = ApiaristClient("/run/apiarist.sock")
+        with self.assertRaises(ValueError):
+            c.mint_token("svc", "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/cli/tests/test_github_token_source_subscriber.py
+++ b/agent/cli/tests/test_github_token_source_subscriber.py
@@ -1,0 +1,360 @@
+"""Tests for the github plugin's ``token_source: subscriber`` mode.
+
+Validates:
+
+- ``token_source: subscriber`` makes ``token_file`` optional in
+  validate() (no error when absent).
+- ``token_source: file`` (default) keeps the existing token_file
+  required check.
+- setup() with ``token_source: subscriber`` does NOT call
+  resolve_github_user / configure_git_auth / clone_or_sync —
+  those are deferred to the subscriber.
+- setup_lifecycle() registers a ``GithubAuthDependentSubscriber``
+  when token_source: subscriber and is a no-op otherwise.
+- The subscriber's on_active reads ``GH_TOKEN`` from env and runs
+  the full auth-required setup.
+- The subscriber's on_active raises a clear error when env is empty
+  (upstream subscriber didn't fire).
+- The subscriber's on_idle is a no-op (workspace persistence + env
+  ownership stays with upstream).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.lifecycle import ContainerLifecycle
+from hivemoot_agent.plugins.interfaces import PluginConfig
+from hivemoot_agent.plugins_builtin.github import GitHubPlugin
+from hivemoot_agent.plugins_builtin.github.auth_subscriber import (
+    GithubAuthDependentSubscriber,
+)
+from hivemoot_agent.plugins_builtin.github.config import GitHubConfig
+from hivemoot_agent.plugins_builtin.github.repo_manager import RepoInfo
+
+
+def _mk_config(
+    *,
+    token_source: str = "file",
+    token_file: Path | None = None,
+    repos: list[str] | None = None,
+    workspace: str = "/workspace",
+) -> PluginConfig:
+    typed = GitHubConfig(
+        repos=repos if repos is not None else ["acme/repo"],
+        token_source=token_source,
+        token_file=token_file,
+        workspace=Path(workspace),
+    )
+    return PluginConfig(name="github", typed=typed)
+
+
+def _clear_token_env() -> None:
+    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        os.environ.pop(var, None)
+
+
+class _EnvIsolatedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        _clear_token_env()
+
+    def tearDown(self) -> None:
+        _clear_token_env()
+
+
+# ── validate() ────────────────────────────────────────────────────
+
+
+class ValidateTest(unittest.TestCase):
+    def test_subscriber_mode_does_not_require_token_file(self) -> None:
+        plugin = GitHubPlugin()
+        cfg = _mk_config(token_source="subscriber", token_file=None)
+        self.assertEqual(plugin.validate(cfg), [])
+
+    def test_file_mode_still_requires_token_file(self) -> None:
+        plugin = GitHubPlugin()
+        cfg = _mk_config(token_source="file", token_file=None)
+        errors = plugin.validate(cfg)
+        self.assertTrue(any("token_file" in e for e in errors))
+
+    def test_subscriber_mode_still_requires_repos(self) -> None:
+        plugin = GitHubPlugin()
+        cfg = _mk_config(token_source="subscriber", repos=[])
+        errors = plugin.validate(cfg)
+        self.assertTrue(any("repos" in e for e in errors))
+
+    def test_invalid_token_source_rejected_by_pydantic(self) -> None:
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            GitHubConfig(repos=["a/b"], token_source="bogus")  # type: ignore[arg-type]
+
+
+# ── setup() in subscriber mode ────────────────────────────────────
+
+
+class SetupSubscriberModeTest(unittest.TestCase):
+    """setup() must not touch the network/disk under subscriber mode."""
+
+    def test_setup_subscriber_mode_skips_auth_required_steps(self) -> None:
+        plugin = GitHubPlugin()
+        cfg = _mk_config(token_source="subscriber", token_file=None)
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.github._configure_git_auth",
+        ) as mock_auth, patch(
+            "hivemoot_agent.plugins_builtin.github._validate_repo_access",
+        ) as mock_validate, patch(
+            "hivemoot_agent.plugins_builtin.github.clone_or_sync",
+        ) as mock_clone, patch(
+            "hivemoot_agent.plugins_builtin.github.resolve_github_user",
+        ) as mock_resolve:
+            plugin.setup(cfg)
+
+        mock_auth.assert_not_called()
+        mock_validate.assert_not_called()
+        mock_clone.assert_not_called()
+        mock_resolve.assert_not_called()
+
+        # But auth-free defaults still set so system_prompt has something.
+        self.assertEqual(plugin._git_name, "hivemoot-agent")
+        self.assertEqual(
+            plugin._git_email, "hivemoot-agent@users.noreply.github.com",
+        )
+        self.assertEqual(plugin._repos, [])
+
+    def test_setup_subscriber_mode_does_not_set_env(self) -> None:
+        """Env is owned by the upstream subscriber — github must not
+        write GH_TOKEN at setup() time."""
+        _clear_token_env()
+        try:
+            plugin = GitHubPlugin()
+            cfg = _mk_config(token_source="subscriber", token_file=None)
+
+            with patch(
+                "hivemoot_agent.plugins_builtin.github._configure_git_auth",
+            ), patch(
+                "hivemoot_agent.plugins_builtin.github._validate_repo_access",
+            ), patch(
+                "hivemoot_agent.plugins_builtin.github.clone_or_sync",
+            ):
+                plugin.setup(cfg)
+
+            self.assertNotIn("GH_TOKEN", os.environ)
+            self.assertNotIn("GITHUB_TOKEN", os.environ)
+        finally:
+            _clear_token_env()
+
+
+# ── setup_lifecycle() ─────────────────────────────────────────────
+
+
+class SetupLifecycleTest(unittest.TestCase):
+    def test_subscriber_mode_registers_auth_subscriber(self) -> None:
+        plugin = GitHubPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _mk_config(token_source="subscriber", token_file=None)
+
+        plugin.setup_lifecycle(lifecycle, cfg)
+
+        self.assertEqual(lifecycle.subscriber_count, 1)
+        self.assertIsInstance(
+            plugin._auth_subscriber, GithubAuthDependentSubscriber,
+        )
+
+    def test_file_mode_does_not_register(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            token_file = Path(tmp) / "tok"
+            token_file.write_text("ghp_x")
+            plugin = GitHubPlugin()
+            lifecycle = ContainerLifecycle()
+            cfg = _mk_config(token_source="file", token_file=token_file)
+
+            plugin.setup_lifecycle(lifecycle, cfg)
+
+            self.assertEqual(lifecycle.subscriber_count, 0)
+            self.assertIsNone(plugin._auth_subscriber)
+
+
+# ── GithubAuthDependentSubscriber ─────────────────────────────────
+
+
+class AuthSubscriberOnActiveTest(_EnvIsolatedTest):
+    def test_on_active_reads_env_and_runs_auth_required_setup(self) -> None:
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"],
+            token_source="subscriber",
+            workspace=Path("/workspace"),
+        )
+        sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+
+        os.environ["GH_TOKEN"] = "ghs_live_token"
+
+        with patch.object(plugin, "_auth_required_setup") as mock_inner:
+            sub.on_active()
+
+        mock_inner.assert_called_once_with(cfg_typed, "ghs_live_token")
+
+    def test_on_active_falls_back_to_github_token_env(self) -> None:
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"], token_source="subscriber",
+        )
+        sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+
+        # Only GITHUB_TOKEN set, GH_TOKEN missing.
+        os.environ["GITHUB_TOKEN"] = "ghs_only_github"
+
+        with patch.object(plugin, "_auth_required_setup") as mock_inner:
+            sub.on_active()
+
+        mock_inner.assert_called_once_with(cfg_typed, "ghs_only_github")
+
+    def test_on_active_raises_when_no_env_set(self) -> None:
+        """Fail-closed when upstream subscriber didn't fire."""
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"], token_source="subscriber",
+        )
+        sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            sub.on_active()
+        msg = str(ctx.exception)
+        self.assertIn("GH_TOKEN", msg)
+        self.assertIn("registration order", msg)
+
+    def test_on_active_propagates_inner_setup_errors(self) -> None:
+        """A failure in clone/validate must bubble out so the lifecycle
+        module rolls back and the job retries."""
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"], token_source="subscriber",
+        )
+        sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+        os.environ["GH_TOKEN"] = "ghs_x"
+
+        with patch.object(
+            plugin, "_auth_required_setup",
+            side_effect=RuntimeError("clone failed"),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                sub.on_active()
+        self.assertIn("clone failed", str(ctx.exception))
+
+
+class AuthSubscriberOnIdleTest(_EnvIsolatedTest):
+    def test_on_idle_does_not_clear_env(self) -> None:
+        """Env is owned by the upstream subscriber to clear."""
+        os.environ["GH_TOKEN"] = "ghs_x"
+        os.environ["GITHUB_TOKEN"] = "ghs_x"
+
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"], token_source="subscriber",
+        )
+        sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+
+        sub.on_idle()
+
+        # Env is intact — github subscriber's on_idle is a no-op.
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_x")
+        self.assertEqual(os.environ["GITHUB_TOKEN"], "ghs_x")
+
+    def test_on_idle_does_not_clear_repos(self) -> None:
+        """Workspace persistence: cloned state survives idle so the
+        next on_active fetches incrementally."""
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"], token_source="subscriber",
+        )
+        sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+
+        # Pretend a prior on_active populated _repos.
+        plugin._repos = [
+            RepoInfo(repo="acme/repo", path="/workspace/acme/repo",
+                     default_branch="main"),
+        ]
+
+        sub.on_idle()
+        self.assertEqual(len(plugin._repos), 1)
+
+
+class AuthSubscriberConstructionTest(unittest.TestCase):
+    def test_missing_plugin_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            GithubAuthDependentSubscriber(
+                None,  # type: ignore[arg-type]
+                GitHubConfig(repos=["a/b"], token_source="subscriber"),
+            )
+
+    def test_missing_cfg_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            GithubAuthDependentSubscriber(
+                GitHubPlugin(),
+                None,  # type: ignore[arg-type]
+            )
+
+
+# ── End-to-end: hivemoot → github subscriber ordering ─────────────
+
+
+class EndToEndOrderingTest(_EnvIsolatedTest):
+    """Simulates the full chain: hivemoot subscriber sets env, then
+    github subscriber reads it. Validates the load-bearing
+    registration order."""
+
+    def test_upstream_subscriber_sets_env_and_github_reads_it(self) -> None:
+        from hivemoot_agent.apiarist_client import MintedToken, Repository
+        from datetime import datetime, timezone
+        from hivemoot_agent.plugins_builtin.hivemoot.auth_subscriber import (
+            HivemootGithubAuthSubscriber,
+        )
+
+        # Fake apiarist client that returns a known token.
+        client = MagicMock()
+        client.mint_token.return_value = MintedToken(
+            token="ghs_fresh_brokered",
+            expires_at=datetime(2026, 4, 25, 23, 59, 59, tzinfo=timezone.utc),
+            installation_id="42",
+            permissions={},
+            repositories=[Repository("acme/repo", 1)],
+        )
+        upstream = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="acme/repo",
+        )
+
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"], token_source="subscriber",
+        )
+        github_sub = GithubAuthDependentSubscriber(plugin, cfg_typed)
+
+        lifecycle = ContainerLifecycle()
+        lifecycle.subscribe(upstream)   # registered first
+        lifecycle.subscribe(github_sub)  # registered second
+
+        captured_token: dict[str, str] = {}
+
+        def capture(cfg, token):
+            captured_token["value"] = token
+
+        with patch.object(plugin, "_auth_required_setup", side_effect=capture):
+            lifecycle.on_job_starting()
+
+        self.assertEqual(captured_token["value"], "ghs_fresh_brokered")
+        # And idle order: hivemoot's on_idle clears env.
+        lifecycle.on_job_finished()
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_github_token_source_subscriber.py
+++ b/agent/cli/tests/test_github_token_source_subscriber.py
@@ -287,6 +287,45 @@ class AuthSubscriberOnIdleTest(_EnvIsolatedTest):
         self.assertEqual(len(plugin._repos), 1)
 
 
+class SystemPromptSubscriberModeTest(_EnvIsolatedTest):
+    """PR #490 R2 fix: in subscriber mode, system_prompt must use
+    placeholder repos when _repos is empty (clone hasn't fired yet),
+    not return the empty-repos prompt.
+    """
+
+    def test_subscriber_mode_uses_placeholder_repos_before_first_active(self) -> None:
+        plugin = GitHubPlugin()
+        cfg = _mk_config(
+            token_source="subscriber",
+            token_file=None,
+            repos=["acme/repo"],
+            workspace="/workspace",
+        )
+
+        # Run setup (subscriber mode skips clone — _repos stays empty
+        # but _setup_attempted=True).
+        with patch(
+            "hivemoot_agent.plugins_builtin.github._configure_git_auth",
+        ), patch(
+            "hivemoot_agent.plugins_builtin.github._validate_repo_access",
+        ), patch(
+            "hivemoot_agent.plugins_builtin.github.clone_or_sync",
+        ):
+            plugin.setup(cfg)
+
+        # _setup_attempted=True (so we know setup ran) but _repos still empty.
+        self.assertTrue(plugin._setup_attempted)
+        self.assertEqual(plugin._repos, [])
+
+        prompt = plugin.system_prompt(cfg)
+
+        # Repo path appears in the prompt — placeholder fallback used.
+        self.assertIn("acme/repo", prompt)
+        self.assertIn("/workspace/acme/repo", prompt)
+        # Prompt is NOT the empty-repos one ("No repositories...").
+        self.assertNotIn("No repositories were pre-cloned", prompt)
+
+
 class AuthSubscriberConstructionTest(unittest.TestCase):
     def test_missing_plugin_rejected(self) -> None:
         with self.assertRaises(ValueError):
@@ -346,14 +385,25 @@ class EndToEndOrderingTest(_EnvIsolatedTest):
         def capture(cfg, token):
             captured_token["value"] = token
 
-        with patch.object(plugin, "_auth_required_setup", side_effect=capture):
-            lifecycle.on_job_starting()
+        # Need to start() the upstream subscriber so its initial mint
+        # populates env — matches what the hivemoot plugin's
+        # setup_lifecycle does in production.
+        upstream.start()
+        try:
+            with patch.object(
+                plugin, "_auth_required_setup", side_effect=capture,
+            ):
+                lifecycle.on_job_starting()
 
-        self.assertEqual(captured_token["value"], "ghs_fresh_brokered")
-        # And idle order: hivemoot's on_idle clears env.
-        lifecycle.on_job_finished()
-        self.assertNotIn("GH_TOKEN", os.environ)
-        self.assertNotIn("GITHUB_TOKEN", os.environ)
+            self.assertEqual(captured_token["value"], "ghs_fresh_brokered")
+
+            # Always-on contract (PR #490 R2): on_idle does NOT clear env.
+            # Trigger threads need the token to keep polling between jobs.
+            lifecycle.on_job_finished()
+            self.assertEqual(os.environ["GH_TOKEN"], "ghs_fresh_brokered")
+            self.assertEqual(os.environ["GITHUB_TOKEN"], "ghs_fresh_brokered")
+        finally:
+            upstream.stop()
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_github_trigger.py
+++ b/agent/cli/tests/test_github_trigger.py
@@ -149,6 +149,146 @@ class TriggerValidationTests(unittest.TestCase):
             self.assertEqual(trig.validate(_plugin_config(cfg)), [])
 
 
+# ── token_source: subscriber compatibility (PR #490 R2 fix) ────────
+
+
+class TriggerSubscriberModeTests(unittest.TestCase):
+    """Watch triggers in token_source: subscriber mode.
+
+    Validates Builder's PR #490 R2 blocker fix: triggers must not bail
+    on missing token_file when token_source is subscriber, because the
+    env-injected token from the hivemoot apiarist auth subscriber is
+    populated asynchronously after setup_lifecycle.
+    """
+
+    def setUp(self) -> None:
+        for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(var, None)
+
+    def tearDown(self) -> None:
+        for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(var, None)
+
+    def test_validate_does_not_require_token_file_in_subscriber_mode(self) -> None:
+        trig = GitHubMentionsTrigger(MagicMock())
+        cfg = GitHubConfig(
+            repos=["owner/repo"],
+            token_source="subscriber",  # token_file None is OK
+        )
+        self.assertEqual(trig.validate(_plugin_config(cfg)), [])
+
+    def test_validate_still_requires_token_file_in_file_mode(self) -> None:
+        """File mode keeps the existing fail-fast contract."""
+        trig = GitHubMentionsTrigger(MagicMock())
+        cfg = GitHubConfig(
+            repos=["owner/repo"],
+            token_source="file",  # default — token_file required
+        )
+        errors = trig.validate(_plugin_config(cfg))
+        self.assertTrue(any("token_file" in e for e in errors))
+
+    def test_subscriber_mode_skips_poll_when_env_empty(self) -> None:
+        """First poll(s) before the upstream subscriber's start() lands —
+        env is empty, trigger logs a "no token this cycle" warning and
+        waits for the next interval. Critically: trigger does NOT crash
+        and does NOT call _poll_events with an empty token."""
+        trig = GitHubMentionsTrigger(MagicMock())
+        with tempfile.TemporaryDirectory(prefix="hm-gh-trig-sub-") as tmpdir:
+            cfg = GitHubConfig(
+                repos=["owner/repo"],
+                token_source="subscriber",
+                watch_state_dir=tmpdir,
+                watch_poll_interval_secs=30,  # schema minimum
+            )
+
+            captured: dict = {}
+            def fake_poll_events(**kwargs):
+                captured["called"] = True
+                return []
+
+            # Stop the trigger after a short delay so the poll loop
+            # exits without waiting the full interval.
+            def stop_soon():
+                time.sleep(0.3)
+                trig.stop()
+            threading.Thread(target=stop_soon, daemon=True).start()
+
+            stderr_buf = io.StringIO()
+            with patch.object(trig, "_poll_events", side_effect=fake_poll_events), \
+                    patch("sys.stderr", stderr_buf):
+                trig.start(_plugin_config(cfg), MagicMock())
+
+            # No poll attempted because env was empty.
+            self.assertNotIn("called", captured)
+            log = stderr_buf.getvalue()
+            self.assertIn("no token this cycle", log)
+            self.assertIn("token_source=subscriber", log)
+
+    def test_subscriber_mode_polls_when_env_populated(self) -> None:
+        """Once GH_TOKEN is populated (by the hivemoot subscriber),
+        the trigger reads it from env and polls successfully."""
+        os.environ["GH_TOKEN"] = "ghs_from_subscriber"
+
+        trig = GitHubMentionsTrigger(MagicMock())
+        with tempfile.TemporaryDirectory(prefix="hm-gh-trig-sub-") as tmpdir:
+            cfg = GitHubConfig(
+                repos=["owner/repo"],
+                token_source="subscriber",
+                watch_state_dir=tmpdir,
+                watch_poll_interval_secs=30,
+            )
+
+            captured: dict[str, str] = {}
+            def fake_poll_events(**kwargs):
+                captured["gh_token"] = kwargs["gh_token"]
+                trig.stop()  # quit the loop after one successful poll
+                return []
+
+            with patch.object(trig, "_poll_events", side_effect=fake_poll_events):
+                trig.start(_plugin_config(cfg), MagicMock())
+
+            # The trigger read the env-populated token.
+            self.assertEqual(captured.get("gh_token"), "ghs_from_subscriber")
+
+    def test_subscriber_mode_picks_up_rotated_token_per_poll(self) -> None:
+        """Token rotation in env is picked up within one poll interval —
+        because we re-resolve in the loop, not just at start()."""
+        os.environ["GH_TOKEN"] = "ghs_v1"
+
+        trig = GitHubMentionsTrigger(MagicMock())
+        with tempfile.TemporaryDirectory(prefix="hm-gh-trig-sub-") as tmpdir:
+            cfg = GitHubConfig(
+                repos=["owner/repo"],
+                token_source="subscriber",
+                watch_state_dir=tmpdir,
+                watch_poll_interval_secs=30,
+            )
+
+            seen: list[str] = []
+            def fake_poll_events(**kwargs):
+                seen.append(kwargs["gh_token"])
+                if len(seen) == 1:
+                    # Simulate the refresh thread rotating the env.
+                    os.environ["GH_TOKEN"] = "ghs_v2_rotated"
+                if len(seen) >= 2:
+                    trig.stop()
+                return []
+
+            # Use a very short poll interval via _stop_event.wait
+            # patching so the second poll lands quickly.
+            orig_wait = trig._stop_event.wait
+            def fast_wait(timeout=None):
+                # Cap at 100ms so the next poll fires fast.
+                return orig_wait(min(timeout or 0.1, 0.1))
+            with patch.object(trig._stop_event, "wait", side_effect=fast_wait), \
+                    patch.object(trig, "_poll_events", side_effect=fake_poll_events):
+                trig.start(_plugin_config(cfg), MagicMock())
+
+            self.assertEqual(seen[0], "ghs_v1")
+            self.assertEqual(seen[1], "ghs_v2_rotated",
+                             "trigger must re-read token per poll iteration")
+
+
 # ── start() dispatch loop ──────────────────────────────────────────
 
 
@@ -414,6 +554,36 @@ class PluginAckLifecycleTests(unittest.TestCase):
         self.assertEqual(args[0], "t1:ts")
         self.assertEqual(args[1], "/state/mentions.json")
         self.assertEqual(args[2], "tok")
+
+    def test_notification_success_uses_env_token_in_subscriber_mode(self) -> None:
+        """PR #490 R2 fix: when token_source: subscriber, the ack must
+        read GH_TOKEN from env (populated by the hivemoot apiarist auth
+        subscriber), not try to read an absent token_file."""
+        plugin = create_plugin()
+        job = self._mention_job()
+        result = AgentResult(exit_code=0, response="ok")
+        # Simulate the hivemoot subscriber having populated env.
+        os.environ["GH_TOKEN"] = "ghs_env_brokered"
+        try:
+            cfg = GitHubConfig(
+                repos=["owner/repo"],
+                token_source="subscriber",
+                # token_file deliberately None — subscriber mode.
+            )
+            plugin_config = _plugin_config(cfg)
+            with patch(
+                "hivemoot_agent.plugins_builtin.github.ack_module.ack_event",
+                return_value=True,
+            ) as ack:
+                plugin.on_job_finished(job, result, plugin_config)
+            ack.assert_called_once()
+            args = ack.call_args.args
+            # CRITICAL: ack received the env token, not "" — without
+            # this fix the notification would have been silently skipped
+            # and replayed forever.
+            self.assertEqual(args[2], "ghs_env_brokered")
+        finally:
+            os.environ.pop("GH_TOKEN", None)
 
     def test_new_pr_success_calls_ack_new_pr(self) -> None:
         plugin = create_plugin()

--- a/agent/cli/tests/test_hivemoot_auth_subscriber.py
+++ b/agent/cli/tests/test_hivemoot_auth_subscriber.py
@@ -1,0 +1,275 @@
+"""Tests for ``HivemootGithubAuthSubscriber``.
+
+Validates the subscriber's lifecycle contract:
+
+- ``on_active`` calls ``client.mint_token`` with correct args, sets
+  both ``GH_TOKEN`` and ``GITHUB_TOKEN``, caches the result.
+- ``on_active`` failure (apiarist down, error envelope) propagates
+  the exception and does NOT touch env (fail-closed).
+- ``on_idle`` clears both env vars and resets cached state.
+- ``on_idle`` is safe to call without a prior ``on_active``.
+- Both env vars get the SAME token value (no split-brain).
+- Construction validates required arguments.
+
+Uses a fake apiarist client (no real socket) — the wire path is
+covered by ``tests.test_apiarist_client``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.apiarist_client import (
+    ApiaristRemoteError,
+    ApiaristTransportError,
+    MintedToken,
+    Repository,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.auth_subscriber import (
+    HivemootGithubAuthSubscriber,
+)
+
+
+def _fake_token(token_str: str = "ghs_fake_xyz") -> MintedToken:
+    return MintedToken(
+        token=token_str,
+        expires_at=datetime(2026, 4, 25, 23, 59, 59, tzinfo=timezone.utc),
+        installation_id="11111",
+        permissions={"contents": "read"},
+        repositories=[Repository(full_name="hivemoot/colony", id=1)],
+    )
+
+
+def _clear_token_env() -> None:
+    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        os.environ.pop(var, None)
+
+
+class _SubscriberTestBase(unittest.TestCase):
+    """Common setUp/tearDown to keep env vars clean across tests."""
+
+    def setUp(self) -> None:
+        _clear_token_env()
+
+    def tearDown(self) -> None:
+        _clear_token_env()
+
+
+# ── on_active happy path ──────────────────────────────────────────
+
+
+class OnActiveSuccessTest(_SubscriberTestBase):
+    def test_mints_with_correct_args_and_sets_both_env_vars(self) -> None:
+        client = MagicMock()
+        token = _fake_token("ghs_active_token")
+        client.mint_token.return_value = token
+
+        sub = HivemootGithubAuthSubscriber(
+            client,
+            service="drone-zai",
+            repo="hivemoot/colony",
+            agent_id="drone",
+        )
+        sub.on_active()
+
+        client.mint_token.assert_called_once_with(
+            service="drone-zai",
+            repo="hivemoot/colony",
+            agent_id="drone",
+        )
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_active_token")
+        self.assertEqual(os.environ["GITHUB_TOKEN"], "ghs_active_token")
+        # Both env vars get the SAME token (no split-brain).
+        self.assertEqual(os.environ["GH_TOKEN"], os.environ["GITHUB_TOKEN"])
+        self.assertIs(sub.current_token, token)
+
+    def test_omits_agent_id_when_none(self) -> None:
+        client = MagicMock()
+        client.mint_token.return_value = _fake_token()
+
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="owner/repo",
+        )
+        sub.on_active()
+
+        client.mint_token.assert_called_once_with(
+            service="svc", repo="owner/repo", agent_id=None,
+        )
+
+    def test_repeated_on_active_re_mints(self) -> None:
+        """Each on_active is a fresh mint — no caching across cycles."""
+        client = MagicMock()
+        client.mint_token.side_effect = [
+            _fake_token("ghs_first"),
+            _fake_token("ghs_second"),
+        ]
+
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="owner/repo",
+        )
+        sub.on_active()
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_first")
+        sub.on_idle()
+        sub.on_active()
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_second")
+
+        self.assertEqual(client.mint_token.call_count, 2)
+
+
+# ── on_active failure paths ───────────────────────────────────────
+
+
+class OnActiveFailureTest(_SubscriberTestBase):
+    """Failure during mint must NOT leave stale env (fail-closed)."""
+
+    def test_transport_error_propagates_without_setting_env(self) -> None:
+        client = MagicMock()
+        client.mint_token.side_effect = ApiaristTransportError("connect refused")
+
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="owner/repo",
+        )
+        with self.assertRaises(ApiaristTransportError):
+            sub.on_active()
+
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+        self.assertIsNone(sub.current_token)
+
+    def test_remote_error_propagates_without_setting_env(self) -> None:
+        client = MagicMock()
+        client.mint_token.side_effect = ApiaristRemoteError(
+            code="BACKEND_FORBIDDEN",
+            message="repo not in token policy",
+        )
+
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="not/allowed",
+        )
+        with self.assertRaises(ApiaristRemoteError) as ctx:
+            sub.on_active()
+
+        self.assertEqual(ctx.exception.code, "BACKEND_FORBIDDEN")
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+
+    def test_mid_cycle_failure_preserves_prior_env(self) -> None:
+        """A failed on_active after a previous successful cycle must not
+        clear env that the previous cycle's on_idle owns clearing."""
+        client = MagicMock()
+        client.mint_token.side_effect = [
+            _fake_token("ghs_first"),
+            ApiaristTransportError("daemon restarted"),
+        ]
+
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="owner/repo",
+        )
+        sub.on_active()  # success — env set
+        sub.on_idle()    # env cleared
+        # Now the second cycle fails. Env should remain CLEARED (not
+        # overwritten with prior value) since on_active never reached
+        # the env-set step.
+        with self.assertRaises(ApiaristTransportError):
+            sub.on_active()
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+
+
+# ── on_idle paths ─────────────────────────────────────────────────
+
+
+class OnIdleTest(_SubscriberTestBase):
+    def test_clears_both_env_vars_after_active(self) -> None:
+        client = MagicMock()
+        client.mint_token.return_value = _fake_token()
+
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="owner/repo",
+        )
+        sub.on_active()
+        self.assertIn("GH_TOKEN", os.environ)
+        self.assertIn("GITHUB_TOKEN", os.environ)
+
+        sub.on_idle()
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+        self.assertIsNone(sub.current_token)
+
+    def test_idle_without_prior_active_is_safe(self) -> None:
+        """Defensive — an early on_idle (lifecycle bug or rollback path)
+        must not raise even though there's no token to clear."""
+        client = MagicMock()
+        sub = HivemootGithubAuthSubscriber(
+            client, service="svc", repo="owner/repo",
+        )
+        # Should NOT raise.
+        sub.on_idle()
+        self.assertIsNone(sub.current_token)
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+
+    def test_idle_does_not_touch_unrelated_env_vars(self) -> None:
+        client = MagicMock()
+        client.mint_token.return_value = _fake_token()
+
+        os.environ["UNRELATED_VAR"] = "preserve me"
+        try:
+            sub = HivemootGithubAuthSubscriber(
+                client, service="svc", repo="owner/repo",
+            )
+            sub.on_active()
+            sub.on_idle()
+            self.assertEqual(os.environ["UNRELATED_VAR"], "preserve me")
+        finally:
+            os.environ.pop("UNRELATED_VAR", None)
+
+
+# ── Construction validation ───────────────────────────────────────
+
+
+class ConstructionValidationTest(unittest.TestCase):
+    def test_missing_client_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            HivemootGithubAuthSubscriber(
+                None,  # type: ignore[arg-type]
+                service="svc",
+                repo="owner/repo",
+            )
+
+    def test_empty_service_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            HivemootGithubAuthSubscriber(
+                MagicMock(), service="", repo="owner/repo",
+            )
+
+    def test_empty_repo_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            HivemootGithubAuthSubscriber(
+                MagicMock(), service="svc", repo="",
+            )
+
+
+# ── Diagnostic property exposure ──────────────────────────────────
+
+
+class DiagnosticPropertyTest(_SubscriberTestBase):
+    def test_repo_and_service_exposed_after_construction(self) -> None:
+        sub = HivemootGithubAuthSubscriber(
+            MagicMock(),
+            service="hivemoot-zai",
+            repo="hivemoot/colony",
+        )
+        self.assertEqual(sub.repo, "hivemoot/colony")
+        self.assertEqual(sub.service, "hivemoot-zai")
+        self.assertIsNone(sub.current_token)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/cli/tests/test_hivemoot_auth_subscriber.py
+++ b/agent/cli/tests/test_hivemoot_auth_subscriber.py
@@ -1,26 +1,36 @@
 """Tests for ``HivemootGithubAuthSubscriber``.
 
-Validates the subscriber's lifecycle contract:
+Validates the new always-on contract (PR #490 R2 — addresses the
+watch-trigger blocker):
 
-- ``on_active`` calls ``client.mint_token`` with correct args, sets
-  both ``GH_TOKEN`` and ``GITHUB_TOKEN``, caches the result.
-- ``on_active`` failure (apiarist down, error envelope) propagates
-  the exception and does NOT touch env (fail-closed).
-- ``on_idle`` clears both env vars and resets cached state.
-- ``on_idle`` is safe to call without a prior ``on_active``.
-- Both env vars get the SAME token value (no split-brain).
-- Construction validates required arguments.
+- ``start()`` mints synchronously and starts a background refresh
+  thread; idempotent on second call.
+- ``stop()`` joins the refresh thread; safe to call multiple times.
+- ``on_active`` is a no-op when the current token is fresh; refreshes
+  proactively when within the lead-time window.
+- ``on_idle`` is a NO-OP (env stays populated for between-jobs trigger
+  polls — drone watch services need this).
+- ``on_active`` without prior ``start()`` force-mints (defensive).
+- Failure during initial ``start()`` propagates so plugin setup
+  fails fast.
+- Refresh loop logs + retries on apiarist errors instead of dying.
+- Both env vars (``GH_TOKEN`` and ``GITHUB_TOKEN``) get the same
+  token value.
+- Construction validates required arguments + new positive-number
+  refresh params.
 
-Uses a fake apiarist client (no real socket) — the wire path is
-covered by ``tests.test_apiarist_client``.
+Uses a fake apiarist client (no real socket) — wire path is covered
+by ``tests.test_apiarist_client``.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+import threading
+import time
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -36,10 +46,15 @@ from hivemoot_agent.plugins_builtin.hivemoot.auth_subscriber import (
 )
 
 
-def _fake_token(token_str: str = "ghs_fake_xyz") -> MintedToken:
+def _fake_token(
+    token_str: str = "ghs_fake_xyz",
+    *,
+    expires_in_secs: int = 3600,
+) -> MintedToken:
+    """Build a MintedToken expiring N seconds from NOW (tz-aware UTC)."""
     return MintedToken(
         token=token_str,
-        expires_at=datetime(2026, 4, 25, 23, 59, 59, tzinfo=timezone.utc),
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in_secs),
         installation_id="11111",
         permissions={"contents": "read"},
         repositories=[Repository(full_name="hivemoot/colony", id=1)],
@@ -56,179 +71,253 @@ class _SubscriberTestBase(unittest.TestCase):
 
     def setUp(self) -> None:
         _clear_token_env()
+        self._subscribers: list[HivemootGithubAuthSubscriber] = []
 
     def tearDown(self) -> None:
+        # Stop any subscribers we started so refresh threads don't leak
+        # into subsequent tests.
+        for sub in self._subscribers:
+            try:
+                sub.stop()
+            except Exception:
+                pass
         _clear_token_env()
 
+    def _make_subscriber(
+        self,
+        client: MagicMock,
+        **kwargs,
+    ) -> HivemootGithubAuthSubscriber:
+        defaults = {"service": "drone-zai", "repo": "hivemoot/colony"}
+        defaults.update(kwargs)
+        # Use a very long refresh lead time so tests don't race the
+        # background thread unless they explicitly want to.
+        defaults.setdefault("refresh_lead_time_secs", 60)
+        sub = HivemootGithubAuthSubscriber(client, **defaults)
+        self._subscribers.append(sub)
+        return sub
 
-# ── on_active happy path ──────────────────────────────────────────
+
+# ── start() / stop() ──────────────────────────────────────────────
 
 
-class OnActiveSuccessTest(_SubscriberTestBase):
-    def test_mints_with_correct_args_and_sets_both_env_vars(self) -> None:
+class StartTest(_SubscriberTestBase):
+    def test_start_mints_synchronously_and_sets_env(self) -> None:
         client = MagicMock()
-        token = _fake_token("ghs_active_token")
+        token = _fake_token("ghs_initial")
         client.mint_token.return_value = token
 
-        sub = HivemootGithubAuthSubscriber(
-            client,
-            service="drone-zai",
-            repo="hivemoot/colony",
-            agent_id="drone",
-        )
-        sub.on_active()
+        sub = self._make_subscriber(client)
+        sub.start()
 
+        # Synchronous initial mint — env populated by the time start
+        # returns, before any background refresh fires.
         client.mint_token.assert_called_once_with(
             service="drone-zai",
             repo="hivemoot/colony",
-            agent_id="drone",
+            agent_id=None,
         )
-        self.assertEqual(os.environ["GH_TOKEN"], "ghs_active_token")
-        self.assertEqual(os.environ["GITHUB_TOKEN"], "ghs_active_token")
-        # Both env vars get the SAME token (no split-brain).
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_initial")
+        self.assertEqual(os.environ["GITHUB_TOKEN"], "ghs_initial")
         self.assertEqual(os.environ["GH_TOKEN"], os.environ["GITHUB_TOKEN"])
         self.assertIs(sub.current_token, token)
+        self.assertTrue(sub.is_started)
 
-    def test_omits_agent_id_when_none(self) -> None:
+    def test_start_is_idempotent(self) -> None:
         client = MagicMock()
         client.mint_token.return_value = _fake_token()
 
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="owner/repo",
-        )
-        sub.on_active()
+        sub = self._make_subscriber(client)
+        sub.start()
+        sub.start()  # second call must NOT re-mint
+        sub.start()  # third call ditto
 
-        client.mint_token.assert_called_once_with(
-            service="svc", repo="owner/repo", agent_id=None,
-        )
+        client.mint_token.assert_called_once()
 
-    def test_repeated_on_active_re_mints(self) -> None:
-        """Each on_active is a fresh mint — no caching across cycles."""
+    def test_start_failure_propagates_for_fail_closed_setup(self) -> None:
         client = MagicMock()
+        client.mint_token.side_effect = ApiaristTransportError("daemon down")
+
+        sub = self._make_subscriber(client)
+        with self.assertRaises(ApiaristTransportError):
+            sub.start()
+
+        # Env not set on failure; subscriber not marked started so
+        # plugin setup_lifecycle bubbles the error and container exits.
+        self.assertNotIn("GH_TOKEN", os.environ)
+        self.assertNotIn("GITHUB_TOKEN", os.environ)
+        self.assertFalse(sub.is_started)
+
+
+class StopTest(_SubscriberTestBase):
+    def test_stop_joins_refresh_thread(self) -> None:
+        client = MagicMock()
+        client.mint_token.return_value = _fake_token()
+
+        sub = self._make_subscriber(client)
+        sub.start()
+        # Refresh thread is started — should be alive briefly.
+        self.assertTrue(sub._refresh_thread is not None)
+        sub.stop()
+        # After stop the thread reference is cleared.
+        self.assertIsNone(sub._refresh_thread)
+
+    def test_stop_safe_before_start(self) -> None:
+        sub = self._make_subscriber(MagicMock())
+        # Must NOT raise even though we never started.
+        sub.stop()
+
+    def test_stop_idempotent(self) -> None:
+        client = MagicMock()
+        client.mint_token.return_value = _fake_token()
+        sub = self._make_subscriber(client)
+        sub.start()
+        sub.stop()
+        sub.stop()  # safe second call
+
+
+# ── on_active behavior ────────────────────────────────────────────
+
+
+class OnActiveAfterStartTest(_SubscriberTestBase):
+    def test_on_active_fresh_token_is_no_op(self) -> None:
+        """Refresh thread keeps token fresh — on_active is mostly no-op."""
+        client = MagicMock()
+        # Long-expiring token — far outside the 60s lead-time window.
+        client.mint_token.return_value = _fake_token(
+            "ghs_fresh", expires_in_secs=3600,
+        )
+
+        sub = self._make_subscriber(client, refresh_lead_time_secs=60)
+        sub.start()
+        client.mint_token.reset_mock()
+
+        sub.on_active()
+        client.mint_token.assert_not_called()
+
+    def test_on_active_near_expiry_refreshes(self) -> None:
+        """Inside the lead-time window — proactively refresh."""
+        client = MagicMock()
+        # Token expiring in 30s, lead-time is 60s → on_active refreshes.
         client.mint_token.side_effect = [
-            _fake_token("ghs_first"),
-            _fake_token("ghs_second"),
+            _fake_token("ghs_near_expiry", expires_in_secs=30),
+            _fake_token("ghs_refreshed", expires_in_secs=3600),
         ]
 
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="owner/repo",
-        )
+        sub = self._make_subscriber(client, refresh_lead_time_secs=60)
+        sub.start()
+        sub.stop()  # quiet the refresh thread so it doesn't race
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_near_expiry")
+
         sub.on_active()
-        self.assertEqual(os.environ["GH_TOKEN"], "ghs_first")
-        sub.on_idle()
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_refreshed")
+
+    def test_on_active_without_prior_start_force_mints(self) -> None:
+        """Defensive — if start() wasn't called, on_active mints anyway."""
+        client = MagicMock()
+        client.mint_token.return_value = _fake_token("ghs_force")
+
+        sub = self._make_subscriber(client)
+        # No start() call.
         sub.on_active()
-        self.assertEqual(os.environ["GH_TOKEN"], "ghs_second")
 
-        self.assertEqual(client.mint_token.call_count, 2)
-
-
-# ── on_active failure paths ───────────────────────────────────────
+        client.mint_token.assert_called_once()
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_force")
 
 
-class OnActiveFailureTest(_SubscriberTestBase):
-    """Failure during mint must NOT leave stale env (fail-closed)."""
-
-    def test_transport_error_propagates_without_setting_env(self) -> None:
-        client = MagicMock()
-        client.mint_token.side_effect = ApiaristTransportError("connect refused")
-
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="owner/repo",
-        )
-        with self.assertRaises(ApiaristTransportError):
-            sub.on_active()
-
-        self.assertNotIn("GH_TOKEN", os.environ)
-        self.assertNotIn("GITHUB_TOKEN", os.environ)
-        self.assertIsNone(sub.current_token)
-
-    def test_remote_error_propagates_without_setting_env(self) -> None:
-        client = MagicMock()
-        client.mint_token.side_effect = ApiaristRemoteError(
-            code="BACKEND_FORBIDDEN",
-            message="repo not in token policy",
-        )
-
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="not/allowed",
-        )
-        with self.assertRaises(ApiaristRemoteError) as ctx:
-            sub.on_active()
-
-        self.assertEqual(ctx.exception.code, "BACKEND_FORBIDDEN")
-        self.assertNotIn("GH_TOKEN", os.environ)
-        self.assertNotIn("GITHUB_TOKEN", os.environ)
-
-    def test_mid_cycle_failure_preserves_prior_env(self) -> None:
-        """A failed on_active after a previous successful cycle must not
-        clear env that the previous cycle's on_idle owns clearing."""
-        client = MagicMock()
-        client.mint_token.side_effect = [
-            _fake_token("ghs_first"),
-            ApiaristTransportError("daemon restarted"),
-        ]
-
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="owner/repo",
-        )
-        sub.on_active()  # success — env set
-        sub.on_idle()    # env cleared
-        # Now the second cycle fails. Env should remain CLEARED (not
-        # overwritten with prior value) since on_active never reached
-        # the env-set step.
-        with self.assertRaises(ApiaristTransportError):
-            sub.on_active()
-        self.assertNotIn("GH_TOKEN", os.environ)
-        self.assertNotIn("GITHUB_TOKEN", os.environ)
-
-
-# ── on_idle paths ─────────────────────────────────────────────────
+# ── on_idle behavior ──────────────────────────────────────────────
 
 
 class OnIdleTest(_SubscriberTestBase):
-    def test_clears_both_env_vars_after_active(self) -> None:
+    def test_on_idle_does_not_clear_env(self) -> None:
+        """Always-on contract: env stays so trigger threads can poll."""
         client = MagicMock()
-        client.mint_token.return_value = _fake_token()
+        client.mint_token.return_value = _fake_token("ghs_persistent")
 
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="owner/repo",
-        )
-        sub.on_active()
-        self.assertIn("GH_TOKEN", os.environ)
-        self.assertIn("GITHUB_TOKEN", os.environ)
+        sub = self._make_subscriber(client)
+        sub.start()
+        sub.stop()  # silence refresh thread
 
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_persistent")
         sub.on_idle()
-        self.assertNotIn("GH_TOKEN", os.environ)
-        self.assertNotIn("GITHUB_TOKEN", os.environ)
+        # Env STILL populated — different from the original V1 design.
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_persistent")
+        self.assertEqual(os.environ["GITHUB_TOKEN"], "ghs_persistent")
+        # current_token also retained for diagnostics.
+        self.assertIsNotNone(sub.current_token)
+
+    def test_on_idle_safe_before_start(self) -> None:
+        sub = self._make_subscriber(MagicMock())
+        sub.on_idle()  # must NOT raise
         self.assertIsNone(sub.current_token)
 
-    def test_idle_without_prior_active_is_safe(self) -> None:
-        """Defensive — an early on_idle (lifecycle bug or rollback path)
-        must not raise even though there's no token to clear."""
+
+# ── Refresh loop behavior ─────────────────────────────────────────
+
+
+class RefreshLoopTest(_SubscriberTestBase):
+    def test_refresh_loop_re_mints_when_token_nears_expiry(self) -> None:
+        """Background thread re-mints periodically.
+
+        Test-style: short-expiring token forces the thread to re-mint
+        almost immediately. We poll for the second call to land.
+        """
         client = MagicMock()
-        sub = HivemootGithubAuthSubscriber(
-            client, service="svc", repo="owner/repo",
+        # First mint expires ~1s after now, refresh lead 1s → thread
+        # sleeps for max(1s, 0s) = 1s then re-mints.
+        client.mint_token.side_effect = [
+            _fake_token("ghs_v1", expires_in_secs=2),
+            _fake_token("ghs_v2", expires_in_secs=3600),
+            _fake_token("ghs_v3", expires_in_secs=3600),
+        ]
+
+        sub = self._make_subscriber(client, refresh_lead_time_secs=1)
+        sub.start()
+        # Wait up to 5s for the second mint to land.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if client.mint_token.call_count >= 2:
+                break
+            time.sleep(0.05)
+        sub.stop()
+
+        self.assertGreaterEqual(
+            client.mint_token.call_count, 2,
+            "refresh thread should have re-minted the near-expiry token",
         )
-        # Should NOT raise.
-        sub.on_idle()
-        self.assertIsNone(sub.current_token)
-        self.assertNotIn("GH_TOKEN", os.environ)
-        self.assertNotIn("GITHUB_TOKEN", os.environ)
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_v2")
 
-    def test_idle_does_not_touch_unrelated_env_vars(self) -> None:
+    def test_refresh_loop_logs_and_retries_on_apiarist_error(self) -> None:
+        """A transient apiarist error must NOT kill the refresh loop."""
         client = MagicMock()
-        client.mint_token.return_value = _fake_token()
+        # First mint succeeds (initial), second mint fails (refresh
+        # attempt), third mint succeeds.
+        client.mint_token.side_effect = [
+            _fake_token("ghs_v1", expires_in_secs=2),
+            ApiaristTransportError("transient"),
+            _fake_token("ghs_v2", expires_in_secs=3600),
+        ]
 
-        os.environ["UNRELATED_VAR"] = "preserve me"
-        try:
-            sub = HivemootGithubAuthSubscriber(
-                client, service="svc", repo="owner/repo",
-            )
-            sub.on_active()
-            sub.on_idle()
-            self.assertEqual(os.environ["UNRELATED_VAR"], "preserve me")
-        finally:
-            os.environ.pop("UNRELATED_VAR", None)
+        sub = self._make_subscriber(
+            client,
+            refresh_lead_time_secs=1,
+            refresh_backoff_on_error_secs=0.5,
+        )
+        sub.start()
+        # Wait for both the failure and the recovery to occur.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if client.mint_token.call_count >= 3:
+                break
+            time.sleep(0.05)
+        sub.stop()
+
+        self.assertGreaterEqual(
+            client.mint_token.call_count, 3,
+            "refresh loop should retry after transient error",
+        )
+        # Final env value is the recovered token.
+        self.assertEqual(os.environ["GH_TOKEN"], "ghs_v2")
 
 
 # ── Construction validation ───────────────────────────────────────
@@ -255,13 +344,32 @@ class ConstructionValidationTest(unittest.TestCase):
                 MagicMock(), service="svc", repo="",
             )
 
+    def test_non_positive_refresh_lead_time_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            HivemootGithubAuthSubscriber(
+                MagicMock(), service="svc", repo="owner/repo",
+                refresh_lead_time_secs=0,
+            )
+        with self.assertRaises(ValueError):
+            HivemootGithubAuthSubscriber(
+                MagicMock(), service="svc", repo="owner/repo",
+                refresh_lead_time_secs=-5,
+            )
+
+    def test_non_positive_refresh_backoff_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            HivemootGithubAuthSubscriber(
+                MagicMock(), service="svc", repo="owner/repo",
+                refresh_backoff_on_error_secs=0,
+            )
+
 
 # ── Diagnostic property exposure ──────────────────────────────────
 
 
 class DiagnosticPropertyTest(_SubscriberTestBase):
-    def test_repo_and_service_exposed_after_construction(self) -> None:
-        sub = HivemootGithubAuthSubscriber(
+    def test_repo_and_service_exposed(self) -> None:
+        sub = self._make_subscriber(
             MagicMock(),
             service="hivemoot-zai",
             repo="hivemoot/colony",
@@ -269,6 +377,7 @@ class DiagnosticPropertyTest(_SubscriberTestBase):
         self.assertEqual(sub.repo, "hivemoot/colony")
         self.assertEqual(sub.service, "hivemoot-zai")
         self.assertIsNone(sub.current_token)
+        self.assertFalse(sub.is_started)
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_config.py
+++ b/agent/cli/tests/test_hivemoot_config.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from pydantic import ValidationError
 
 from hivemoot_agent.plugins_builtin.hivemoot.config import (
+    HivemootApiaristConfig,
     HivemootConfig,
     HivemootGithubWorkflowsConfig,
     HivemootHealthConfig,
@@ -24,6 +25,7 @@ class DefaultsTests(unittest.TestCase):
         self.assertFalse(cfg.health.enabled)
         self.assertFalse(cfg.tasks.enabled)
         self.assertFalse(cfg.github_workflows.enabled)
+        self.assertFalse(cfg.apiarist.enabled)
 
     def test_health_defaults(self) -> None:
         cfg = HivemootHealthConfig()
@@ -40,6 +42,14 @@ class DefaultsTests(unittest.TestCase):
         cfg = HivemootGithubWorkflowsConfig()
         self.assertEqual(cfg.clone_depth, 50)
         self.assertEqual(cfg.role_name, "")
+
+    def test_apiarist_defaults(self) -> None:
+        cfg = HivemootApiaristConfig()
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(str(cfg.socket_path), "/run/apiarist.sock")
+        self.assertEqual(cfg.timeout_seconds, 10.0)
+        self.assertEqual(cfg.service, "")
+        self.assertEqual(cfg.repo, "")
 
 
 class StrictnessTests(unittest.TestCase):
@@ -68,6 +78,12 @@ class RangeTests(unittest.TestCase):
         # Documented: 0 disables the per-task heartbeat thread.
         cfg = HivemootTasksConfig(heartbeat_interval_secs=0)
         self.assertEqual(cfg.heartbeat_interval_secs, 0)
+
+    def test_apiarist_timeout_must_be_positive(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootApiaristConfig(timeout_seconds=0)
+        with self.assertRaises(ValidationError):
+            HivemootApiaristConfig(timeout_seconds=-1)
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_setup_lifecycle.py
+++ b/agent/cli/tests/test_hivemoot_setup_lifecycle.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 import os
 import sys
 import unittest
-from unittest.mock import patch
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from hivemoot_agent.apiarist_client import MintedToken
 from hivemoot_agent.lifecycle import ContainerLifecycle
 from hivemoot_agent.plugins.interfaces import PluginConfig
 from hivemoot_agent.plugins_builtin.hivemoot import HivemootPlugin
@@ -44,27 +46,92 @@ def _make_plugin_config(apiarist: HivemootApiaristConfig | None = None) -> Plugi
     return PluginConfig(name="hivemoot", typed=typed)
 
 
-class DisabledNoOpTest(unittest.TestCase):
+def _fake_token_response() -> MintedToken:
+    """A long-expiring fake token so the refresh thread sleeps quietly."""
+    return MintedToken(
+        token="ghs_test_token",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        installation_id="11111",
+        permissions={},
+        repositories=[],
+    )
+
+
+class _LifecycleTestBase(unittest.TestCase):
+    """Patches ApiaristClient so subscriber.start() doesn't try to
+    open a real socket. Cleans up subscribers (and their refresh
+    threads) after each test.
+    """
+
+    def setUp(self) -> None:
+        self._spawned_subs: list[HivemootGithubAuthSubscriber] = []
+        # Patch ApiaristClient at the source so the local import inside
+        # hivemoot.setup_lifecycle picks up the mock instead of the
+        # real class. Each call to setup_lifecycle re-imports, but the
+        # name resolution still goes through hivemoot_agent.apiarist_client
+        # so patching at the source covers both.
+        patcher = patch(
+            "hivemoot_agent.apiarist_client.ApiaristClient",
+        )
+        self._mock_client_cls = patcher.start()
+        self.addCleanup(patcher.stop)
+        # Configure the fake client so mint_token returns a valid
+        # token; no real socket needed.
+        self._mock_client = MagicMock()
+        self._mock_client.mint_token.return_value = _fake_token_response()
+        self._mock_client_cls.return_value = self._mock_client
+        # Clear env so previous tests don't pollute current.
+        for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(var, None)
+
+    def tearDown(self) -> None:
+        # Stop refresh threads from any subscribers spawned during
+        # the test so they don't outlive the test.
+        for sub in self._spawned_subs:
+            try:
+                sub.stop()
+            except Exception:
+                pass
+        for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(var, None)
+
+    def _setup_lifecycle(
+        self, plugin: HivemootPlugin, lifecycle: ContainerLifecycle,
+        cfg: PluginConfig,
+    ) -> None:
+        plugin.setup_lifecycle(lifecycle, cfg)
+        if plugin._auth_subscriber is not None:
+            self._spawned_subs.append(plugin._auth_subscriber)
+
+
+class DisabledNoOpTest(_LifecycleTestBase):
     def test_apiarist_disabled_does_not_subscribe(self) -> None:
-        """Default config (apiarist.enabled=False) is a no-op."""
+        """Default config (apiarist.enabled=False) is a no-op.
+
+        ApiaristClient must NOT be constructed when disabled — no
+        subscriber, no thread, no socket touched.
+        """
         plugin = HivemootPlugin()
         lifecycle = ContainerLifecycle()
         cfg = _make_plugin_config()  # all defaults
 
-        plugin.setup_lifecycle(lifecycle, cfg)
+        self._setup_lifecycle(plugin, lifecycle, cfg)
 
         self.assertEqual(lifecycle.subscriber_count, 0)
         self.assertIsNone(plugin._auth_subscriber)
+        self._mock_client_cls.assert_not_called()
 
 
-class EnabledRegistersSubscriberTest(unittest.TestCase):
-    """When fully configured, a subscriber registers correctly."""
+class EnabledRegistersSubscriberTest(_LifecycleTestBase):
+    """When fully configured, a subscriber registers + start()s correctly."""
 
     def setUp(self) -> None:
+        super().setUp()
         os.environ.pop("AGENT_ID", None)
 
     def tearDown(self) -> None:
         os.environ.pop("AGENT_ID", None)
+        super().tearDown()
 
     def test_full_config_registers_subscriber(self) -> None:
         plugin = HivemootPlugin()
@@ -77,13 +144,20 @@ class EnabledRegistersSubscriberTest(unittest.TestCase):
             )
         )
 
-        plugin.setup_lifecycle(lifecycle, cfg)
+        self._setup_lifecycle(plugin, lifecycle, cfg)
 
         self.assertEqual(lifecycle.subscriber_count, 1)
         sub = plugin._auth_subscriber
         self.assertIsInstance(sub, HivemootGithubAuthSubscriber)
         self.assertEqual(sub.service, "drone-zai")
         self.assertEqual(sub.repo, "hivemoot/colony")
+        # start() was called → subscriber is started + initial mint fired.
+        self.assertTrue(sub.is_started)
+        self._mock_client.mint_token.assert_called_once_with(
+            service="drone-zai",
+            repo="hivemoot/colony",
+            agent_id=None,
+        )
 
     def test_service_falls_back_to_agent_id(self) -> None:
         os.environ["AGENT_ID"] = "drone"
@@ -97,7 +171,7 @@ class EnabledRegistersSubscriberTest(unittest.TestCase):
             )
         )
 
-        plugin.setup_lifecycle(lifecycle, cfg)
+        self._setup_lifecycle(plugin, lifecycle, cfg)
 
         sub = plugin._auth_subscriber
         self.assertEqual(sub.service, "drone")
@@ -114,18 +188,20 @@ class EnabledRegistersSubscriberTest(unittest.TestCase):
             )
         )
 
-        plugin.setup_lifecycle(lifecycle, cfg)
+        self._setup_lifecycle(plugin, lifecycle, cfg)
         self.assertEqual(plugin._auth_subscriber.service, "custom-service")
 
 
-class FailureModeTest(unittest.TestCase):
+class FailureModeTest(_LifecycleTestBase):
     """Misconfiguration raises clearly at setup time, not job-dispatch time."""
 
     def setUp(self) -> None:
+        super().setUp()
         os.environ.pop("AGENT_ID", None)
 
     def tearDown(self) -> None:
         os.environ.pop("AGENT_ID", None)
+        super().tearDown()
 
     def test_no_service_and_no_agent_id_raises(self) -> None:
         plugin = HivemootPlugin()

--- a/agent/cli/tests/test_hivemoot_setup_lifecycle.py
+++ b/agent/cli/tests/test_hivemoot_setup_lifecycle.py
@@ -1,0 +1,226 @@
+"""Tests for ``HivemootPlugin.setup_lifecycle`` integration with the engine.
+
+Validates:
+
+- When ``apiarist.enabled`` is False (default), setup_lifecycle is a no-op
+  — no subscriber gets registered, lifecycle stays empty.
+- When ``apiarist.enabled`` is True with full config, a subscriber is
+  registered with the right service/repo/agent_id.
+- When ``apiarist.repo`` is empty, the github plugin's ``repos[0]`` is used.
+- When ``apiarist.service`` is empty, ``AGENT_ID`` env is used.
+- Missing service AND missing AGENT_ID raises a clear RuntimeError.
+- Missing repo AND missing github plugin config raises a clear RuntimeError.
+
+These tests instantiate ContainerLifecycle directly (no engine) so they
+exercise the plugin → lifecycle wiring without spinning up the full
+engine. End-to-end engine wiring is exercised by the existing
+test_engine_lifecycle suite which now goes through the lifecycle wrap.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.lifecycle import ContainerLifecycle
+from hivemoot_agent.plugins.interfaces import PluginConfig
+from hivemoot_agent.plugins_builtin.hivemoot import HivemootPlugin
+from hivemoot_agent.plugins_builtin.hivemoot.auth_subscriber import (
+    HivemootGithubAuthSubscriber,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.config import (
+    HivemootApiaristConfig,
+    HivemootConfig,
+)
+
+
+def _make_plugin_config(apiarist: HivemootApiaristConfig | None = None) -> PluginConfig:
+    """Build a PluginConfig with HivemootConfig.typed."""
+    typed = HivemootConfig(apiarist=apiarist or HivemootApiaristConfig())
+    return PluginConfig(name="hivemoot", typed=typed)
+
+
+class DisabledNoOpTest(unittest.TestCase):
+    def test_apiarist_disabled_does_not_subscribe(self) -> None:
+        """Default config (apiarist.enabled=False) is a no-op."""
+        plugin = HivemootPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _make_plugin_config()  # all defaults
+
+        plugin.setup_lifecycle(lifecycle, cfg)
+
+        self.assertEqual(lifecycle.subscriber_count, 0)
+        self.assertIsNone(plugin._auth_subscriber)
+
+
+class EnabledRegistersSubscriberTest(unittest.TestCase):
+    """When fully configured, a subscriber registers correctly."""
+
+    def setUp(self) -> None:
+        os.environ.pop("AGENT_ID", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("AGENT_ID", None)
+
+    def test_full_config_registers_subscriber(self) -> None:
+        plugin = HivemootPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _make_plugin_config(
+            HivemootApiaristConfig(
+                enabled=True,
+                service="drone-zai",
+                repo="hivemoot/colony",
+            )
+        )
+
+        plugin.setup_lifecycle(lifecycle, cfg)
+
+        self.assertEqual(lifecycle.subscriber_count, 1)
+        sub = plugin._auth_subscriber
+        self.assertIsInstance(sub, HivemootGithubAuthSubscriber)
+        self.assertEqual(sub.service, "drone-zai")
+        self.assertEqual(sub.repo, "hivemoot/colony")
+
+    def test_service_falls_back_to_agent_id(self) -> None:
+        os.environ["AGENT_ID"] = "drone"
+        plugin = HivemootPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _make_plugin_config(
+            HivemootApiaristConfig(
+                enabled=True,
+                service="",  # empty → AGENT_ID
+                repo="hivemoot/colony",
+            )
+        )
+
+        plugin.setup_lifecycle(lifecycle, cfg)
+
+        sub = plugin._auth_subscriber
+        self.assertEqual(sub.service, "drone")
+
+    def test_explicit_service_wins_over_agent_id(self) -> None:
+        os.environ["AGENT_ID"] = "drone"
+        plugin = HivemootPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _make_plugin_config(
+            HivemootApiaristConfig(
+                enabled=True,
+                service="custom-service",
+                repo="hivemoot/colony",
+            )
+        )
+
+        plugin.setup_lifecycle(lifecycle, cfg)
+        self.assertEqual(plugin._auth_subscriber.service, "custom-service")
+
+
+class FailureModeTest(unittest.TestCase):
+    """Misconfiguration raises clearly at setup time, not job-dispatch time."""
+
+    def setUp(self) -> None:
+        os.environ.pop("AGENT_ID", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("AGENT_ID", None)
+
+    def test_no_service_and_no_agent_id_raises(self) -> None:
+        plugin = HivemootPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _make_plugin_config(
+            HivemootApiaristConfig(
+                enabled=True,
+                service="",  # missing
+                repo="hivemoot/colony",
+            )
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            plugin.setup_lifecycle(lifecycle, cfg)
+        self.assertIn("apiarist.service", str(ctx.exception))
+        self.assertIn("AGENT_ID", str(ctx.exception))
+        self.assertEqual(lifecycle.subscriber_count, 0)
+
+    def test_no_repo_and_no_github_plugin_raises(self) -> None:
+        os.environ["AGENT_ID"] = "drone"
+        plugin = HivemootPlugin()
+        lifecycle = ContainerLifecycle()
+        cfg = _make_plugin_config(
+            HivemootApiaristConfig(
+                enabled=True,
+                service="drone-zai",
+                repo="",  # missing — no github plugin to fall back to either
+            )
+        )
+
+        # No github plugin in registry → fallback returns "" → raise.
+        with patch(
+            "hivemoot_agent.plugins.registry.config_for_or_none",
+            return_value=None,
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                plugin.setup_lifecycle(lifecycle, cfg)
+
+        self.assertIn("apiarist.repo", str(ctx.exception))
+        self.assertIn("github.repos", str(ctx.exception))
+        self.assertEqual(lifecycle.subscriber_count, 0)
+
+
+class EngineSetupOrderingTest(unittest.TestCase):
+    """The engine's _setup_plugins runs setup() across all plugins BEFORE
+    setup_lifecycle() across all plugins (apiarist DESIGN.md §12.3)."""
+
+    def test_two_phase_setup_runs_setup_then_setup_lifecycle(self) -> None:
+        events: list[str] = []
+
+        class _RecordingPlugin:
+            name = "rec"
+            version = "0.0.0"
+            description = "test"
+
+            def __init__(self, label: str) -> None:
+                self._label = label
+
+            def validate(self, config: PluginConfig) -> list[str]:
+                return []
+
+            def setup(self, config: PluginConfig) -> None:
+                events.append(f"{self._label}:setup")
+
+            def setup_lifecycle(self, lifecycle, config) -> None:
+                events.append(f"{self._label}:setup_lifecycle")
+
+        from hivemoot_agent.engine import Engine
+        from hivemoot_agent.plugins import registry as _registry
+
+        engine = Engine()
+        plugins = {
+            "first": _RecordingPlugin("first"),
+            "second": _RecordingPlugin("second"),
+        }
+
+        # Stub registry.config_for so _setup_plugins can find configs.
+        with patch.object(
+            _registry, "config_for",
+            return_value=PluginConfig(name="rec"),
+        ):
+            ok = engine._setup_plugins(plugins)
+
+        self.assertTrue(ok)
+        # Two-phase: ALL setup() before ANY setup_lifecycle().
+        self.assertEqual(
+            events,
+            [
+                "first:setup",
+                "second:setup",
+                "first:setup_lifecycle",
+                "second:setup_lifecycle",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_lifecycle.py
+++ b/agent/cli/tests/test_lifecycle.py
@@ -1,0 +1,361 @@
+"""Tests for ``hivemoot_agent.lifecycle.ContainerLifecycle``.
+
+Validates the five invariants documented in the class docstring
+(I1-I5 — apiarist DESIGN.md §12.3.2):
+
+- I1: when ``on_job_starting`` returns, every subscriber's
+  ``on_active`` has run exactly once on the IDLE→ACTIVE boundary.
+- I2: ``on_job_finished`` triggers every subscriber's ``on_idle``
+  on the ACTIVE→IDLE boundary.
+- I3: a subscriber raising in ``on_active`` rolls the counter back
+  and tears down prior successful subscribers in reverse order.
+- I4: a subscriber raising in ``on_idle`` is logged but doesn't
+  block other subscribers' cleanup.
+- I5: counter ``max(0, …)`` clamp defends against a stray
+  ``on_job_finished`` call (e.g. a buggy engine path).
+
+Plus reference-counting (intermediate 1→2 / 2→1 don't fire
+subscribers — only the 0↔1 boundary does).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stderr
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.lifecycle import ContainerLifecycle, LifecycleSubscriber
+
+
+class _RecordingSubscriber(LifecycleSubscriber):
+    """Simple subscriber that records the order of lifecycle calls.
+
+    Optionally raises on ``on_active`` / ``on_idle`` to exercise
+    failure paths. The shared ``events`` list is supplied by the test
+    so multiple subscribers can be ordered against each other.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        events: list[str],
+        *,
+        raise_on_active: bool = False,
+        raise_on_idle: bool = False,
+    ) -> None:
+        self.name = name
+        self.events = events
+        self.raise_on_active = raise_on_active
+        self.raise_on_idle = raise_on_idle
+
+    def on_active(self) -> None:
+        self.events.append(f"{self.name}:on_active")
+        if self.raise_on_active:
+            raise RuntimeError(f"{self.name} on_active failed")
+
+    def on_idle(self) -> None:
+        self.events.append(f"{self.name}:on_idle")
+        if self.raise_on_idle:
+            raise RuntimeError(f"{self.name} on_idle failed")
+
+
+# ── Empty / single-subscriber baselines ────────────────────────────
+
+
+class EmptySubscriberListTest(unittest.TestCase):
+    """No subscribers → counter still tracked, no callbacks attempted."""
+
+    def test_starts_idle(self) -> None:
+        lc = ContainerLifecycle()
+        self.assertFalse(lc.is_active)
+        self.assertEqual(lc.active_job_count, 0)
+        self.assertEqual(lc.subscriber_count, 0)
+
+    def test_no_op_transitions_with_no_subscribers(self) -> None:
+        lc = ContainerLifecycle()
+        lc.on_job_starting()
+        self.assertTrue(lc.is_active)
+        self.assertEqual(lc.active_job_count, 1)
+        lc.on_job_finished()
+        self.assertFalse(lc.is_active)
+        self.assertEqual(lc.active_job_count, 0)
+
+
+class SingleSubscriberBoundaryTest(unittest.TestCase):
+    """I1+I2 minimum case: one subscriber sees one on_active, one on_idle per cycle."""
+
+    def test_single_subscriber_fires_on_0_to_1_and_1_to_0(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("only", events))
+
+        lc.on_job_starting()
+        lc.on_job_finished()
+
+        self.assertEqual(events, ["only:on_active", "only:on_idle"])
+
+    def test_subscriber_count_reflects_registration(self) -> None:
+        lc = ContainerLifecycle()
+        self.assertEqual(lc.subscriber_count, 0)
+        lc.subscribe(_RecordingSubscriber("a", []))
+        self.assertEqual(lc.subscriber_count, 1)
+        lc.subscribe(_RecordingSubscriber("b", []))
+        self.assertEqual(lc.subscriber_count, 2)
+
+
+# ── Multi-subscriber ordering ─────────────────────────────────────
+
+
+class RegistrationOrderTest(unittest.TestCase):
+    """on_active runs subscribers in registration order (load-bearing)."""
+
+    def test_on_active_in_registration_order(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("first", events))
+        lc.subscribe(_RecordingSubscriber("second", events))
+        lc.subscribe(_RecordingSubscriber("third", events))
+
+        lc.on_job_starting()
+        lc.on_job_finished()
+
+        self.assertEqual(
+            events,
+            [
+                "first:on_active",
+                "second:on_active",
+                "third:on_active",
+                "first:on_idle",
+                "second:on_idle",
+                "third:on_idle",
+            ],
+            "on_active and on_idle must both run in registration order "
+            "(load-bearing for hivemoot→github auth env handoff)",
+        )
+
+
+# ── Reference counting (overlapping jobs) ─────────────────────────
+
+
+class ReferenceCountingTest(unittest.TestCase):
+    """Intermediate counter changes (1↔2) MUST NOT fire subscribers."""
+
+    def test_overlapping_jobs_only_fire_subscribers_at_boundary(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("sub", events))
+
+        lc.on_job_starting()  # 0→1: fires on_active
+        lc.on_job_starting()  # 1→2: no-op
+        lc.on_job_starting()  # 2→3: no-op
+        self.assertEqual(lc.active_job_count, 3)
+        self.assertEqual(events, ["sub:on_active"])
+
+        lc.on_job_finished()  # 3→2: no-op
+        lc.on_job_finished()  # 2→1: no-op
+        self.assertEqual(events, ["sub:on_active"])
+
+        lc.on_job_finished()  # 1→0: fires on_idle
+        self.assertEqual(events, ["sub:on_active", "sub:on_idle"])
+        self.assertEqual(lc.active_job_count, 0)
+
+    def test_repeated_cycles_re_fire_subscribers(self) -> None:
+        """Subscribers must be idempotent across cycles — each IDLE→ACTIVE
+        boundary fires on_active again."""
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("sub", events))
+
+        for _ in range(3):
+            lc.on_job_starting()
+            lc.on_job_finished()
+
+        self.assertEqual(
+            events,
+            [
+                "sub:on_active", "sub:on_idle",
+                "sub:on_active", "sub:on_idle",
+                "sub:on_active", "sub:on_idle",
+            ],
+        )
+
+
+# ── Failure paths (I3 + I4) ───────────────────────────────────────
+
+
+class OnActiveFailureRollsBackTest(unittest.TestCase):
+    """I3: subscriber raising in on_active rolls back counter + reverse-order cleanup."""
+
+    def test_failure_in_first_subscriber_raises_no_cleanup_no_increment(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("fail", events, raise_on_active=True))
+
+        with self.assertRaises(RuntimeError):
+            lc.on_job_starting()
+
+        self.assertEqual(events, ["fail:on_active"])
+        self.assertEqual(
+            lc.active_job_count, 0,
+            "counter must be rolled back to its pre-call value (I3) "
+            "so the next job-start retries the full chain cleanly",
+        )
+
+    def test_failure_in_middle_subscriber_unwinds_priors_in_reverse(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("a", events))
+        lc.subscribe(_RecordingSubscriber("b", events))
+        lc.subscribe(_RecordingSubscriber("c_fails", events, raise_on_active=True))
+        lc.subscribe(_RecordingSubscriber("d_never", events))
+
+        with self.assertRaises(RuntimeError):
+            lc.on_job_starting()
+
+        self.assertEqual(
+            events,
+            [
+                "a:on_active",
+                "b:on_active",
+                "c_fails:on_active",
+                # Rollback in REVERSE registration order — b before a.
+                "b:on_idle",
+                "a:on_idle",
+            ],
+            "rollback must call on_idle on completed subscribers in "
+            "reverse registration order (mirrors dependency teardown)",
+        )
+        self.assertEqual(lc.active_job_count, 0)
+
+    def test_cleanup_failure_during_rollback_does_not_mask_original(self) -> None:
+        """A bad on_idle during rollback must not mask the on_active error."""
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("a_bad_cleanup", events, raise_on_idle=True))
+        lc.subscribe(_RecordingSubscriber("b_fails", events, raise_on_active=True))
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(RuntimeError) as ctx:
+            lc.on_job_starting()
+
+        # The ORIGINAL on_active failure bubbles, not the cleanup error.
+        self.assertIn("b_fails on_active failed", str(ctx.exception))
+        # All three events recorded: a's on_active, b's failed on_active,
+        # a's failed on_idle (during rollback).
+        self.assertEqual(
+            events,
+            ["a_bad_cleanup:on_active", "b_fails:on_active", "a_bad_cleanup:on_idle"],
+        )
+        # Cleanup failure was logged (not silently swallowed).
+        log = stderr.getvalue()
+        self.assertIn("[lifecycle]", log)
+        self.assertIn("rollback", log)
+        self.assertIn("a_bad_cleanup", log)
+        self.assertEqual(lc.active_job_count, 0)
+
+
+class OnIdleFailureContinuesTest(unittest.TestCase):
+    """I4: on_idle errors are logged + cleanup continues across other subscribers."""
+
+    def test_on_idle_failure_does_not_block_others(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("a_bad", events, raise_on_idle=True))
+        lc.subscribe(_RecordingSubscriber("b_ok", events))
+        lc.subscribe(_RecordingSubscriber("c_bad", events, raise_on_idle=True))
+
+        lc.on_job_starting()
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            # Must NOT raise — best-effort cleanup (I4).
+            lc.on_job_finished()
+
+        # All three saw on_idle even though two raised.
+        self.assertEqual(
+            [e for e in events if e.endswith("on_idle")],
+            ["a_bad:on_idle", "b_ok:on_idle", "c_bad:on_idle"],
+        )
+        # Both failures logged.
+        log = stderr.getvalue()
+        self.assertIn("a_bad", log)
+        self.assertIn("c_bad", log)
+        self.assertEqual(lc.active_job_count, 0)
+
+
+# ── Counter clamp (I5) ────────────────────────────────────────────
+
+
+class CounterClampTest(unittest.TestCase):
+    """I5: extra on_job_finished must not drive counter negative."""
+
+    def test_extra_on_job_finished_clamps_at_zero(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("sub", events))
+
+        lc.on_job_starting()
+        lc.on_job_finished()
+        self.assertEqual(lc.active_job_count, 0)
+        self.assertEqual(events, ["sub:on_active", "sub:on_idle"])
+
+        # Buggy extra call — must clamp, not go negative.
+        lc.on_job_finished()
+        self.assertEqual(
+            lc.active_job_count, 0,
+            "max(0, ...) clamp must keep counter non-negative so the "
+            "next 0→1 transition still fires on_active",
+        )
+
+        # Crucially the next start must still fire on_active.
+        lc.on_job_starting()
+        self.assertEqual(
+            events,
+            ["sub:on_active", "sub:on_idle", "sub:on_active"],
+            "after counter clamp, the next IDLE→ACTIVE boundary must "
+            "still fire on_active (otherwise the clamp masks bugs that "
+            "would silently disable lifecycle events)",
+        )
+
+    def test_extra_on_job_finished_does_not_re_fire_on_idle(self) -> None:
+        events: list[str] = []
+        lc = ContainerLifecycle()
+        lc.subscribe(_RecordingSubscriber("sub", events))
+
+        lc.on_job_starting()
+        lc.on_job_finished()
+        # Already at 0; clamp keeps us at 0 and on_idle does NOT re-fire.
+        lc.on_job_finished()
+        lc.on_job_finished()
+
+        self.assertEqual(
+            events,
+            ["sub:on_active", "sub:on_idle"],
+            "on_idle must fire exactly once per cycle — extra "
+            "on_job_finished calls at zero must be a no-op",
+        )
+
+
+# ── Diagnostic property snapshots ─────────────────────────────────
+
+
+class DiagnosticPropertiesTest(unittest.TestCase):
+    def test_is_active_reflects_counter(self) -> None:
+        lc = ContainerLifecycle()
+        self.assertFalse(lc.is_active)
+        lc.on_job_starting()
+        self.assertTrue(lc.is_active)
+        lc.on_job_starting()
+        self.assertTrue(lc.is_active)
+        lc.on_job_finished()
+        self.assertTrue(lc.is_active)
+        lc.on_job_finished()
+        self.assertFalse(lc.is_active)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -190,11 +190,17 @@ all of the above without restructuring.**
   apiarist auth via `refresh_token: true` in `apiary.yaml`). Apiarist
   holds them in process memory for a short cache window (default
   5 min); the agent receives them over the socket and exposes them
-  to its tooling via the `GITHUB_TOKEN` env var for the duration of
-  the agent's ACTIVE period (any GitHub-touching work in flight).
-  When the agent becomes fully idle, the env var is cleared. See
-  §12.3 for the activity-gated FSM and what "ACTIVE period" means
-  in practice.
+  to its tooling via the `GITHUB_TOKEN` env var. **Phase L'
+  shipping change (2026-04-26):** the env var stays populated for
+  the container lifetime, refreshed by a background thread when
+  within ~5 min of expiry. The original sketch cleared env on IDLE,
+  but watch-driven services (drone with `watch_*` triggers) need a
+  valid token to poll between jobs, and clearing on IDLE deadlocks
+  those services. The strong guarantee — short token TTL via
+  apiarist's policy + the GitHub App 1h cap — is preserved by the
+  refresh thread; the weaker "env clear when idle" defense-in-depth
+  layer was traded for trigger viability. See §12.3 for the FSM
+  semantics and the always-on env model.
 
   Repos that have NOT opted in (the default `refresh_token: false`)
   retain today's static-PAT model: the token comes from
@@ -510,7 +516,7 @@ Phase A-B's single-token assumption stays compatible: if an
 
 | Threat | Defense |
 |---|---|
-| Container compromise (`refresh_token: true` repos) | Token in container is short-lived (1h max from GitHub) and resident in `os.environ["GITHUB_TOKEN"]` only during the agent's ACTIVE period (any GitHub-touching work in flight; see §12.3). When the agent goes IDLE, the env var is cleared. Realistic ACTIVE periods are minutes to a few hours; never the container's full uptime. GitHub-side narrowing via `permissions` (and, in V1.5+, `repository_ids` — see V1 caveat row below) means a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into refresh_token containers) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. **Subprocess caveat:** subprocesses spawned during ACTIVE inherit the env at fork time and retain `GITHUB_TOKEN` until they exit; the parent's IDLE-time cleanup doesn't reach them. Short-lived `gh`/`git` invocations (the common case) are fine. Long-running spawned processes inheriting the env need to be explicitly bounded by the caller. |
+| Container compromise (`refresh_token: true` repos) | Token in container is short-lived (1h max from GitHub, refreshed ~5 min before expiry) and resident in `os.environ["GITHUB_TOKEN"]` for the container's full uptime — **Phase L' shipping change (2026-04-26)**: the original sketch cleared env on IDLE, but watch-driven services need a valid token to poll between jobs and clearing on IDLE deadlocks them. The strong scope-narrowing guarantee (1h TTL via GitHub + apiarist policy server-side) is unchanged; the weaker "env clear when idle" layer was dropped for trigger viability. GitHub-side narrowing via `permissions` (and, in V1.5+, `repository_ids` — see V1 caveat row below) means a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into refresh_token containers) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. **Window comparison:** before Phase L', the exposure window was the ACTIVE period (minutes to hours); now it's container uptime (hours to days, bounded by the deploy cycle). The trade is documented in §12.3. **Subprocess caveat unchanged:** subprocesses spawned anytime inherit the env at fork time and retain `GITHUB_TOKEN` until they exit. Short-lived `gh`/`git` invocations (the common case) are fine. Long-running spawned processes inheriting the env need to be explicitly bounded by the caller. |
 | Container compromise (static-PAT repos, default until migration) | Token comes from `apiary.secrets.yaml`, is staged on disk at deploy time, and is resident in env from container boot until container exit. A compromised container leaks the static PAT in full; the only TTL bound is when the operator manually rotates the PAT (months in practice). This is today's posture for every repo without `refresh_token: true`. The apiarist migration shrinks this exposure to the ACTIVE-period model row above; until a repo is flagged, that row's defenses don't apply. |
 | V1 token-policy enforcement (allowed_repos, **shipped**) | Agent token envelope carries an optional `policy: { allowed_repos: string[] }` field (`web/src/server/agent-token.ts:AgentTokenPolicy`). Mint endpoint enforces `request.repo ∈ policy.allowed_repos` if the policy is set; legacy tokens (no policy field) defer to GitHub's installation grant with an explicit `console.warn` pointing operators at `setAgentTokenPolicy` as the remediation. Policy is set via `web/scripts/set-agent-policy.ts` (operator CLI; production-mutate requires `--i-know-what-im-doing` flag). Empty `allowed_repos: []` is intentional reject-all (distinct from `undefined` legacy-permissive). The V1.5 ship narrows to `(request) ⊆ (token policy)`; the second containment `⊆ (installation grant)` is enforced by GitHub itself when the request hits `/access_tokens`. `allowed_permissions` enforcement is deferred to V1.6 — V1 already hard-codes a fixed permission set; per-token permission narrowing is a second layer of defense and hasn't been needed yet. |
 | V1 short-name narrowing gap (until V1.5) | The mint endpoint passes `repositories: [<short-name>]` to GitHub rather than `repository_ids: [<numeric-id>]`. Short names are mutable (rename / transfer); a stale `apiary.yaml` requesting an old name could mint for a new repo at the same short-name slot if the installation covers all repos. V1.5 target: stand up a Redis-backed `installation:<id>:repos` cache populated by the bot's `installation.repositories.added/removed` webhooks, resolve `owner/name` → numeric `id` before the GitHub call, and fail-closed on rename. Tracked in §16 #9. |
@@ -975,6 +981,34 @@ or privileged flag is needed.
 
 ### 12.3 Agent runtime change (monorepo, not apiary)
 
+> **Phase L' shipped (2026-04-26) — read this before the pseudocode.**
+> The behavior tables (§12.3.1, §12.3.6) and failure-mode text
+> (§12.3.7) are the **current truth**. The pseudocode in §12.3.2,
+> §12.3.3, §12.3.4 is **aspirational and out of date** — the shipping
+> implementation is sync (Python 3.14 `threading.RLock` + a daemon
+> refresh thread, not asyncio), and the auth subscriber's `on_idle`
+> is a NO-OP under the always-on env model. The architectural
+> rationale (engine-owned FSM, subscriber pattern, registration
+> order load-bearing) is preserved exactly. For ground truth on
+> shipped semantics, read `agent/cli/hivemoot_agent/lifecycle.py`
+> and `plugins_builtin/hivemoot/auth_subscriber.py`. Two
+> changes vs. the original sketch worth flagging up front:
+>
+> - **Always-on env, not "clear on IDLE"**: the auth subscriber
+>   mints + starts a background refresh thread at `setup_lifecycle`
+>   time and keeps `GH_TOKEN`/`GITHUB_TOKEN` populated for the
+>   container lifetime. `on_idle` is a no-op. Required so
+>   watch-driven services (drone with `watch_*`) can poll between
+>   jobs. Trade-off detailed in §10 (threat model row) and
+>   §12.3.7 (failure modes).
+> - **Sync, not async**: the engine's plugin contract was already
+>   sync (`def setup`, `def on_job_started`); ContainerLifecycle
+>   matches that to avoid an async/sync boundary. The pseudocode
+>   showing `async def`, `await`, `asyncio.gather`, etc. should be
+>   read as "intent + invariants" — the actual code uses
+>   `threading.RLock`, sequential `for` loops, and a `threading.Thread`
+>   for the refresh loop.
+
 The agent runtime grows three layered pieces, with strict separation
 of concerns:
 
@@ -1037,7 +1071,7 @@ Two valid configurations for any repo:
 | Config | What happens | When to use |
 |---|---|---|
 | `refresh_token: false` (or absent) | Static PAT path. Env populated at deploy from `apiary.secrets.yaml`. Never changes during the agent run. Subscriber not registered. | Default. Repos without the bot installed. Backwards compat. |
-| `refresh_token: true` | Subscriber registered. On each ACTIVE period: mint via apiarist, set env, refresh in background, clear on IDLE. | Repos where the bot is installed and the operator has explicitly opted in. |
+| `refresh_token: true` | Subscriber registered. **Phase L' (always-on env)**: at `setup_lifecycle` time the subscriber mints via apiarist, sets env, AND launches a background refresh thread that re-mints when within ~5 min of expiry. `on_active` is a defensive proactive-refresh; `on_idle` is a NO-OP (env stays for the container lifetime so trigger threads can poll between jobs). The original "clear on IDLE" sketch was dropped because it deadlocks watch-driven services like drone whose only work source is the trigger threads. | Repos where the bot is installed and the operator has explicitly opted in. |
 
 **Hard precondition for `refresh_token: true`:** the Hivemoot Bot
 GitHub App must be installed on the target repo. Apiarist mints
@@ -1563,18 +1597,31 @@ from 2d to 2.5d to reflect the additional refactor.
 
 #### 12.3.6 Lifecycle (showing overlapping work)
 
+**Phase L' shipping note (2026-04-26):** the table below was rewritten
+when the always-on env model replaced the original "mint on ACTIVE,
+clear on IDLE" sketch. The driving constraint was watch-driven
+services (drone with `watch_*` triggers) that have NO work source
+besides their trigger threads — clearing env on IDLE deadlocks them.
+The auth subscriber now mints + starts the refresh thread at
+`setup_lifecycle` time, BEFORE any subscriber registration, so triggers
+see a valid token on their first poll. `on_active` is a defensive
+proactive-refresh; `on_idle` is a NO-OP. See §12.3.7 for the
+container-uptime exposure trade-off.
+
 | Event | Count | State | Engine action |
 |---|---|---|---|
 | Container boot | 0 | IDLE | nothing |
-| Job A starts (engine `on_job_starting`) | 0→1 | IDLE→ACTIVE | await all subscribers' `on_active`; auth subscriber mints, sets env, starts refresh loop |
+| Plugin `setup_lifecycle` (auth subscriber) | 0 | IDLE | auth subscriber mints initial token, sets env, starts background refresh thread; subscribes |
+| Trigger thread starts polling | 0 | IDLE | reads env GH_TOKEN; polls GitHub for events; valid token from refresh thread |
+| Job A starts (engine `on_job_starting`) | 0→1 | IDLE→ACTIVE | sequential `on_active`; auth subscriber's `on_active` is a no-op (token still fresh) OR proactive refresh (within ~5 min of expiry) |
 | Engine dispatches Job A to plugin | 1 | ACTIVE | env populated; job sees valid token |
 | Job B starts (overlapping) | 1→2 | ACTIVE | no transition; subscribers not called |
 | Job A finishes | 2→1 | ACTIVE | no transition |
-| Refresh loop fires (~55 min in) | 2 | ACTIVE | auth subscriber's loop re-mints, updates env transparently |
-| Job B finishes (last) | 1→0 | ACTIVE→IDLE | await all subscribers' `on_idle`; auth subscriber cancels refresh, awaits drain, clears env |
-| Long idle (5h) | 0 | IDLE | zero mints, zero env |
-| Job C starts (next trigger, hours later) | 0→1 | IDLE→ACTIVE | full wake-up cycle again |
-| Container exits (eventually) | — | — | process dies, env evaporates |
+| Refresh thread fires (~55 min in) | 2 | ACTIVE | auth subscriber's thread re-mints, updates env transparently |
+| Job B finishes (last) | 1→0 | ACTIVE→IDLE | sequential `on_idle`; auth subscriber's `on_idle` is a NO-OP — env stays populated for trigger threads |
+| Long idle (5h) | 0 | IDLE | refresh thread keeps re-minting every ~55 min; trigger threads continue polling with valid env |
+| Job C starts (next trigger, hours later) | 0→1 | IDLE→ACTIVE | env already populated by refresh thread; auth subscriber's `on_active` is a no-op |
+| Container exits (eventually) | — | — | refresh thread (daemon) dies with the process; env evaporates |
 
 The "fully idle" definition is critical: the IDLE transition only
 fires when the counter reaches 0. Intermediate decrements (2→1, 1→2,
@@ -1582,31 +1629,38 @@ etc.) don't trigger subscriber events.
 
 #### 12.3.7 Failure modes
 
-- *Apiarist unreachable when waking up* (or *repo not covered by an
-  installation* — `BACKEND_FORBIDDEN`) → auth subscriber's
-  `on_active` raises. `on_job_starting` halts the sequential
-  subscriber chain at this point, awaits `on_idle` on every prior
-  successful subscriber in reverse registration order (best-effort
-  cleanup), rolls the counter back to 0, and re-raises. The
-  triggering job fails to start. Runtime treats it as transient
-  and retries; the next job triggers a fresh `on_job_starting`
-  and re-runs the whole subscriber-setup phase cleanly. The
-  most-common operational failure here is a misconfigured repo
-  (operator set `refresh_token: true` without installing the bot);
-  the daemon's
-  error message includes the repo name so the cause is visible
-  immediately.
-- *Refresh fails mid-active* → auth subscriber's `_on_refresh_died`
-  callback fires, logs loudly, schedules
-  `_reset_after_refresh_crash` which clears env. Any in-flight job
-  will see env cleared on its next GitHub call, fail with 401, and
-  the runtime retries the job; the retry doesn't trigger a new
-  `on_job_starting` (engine still sees us as ACTIVE), so the auth
-  subscriber doesn't re-run setup automatically — the
-  `_reset_after_refresh_crash` path is best-effort. If 401 storms
-  are observed in production after refresh deaths, the right fix is
-  a "subscriber-requested reset" hook in the engine; tracked in §16
-  open questions.
+- *Apiarist unreachable at container boot* (or *repo not covered by
+  an installation* — `BACKEND_FORBIDDEN`) → auth subscriber's
+  `start()` raises during `setup_lifecycle`. Plugin setup fails
+  fast; container exits with the apiarist error in stderr. Operator
+  fixes apiarist health (it's a systemd unit on the host) or repo
+  policy (via `set-agent-policy` CLI), then redeploys. Container
+  restart reattempts the full chain. The most-common operational
+  failure here is a misconfigured repo (operator set
+  `refresh_token: true` without installing the bot); the apiarist
+  error message includes the repo name so the cause is visible.
+- *Apiarist unreachable mid-active* (defensive `on_active` refresh
+  near expiry can't reach socket) → `on_active` raises;
+  `on_job_starting` halts the sequential subscriber chain, awaits
+  `on_idle` on prior successful subscribers in reverse registration
+  order (best-effort cleanup), rolls the counter back to 0, and
+  re-raises. The triggering job fails to start. Runtime treats it
+  as transient and retries; if apiarist recovers, the next
+  `on_job_starting` runs cleanly.
+- *Refresh fails periodically in background* (Phase L'
+  always-on model) → auth subscriber's refresh thread logs each
+  failure ("[hivemoot-auth] refresh failed for `<repo>`: ...; retrying
+  in `<backoff>`s") and waits `refresh_backoff_on_error_secs` (default
+  60s) before retrying. The previous (about-to-expire) token stays
+  in env — once the GitHub TTL elapses, in-flight job calls and
+  trigger polls start failing with 401. The 401 storm IS the
+  visible signal — operator sees it in agent logs alongside the
+  refresh-failure log lines and correlates with apiarist health.
+  The refresh thread keeps retrying; recovery is automatic when
+  apiarist comes back. There is no "best-effort env clear" path
+  because that would just substitute one symptom (401) for
+  another (outright auth-missing); the documented contract is
+  "401 visibility instead of silent reuse of expired token."
 - *401 mid-job* (clock skew, manual revocation via App admin UI) →
   job fails with normal HTTP error, runtime retries; refresh loop
   may have already updated env on the retry. If 401 recurs the job

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -517,7 +517,7 @@ Phase A-B's single-token assumption stays compatible: if an
 | Threat | Defense |
 |---|---|
 | Container compromise (`refresh_token: true` repos) | Token in container is short-lived (1h max from GitHub, refreshed ~5 min before expiry) and resident in `os.environ["GITHUB_TOKEN"]` for the container's full uptime — **Phase L' shipping change (2026-04-26)**: the original sketch cleared env on IDLE, but watch-driven services need a valid token to poll between jobs and clearing on IDLE deadlocks them. The strong scope-narrowing guarantee (1h TTL via GitHub + apiarist policy server-side) is unchanged; the weaker "env clear when idle" layer was dropped for trigger viability. GitHub-side narrowing via `permissions` (and, in V1.5+, `repository_ids` — see V1 caveat row below) means a leaked token reaches only the policy-allowed scope. Container *can* reach apiarist socket (mounted into refresh_token containers) but cannot mint outside its `AGENT_SERVICE`'s token policy — apiarist looks up the policy server-side, container's request doesn't choose it. **Window comparison:** before Phase L', the exposure window was the ACTIVE period (minutes to hours); now it's container uptime (hours to days, bounded by the deploy cycle). The trade is documented in §12.3. **Subprocess caveat unchanged:** subprocesses spawned anytime inherit the env at fork time and retain `GITHUB_TOKEN` until they exit. Short-lived `gh`/`git` invocations (the common case) are fine. Long-running spawned processes inheriting the env need to be explicitly bounded by the caller. |
-| Container compromise (static-PAT repos, default until migration) | Token comes from `apiary.secrets.yaml`, is staged on disk at deploy time, and is resident in env from container boot until container exit. A compromised container leaks the static PAT in full; the only TTL bound is when the operator manually rotates the PAT (months in practice). This is today's posture for every repo without `refresh_token: true`. The apiarist migration shrinks this exposure to the ACTIVE-period model row above; until a repo is flagged, that row's defenses don't apply. |
+| Container compromise (static-PAT repos, default until migration) | Token comes from `apiary.secrets.yaml`, is staged on disk at deploy time, and is resident in env from container boot until container exit. A compromised container leaks the static PAT in full; the only TTL bound is when the operator manually rotates the PAT (months in practice). This is today's posture for every repo without `refresh_token: true`. The apiarist migration shrinks this exposure to the short-TTL refresh model in the row above (~1h max from GitHub, refreshed automatically) — strictly better than months-of-PAT lifetime even without the original "clear on idle" defense-in-depth layer. Until a repo is flagged, that row's defenses don't apply. |
 | V1 token-policy enforcement (allowed_repos, **shipped**) | Agent token envelope carries an optional `policy: { allowed_repos: string[] }` field (`web/src/server/agent-token.ts:AgentTokenPolicy`). Mint endpoint enforces `request.repo ∈ policy.allowed_repos` if the policy is set; legacy tokens (no policy field) defer to GitHub's installation grant with an explicit `console.warn` pointing operators at `setAgentTokenPolicy` as the remediation. Policy is set via `web/scripts/set-agent-policy.ts` (operator CLI; production-mutate requires `--i-know-what-im-doing` flag). Empty `allowed_repos: []` is intentional reject-all (distinct from `undefined` legacy-permissive). The V1.5 ship narrows to `(request) ⊆ (token policy)`; the second containment `⊆ (installation grant)` is enforced by GitHub itself when the request hits `/access_tokens`. `allowed_permissions` enforcement is deferred to V1.6 — V1 already hard-codes a fixed permission set; per-token permission narrowing is a second layer of defense and hasn't been needed yet. |
 | V1 short-name narrowing gap (until V1.5) | The mint endpoint passes `repositories: [<short-name>]` to GitHub rather than `repository_ids: [<numeric-id>]`. Short names are mutable (rename / transfer); a stale `apiary.yaml` requesting an old name could mint for a new repo at the same short-name slot if the installation covers all repos. V1.5 target: stand up a Redis-backed `installation:<id>:repos` cache populated by the bot's `installation.repositories.added/removed` webhooks, resolve `owner/name` → numeric `id` before the GitHub call, and fail-closed on rename. Tracked in §16 #9. |
 | Cross-service token theft | An agent claiming `service: builder-claude` in its UDS request still authenticates against the **builder-claude token's policy** server-side. Apiarist trusts `AGENT_SERVICE` env (set by deploy, not by container code), and the broker→backend flow uses the bearer keyed off that. A compromised builder container cannot trick apiarist into minting against guard's token by lying about its service — apiarist's per-service policy lookup is the gate. (This does mean a fully-compromised container can mint within its OWN policy without bound — which is exactly the policy-shrink mitigation: don't grant a token broader scope than the agent legitimately needs.) |
@@ -1677,32 +1677,36 @@ inline at the point it knows the env token may have aged out. The
 inline mint should also update `os.environ[token_env]` if the job
 expects sibling tooling (subprocesses, other libraries reading env)
 to see the fresh value. Opt-in, no subscriber change required. Rare
-in practice — the refresh loop covers steady-state ACTIVE periods
-regardless of duration.
+in practice — the refresh thread covers the entire container
+uptime regardless of ACTIVE/IDLE state.
 
-**Subprocess env inheritance** (V1 trust model honesty): when the
-agent spawns subprocesses during ACTIVE — `gh`, `git` (via askpass),
-anything else exec'd — those subprocesses receive a fork-time copy
-of env including `GITHUB_TOKEN`. The token persists in the
-subprocess until **the subprocess** exits, not until the parent
-transitions to IDLE. Short-lived `gh`/`git` invocations are fine.
-Long-running spawned processes (a watch loop, a wrapper that never
-exits) need to be explicitly bounded by the caller; the parent's
-`os.environ.pop` doesn't reach them.
+**Subprocess env inheritance** (V1 trust model honesty): whenever
+the agent spawns subprocesses — `gh`, `git` (via askpass), anything
+else exec'd — those subprocesses receive a fork-time copy of env
+including `GITHUB_TOKEN`. The token persists in the subprocess
+until **the subprocess** exits. Short-lived `gh`/`git` invocations
+are fine. Long-running spawned processes (a watch loop, a wrapper
+that never exits) need to be explicitly bounded by the caller — the
+refresh thread updates the parent's `os.environ` in place but
+does NOT reach into already-spawned subprocesses (their env is a
+fork-time snapshot). Concretely, a long-running subprocess that
+holds an old token while the parent's env contains a fresh one
+will start failing with 401 after ~1h and the operator must kill +
+respawn it.
 
 #### 12.3.8 What this design does NOT do (intentionally)
 
-- Mint at container startup (wrong moment — work hasn't arrived).
-- Run a perpetual background refresh loop (only runs during ACTIVE).
-- Reactively re-mint on 401 (refresh covers steady-state; 401
-  fails the job; runtime retry path handles recovery).
-- Mint per-job (chained jobs share env via the engine's lifecycle
-  state; per-job mint would burn redundant mints + tear down env
-  between rapid-fire triggers).
-- Restrict in-process token lifetime during ACTIVE (env is
-  process-global; agent code and subprocesses can read it).
+- Reactively re-mint on 401 (the refresh thread covers steady-state;
+  a 401 fails the job; the runtime retry path handles recovery).
+- Mint per-job (jobs share env via the always-on subscriber; per-job
+  mint would burn redundant mints when the refresh thread already
+  keeps env fresh).
+- Restrict in-process token lifetime (env is process-global; agent
+  code and subprocesses can read it for the container lifetime,
+  bounded by the short token TTL via apiarist's policy).
 - Restrict subprocess token lifetime once spawned (subprocess
-  inherits env at fork; parent IDLE cleanup doesn't reach it).
+  inherits env at fork; the refresh thread cannot reach into a
+  spawned subprocess's env to update it).
 - Drive auth from the github plugin (it's a tool provider, not an
   identity owner; the dependency direction is auth → tools, not
   the reverse).
@@ -1752,9 +1756,22 @@ the Hivemoot Bot installed already.
   cross-cutting concerns reuse; the subscriber implements the
   apiarist-specific logic.
 - Flag drone's repo block in `apiary.yaml` with `refresh_token: true`.
-- Deploy and observe one full review cycle. Audit logs should show
-  exactly one token mint per ACTIVE period, ≤1h TTL, scoped to
-  `hivemoot/hivemoot`.
+- Deploy and observe one full review cycle. Validation criteria
+  under the always-on env model (Phase L' shipping):
+  * Initial `mint_token` call lands at container boot
+    (`setup_lifecycle` → subscriber `start()`).
+  * Subsequent `mint_token` calls fire from the refresh thread on
+    a steady ~`(token TTL − 5min)` cadence (so ~55min for a 1h
+    GitHub TTL), regardless of how many ACTIVE/IDLE transitions
+    happened in between. A drone container that goes 4h without a
+    job should still show ~4 mints in apiarist's audit log
+    (boot + 3 refreshes), not zero.
+  * Every minted token is ≤1h TTL and scoped to
+    `hivemoot/hivemoot` (verify via apiarist's per-mint log line:
+    `installation=<id>, expires_at=<iso>`).
+  * Drone successfully posts a review comment using the token
+    (this exercises `gh` reading `GH_TOKEN` from env populated by
+    the subscriber).
 
 **Phase 1.5 — Foxstoria** (week 2-3)
 
@@ -1806,7 +1823,7 @@ in `apiary.secrets.yaml`.
 | **I.** Systemd unit | `apiarist.service` with hardening attrs (§10) | 0.25d | E |
 | **J.** Install script | `deploy/install.sh`: create user, copy files, enable unit | 0.5d | I |
 | **K.** Apiary integration — deploy script | `apiary/deploy-apiary.sh` patch (§12.2): when `refresh_token: true`, skip static token staging, bind-mount `/run/apiarist/apiarist.sock` (host) → `/run/apiarist.sock` (container), emit `APIARIST_TOKEN_ENV=<env_var>`, omit github plugin's `token_file:` line, emit a new `hivemoot.apiarist:` block (enabled, socket_path, repo, env_var) for Phase L′ to consume. Two new validating helpers (`get_repo_refresh_token`, `get_repo_token_env`) reject malformed inputs at parse time. Fail-fast deploy if the host apiarist socket isn't present. PR opened against `hivemoot/apiary` (no fleet review there, self-merge per CLAUDE.md memory). **Shipped** in `hivemoot/apiary` PR #67. | 0.5d | — (parallel) |
-| **L′.** Engine lifecycle FSM + hivemoot auth subscriber + github plugin refactor | Four layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber; (d) **github plugin refactor**: split `setup()` into auth-free (workspace bootstrap, `gh` CLI discovery) + the **full auth-required sequence per §12.3.5a** — `resolve_github_user`, `_configure_git_auth`, `_validate_repo_access`, `clone_or_sync`, `configure_git_user` (in that exact order; see §12.3.5a for file:line references). The auth-required half moves to a github-plugin-owned `LifecycleSubscriber` whose `on_active` reads the token from `os.environ[token_env]` (populated by the hivemoot subscriber that registered before us per the load-bearing registration-order contract) and runs the five operations idempotently — clone happens once per process, env reads cycle per ACTIVE/IDLE. `validate()` grows a `token_source: subscriber` opt that permits absent `token_file:` (deploy-apiary.sh emits this for `refresh_token: true`). Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. Github plugin's tooling-provider runtime contract is unchanged; only its plugin-load model splits. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2.5d | D, E |
+| **L′.** Engine lifecycle FSM + hivemoot auth subscriber + github plugin refactor | Four layered changes: (a) **engine.py** gains `ContainerLifecycle` (generic IDLE/ACTIVE FSM with subscriber pattern) and a `LifecycleSubscriber` interface, with engine's job-dispatch loop calling `on_job_starting`/`on_job_finished` around each job; (b) new `plugins_builtin/hivemoot/auth/` submodule with `HivemootGithubAuthSubscriber` (implements `LifecycleSubscriber`, owns mint/refresh/env management) and `apiarist_client.py` (~50 LOC UDS client); (c) hivemoot plugin's `setup` reads per-repo config (`refresh_token: true`, `token_env: GITHUB_TOKEN`) and conditionally registers the subscriber; (d) **github plugin refactor**: split `setup()` into auth-free (workspace bootstrap, `gh` CLI discovery) + the **full auth-required sequence per §12.3.5a** — `resolve_github_user`, `_configure_git_auth`, `_validate_repo_access`, `clone_or_sync`, `configure_git_user` (in that exact order; see §12.3.5a for file:line references). The auth-required half moves to a github-plugin-owned `LifecycleSubscriber` whose `on_active` reads the token from `os.environ[token_env]` (populated by the hivemoot subscriber that registered before us per the load-bearing registration-order contract) and runs the five operations idempotently — clone happens once per process, env reads return the same value for the container lifetime once the hivemoot subscriber's refresh thread is running (Phase L' shipping change: env is always-on, refreshed every ~55min via background thread, no longer cleared on IDLE). `validate()` grows a `token_source: subscriber` opt that permits absent `token_file:` (deploy-apiary.sh emits this for `refresh_token: true`). Engine knows lifecycle, doesn't know auth. Auth subscriber knows auth, doesn't know lifecycle internals. Github plugin's tooling-provider runtime contract is unchanged; only its plugin-load model splits. **Hard precondition for opt-in: target repo must have the Hivemoot Bot GitHub App installed** — non-installed repos stay on static-PAT (the default). | 2.5d | D, E |
 | **M.** Shadow deploy on Hive | rsync, install, verify socket creation, exercise via examples/client.py without flagging any service. | 0.5d | J, K, L′ |
 | **N.** Drone pilot | The V1 pilot is **drone**, not foxstoria — drone is a fleet member on `hivemoot/hivemoot` (which already has the bot installed) AND its existing PAT is invalid as of 2026-04-25 so migrating it can't regress anything. Flag drone's repo block (`hivemoot:` in `apiary.yaml`) with `refresh_token: true`, deploy, observe one full review cycle. Verify a `ghs_` token reaches GitHub successfully and zero token files appear on disk. Foxstoria opt-in is deferred to Phase 1.5 (see §13) — it works under the engine-lifecycle architecture but is shipped after the drone pilot validates the path. | 0.5d | M, **backend endpoint live** |
 | **O.** Runbook + metrics | `apiarist/README.md` ops guide. Document `journalctl -u apiarist`, common failure modes, how to validate a service is using App auth vs PAT. | 0.5d | N |
@@ -1901,15 +1918,29 @@ on Hive (Phase 0).
 6. **Telemetry.** Emit logs only in V1. Add Prometheus metrics endpoint
    when (a) we deploy multiple Hives and want fleet-wide visibility, or
    (b) we have a Prometheus scraper anywhere. **Neither today.**
-7. **Subscriber-requested-reset hook in `ContainerLifecycle`.** §12.3.4
-   notes that the hivemoot auth subscriber's `_reset_after_refresh_crash`
-   path doesn't trigger an engine IDLE transition — that would require
-   a callback from subscriber → engine which V1 doesn't have. If
-   401-storms are observed in production after refresh-task crashes
-   (subscriber clears env but engine still thinks it's ACTIVE so no
-   re-wake on next job-start), V1.1 adds a `subscriber.request_reset()`
-   API that triggers a forced ACTIVE→IDLE→ACTIVE cycle. Defer until
-   we have telemetry evidence the gap matters in practice.
+7. **Refresh-thread crash recovery.** Phase L' shipping behavior
+   (§12.3.7 failure modes): the refresh thread logs each mint
+   failure ("[hivemoot-auth] refresh failed for `<repo>`: ...; retrying
+   in `<backoff>`s") and waits `refresh_backoff_on_error_secs`
+   (default 60s) before retrying. The previous (about-to-expire)
+   token stays in env; once the GitHub TTL elapses, in-flight
+   calls and trigger polls start failing with 401, and the 401
+   storm IS the visible signal alongside the refresh-failure log
+   lines. There is no automatic env-clear path because that would
+   substitute one symptom (401) for another (outright auth-missing)
+   without recovery being any faster — the refresh thread keeps
+   retrying; recovery is automatic when apiarist comes back. If
+   ever the documented "401 visibility" path proves operationally
+   insufficient (e.g. because 401s don't surface in agent dashboards
+   for a class of repos), V1.1 could revisit:
+   * adding a structured-event emission for refresh failures (vs
+     the current stderr-only log), so dashboards can surface them
+     directly without parsing log lines, OR
+   * a `subscriber.request_health_check()` API that lets the
+     subscriber escalate persistent failures to the engine for
+     a graceful container restart.
+   Defer until we have telemetry evidence the gap matters in
+   practice.
 8. **Token-policy scoping in agent-token envelope.** **Partially shipped
    in V1.5** (PR #489): the envelope now carries `policy: { allowed_repos:
    string[] }`, the mint endpoint enforces `request.repo ∈

--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -1532,13 +1532,21 @@ Phase L′ therefore includes a real refactor of github plugin's
   `os.environ[token_env]` at on_active entry** — the hivemoot auth
   subscriber registered before us (per the load-bearing
   registration-order contract in §12.3.2's `subscribe()` docstring)
-  has populated env by the time our `on_active` fires. The github
-  subscriber doesn't take a token in its constructor; it's an
-  ambient-env read inside on_active. An idempotency guard at the
-  subscriber level skips the clone work after the first successful
-  on_active per process — subsequent IDLE→ACTIVE cycles re-mint the
-  token but don't re-clone (clone output is process-stable, only
-  the env value cycles per ACTIVE/IDLE).
+  has populated env at its own `start()` time (called from
+  `setup_lifecycle`, before the engine starts dispatching jobs)
+  and keeps env populated for the container lifetime via a
+  background refresh thread. The github subscriber doesn't take a
+  token in its constructor; it's an ambient-env read inside
+  on_active. The clone work is itself idempotent (`clone_or_sync`
+  fetches an existing checkout instead of re-cloning), so per-job
+  re-runs are cheap (~1-2 seconds for `_validate_repo_access` +
+  `git fetch`). The value of running them per-on_active is fail-fast
+  verification of the current env token + a fresh fetch of upstream
+  changes. Note that env reads inside on_active return the same
+  value the refresh thread last wrote — under the always-on contract
+  there is no per-cycle env "rotation"; only periodic refreshes
+  driven by token expiry (see §12.3.6 lifecycle table for the
+  steady-state cadence).
 
 **2. Subscriber registration order matters.**
 


### PR DESCRIPTION
## Summary

Implements the runtime side of [apiarist DESIGN.md §12.3](https://github.com/hivemoot/hivemoot/blob/main/apiarist/DESIGN.md): engine-owned IDLE/ACTIVE state machine with subscriber/event-bus pattern. The hivemoot plugin wires a subscriber that brokers GitHub installation tokens via the apiarist UDS daemon; the github plugin gains `token_source: subscriber` mode whose auth-required setup moves into a github-owned subscriber that fires AFTER the upstream env populator.

This is the runtime contract that PR #485 (apiarist daemon), PR #486 (DESIGN), PR #487 (systemd unit), PR #488 (deploy/install.sh), and PR #489 (backend mint endpoint) have been building toward. Drone is the V1 pilot — its config flips to ` refresh_token: true` once this lands and the agent image is rebuilt + redeployed.

## What it looks like

**Plugin order in generated `hivemoot.yaml` — file mode (existing behavior, unchanged):**
\`\`\`yaml
plugins:
  github:
    repos: [hivemoot/colony]
    token_file: /run/secrets/github-token
    workspace: /data/workspace
  hivemoot:
    health: { enabled: true, repo: hivemoot/colony }
    github_workflows: { enabled: true, role_name: drone, workspace: /data/workspace }
\`\`\`

**Plugin order in generated `hivemoot.yaml` — subscriber mode (new, when `refresh_token: true`):**
\`\`\`yaml
plugins:
  hivemoot:
    health: { enabled: true, repo: hivemoot/colony }
    github_workflows: { enabled: true, role_name: drone, workspace: /data/workspace }
    apiarist:
      enabled: true
      socket_path: /run/apiarist.sock
      repo: hivemoot/colony
  github:
    repos: [hivemoot/colony]
    token_source: subscriber
    workspace: /data/workspace
\`\`\`

> Plugin order is load-bearing in subscriber mode — the hivemoot auth subscriber must register first so its \`on_active\` populates \`GH_TOKEN\`/\`GITHUB_TOKEN\` env BEFORE the github auth subscriber's \`on_active\` reads it. The deploy-apiary.sh changes (separate PR against \`hivemoot/apiary\`) handle the order swap.

**Operator-visible startup logs (subscriber mode):**
\`\`\`
[hivemoot-auth] registered apiarist auth subscriber (socket=/run/apiarist.sock, service=drone, repo=hivemoot/colony)
[github] registered auth-dependent subscriber (token_source: subscriber)
[hivemoot-auth] minted token for hivemoot/colony (installation=98765, expires_at=2026-04-25T18:34:56+00:00)
[github] auth-dependent setup completed for 1 repo(s)
…job runs…
[hivemoot-auth] cleared token env for hivemoot/colony (installation=98765)
\`\`\`

## What's in the diff

**New modules:**
- \`agent/cli/hivemoot_agent/lifecycle.py\` — \`ContainerLifecycle\` FSM + \`LifecycleSubscriber\` abc; 5 invariants documented (I1-I5 from DESIGN §12.3.2); \`threading.RLock\` for callback safety; sequential subscribers with reverse-order rollback on partial-success failure.
- \`agent/cli/hivemoot_agent/apiarist_client.py\` — pure-stdlib sync UDS client mirroring apiarist's length-prefixed JSON wire format. Typed errors (\`ApiaristTransportError\`, \`ApiaristProtocolError\`, \`ApiaristRemoteError\`) so callers can branch on retry policy.
- \`agent/cli/hivemoot_agent/plugins_builtin/hivemoot/auth_subscriber.py\` — \`HivemootGithubAuthSubscriber\` mints token on \`on_active\`, sets \`GH_TOKEN\`+\`GITHUB_TOKEN\` env, clears on \`on_idle\`. Fail-closed: a missing token aborts the job rather than silently falling back to anonymous.
- \`agent/cli/hivemoot_agent/plugins_builtin/github/auth_subscriber.py\` — \`GithubAuthDependentSubscriber\` reads env on \`on_active\`, runs the auth-required setup. Delegates to \`plugin._auth_required_setup\` so file-mode and subscriber-mode share one source of truth.

**Engine changes:**
- \`engine.py\` — instantiates \`self.lifecycle\`, two-phase \`_setup_plugins\` (all \`setup()\` then all \`setup_lifecycle()\`), wraps both daemon \`run_agent\` and oneshot dispatch with \`on_job_starting\`/\`on_job_finished\`. Extracted \`_run_agent_inner\` so the lifecycle wrap is one thin layer.

**Plugin updates:**
- \`hivemoot/__init__.py\` — \`setup_lifecycle\` registers the auth subscriber when \`apiarist.enabled\`. \`_validate_github_workflows\` is order-tolerant (cross-plugin presence check moves to setup phase, since \`validate()\` runs before plugins are configured). \`_setup_github_workflows\` tolerates a not-yet-cloned repo when \`github.token_source: subscriber\` (clone happens at first \`on_active\`).
- \`hivemoot/config.py\` — new \`HivemootApiaristConfig\` (enabled, socket_path, service, repo, timeout_seconds).
- \`github/__init__.py\` — \`setup()\` splits into auth-free + auth-required halves; \`setup_lifecycle\` hook registers the github auth subscriber when \`token_source: subscriber\`.
- \`github/config.py\` — \`token_source: Literal[\"file\", \"subscriber\"]\` field (default \"file\" preserves existing behavior).

## Test plan

- [x] **Unit tests for \`lifecycle.py\` (14 tests)** — all 5 invariants (I1-I5), reference counting (1↔2 doesn't fire subscribers), reverse-order rollback on \`on_active\` failure, best-effort cleanup on \`on_idle\` failure, counter clamp on stray \`on_job_finished\`. TDD discipline caught a real bug: original \`max(0, ...)\` clamp didn't prevent \`on_idle\` re-firing on stray finish calls.
- [x] **Unit tests for \`apiarist_client.py\` (19 tests)** — real Unix-domain-socket server in a background thread; covers happy path, error envelope, transport failures (connect refused, EOF mid-stream), protocol violations (oversize length, invalid JSON, request_id mismatch), construction validation.
- [x] **Unit tests for \`HivemootGithubAuthSubscriber\` (13 tests)** — env set on \`on_active\`, cleared on \`on_idle\`, fail-closed when mint raises, mid-cycle failure preserves prior env, repeated cycles re-mint.
- [x] **Unit tests for github subscriber refactor (17 tests)** — \`token_source: subscriber\` makes \`token_file\` optional, \`setup()\` skips network/disk in subscriber mode, \`setup_lifecycle\` registers subscriber correctly. **Crowning end-to-end test** wires fake apiarist → hivemoot subscriber → github subscriber and validates the full chain.
- [x] **Integration tests for \`setup_lifecycle\` (8 tests)** — disabled config is a no-op, full config registers, fallback to \`AGENT_ID\` env when service empty, two-phase setup ordering invariant.
- [x] **Existing test suite (416 → 474 tests, all passing)** — engine lifecycle bug regression tests still pass through the new wrap; github plugin file-mode behavior unchanged; hivemoot config strictness preserved.

**Companion PRs (separate):**
- \`hivemoot/apiary\`: deploy-apiary.sh updated to emit hivemoot-first plugin order when \`refresh_token: true\`. Will land after this PR + after the agent docker image is rebuilt + pushed.