### PR TITLE
Add expiry support for agent tokens

### DIFF
--- a/web/AGENT_HEALTH_CONTRACT.md
+++ b/web/AGENT_HEALTH_CONTRACT.md
@@ -115,6 +115,7 @@ Success:
 
 Error:
 - `401` `agent_health_not_authenticated` for missing/invalid agent token.
+- `401` `agent_health_token_expired` when a recognized agent token is past its configured expiry.
 - `409` `agent_health_idempotency_conflict` when `run_id` is reused with different payload.
 - `409` `agent_health_idempotency_pending` when the same report is still in-flight.
 - `429` `agent_health_rate_limited` when exceeding one report per 60s for installation+agent+repo.
@@ -153,11 +154,18 @@ Token format and storage:
 - Raw token is 64-char hex (32 random bytes).
 - Exactly one active token per installation.
 - On rotate, old token is revoked atomically.
+- New tokens may be generated with `POST /api/agent-token` body `{ "expiresIn": "90d" }`.
+  Supported units are `m`, `h`, and `d`, capped at 365 days. Omitted or `null` keeps
+  the existing no-expiry behavior for backward compatibility.
 
 Security model:
 - Raw token is encrypted with BYOK keyring and stored at `hive:agent-token:{installationId}`.
-- A SHA-256 hash reverse index is stored at `agent-token-hash:{hash}` -> `{ installationId }`.
+- The encrypted envelope stores `expiresAt: string | null`.
+- A SHA-256 hash reverse index is stored at `agent-token-hash:{hash}` ->
+  `{ installationId, expiresAt }`.
 - `POST /api/agent-health` resolves installation by hash lookup (O(1)); no GitHub `/user` call on write path.
+- Expired tokens are rejected during hash-index resolution. Legacy records without
+  `expiresAt` remain valid until manually rotated or revoked.
 
 Operational note:
 - `GET /api/agent-token` intentionally returns plaintext token for admin recovery/copy flows. Treat this route as sensitive and setup-session protected.
@@ -209,6 +217,7 @@ Error responses use the `agent_health_*` namespace:
 - `agent_health_lock_timeout`
 - `agent_health_token_already_exists`
 - `agent_health_token_not_found`
+- `agent_health_token_expired`
 - `agent_health_idempotency_conflict`
 - `agent_health_idempotency_pending`
 - `agent_health_rate_limited`

--- a/web/src/app/api/agent-token/route.test.ts
+++ b/web/src/app/api/agent-token/route.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/server/agent-health-error", async () => {
       SERVER_MISCONFIGURATION: "agent_health_server_misconfiguration",
       TOKEN_ALREADY_EXISTS: "agent_health_token_already_exists",
       TOKEN_NOT_FOUND: "agent_health_token_not_found",
+      TOKEN_EXPIRED: "agent_health_token_expired",
       LOCK_TIMEOUT: "agent_health_lock_timeout",
       IDEMPOTENCY_CONFLICT: "agent_health_idempotency_conflict",
       IDEMPOTENCY_PENDING: "agent_health_idempotency_pending",
@@ -88,8 +89,24 @@ function mockAuthStale() {
   mockAuthFailure(401, "byok_session_stale", "Re-authentication required");
 }
 
-function makeRequest(method: string) {
-  return new NextRequest("https://example.com/api/agent-token", { method });
+function makeRequest(method: string, body?: unknown) {
+  return new NextRequest("https://example.com/api/agent-token", {
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+  });
+}
+
+function makeRawRequest(method: string, body: string) {
+  return new NextRequest("https://example.com/api/agent-token", {
+    method,
+    headers: { "content-type": "application/json" },
+    body,
+  });
 }
 
 beforeEach(() => {
@@ -112,6 +129,7 @@ describe("POST /api/agent-token", () => {
     const body = await res.json();
     expect(body.token).toBe(fakeToken);
     expect(body.fingerprint).toBe(fakeToken.slice(-8));
+    expect(body.expiresAt).toBeNull();
     expect(body.message).toContain("Store this token securely");
   });
 
@@ -125,7 +143,48 @@ describe("POST /api/agent-token", () => {
       "v1",
       MOCK_KEYRING,
       expect.anything(),
+      null,
     );
+  });
+
+  it("accepts an optional expiresIn duration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+    const expectedExpiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+    vi.mocked(generateAgentToken).mockResolvedValue("c".repeat(64));
+
+    const res = await POST(makeRequest("POST", { expiresIn: "90d" }));
+    expect(res.status).toBe(200);
+
+    expect(generateAgentToken).toHaveBeenCalledWith(
+      "123",
+      "alice",
+      "v1",
+      MOCK_KEYRING,
+      expect.anything(),
+      expectedExpiresAt,
+    );
+    const body = await res.json();
+    expect(body.expiresAt).toBe(expectedExpiresAt);
+    vi.useRealTimers();
+  });
+
+  it("returns validation error for invalid expiresIn", async () => {
+    const res = await POST(makeRequest("POST", { expiresIn: "0d" }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_validation_failed");
+    expect(generateAgentToken).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid-json error for malformed JSON bodies", async () => {
+    const res = await POST(makeRawRequest("POST", "{not json"));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.code).toBe("agent_health_invalid_json");
+    expect(generateAgentToken).not.toHaveBeenCalled();
   });
 
   it("returns auth error when not authenticated", async () => {
@@ -175,6 +234,7 @@ describe("GET /api/agent-token", () => {
       fingerprint: "abcd1234",
       createdAt: "2026-02-24T00:00:00Z",
       createdBy: "alice",
+      expiresAt: null,
     });
 
     const res = await GET(makeRequest("GET"));
@@ -184,6 +244,7 @@ describe("GET /api/agent-token", () => {
     expect(body.token).toBe("a".repeat(64));
     expect(body.fingerprint).toBe("abcd1234");
     expect(body.createdBy).toBe("alice");
+    expect(body.expiresAt).toBeNull();
   });
 
   it("passes keyring context to getAgentToken", async () => {
@@ -192,6 +253,7 @@ describe("GET /api/agent-token", () => {
       fingerprint: "bbbbbbbb",
       createdAt: "2026-02-24T00:00:00Z",
       createdBy: "alice",
+      expiresAt: "2026-07-25T00:00:00.000Z",
     });
 
     await GET(makeRequest("GET"));

--- a/web/src/app/api/agent-token/route.ts
+++ b/web/src/app/api/agent-token/route.ts
@@ -20,6 +20,67 @@ import {
 } from "@/server/agent-token";
 import { AGENT_HEALTH_ERROR, agentHealthError } from "@/server/agent-health-error";
 
+const EXPIRES_IN_PATTERN = /^([1-9]\d*)([mhd])$/;
+const EXPIRES_IN_UNITS_MS = {
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+} as const;
+const MAX_EXPIRES_IN_MS = 365 * EXPIRES_IN_UNITS_MS.d;
+
+type ParsedBodyResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: NextResponse };
+
+function parseExpiresAt(expiresIn: unknown): { ok: true; expiresAt: string | null } | { ok: false; message: string } {
+  if (expiresIn == null) return { ok: true, expiresAt: null };
+  if (typeof expiresIn !== "string") {
+    return { ok: false, message: "expiresIn must be a duration string like '90d'." };
+  }
+
+  const match = EXPIRES_IN_PATTERN.exec(expiresIn.trim().toLowerCase());
+  if (!match) {
+    return { ok: false, message: "expiresIn must use a positive integer plus m, h, or d." };
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2] as keyof typeof EXPIRES_IN_UNITS_MS;
+  const durationMs = amount * EXPIRES_IN_UNITS_MS[unit];
+  if (!Number.isSafeInteger(durationMs) || durationMs > MAX_EXPIRES_IN_MS) {
+    return { ok: false, message: "expiresIn must be no more than 365 days." };
+  }
+
+  return { ok: true, expiresAt: new Date(Date.now() + durationMs).toISOString() };
+}
+
+async function readOptionalJsonObject(request: NextRequest): Promise<ParsedBodyResult> {
+  if (request.body === null) return { ok: true, body: {} };
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: agentHealthError(AGENT_HEALTH_ERROR.INVALID_JSON, "Invalid JSON body", 400),
+    };
+  }
+
+  if (body == null) return { ok: true, body: {} };
+  if (typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      response: agentHealthError(
+        AGENT_HEALTH_ERROR.VALIDATION_FAILED,
+        "Request body must be a JSON object.",
+        400,
+      ),
+    };
+  }
+
+  return { ok: true, body: body as Record<string, unknown> };
+}
+
 export async function POST(request: NextRequest) {
   const auth = await authenticateByokRequest(request, { requireFresh: true });
   if (!auth.ok) return auth.response;
@@ -29,17 +90,27 @@ export async function POST(request: NextRequest) {
   const installationId = installationCheck.installationId;
 
   try {
+    const parsedBody = await readOptionalJsonObject(request);
+    if (!parsedBody.ok) return parsedBody.response;
+
+    const expiry = parseExpiresAt(parsedBody.body.expiresIn);
+    if (!expiry.ok) {
+      return agentHealthError(AGENT_HEALTH_ERROR.VALIDATION_FAILED, expiry.message, 400);
+    }
+
     const token = await generateAgentToken(
       installationId,
       auth.session.userLogin,
       auth.activeKeyVersion,
       auth.keyring,
       auth.redis,
+      expiry.expiresAt,
     );
 
     return NextResponse.json({
       token,
       fingerprint: token.slice(-8),
+      expiresAt: expiry.expiresAt,
       message: "Store this token securely and rotate it immediately if compromised.",
     });
   } catch (err) {

--- a/web/src/server/agent-health-auth.test.ts
+++ b/web/src/server/agent-health-auth.test.ts
@@ -11,12 +11,25 @@ vi.mock("@/server/env", () => ({
 vi.mock("@/server/redis", () => ({
   getRedisClient: vi.fn(() => ({} as never)),
 }));
-vi.mock("@/server/agent-token", () => ({
-  resolveTokenToInstallationAndPolicy: vi.fn(),
-}));
+vi.mock("@/server/agent-token", () => {
+  class AgentTokenExpiredError extends Error {
+    constructor() {
+      super("Agent token expired");
+      this.name = "AgentTokenExpiredError";
+    }
+  }
+
+  return {
+    AgentTokenExpiredError,
+    resolveTokenToInstallationAndPolicy: vi.fn(),
+  };
+});
 
 import { validateEnv } from "@/server/env";
-import { resolveTokenToInstallationAndPolicy } from "@/server/agent-token";
+import {
+  AgentTokenExpiredError,
+  resolveTokenToInstallationAndPolicy,
+} from "@/server/agent-token";
 import { authenticateAgentRequest } from "./agent-health-auth";
 
 // ---------------------------------------------------------------------------
@@ -137,6 +150,21 @@ describe("authenticateAgentRequest", () => {
       expect(result.response.status).toBe(401);
       const body = await result.response.json();
       expect(body.message).toBe("Invalid or missing agent token");
+    }
+  });
+
+  it("returns 401 with token-expired code when token is expired", async () => {
+    vi.mocked(resolveTokenToInstallationAndPolicy).mockRejectedValue(
+      new AgentTokenExpiredError(),
+    );
+
+    const result = await authenticateAgentRequest(makeRequest("Bearer expired-token"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      const body = await result.response.json();
+      expect(body.code).toBe("agent_health_token_expired");
+      expect(body.message).toBe("Agent token expired");
     }
   });
 

--- a/web/src/server/agent-health-auth.ts
+++ b/web/src/server/agent-health-auth.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateEnv } from "@/server/env";
 import { getRedisClient } from "@/server/redis";
 import {
+  AgentTokenExpiredError,
   resolveTokenToInstallationAndPolicy,
   type AgentTokenPolicy,
 } from "@/server/agent-token";
@@ -40,6 +41,17 @@ function unauthenticatedResponse() {
     response: agentHealthError(
       AGENT_HEALTH_ERROR.NOT_AUTHENTICATED,
       "Invalid or missing agent token",
+      401,
+    ),
+  };
+}
+
+function tokenExpiredResponse() {
+  return {
+    ok: false as const,
+    response: agentHealthError(
+      AGENT_HEALTH_ERROR.TOKEN_EXPIRED,
+      "Agent token expired",
       401,
     ),
   };
@@ -83,7 +95,13 @@ export async function authenticateAgentRequest(
   if (!rawToken) return unauthenticatedResponse();
 
   const redis = getRedisClient(redisRestUrl, redisRestToken);
-  const resolved = await resolveTokenToInstallationAndPolicy(rawToken, redis);
+  let resolved: Awaited<ReturnType<typeof resolveTokenToInstallationAndPolicy>>;
+  try {
+    resolved = await resolveTokenToInstallationAndPolicy(rawToken, redis);
+  } catch (err) {
+    if (err instanceof AgentTokenExpiredError) return tokenExpiredResponse();
+    throw err;
+  }
 
   if (resolved === null) return unauthenticatedResponse();
 

--- a/web/src/server/agent-health-error.ts
+++ b/web/src/server/agent-health-error.ts
@@ -16,6 +16,7 @@ export const AGENT_HEALTH_ERROR = {
   LOCK_TIMEOUT: "agent_health_lock_timeout",
   TOKEN_ALREADY_EXISTS: "agent_health_token_already_exists",
   TOKEN_NOT_FOUND: "agent_health_token_not_found",
+  TOKEN_EXPIRED: "agent_health_token_expired",
   IDEMPOTENCY_CONFLICT: "agent_health_idempotency_conflict",
   IDEMPOTENCY_PENDING: "agent_health_idempotency_pending",
   RATE_LIMITED: "agent_health_rate_limited",

--- a/web/src/server/agent-token.test.ts
+++ b/web/src/server/agent-token.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/server/crypto", () => ({
 }));
 
 import {
+  AgentTokenExpiredError,
   generateAgentToken,
   getAgentToken,
   getAgentTokenMeta,
@@ -123,15 +124,38 @@ describe("generateAgentToken", () => {
   it("stores a hash reverse index", async () => {
     const token = await generateAgentToken("inst-1", "alice", "v1", MOCK_KEYRING, redis);
     const hash = hashToken(token);
-    const record = redis._store.get(`agent-token-hash:${hash}`) as { installationId: string };
+    const record = redis._store.get(`agent-token-hash:${hash}`) as {
+      installationId: string;
+      expiresAt: string | null;
+    };
     expect(record.installationId).toBe("inst-1");
+    expect(record.expiresAt).toBeNull();
   });
 
-  it("sets createdBy and fingerprint in the envelope", async () => {
+  it("sets createdBy, fingerprint, and null expiry in the envelope", async () => {
     const token = await generateAgentToken("inst-1", "alice", "v1", MOCK_KEYRING, redis);
     const envelope = redis._store.get("hive:agent-token:inst-1") as Record<string, unknown>;
     expect(envelope.createdBy).toBe("alice");
     expect(envelope.fingerprint).toBe(token.slice(-8));
+    expect(envelope.expiresAt).toBeNull();
+  });
+
+  it("stores configured expiry in the envelope and hash index", async () => {
+    const expiresAt = "2026-07-25T00:00:00.000Z";
+    const token = await generateAgentToken(
+      "inst-1",
+      "alice",
+      "v1",
+      MOCK_KEYRING,
+      redis,
+      expiresAt,
+    );
+    const hash = hashToken(token);
+    const envelope = redis._store.get("hive:agent-token:inst-1") as Record<string, unknown>;
+    const record = redis._store.get(`agent-token-hash:${hash}`) as Record<string, unknown>;
+
+    expect(envelope.expiresAt).toBe(expiresAt);
+    expect(record.expiresAt).toBe(expiresAt);
   });
 
   it("removes old hash index when generating a new token for the same installation", async () => {
@@ -226,6 +250,7 @@ describe("getAgentTokenMeta", () => {
     expect(meta!.createdBy).toBe("alice");
     expect(meta!.hasToken).toBe(true);
     expect(meta!.createdAt).toBeDefined();
+    expect(meta!.expiresAt).toBeNull();
   });
 
   it("does not expose ciphertext or token hash", async () => {
@@ -260,6 +285,7 @@ describe("getAgentToken", () => {
     expect(record!.fingerprint).toBe(token.slice(-8));
     expect(record!.createdBy).toBe("alice");
     expect(record!.createdAt).toBeDefined();
+    expect(record!.expiresAt).toBeNull();
   });
 });
 
@@ -353,6 +379,21 @@ describe("reEncryptAgentToken", () => {
     const meta = await getAgentTokenMeta("inst-1", redis);
     expect(meta!.fingerprint).toBe(token.slice(-8));
   });
+
+  it("preserves expiry while re-encrypting", async () => {
+    const expiresAt = "2026-07-25T00:00:00.000Z";
+    await generateAgentToken("inst-1", "alice", "v1", MOCK_KEYRING, redis, expiresAt);
+
+    const keyring = new Map([
+      ["v1", Buffer.alloc(32)],
+      ["v2", Buffer.alloc(32)],
+    ]);
+    const result = await reEncryptAgentToken("inst-1", "v2", keyring, redis);
+    expect(result).toBe(true);
+
+    const meta = await getAgentTokenMeta("inst-1", redis);
+    expect(meta!.expiresAt).toBe(expiresAt);
+  });
 });
 
 describe("resolveTokenToInstallation", () => {
@@ -372,6 +413,21 @@ describe("resolveTokenToInstallation", () => {
     const token = await generateAgentToken("inst-42", "bob", "v1", MOCK_KEYRING, redis);
     const resolved = await resolveTokenToInstallation(token, redis);
     expect(resolved).toBe("inst-42");
+  });
+
+  it("rejects an expired token with a distinct error", async () => {
+    const token = await generateAgentToken(
+      "inst-42",
+      "bob",
+      "v1",
+      MOCK_KEYRING,
+      redis,
+      "2020-01-01T00:00:00.000Z",
+    );
+
+    await expect(resolveTokenToInstallation(token, redis)).rejects.toBeInstanceOf(
+      AgentTokenExpiredError,
+    );
   });
 });
 
@@ -424,6 +480,21 @@ describe("resolveTokenToInstallationAndPolicy", () => {
 
     const result = await resolveTokenToInstallationAndPolicy(token, redis);
     expect(result).toBeNull();
+  });
+
+  it("rejects when the envelope expiry is in the past", async () => {
+    const token = await generateAgentToken(
+      "inst-8",
+      "carol",
+      "v1",
+      MOCK_KEYRING,
+      redis,
+      "2020-01-01T00:00:00.000Z",
+    );
+
+    await expect(resolveTokenToInstallationAndPolicy(token, redis)).rejects.toBeInstanceOf(
+      AgentTokenExpiredError,
+    );
   });
 });
 

--- a/web/src/server/agent-token.ts
+++ b/web/src/server/agent-token.ts
@@ -88,6 +88,7 @@ export interface AgentTokenEnvelope {
   fingerprint: string; // last 8 chars of token for display
   createdAt: string; // ISO 8601
   createdBy: string; // GitHub login
+  expiresAt: string | null; // ISO 8601, null for legacy/no-expiry tokens
   /** V1.5+: per-token authorization policy. Absent on legacy tokens
    * (created pre-V1.5); set via `setAgentTokenPolicy`. Mint endpoint
    * treats absence as legacy-permissive (logged warning) and presence
@@ -95,10 +96,16 @@ export interface AgentTokenEnvelope {
   policy?: AgentTokenPolicy;
 }
 
+export interface AgentTokenHashRecord {
+  installationId: string;
+  expiresAt?: string | null;
+}
+
 export interface AgentTokenMeta {
   fingerprint: string;
   createdAt: string;
   createdBy: string;
+  expiresAt: string | null;
   hasToken: true;
 }
 
@@ -107,6 +114,14 @@ export interface AgentTokenRecord {
   fingerprint: string;
   createdAt: string;
   createdBy: string;
+  expiresAt: string | null;
+}
+
+export class AgentTokenExpiredError extends Error {
+  constructor() {
+    super("Agent token expired");
+    this.name = "AgentTokenExpiredError";
+  }
 }
 
 // Re-exported so API route consumers can import from a single location.
@@ -130,6 +145,16 @@ function redisHashKey(hash: string): string {
 
 function redisLockKey(installationId: string): string {
   return `${LOCK_PREFIX}${installationId}`;
+}
+
+function assertTokenNotExpired(expiresAt: unknown): void {
+  if (expiresAt == null) return;
+  if (typeof expiresAt !== "string") throw new AgentTokenExpiredError();
+
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+    throw new AgentTokenExpiredError();
+  }
 }
 
 function withInstallationLock<T>(
@@ -163,6 +188,7 @@ export async function generateAgentToken(
   activeKeyVersion: string,
   keyring: Map<string, Buffer>,
   redis: Redis,
+  expiresAt: string | null = null,
 ): Promise<string> {
   return withInstallationLock(installationId, redis, async () => {
     const existing = await redis.get<AgentTokenEnvelope>(redisTokenKey(installationId));
@@ -181,6 +207,7 @@ export async function generateAgentToken(
       fingerprint: rawToken.slice(-8),
       createdAt: new Date().toISOString(),
       createdBy,
+      expiresAt,
     };
 
     await redis.eval(
@@ -195,7 +222,7 @@ export async function generateAgentToken(
       [
         hasExisting ? "1" : "0",
         JSON.stringify(envelope),
-        JSON.stringify({ installationId }),
+        JSON.stringify({ installationId, expiresAt }),
       ],
     );
 
@@ -217,6 +244,7 @@ export async function getAgentTokenMeta(
     fingerprint: envelope.fingerprint,
     createdAt: envelope.createdAt,
     createdBy: envelope.createdBy,
+    expiresAt: envelope.expiresAt ?? null,
     hasToken: true,
   };
 }
@@ -258,6 +286,7 @@ export async function getAgentToken(
     fingerprint: envelope.fingerprint,
     createdAt: envelope.createdAt,
     createdBy: envelope.createdBy,
+    expiresAt: envelope.expiresAt ?? null,
   };
 }
 
@@ -333,8 +362,9 @@ export async function resolveTokenToInstallation(
   redis: Redis,
 ): Promise<string | null> {
   const hash = hashToken(rawToken);
-  const record = await redis.get<{ installationId: string }>(redisHashKey(hash));
+  const record = await redis.get<AgentTokenHashRecord>(redisHashKey(hash));
   if (!record || typeof record.installationId !== "string") return null;
+  assertTokenNotExpired(record.expiresAt);
   return record.installationId;
 }
 
@@ -364,6 +394,7 @@ export async function resolveTokenToInstallationAndPolicy(
   // (atomic rotate keeps both in sync), but if it does treat as unknown
   // rather than fail-open with no policy.
   if (!envelope) return null;
+  assertTokenNotExpired(envelope.expiresAt);
 
   return { installationId, policy: envelope.policy };
 }

--- a/web/src/server/task-error.ts
+++ b/web/src/server/task-error.ts
@@ -9,6 +9,7 @@ export const TASK_ERROR = {
   INVALID_TRANSITION: "task_invalid_transition",
   INVALID_TASK_ID: "task_invalid_task_id",
   NOT_AUTHENTICATED: "task_not_authenticated",
+  TOKEN_EXPIRED: "task_token_expired",
   FORBIDDEN: "task_forbidden",
   TASK_NOT_FOUND: "task_not_found",
   RATE_LIMITED: "task_rate_limited",

--- a/web/src/server/task-executor-auth.test.ts
+++ b/web/src/server/task-executor-auth.test.ts
@@ -7,12 +7,22 @@ vi.mock("@/server/env", () => ({
 vi.mock("@/server/redis", () => ({
   getRedisClient: vi.fn(() => ({} as never)),
 }));
-vi.mock("@/server/agent-token", () => ({
-  resolveTokenToInstallation: vi.fn(),
-}));
+vi.mock("@/server/agent-token", () => {
+  class AgentTokenExpiredError extends Error {
+    constructor() {
+      super("Agent token expired");
+      this.name = "AgentTokenExpiredError";
+    }
+  }
+
+  return {
+    AgentTokenExpiredError,
+    resolveTokenToInstallation: vi.fn(),
+  };
+});
 
 import { validateEnv } from "@/server/env";
-import { resolveTokenToInstallation } from "@/server/agent-token";
+import { AgentTokenExpiredError, resolveTokenToInstallation } from "@/server/agent-token";
 import { authenticateTaskExecutorRequest } from "@/server/task-executor-auth";
 
 function makeRequest(authHeader?: string) {
@@ -66,6 +76,18 @@ describe("authenticateTaskExecutorRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("returns 401 with token-expired code when token is expired", async () => {
+    vi.mocked(resolveTokenToInstallation).mockRejectedValue(new AgentTokenExpiredError());
+
+    const result = await authenticateTaskExecutorRequest(makeRequest("Bearer expired"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      const body = await result.response.json();
+      expect(body.code).toBe("task_token_expired");
     }
   });
 

--- a/web/src/server/task-executor-auth.ts
+++ b/web/src/server/task-executor-auth.ts
@@ -2,7 +2,7 @@ import { type Redis } from "@upstash/redis";
 import { NextRequest, NextResponse } from "next/server";
 import { validateEnv } from "@/server/env";
 import { getRedisClient } from "@/server/redis";
-import { resolveTokenToInstallation } from "@/server/agent-token";
+import { AgentTokenExpiredError, resolveTokenToInstallation } from "@/server/agent-token";
 import { TASK_ERROR, taskError } from "@/server/task-error";
 
 export type TaskExecutorAuthResult =
@@ -22,6 +22,17 @@ function unauthorizedResponse() {
     response: taskError(
       TASK_ERROR.NOT_AUTHENTICATED,
       "Invalid or missing executor token",
+      401,
+    ),
+  };
+}
+
+function tokenExpiredResponse() {
+  return {
+    ok: false as const,
+    response: taskError(
+      TASK_ERROR.TOKEN_EXPIRED,
+      "Executor token expired",
       401,
     ),
   };
@@ -63,7 +74,13 @@ export async function authenticateTaskExecutorRequest(
   if (!rawToken) return unauthorizedResponse();
 
   const redis = getRedisClient(redisRestUrl, redisRestToken);
-  const installationId = await resolveTokenToInstallation(rawToken, redis);
+  let installationId: Awaited<ReturnType<typeof resolveTokenToInstallation>>;
+  try {
+    installationId = await resolveTokenToInstallation(rawToken, redis);
+  } catch (err) {
+    if (err instanceof AgentTokenExpiredError) return tokenExpiredResponse();
+    throw err;
+  }
   if (!installationId) return unauthorizedResponse();
 
   return {


### PR DESCRIPTION
## Description

Fixes #424.

Adds opt-in expiry support for agent bearer tokens so recovered or leaked tokens do not have to remain valid indefinitely. Existing tokens stay compatible because missing or null expiry is treated as no expiry until an operator rotates them.

## Changes

- Stores `expiresAt` on both the encrypted token envelope and hash reverse index.
- Accepts optional `expiresIn` on `POST /api/agent-token`, for example `{ "expiresIn": "90d" }`.
- Rejects expired tokens during bearer-token resolution with distinct expired-token error codes for agent health and task executor auth.
- Updates the Agent Health contract and regression coverage for expiry storage, route validation, and auth behavior.

## Validation

- `npm --prefix web test -- agent-token agent-health-auth task-executor-auth`
- `npm --prefix web run typecheck`
- `npm --prefix web test`
- `npm --prefix web run lint`
