### PR TITLE
Add app-optional local onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Install the [Hivemoot Bot](https://github.com/hivemoot/hivemoot/tree/main/bot) G
 git clone https://github.com/hivemoot/hivemoot.git
 cd hivemoot/agent
 cp .env.example .env
-# Set TARGET_REPO, agent tokens, and your LLM provider API key
+# Set plugins.github.repos in hivemoot.yaml, then mount repo/model/dashboard keys
 docker compose run --rm hivemoot-agent
 ```
 

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,6 +1,6 @@
 # Local-only runtime config. Do not commit .env.
 
-# Plugin stack / worker execution.
+# Worker execution.
 # Workers run the Python plugin engine in oneshot mode. Triggers live in
 # the daemon runtime started by `hivemoot-agent run`. The root prompt is
 # always applied; per-agent voice comes from AGENT_IDENTITY_FILE.
@@ -13,8 +13,11 @@
 #     __init__.py exporting create_plugin()).  Built-ins win on name
 #     collision; use a fleet-prefixed name (e.g. apiary-foo) to avoid
 #     shadowing.
-# Run `hivemoot-agent plugin list` to see what's loaded and which
-# source each plugin came from.
+# Run `hivemoot-agent plugin list` to see what's installed and which
+# source each plugin came from. Plugin activation and plugin-specific
+# settings live in hivemoot.yaml under the `plugins:` section.
+# Legacy worker paths still accept AGENT_PLUGINS, but the engine ignores
+# it when loading plugins.
 AGENT_PLUGINS=github,hivemoot
 
 # Provider runtime: codex | gemini | claude | kilo | opencode
@@ -25,7 +28,8 @@ AGENT_PROVIDER=codex
 # docker-compose.subscription.local.yml.
 AGENT_AUTH_MODE=api_key
 
-# Required target repo in owner/repo format.
+# Compatibility target repo in owner/repo format. Current GitHub plugin
+# configuration reads repos from plugins.github.repos in hivemoot.yaml.
 TARGET_REPO=owner/repo
 # Workspace path inside container for this service.
 WORKSPACE_ROOT=/workspace/repo
@@ -190,9 +194,8 @@ AGENT_EXTRA_PROMPT=
 # Optional Hivemoot role override for autonomous repo work.
 # Defaults to AGENT_ID (or legacy slot 01) when unset.
 HIVEMOOT_BUZZ_ROLE=
-# GitHub plugin settings (AGENT_PLUGINS=github or github,hivemoot).
-# If GITHUB_WORKSPACE is empty, the plugin defaults to WORKSPACE_ROOT.
-# The hivemoot plugin's github_workflows feature requires github to be listed first.
+# Compatibility GitHub env aliases. Current GitHub plugin settings live
+# under plugins.github in hivemoot.yaml.
 GITHUB_TOKEN=
 GITHUB_TOKEN_FILE=
 GITHUB_REPOS=
@@ -276,4 +279,3 @@ MESSAGING_ALLOWED_CHAT_IDS=
 # Telegram: bot token.  Prefer *_FILE in production.
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_BOT_TOKEN_FILE=
-

--- a/agent/README.md
+++ b/agent/README.md
@@ -120,89 +120,130 @@ cd hivemoot/agent
 cp .env.example .env
 ```
 
-2. Edit `.env` with the minimum required values:
+2. Edit `.env` with the minimum runtime values:
 
 ```bash
 AGENT_PROVIDER=claude
 AGENT_AUTH_MODE=api_key
-TARGET_REPO=owner/repo
 
 AGENT_ID=worker
-AGENT_TOKEN=ghp_xxx
 
 # provider key (example for Claude)
 ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_api_key
 ```
 
-3. Place your provider key under `./secrets/`:
+3. Configure plugins in `config/hivemoot.yaml`:
+
+```bash
+mkdir -p config
+
+cat > config/hivemoot.yaml <<'YAML'
+plugins:
+  github:
+    repos:
+      - owner/repo
+    token_file: !secret github_token
+    workspace: /workspace/repo
+  hivemoot:
+    token_file: !secret hivemoot_agent_token
+    health:
+      enabled: true
+      repo: owner/repo
+    tasks:
+      enabled: true
+YAML
+
+cat > config/hivemoot.secrets.yaml <<'YAML'
+github_token: /run/secrets/github_token
+hivemoot_agent_token: /run/secrets/hivemoot_agent_token
+YAML
+```
+
+If you are not using dashboard tasks or health reporting, omit the
+`hivemoot:` block.
+
+4. Place your tokens under `./secrets/`:
 
 ```bash
 mkdir -p secrets
+printf '%s' "<github-token>" > secrets/github_token
 printf '%s' "<your-api-key>" > secrets/anthropic_api_key
-chmod 600 secrets/anthropic_api_key
+printf '%s' "<dashboard-agent-token>" > secrets/hivemoot_agent_token
+chmod 600 secrets/*
 ```
 
-4. Run — add `-v` to mount your secrets directory:
+5. Run — add `-v` mounts for config and secrets:
 
 ```bash
-docker compose run --rm -v ./secrets:/run/secrets:ro hivemoot-agent
+docker compose run --rm \
+  -v ./config/hivemoot.yaml:/run/agent/hivemoot.yaml:ro \
+  -v ./config/hivemoot.secrets.yaml:/run/agent/hivemoot.secrets.yaml:ro \
+  -v ./secrets:/run/secrets:ro \
+  hivemoot-agent
 ```
 
 > Secrets are not mounted by default — you choose what to expose on each run.
 > See [Secrets](#secrets) for persistent setup options.
 
-5. Check outputs:
+6. Check outputs:
 
 - Logs: `./data/runs/<agent-id>/<run-id>.log`
 - Repo clones: `./data/agents/<agent-id>/repo`
 
 ## Plugin Engine
 
-Each container runs one agent identity via `AGENT_ID` + `AGENT_TOKEN(_FILE)`.
-`AGENT_PLUGINS` picks the plugin stack; there is no shell-workload fallback.
+Each container runs one agent identity via `AGENT_ID`. Plugin activation and
+plugin-specific settings live in `hivemoot.yaml`; there is no shell-workload
+fallback.
 
-- `AGENT_PLUGINS` selects the plugin stack for the run (required)
+- `hivemoot.yaml` selects the plugin stack for the run
 - Triggers are owned by their plugins and run in-process inside
   `hivemoot-agent run`
 
 **Direct single run** (default) — execute one worker run, then exit:
 
 ```bash
-docker compose run --rm -v ./secrets:/run/secrets:ro hivemoot-agent
+docker compose run --rm \
+  -v ./config/hivemoot.yaml:/run/agent/hivemoot.yaml:ro \
+  -v ./config/hivemoot.secrets.yaml:/run/agent/hivemoot.secrets.yaml:ro \
+  -v ./secrets:/run/secrets:ro \
+  hivemoot-agent
 ```
 
 This path is intentionally simple:
 - one plugin stack
 - one worker execution
-- one agent identity via `AGENT_ID` + `AGENT_TOKEN(_FILE)`
+- one agent identity via `AGENT_ID`
 - persistent agent memory mounted from `AGENT_MEMORY_DATA` (default `./data/memory`)
 
 Legacy slot `01` envs are still accepted for compatibility, but they are no longer the primary worker contract.
 
 For the default Hivemoot repo workflow, use
-`AGENT_PLUGINS=github,hivemoot` with `github_workflows.enabled: true`
-under `plugins.hivemoot` in `hivemoot.yaml`.
+`plugins.github.repos` with `github_workflows.enabled: true` under
+`plugins.hivemoot` in `hivemoot.yaml`.
 
 **Minimal plugin-mode config**:
 
-```env
-AGENT_PLUGINS=github,hivemoot
-GITHUB_TOKEN_FILE=/run/secrets/github_token
-GITHUB_REPOS=owner/repo
-TARGET_REPO=owner/repo
-HIVEMOOT_BUZZ_ROLE=worker
-# Optional. Defaults to WORKSPACE_ROOT when unset.
-GITHUB_WORKSPACE=
+```yaml
+plugins:
+  github:
+    repos:
+      - owner/repo
+    token_file: !secret github_token
+    workspace: /workspace/repo
+  hivemoot:
+    token_file: !secret hivemoot_agent_token
+    github_workflows:
+      enabled: true
 ```
 
 Notes:
 - the worker entrypoint `exec`s `hivemoot-agent oneshot`; there is no separate "driver" selection
-- `AGENT_TOKEN(_FILE)` and `AGENT_GITHUB_TOKEN(_FILE)` are bridged to `GITHUB_TOKEN(_FILE)` if the GitHub plugin needs auth
-- if `GITHUB_REPOS` is empty and `TARGET_REPO` is set, the worker uses `TARGET_REPO` as the single GitHub repo
+- `TARGET_REPO` and `GITHUB_REPOS` are compatibility aliases on the worker path; the current GitHub plugin reads repo scope from `plugins.github.repos`
 - the same `AGENT_MEMORY_DATA` mount is available at `~/.hivemoot/memory`
-- use `AGENT_PLUGINS=github` for generic GitHub repo automation
-- use `AGENT_PLUGINS=github,hivemoot` with `plugins.hivemoot.github_workflows.enabled: true` for the Hivemoot contribution workflow
-- the `hivemoot` plugin's `github_workflows` feature requires the `hivemoot` CLI in the image and `github` listed first in `AGENT_PLUGINS`
+- configure `plugins.github` for generic GitHub repo automation
+- configure `plugins.github` plus `plugins.hivemoot.github_workflows.enabled: true` for the Hivemoot contribution workflow
+- the `hivemoot` plugin's `github_workflows` feature requires the `hivemoot` CLI in the image and `github` configured in the same `plugins:` section
 
 For recurring runs, use the `cron` plugin — list of named tasks, each
 with its own cron expression and prompt.  Cron triggers fire inside
@@ -802,7 +843,8 @@ When running Gemini against untrusted repositories, treat the container boundary
 
 | Error | Fix |
 | ----- | --- |
-| `TARGET_REPO is required` | Set `TARGET_REPO=owner/repo` in `.env` |
+| `plugins.github.repos is required` | Add `plugins.github.repos: [owner/repo]` to `hivemoot.yaml` |
+| `TARGET_REPO is required` | Legacy worker path only: set `TARGET_REPO=owner/repo`, or migrate to `plugins.github.repos` |
 | `GitHub token cannot access target repository` | Token lacks access to that repo |
 | Provider auth errors in `api_key` mode | Verify key env/file is set |
 | Subscription auth errors | Use `docker-compose.subscription.local.yml`, run the matching `auth-*` command, then run `hivemoot-agent-subscription` |

--- a/web/src/app/NavActions.tsx
+++ b/web/src/app/NavActions.tsx
@@ -11,13 +11,13 @@ const GET_STARTED_URL = "/setup";
  * Client component that renders the right side of the landing-page navbar.
  *
  * Hydration approach: state starts null, so server and client both render the
- * Sign in / Get Started buttons on initial render — no mismatch. After mount,
- * if the cookie is present and valid, the buttons are replaced with the user's
- * GitHub avatar chip.
+ * Get Started button on initial render — no mismatch. After mount, if the
+ * cookie is present and valid, the button is replaced with the user's GitHub
+ * avatar chip.
  *
  * Note: unlike RememberedUserCard (which renders null before mount and hides
- * entirely), this component always shows the Sign in / Get Started fallback on
- * initial render. Both are hydration-safe, but via different initial states.
+ * entirely), this component always shows the Get Started fallback on initial
+ * render. Both are hydration-safe, but via different initial states.
  */
 export default function NavActions() {
   const [user, setUser] = useState<string | null>(null);
@@ -55,19 +55,11 @@ export default function NavActions() {
   }
 
   return (
-    <>
-      <a
-        href="/api/auth/github/start-discover"
-        className="text-sm text-zinc-400 transition-colors hover:text-[#fafafa]"
-      >
-        Sign in
-      </a>
-      <Link
-        href={GET_STARTED_URL}
-        className="rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
-      >
-        Get Started
-      </Link>
-    </>
+    <Link
+      href={GET_STARTED_URL}
+      className="rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
+    >
+      Get Started
+    </Link>
   );
 }

--- a/web/src/app/api/agent-token/route.ts
+++ b/web/src/app/api/agent-token/route.ts
@@ -1,8 +1,9 @@
 /**
  * POST / GET / DELETE  /api/agent-token
  *
- * Manages per-installation agent bearer tokens used to authenticate health
- * reports. All three methods require a valid setup session (cookie auth).
+ * Manages per-dashboard-scope agent bearer tokens used to authenticate health
+ * reports and task execution. All three methods require a valid setup session
+ * (cookie auth), but do not require a GitHub App installation.
  *
  * POST   — Generate a new token (rotates if one exists).
  * GET    — Return the current token and metadata so admins can copy/recover it.

--- a/web/src/app/api/auth/github/callback/route.test.ts
+++ b/web/src/app/api/auth/github/callback/route.test.ts
@@ -18,7 +18,9 @@ vi.mock("@/server/github-auth", () => ({
 vi.mock("@/server/setup-session", () => ({
   validateOAuthState: vi.fn(),
   createSetupSession: vi.fn(),
+  createUserScopeId: vi.fn((userId: number) => `user:${userId}`),
   DISCOVER_SENTINEL: "discover",
+  isGitHubInstallationScope: vi.fn((scopeId: string) => /^\d+$/.test(scopeId)),
   OAUTH_STATE_BINDING_COOKIE: "oauth_state_binding",
   SETUP_SESSION_COOKIE: "setup_session",
   SESSION_TTL_SECONDS: 86400,
@@ -41,6 +43,7 @@ import {
   validateOAuthState,
   createSetupSession,
   OAUTH_STATE_BINDING_COOKIE,
+  createUserScopeId,
 } from "@/server/setup-session";
 import { SETUP_SESSION_COOKIE } from "@/server/setup-session";
 import { hasByokEnvelope } from "@/server/byok-store";
@@ -245,7 +248,7 @@ describe("GET /api/auth/github/callback — rejections", () => {
   it("cross-installation write attempt is blocked (installationId from state, not URL)", async () => {
     // Attacker sets state=legit-state but the URL has a different installation_id.
     // The route ignores any installation_id in the URL and uses only the one from Redis state.
-    vi.mocked(validateOAuthState).mockResolvedValue({ installationId: "VICTIM_INSTALL" });
+    vi.mocked(validateOAuthState).mockResolvedValue({ installationId: "999" });
     vi.mocked(getInstallation).mockResolvedValue({
       account: { login: "alice", type: "User" },
     });
@@ -258,7 +261,7 @@ describe("GET /api/auth/github/callback — rejections", () => {
 
     // Session must be created with the installationId FROM REDIS, not from the URL
     expect(createSetupSession).toHaveBeenCalledWith(
-      expect.objectContaining({ installationId: "VICTIM_INSTALL" }),
+      expect.objectContaining({ installationId: "999" }),
       expect.anything(),
     );
   });
@@ -375,7 +378,7 @@ describe("GET /api/auth/github/callback — discovery flow", () => {
     expect(getInstallation).toHaveBeenCalledWith("67890", "app-jwt");
   });
 
-  it("redirects to not_installed when no installations are found", async () => {
+  it("creates a user-scoped dashboard session when no installations are found", async () => {
     vi.mocked(getUserInstallations).mockResolvedValue([]);
 
     const req = makeRequestWithCookie(
@@ -385,9 +388,16 @@ describe("GET /api/auth/github/callback — discovery flow", () => {
     const res = await GET(req);
 
     expect(res.status).toBe(307);
-    const location = res.headers.get("location")!;
-    expect(location).toContain("auth=not_installed");
-    expect(location).not.toContain("installation_id=");
+    const location = new URL(res.headers.get("location")!);
+    expect(location.pathname).toBe("/dashboard/credentials");
+    expect(location.searchParams.has("auth")).toBe(false);
+    expect(location.searchParams.has("installation_id")).toBe(false);
+    expect(createUserScopeId).toHaveBeenCalledWith(1);
+    expect(getInstallation).not.toHaveBeenCalled();
+    expect(createSetupSession).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "user:1" }),
+      expect.anything(),
+    );
   });
 
   it("uses the first installation when multiple exist", async () => {

--- a/web/src/app/api/auth/github/callback/route.ts
+++ b/web/src/app/api/auth/github/callback/route.ts
@@ -6,11 +6,12 @@
  * Security sequence:
  * 1. Validate `state` against Redis — reject if unknown/expired (CSRF protection)
  * 2. Exchange `code` for a user access token
- * 2b. If state held the "discover" sentinel (user started from the "already installed"
- *     flow), resolve the real installationId via GET /user/installations
+ * 2b. If state held the "discover" sentinel, resolve a GitHub App installation
+ *     via GET /user/installations. If none exists, create a dashboard-only
+ *     user scope so credentials, task execution, and health reporting still work.
  * 3. Fetch authenticated user identity
- * 4. Fetch installation metadata (via App JWT)
- * 5. Authorization check:
+ * 4. Fetch installation metadata (via App JWT) only for installation-scoped sessions
+ * 5. Authorization check for installation-scoped sessions:
  *    - Org installations: caller must have admin role in the org
  *    - User installations: authenticated login must match installation account
  * 6. Issue setup session token, store in Redis, set as HttpOnly cookie
@@ -34,7 +35,9 @@ import {
 import {
   validateOAuthState,
   createSetupSession,
+  createUserScopeId,
   DISCOVER_SENTINEL,
+  isGitHubInstallationScope,
   OAUTH_STATE_BINDING_COOKIE,
   SETUP_SESSION_COOKIE,
   SESSION_TTL_SECONDS,
@@ -61,6 +64,10 @@ function setupErrorRedirect(
   url.searchParams.set("code", code);
   if (installationId) url.searchParams.set("installation_id", installationId);
   return NextResponse.redirect(url.toString());
+}
+
+function setupErrorInstallationParam(installationId: string): string | undefined {
+  return isGitHubInstallationScope(installationId) ? installationId : undefined;
 }
 
 export async function GET(request: NextRequest) {
@@ -107,7 +114,7 @@ export async function GET(request: NextRequest) {
     if (state) {
       try {
         const deniedResult = await validateOAuthState(state, oauthStateBinding, redis);
-        if (deniedResult && deniedResult.installationId !== DISCOVER_SENTINEL) {
+        if (deniedResult && isGitHubInstallationScope(deniedResult.installationId)) {
           deniedUrl.searchParams.set("installation_id", deniedResult.installationId);
         }
       } catch (err) {
@@ -152,23 +159,31 @@ export async function GET(request: NextRequest) {
     userToken = await exchangeOAuthCode(code, githubClientId, githubClientSecret);
   } catch (err) {
     console.error("[oauth-callback] Failed to exchange OAuth code", { error: err });
-    const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
+    const errResponse = setupErrorRedirect(
+      siteUrl,
+      "server_error",
+      setupErrorInstallationParam(installationId),
+    );
     clearOAuthStateBindingCookie(errResponse);
     return errResponse;
   }
 
-  // --- Step 2b: Discover installation if the user started from the "already installed" flow ---
+  let user: { login: string; id: number } | null = null;
+  let installation: { account: { login: string; type: string } } | null = null;
+
+  // --- Step 2b: Discover installation if the user started from the discovery flow ---
   if (installationId === DISCOVER_SENTINEL) {
     try {
-      const installations = await getUserInstallations(userToken, githubAppId!);
+      const [authenticatedUser, installations] = await Promise.all([
+        getAuthenticatedUser(userToken),
+        getUserInstallations(userToken, githubAppId!),
+      ]);
+      user = authenticatedUser;
       if (installations.length === 0) {
-        const notInstalledUrl = new URL(`${siteUrl}/setup`);
-        notInstalledUrl.searchParams.set("auth", "not_installed");
-        const response = NextResponse.redirect(notInstalledUrl.toString());
-        clearOAuthStateBindingCookie(response);
-        return response;
+        installationId = createUserScopeId(user.id);
+      } else {
+        installationId = String(installations[0].id);
       }
-      installationId = String(installations[0].id);
     } catch (err) {
       console.error("[oauth-callback] Failed to discover user installations", { error: err });
       const errResponse = setupErrorRedirect(siteUrl, "server_error");
@@ -177,58 +192,78 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  let user: { login: string; id: number };
-  let installation: { account: { login: string; type: string } };
-
-  try {
-    // --- Step 3 & 4: Fetch user identity and installation in parallel ---
-    const appJwt = generateAppJwt(githubAppId!, githubAppPrivateKey!);
-    [user, installation] = await Promise.all([
-      getAuthenticatedUser(userToken),
-      getInstallation(installationId, appJwt),
-    ]);
-  } catch (err) {
-    console.error("[oauth-callback] Failed to fetch user/installation", { installationId, error: err });
-    const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
-    clearOAuthStateBindingCookie(errResponse);
-    return errResponse;
-  }
-
-  // --- Step 5: Authorization check ---
-  const accountType = installation.account.type;
-  const accountLogin = installation.account.login;
-
-  if (accountType === "Organization") {
-    // Org installation: caller must be an org admin
-    let isAdmin: boolean;
+  if (isGitHubInstallationScope(installationId)) {
     try {
-      isAdmin = await checkOrgAdmin(userToken, accountLogin);
+      // --- Step 3 & 4: Fetch user identity and installation metadata ---
+      const appJwt = generateAppJwt(githubAppId!, githubAppPrivateKey!);
+      if (user) {
+        installation = await getInstallation(installationId, appJwt);
+      } else {
+        [user, installation] = await Promise.all([
+          getAuthenticatedUser(userToken),
+          getInstallation(installationId, appJwt),
+        ]);
+      }
     } catch (err) {
-      console.error("[oauth-callback] Failed to check org admin status", { accountLogin, error: err });
+      console.error("[oauth-callback] Failed to fetch user/installation", { installationId, error: err });
       const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
       clearOAuthStateBindingCookie(errResponse);
       return errResponse;
     }
-    if (!isAdmin) {
-      const forbiddenUrl = new URL(`${siteUrl}/setup`);
-      forbiddenUrl.searchParams.set("installation_id", installationId);
-      forbiddenUrl.searchParams.set("auth", "forbidden");
-      forbiddenUrl.searchParams.set("reason", "not_org_admin");
-      const response = NextResponse.redirect(forbiddenUrl.toString());
-      clearOAuthStateBindingCookie(response);
-      return response;
+    if (!user || !installation) {
+      console.error("[oauth-callback] Missing user or installation after GitHub lookup", { installationId });
+      const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
+      clearOAuthStateBindingCookie(errResponse);
+      return errResponse;
     }
-  } else {
-    // User installation: authenticated user must be the installer
-    if (user.login.toLowerCase() !== accountLogin.toLowerCase()) {
-      const forbiddenUrl = new URL(`${siteUrl}/setup`);
-      forbiddenUrl.searchParams.set("installation_id", installationId);
-      forbiddenUrl.searchParams.set("auth", "forbidden");
-      forbiddenUrl.searchParams.set("reason", "user_mismatch");
-      const response = NextResponse.redirect(forbiddenUrl.toString());
-      clearOAuthStateBindingCookie(response);
-      return response;
+
+    // --- Step 5: Authorization check ---
+    const accountType = installation.account.type;
+    const accountLogin = installation.account.login;
+
+    if (accountType === "Organization") {
+      // Org installation: caller must be an org admin
+      let isAdmin: boolean;
+      try {
+        isAdmin = await checkOrgAdmin(userToken, accountLogin);
+      } catch (err) {
+        console.error("[oauth-callback] Failed to check org admin status", { accountLogin, error: err });
+        const errResponse = setupErrorRedirect(siteUrl, "server_error", installationId);
+        clearOAuthStateBindingCookie(errResponse);
+        return errResponse;
+      }
+      if (!isAdmin) {
+        const forbiddenUrl = new URL(`${siteUrl}/setup`);
+        forbiddenUrl.searchParams.set("installation_id", installationId);
+        forbiddenUrl.searchParams.set("auth", "forbidden");
+        forbiddenUrl.searchParams.set("reason", "not_org_admin");
+        const response = NextResponse.redirect(forbiddenUrl.toString());
+        clearOAuthStateBindingCookie(response);
+        return response;
+      }
+    } else {
+      // User installation: authenticated user must be the installer
+      if (user.login.toLowerCase() !== accountLogin.toLowerCase()) {
+        const forbiddenUrl = new URL(`${siteUrl}/setup`);
+        forbiddenUrl.searchParams.set("installation_id", installationId);
+        forbiddenUrl.searchParams.set("auth", "forbidden");
+        forbiddenUrl.searchParams.set("reason", "user_mismatch");
+        const response = NextResponse.redirect(forbiddenUrl.toString());
+        clearOAuthStateBindingCookie(response);
+        return response;
+      }
     }
+  }
+
+  if (!user) {
+    console.error("[oauth-callback] Missing authenticated user after OAuth callback", { installationId });
+    const errResponse = setupErrorRedirect(
+      siteUrl,
+      "server_error",
+      setupErrorInstallationParam(installationId),
+    );
+    clearOAuthStateBindingCookie(errResponse);
+    return errResponse;
   }
 
   // --- Step 6: Issue setup session token ---
@@ -263,10 +298,14 @@ export async function GET(request: NextRequest) {
   if (setupComplete) {
     const destination = oauthNext ?? "/dashboard";
     successUrl = new URL(`${siteUrl}${destination}`);
-  } else {
+  } else if (oauthNext) {
+    successUrl = new URL(`${siteUrl}${oauthNext}`);
+  } else if (isGitHubInstallationScope(installationId)) {
     successUrl = new URL(`${siteUrl}/setup`);
     successUrl.searchParams.set("installation_id", installationId);
     successUrl.searchParams.set("auth", "ok");
+  } else {
+    successUrl = new URL(`${siteUrl}/dashboard/credentials`);
   }
   const response = NextResponse.redirect(successUrl.toString());
 

--- a/web/src/app/api/auth/github/start-discover/route.test.ts
+++ b/web/src/app/api/auth/github/start-discover/route.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/server/redis", () => ({
 vi.mock("@/server/setup-session", () => ({
   createOAuthState: vi.fn(),
   getSetupSession: vi.fn(),
+  isGitHubInstallationScope: vi.fn((scopeId: string) => /^\d+$/.test(scopeId)),
   DISCOVER_SENTINEL: "discover",
   OAUTH_STATE_BINDING_COOKIE: "oauth_state_binding",
   SETUP_SESSION_COOKIE: "setup_session",
@@ -63,11 +64,16 @@ function makeRequestWithCookie(cookie: string, search = "") {
 }
 
 const VALID_SESSION = {
-  installationId: "inst-1",
+  installationId: "123",
   userId: 42,
   userLogin: "alice",
   expiresAt: Date.now() + 86400 * 1000,
   iat: Date.now(),
+};
+
+const USER_SCOPE_SESSION = {
+  ...VALID_SESSION,
+  installationId: "user:42",
 };
 
 beforeEach(() => {
@@ -194,6 +200,21 @@ describe("GET /api/auth/github/start-discover — fast-path (valid session)", ()
     expect(res.status).toBe(307);
     const location = res.headers.get("location")!;
     expect(location).toContain("/setup");
+    expect(location).toContain("installation_id=123");
+    expect(createOAuthState).not.toHaveBeenCalled();
+  });
+
+  it("redirects user-scoped sessions to credentials when BYOK is not configured", async () => {
+    vi.mocked(getSetupSession).mockResolvedValue(USER_SCOPE_SESSION);
+    vi.mocked(hasByokEnvelope).mockResolvedValue(false);
+
+    const req = makeRequestWithCookie("setup_session=valid-token");
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = new URL(res.headers.get("location")!);
+    expect(location.pathname).toBe("/dashboard/credentials");
+    expect(location.searchParams.has("installation_id")).toBe(false);
     expect(createOAuthState).not.toHaveBeenCalled();
   });
 

--- a/web/src/app/api/auth/github/start-discover/route.ts
+++ b/web/src/app/api/auth/github/start-discover/route.ts
@@ -5,8 +5,8 @@
  *
  * Unlike /api/auth/github/start, this route does NOT require an installation_id.
  * It stores a "discover" sentinel in the OAuth state. After the user authorizes,
- * the callback detects the sentinel and resolves the real installation_id via
- * GET /user/installations.
+ * the callback detects the sentinel and either resolves a real installation_id
+ * via GET /user/installations or creates a dashboard-only user scope.
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -18,6 +18,7 @@ import {
   OAUTH_STATE_BINDING_COOKIE,
   SETUP_SESSION_COOKIE,
   getSetupSession,
+  isGitHubInstallationScope,
 } from "@/server/setup-session";
 import { hasByokEnvelope } from "@/server/byok-store";
 import { buildOAuthAuthorizeUrl, getOAuthStateCookieOptions, isSafeNextPath } from "@/server/github-auth";
@@ -70,7 +71,9 @@ export async function GET(request: NextRequest) {
               // Fall through to dashboard on BYOK check failure.
             }
             if (!setupComplete) {
-              destination = `/setup?installation_id=${encodeURIComponent(session.installationId)}&auth=ok`;
+              destination = isGitHubInstallationScope(session.installationId)
+                ? `/setup?installation_id=${encodeURIComponent(session.installationId)}&auth=ok`
+                : "/dashboard/credentials";
             }
           }
           return NextResponse.redirect(new URL(`${siteUrl}${destination}`).toString());

--- a/web/src/app/api/repos/[owner]/[repo]/roles/route.ts
+++ b/web/src/app/api/repos/[owner]/[repo]/roles/route.ts
@@ -20,6 +20,7 @@ import { parse as parseYaml, parseDocument } from "yaml";
 import { authenticateByokRequest } from "@/server/byok-auth";
 import { validateEnv } from "@/server/env";
 import { generateAppJwt, generateInstallationToken } from "@/server/github-auth";
+import { isGitHubInstallationScope } from "@/server/setup-session";
 import {
   readRepoFile,
   getBranchSha,
@@ -153,6 +154,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
   const { owner, repo } = parsed;
 
+  if (!isGitHubInstallationScope(auth.session.installationId)) {
+    return repoError(
+      "github_app_required",
+      "Install the GitHub App to manage repo roles.",
+      403,
+    );
+  }
+
   const env = validateEnv();
   if (!env.ok) {
     return repoError("server_misconfiguration", "Server misconfiguration", 503);
@@ -218,6 +227,14 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
     return repoError("invalid_path", "Invalid repository path", 400);
   }
   const { owner, repo } = parsed;
+
+  if (!isGitHubInstallationScope(auth.session.installationId)) {
+    return repoError(
+      "github_app_required",
+      "Install the GitHub App to manage repo roles.",
+      403,
+    );
+  }
 
   let body: PutRoleBody;
   try {

--- a/web/src/app/dashboard/credentials/CredentialsPanel.tsx
+++ b/web/src/app/dashboard/credentials/CredentialsPanel.tsx
@@ -801,7 +801,7 @@ function AgentTokenSection({
         <div>
           <h2 className="text-lg font-semibold text-[#fafafa]">Agent Token</h2>
           <p className="mt-0.5 text-sm text-zinc-400">
-            Bearer token used by agents to authenticate health reports.
+            Bearer token used by agents for dashboard task execution and health reports.
           </p>
         </div>
       </div>
@@ -925,7 +925,7 @@ function AgentTokenSection({
             <span className="text-sm font-medium text-zinc-500">Not configured</span>
           </div>
           <p className="mb-6 text-sm text-zinc-400">
-            Generate a bearer token so your agents can authenticate when sending health reports.
+            Generate a bearer token so your agents can claim dashboard tasks and send health reports.
           </p>
           <button
             type="button"

--- a/web/src/app/dashboard/credentials/page.tsx
+++ b/web/src/app/dashboard/credentials/page.tsx
@@ -4,6 +4,7 @@ import { getRedisClient } from "@/server/redis";
 import { validateEnv } from "@/server/env";
 import {
   getSetupSession,
+  isGitHubInstallationScope,
   isSessionFresh,
   SETUP_SESSION_COOKIE,
 } from "@/server/setup-session";
@@ -28,11 +29,13 @@ export default async function CredentialsPage() {
         const session = await getSetupSession(token, redis);
         if (session) {
           fresh = isSessionFresh(session);
-          // Route re-auth through /start with the known installationId so the
-          // callback skips discovery and stays pinned to the current installation.
-          // Using start-discover would pick installations[0], silently switching
-          // multi-install users to the wrong installation.
-          reAuthUrl = `/api/auth/github/start?installation_id=${encodeURIComponent(session.installationId)}&next=/dashboard/credentials`;
+          if (isGitHubInstallationScope(session.installationId)) {
+            // Route re-auth through /start with the known installationId so the
+            // callback skips discovery and stays pinned to the current installation.
+            // Using start-discover would pick installations[0], silently switching
+            // multi-install users to the wrong installation.
+            reAuthUrl = `/api/auth/github/start?installation_id=${encodeURIComponent(session.installationId)}&next=/dashboard/credentials`;
+          }
         }
       } catch {
         // Treat as stale on Redis error. Fall back to the discovery path.

--- a/web/src/app/setup/SetupLocalFlow.tsx
+++ b/web/src/app/setup/SetupLocalFlow.tsx
@@ -1,0 +1,893 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+const AGENT_RUNNER_DOCS_URL = "https://github.com/hivemoot/hivemoot/tree/main/agent";
+const GITHUB_APP_INSTALL_URL = "https://github.com/apps/hivemoot/installations/new";
+const CREDENTIALS_URL = "/api/auth/github/start-discover?next=/dashboard/credentials";
+
+type FlowStep = 1 | 2 | 3 | 4;
+type ProviderId = "codex" | "claude" | "gemini" | "opencode";
+type PluginId = "github" | "browser" | "cron";
+type HivemootFeature = "health" | "tasks" | "githubWorkflows";
+
+const FLOW_STEPS: { number: FlowStep; label: string }[] = [
+  { number: 1, label: "Tool" },
+  { number: 2, label: "Plugins" },
+  { number: 3, label: "Hivemoot" },
+  { number: 4, label: "Config" },
+];
+
+const PROVIDERS: Record<
+  ProviderId,
+  {
+    label: string;
+    eyebrow: string;
+    detail: string;
+    model: string;
+    env: string[];
+    secretLine: string;
+  }
+> = {
+  codex: {
+    label: "Codex",
+    eyebrow: "OpenAI CLI",
+    detail: "Good default for code tasks.",
+    model: "gpt-5.5",
+    env: [
+      "AGENT_PROVIDER=codex",
+      "AGENT_AUTH_MODE=api_key",
+      "OPENAI_API_KEY_FILE=/run/secrets/openai_api_key",
+      "AGENT_MODEL=gpt-5.5",
+    ],
+    secretLine: "openai_api_key: /run/secrets/openai_api_key",
+  },
+  claude: {
+    label: "Claude Code",
+    eyebrow: "Anthropic CLI",
+    detail: "Use your Anthropic key.",
+    model: "claude-opus-4-7",
+    env: [
+      "AGENT_PROVIDER=claude",
+      "AGENT_AUTH_MODE=api_key",
+      "ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_api_key",
+      "AGENT_MODEL=claude-opus-4-7",
+    ],
+    secretLine: "anthropic_api_key: /run/secrets/anthropic_api_key",
+  },
+  gemini: {
+    label: "Gemini CLI",
+    eyebrow: "Google CLI",
+    detail: "Use your Google AI key.",
+    model: "gemini-3.1-pro-preview",
+    env: [
+      "AGENT_PROVIDER=gemini",
+      "AGENT_AUTH_MODE=api_key",
+      "GEMINI_API_KEY_FILE=/run/secrets/gemini_api_key",
+      "AGENT_MODEL=gemini-3.1-pro-preview",
+    ],
+    secretLine: "gemini_api_key: /run/secrets/gemini_api_key",
+  },
+  opencode: {
+    label: "OpenCode",
+    eyebrow: "OpenCode CLI",
+    detail: "Use OpenRouter routing.",
+    model: "anthropic/claude-opus-4.7",
+    env: [
+      "AGENT_PROVIDER=opencode",
+      "AGENT_AUTH_MODE=api_key",
+      "OPENCODE_PROVIDER=openrouter",
+      "OPENCODE_MODEL=anthropic/claude-opus-4.7",
+      "OPENROUTER_API_KEY_FILE=/run/secrets/openrouter_api_key",
+    ],
+    secretLine: "openrouter_api_key: /run/secrets/openrouter_api_key",
+  },
+};
+
+const PLUGINS: {
+  id: PluginId;
+  label: string;
+  detail: string;
+  defaultEnabled: boolean;
+}[] = [
+  {
+    id: "github",
+    label: "GitHub",
+    detail: "Pre-clone repos and wake agents from mentions, review requests, or new PRs.",
+    defaultEnabled: true,
+  },
+  {
+    id: "browser",
+    label: "Browser",
+    detail: "Attach a browser sidecar for page checks, web QA, and saved browser state.",
+    defaultEnabled: false,
+  },
+  {
+    id: "cron",
+    label: "Cron",
+    detail: "Run named prompts on a schedule for recurring maintenance work.",
+    defaultEnabled: false,
+  },
+];
+
+const HIVEMOOT_FEATURES: {
+  id: HivemootFeature;
+  label: string;
+  detail: string;
+  defaultEnabled: boolean;
+}[] = [
+  {
+    id: "health",
+    label: "Health reports",
+    detail: "Show runner status in the dashboard.",
+    defaultEnabled: true,
+  },
+  {
+    id: "tasks",
+    label: "Task system",
+    detail: "Claim work and post results.",
+    defaultEnabled: true,
+  },
+  {
+    id: "githubWorkflows",
+    label: "Hivemoot governance",
+    detail: "Load proposal, voting, label, and PR coordination rules for Hivemoot repos.",
+    defaultEnabled: false,
+  },
+];
+
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-5 w-5"}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
+    </svg>
+  );
+}
+
+function CopyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-4 w-4"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="5" y="5" width="8" height="8" rx="1" />
+      <path d="M3 11V3a1 1 0 0 1 1-1h8" />
+    </svg>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-4 w-4"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="3.5 8.5 6.5 11.5 12.5 4.5" />
+    </svg>
+  );
+}
+
+function AuthStatusBanner({ auth, reason }: { auth: string; reason?: string }) {
+  if (auth === "ok") {
+    return (
+      <div className="rounded-lg border border-green-500/20 bg-green-500/5 px-4 py-3 text-sm text-green-400">
+        GitHub authorization succeeded. Continue with Agent Token setup.
+      </div>
+    );
+  }
+
+  if (auth === "not_installed") {
+    return null;
+  }
+
+  if (auth === "forbidden") {
+    const message =
+      reason === "not_org_admin"
+        ? "You need to be an organization admin to configure this installation."
+        : reason === "user_mismatch"
+          ? "The GitHub account you authorized does not match this installation."
+          : "You are not authorized to configure this installation.";
+
+    return (
+      <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3 text-sm text-red-400">
+        {message}
+      </div>
+    );
+  }
+
+  if (auth === "expired" || auth === "denied") {
+    return (
+      <div className="rounded-lg border border-white/[0.08] bg-white/[0.03] px-4 py-3 text-sm text-zinc-400">
+        GitHub authorization was not completed. You can still run agents locally.
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function highlightCodeLine(line: string) {
+  if (line.trimStart().startsWith("#")) {
+    return <span className="text-zinc-600">{line}</span>;
+  }
+
+  const envMatch = line.match(/^([A-Z0-9_]+)(=)(.*)$/);
+  if (envMatch) {
+    return (
+      <>
+        <span className="text-honey-400">{envMatch[1]}</span>
+        <span className="text-zinc-600">{envMatch[2]}</span>
+        <span className="text-zinc-300">{envMatch[3]}</span>
+      </>
+    );
+  }
+
+  const shellMatch = line.match(/^([a-z][\w-]*)(\s.*)?$/);
+  if (shellMatch && !line.includes(":")) {
+    return (
+      <>
+        <span className="text-honey-400">{shellMatch[1]}</span>
+        <span>{shellMatch[2] ?? ""}</span>
+      </>
+    );
+  }
+
+  const yamlMatch = line.match(/^(\s*)([\w.-]+)(:)(.*)$/);
+  if (yamlMatch) {
+    return (
+      <>
+        <span>{yamlMatch[1]}</span>
+        <span className="text-honey-400">{yamlMatch[2]}</span>
+        <span className="text-zinc-600">{yamlMatch[3]}</span>
+        <span className={yamlMatch[4].includes("!secret") ? "text-green-400/80" : "text-zinc-300"}>
+          {yamlMatch[4]}
+        </span>
+      </>
+    );
+  }
+
+  if (line.trimStart().startsWith("- ")) {
+    const indentation = line.match(/^\s*/)?.[0] ?? "";
+    return (
+      <>
+        <span>{indentation}</span>
+        <span className="text-zinc-600">- </span>
+        <span className="text-zinc-300">{line.trimStart().slice(2)}</span>
+      </>
+    );
+  }
+
+  return <span>{line}</span>;
+}
+
+function CodeWidget({
+  title,
+  language,
+  children,
+}: {
+  title: string;
+  language: string;
+  children: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const lines = children.split("\n");
+
+  async function copyCode() {
+    try {
+      await navigator.clipboard.writeText(children);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-white/[0.08] bg-[#0d0d0f]">
+      <div className="flex items-center justify-between gap-3 border-b border-white/[0.06] bg-white/[0.025] px-3 py-2">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-medium text-zinc-300">{title}</p>
+          <p className="text-[10px] uppercase tracking-wide text-zinc-600">{language}</p>
+        </div>
+        <button
+          type="button"
+          onClick={copyCode}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-white/[0.08] px-2.5 text-xs font-medium text-zinc-400 transition-colors hover:border-honey-500/30 hover:text-honey-400"
+          aria-label={`Copy ${title}`}
+        >
+          <CopyIcon className="h-3.5 w-3.5" />
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="overflow-x-auto px-3 py-3 text-xs leading-6 text-zinc-400">
+        <code>
+          {lines.map((line, index) => (
+            <span key={`${index}-${line}`} className="grid grid-cols-[2.25rem_1fr] gap-3">
+              <span className="select-none text-right text-zinc-700">{index + 1}</span>
+              <span>{highlightCodeLine(line)}</span>
+            </span>
+          ))}
+        </code>
+      </pre>
+    </div>
+  );
+}
+
+function StepNav({
+  activeStep,
+  onStepChange,
+}: {
+  activeStep: FlowStep;
+  onStepChange: (step: FlowStep) => void;
+}) {
+  return (
+    <aside className="shrink-0 lg:w-48">
+      <ol className="flex gap-2 lg:flex-col lg:gap-0" aria-label="Setup progress">
+        {FLOW_STEPS.map((step, index) => {
+          const isActive = step.number === activeStep;
+          const isComplete = step.number < activeStep;
+          return (
+            <li key={step.number} className="contents">
+              <button
+                type="button"
+                onClick={() => onStepChange(step.number)}
+                className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-white/[0.03] lg:flex-none"
+              >
+                <span
+                  className={`
+                    flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold transition-colors
+                    ${isActive ? "bg-honey-500 text-[#0a0a0a]" : ""}
+                    ${isComplete ? "bg-honey-500/20 text-honey-400 ring-1 ring-honey-500/40" : ""}
+                    ${!isActive && !isComplete ? "bg-white/5 text-zinc-500 ring-1 ring-white/10" : ""}
+                  `}
+                >
+                  {isComplete ? <CheckIcon /> : step.number}
+                </span>
+                <span
+                  className={`truncate text-sm ${isActive ? "font-medium text-[#fafafa]" : isComplete ? "text-honey-400" : "text-zinc-500"}`}
+                >
+                  {step.label}
+                </span>
+              </button>
+              {index < FLOW_STEPS.length - 1 && (
+                <div aria-hidden="true" className="hidden pl-[22px] lg:block">
+                  <div className={`h-5 w-px ${step.number < activeStep ? "bg-honey-500/30" : "bg-white/5"}`} />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </aside>
+  );
+}
+
+function StepActions({
+  activeStep,
+  onStepChange,
+}: {
+  activeStep: FlowStep;
+  onStepChange: (step: FlowStep) => void;
+}) {
+  const nextLabels: Record<Exclude<FlowStep, 4>, string> = {
+    1: "Choose plugins",
+    2: "Hivemoot options",
+    3: "Generate config",
+  };
+
+  return (
+    <div className="mt-8 flex flex-wrap items-center justify-between gap-3 border-t border-white/[0.06] pt-5">
+      <button
+        type="button"
+        onClick={() => onStepChange((activeStep - 1) as FlowStep)}
+        disabled={activeStep === 1}
+        className="rounded-lg border border-white/[0.08] px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-white/[0.03] disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Back
+      </button>
+      {activeStep < 4 ? (
+        <button
+          type="button"
+          onClick={() => onStepChange((activeStep + 1) as FlowStep)}
+          className="rounded-lg bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-colors hover:bg-honey-400"
+        >
+          {nextLabels[activeStep as Exclude<FlowStep, 4>]}
+        </button>
+      ) : (
+        <a
+          href={AGENT_RUNNER_DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-lg border border-white/[0.08] px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-white/[0.03]"
+        >
+          Agent runner docs
+        </a>
+      )}
+    </div>
+  );
+}
+
+function OptionButton({
+  active,
+  eyebrow,
+  title,
+  detail,
+  onClick,
+}: {
+  active: boolean;
+  eyebrow: string;
+  title: string;
+  detail: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`
+        group flex min-h-[104px] flex-col justify-between rounded-lg border p-4 text-left transition-colors
+        ${active ? "border-honey-500/50 bg-honey-500/[0.08]" : "border-white/[0.07] bg-white/[0.015] hover:border-white/15 hover:bg-white/[0.03]"}
+      `}
+    >
+      <span className="flex items-center justify-between gap-3">
+        <span className={`text-[10px] font-medium uppercase tracking-wide ${active ? "text-honey-400" : "text-zinc-600"}`}>
+          {eyebrow}
+        </span>
+        <span
+          className={`flex h-5 w-5 items-center justify-center rounded-full border ${active ? "border-honey-500 bg-honey-500 text-[#111114]" : "border-white/10 text-transparent"}`}
+        >
+          <CheckIcon className="h-3 w-3" />
+        </span>
+      </span>
+      <span>
+        <span className="block text-base font-semibold text-[#fafafa]">{title}</span>
+        <span className="mt-1 block text-sm text-zinc-500">{detail}</span>
+      </span>
+    </button>
+  );
+}
+
+function ToggleRow({
+  checked,
+  label,
+  detail,
+  onChange,
+  disabled = false,
+}: {
+  checked: boolean;
+  label: string;
+  detail: string;
+  onChange: () => void;
+  disabled?: boolean;
+}) {
+  if (disabled) {
+    return (
+      <div className="flex w-full items-center justify-between gap-4 border-b border-white/[0.06] py-4 text-left last:border-b-0 opacity-45">
+        <span className="min-w-0">
+          <span className="block text-sm font-medium text-[#fafafa]">{label}</span>
+          <span className="mt-1 block text-sm text-zinc-500">{detail}</span>
+        </span>
+        <span className="flex h-6 w-11 shrink-0 items-center rounded-full bg-white/10 p-0.5">
+          <span className="h-5 w-5 rounded-full bg-[#111114]" />
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-pressed={checked}
+      onClick={onChange}
+      className="flex w-full items-center justify-between gap-4 border-b border-white/[0.06] py-4 text-left last:border-b-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-honey-500/25"
+    >
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-[#fafafa]">{label}</span>
+        <span className="mt-1 block text-sm text-zinc-500">{detail}</span>
+      </span>
+      <span
+        className={`flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors ${checked ? "bg-honey-500" : "bg-white/10"}`}
+      >
+        <span
+          className={`h-5 w-5 rounded-full bg-[#111114] transition-transform ${checked ? "translate-x-5" : "translate-x-0"}`}
+        />
+      </span>
+    </button>
+  );
+}
+
+function StepHeader({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  children: string;
+}) {
+  return (
+    <header>
+      <p className="text-xs font-medium uppercase tracking-wide text-honey-500">
+        {eyebrow}
+      </p>
+      <h2 className="mt-2 text-xl font-semibold tracking-tight text-[#fafafa]">
+        {title}
+      </h2>
+      <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-400">
+        {children}
+      </p>
+    </header>
+  );
+}
+
+function ToolStep({
+  provider,
+  onProviderChange,
+}: {
+  provider: ProviderId;
+  onProviderChange: (provider: ProviderId) => void;
+}) {
+  return (
+    <div>
+      <StepHeader eyebrow="Start here" title="Which agent CLI should run?">
+        Pick the runtime. You can change it later by editing AGENT_PROVIDER.
+      </StepHeader>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-3">
+        {(Object.keys(PROVIDERS) as ProviderId[]).map((id) => {
+          const option = PROVIDERS[id];
+          return (
+            <OptionButton
+              key={id}
+              active={provider === id}
+              eyebrow={option.eyebrow}
+              title={option.label}
+              detail={option.detail}
+              onClick={() => onProviderChange(id)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function PluginStep({
+  selectedPlugins,
+  onTogglePlugin,
+}: {
+  selectedPlugins: Record<PluginId, boolean>;
+  onTogglePlugin: (plugin: PluginId) => void;
+}) {
+  return (
+    <div>
+      <StepHeader eyebrow="Plugin stack" title="What should the runner know how to do?">
+        Choose the context, tools, and triggers to wire into this runner.
+      </StepHeader>
+
+      <div className="mt-5">
+        {PLUGINS.map((plugin) => (
+          <ToggleRow
+            key={plugin.id}
+            checked={selectedPlugins[plugin.id]}
+            label={plugin.label}
+            detail={plugin.detail}
+            onChange={() => onTogglePlugin(plugin.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HivemootStep({
+  features,
+  githubEnabled,
+  onToggleFeature,
+}: {
+  features: Record<HivemootFeature, boolean>;
+  githubEnabled: boolean;
+  onToggleFeature: (feature: HivemootFeature) => void;
+}) {
+  return (
+    <div>
+      <StepHeader eyebrow="Dashboard connection" title="Should this runner report back?">
+        Enable these when you want dashboard visibility or delegated tasks.
+      </StepHeader>
+
+      <div className="mt-5">
+        {HIVEMOOT_FEATURES.map((feature) => (
+          <ToggleRow
+            key={feature.id}
+            checked={features[feature.id]}
+            label={feature.label}
+            detail={
+              feature.id === "githubWorkflows" && !githubEnabled
+                ? "Requires the GitHub plugin."
+                : feature.detail
+            }
+            disabled={feature.id === "githubWorkflows" && !githubEnabled}
+            onChange={() => onToggleFeature(feature.id)}
+          />
+        ))}
+      </div>
+
+      {(features.health || features.tasks) && (
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <a
+            href={CREDENTIALS_URL}
+            className="rounded-lg bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-colors hover:bg-honey-400"
+          >
+            Generate Agent Token
+          </a>
+          <span className="text-sm text-zinc-500">
+            Needed for health reports and task execution.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConfigStep({
+  generatedConfig,
+  features,
+  installationId,
+}: {
+  generatedConfig: string;
+  features: Record<HivemootFeature, boolean>;
+  installationId?: string;
+}) {
+  const appHref = installationId
+    ? `/api/auth/github/start?installation_id=${encodeURIComponent(installationId)}`
+    : GITHUB_APP_INSTALL_URL;
+
+  return (
+    <div>
+      <StepHeader eyebrow="Generated config" title="Copy this into your local runner.">
+        This is built from the choices you made.
+      </StepHeader>
+
+      <div className="mt-6">
+        <CodeWidget title="Local runner config" language="env + yaml">
+          {generatedConfig}
+        </CodeWidget>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-3">
+        {(features.health || features.tasks) && (
+          <a
+            href={CREDENTIALS_URL}
+            className="rounded-lg bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-colors hover:bg-honey-400"
+          >
+            Generate Agent Token
+          </a>
+        )}
+        {features.githubWorkflows && (
+          <a
+            href={appHref}
+            className="inline-flex items-center gap-2 rounded-lg border border-honey-500/30 px-4 py-2 text-sm font-semibold text-honey-400 transition-colors hover:border-honey-500/50 hover:bg-honey-500/10"
+          >
+            <GitHubIcon className="h-4 w-4" />
+            Optional GitHub App
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function buildGeneratedConfig({
+  provider,
+  selectedPlugins,
+  features,
+}: {
+  provider: ProviderId;
+  selectedPlugins: Record<PluginId, boolean>;
+  features: Record<HivemootFeature, boolean>;
+}) {
+  const envLines = [
+    "# .env",
+    ...PROVIDERS[provider].env,
+    "AGENT_ID=worker",
+    "WORKSPACE_ROOT=/workspace/repo",
+  ];
+
+  const pluginLines = ["# config/hivemoot.yaml", "plugins:"];
+
+  if (selectedPlugins.github) {
+    pluginLines.push(
+      "  github:",
+      "    repos:",
+      "      - owner/repo",
+      "    token_file: !secret github_token",
+      "    workspace: /workspace/repo",
+      "    # Optional event-driven runs:",
+      "    # watch_mentions: true",
+      "    # watch_review_requests: true",
+      "    # watch_new_prs: true",
+    );
+  }
+
+  if (selectedPlugins.browser) {
+    pluginLines.push(
+      "  browser:",
+      "    cdp_url: http://hivemoot-browser:3000",
+      "    state_dir: /state",
+    );
+  }
+
+  if (selectedPlugins.cron) {
+    pluginLines.push(
+      "  cron:",
+      "    schedules:",
+      "      - name: autonomous",
+      "        schedule: \"@every 1h\"",
+      "        prompt: \"Inspect the repo and propose useful next work.\"",
+    );
+  }
+
+  if (features.health || features.tasks || features.githubWorkflows) {
+    pluginLines.push("  hivemoot:", "    token_file: !secret hivemoot_agent_token");
+
+    if (features.health) {
+      pluginLines.push(
+        "    health:",
+        "      enabled: true",
+        "      repo: owner/repo",
+      );
+    }
+
+    if (features.tasks) {
+      pluginLines.push(
+        "    tasks:",
+        "      enabled: true",
+        "      claim_url: https://www.hivemoot.dev/api/tasks/claim",
+        "      execute_base_url: https://www.hivemoot.dev/api/tasks",
+      );
+    }
+
+    if (features.githubWorkflows) {
+      pluginLines.push(
+        "    github_workflows:",
+        "      enabled: true",
+        "      role_name: builder",
+      );
+    }
+  }
+
+  if (pluginLines.length === 2) {
+    pluginLines.push("  {}");
+  }
+
+  const secretLines = [
+    "# config/hivemoot.secrets.yaml",
+    PROVIDERS[provider].secretLine,
+  ];
+
+  if (selectedPlugins.github) {
+    secretLines.push("github_token: /run/secrets/github_token");
+  }
+
+  if (features.health || features.tasks || features.githubWorkflows) {
+    secretLines.push("hivemoot_agent_token: /run/secrets/hivemoot_agent_token");
+  }
+
+  return [
+    "mkdir -p config secrets",
+    "",
+    ...envLines,
+    "",
+    ...pluginLines,
+    "",
+    ...secretLines,
+  ].join("\n");
+}
+
+export default function SetupLocalFlow({
+  auth,
+  reason,
+  installationId,
+}: {
+  auth?: string;
+  reason?: string;
+  installationId?: string;
+}) {
+  const [activeStep, setActiveStep] = useState<FlowStep>(1);
+  const [provider, setProvider] = useState<ProviderId>("codex");
+  const [selectedPlugins, setSelectedPlugins] = useState<Record<PluginId, boolean>>(
+    () =>
+      PLUGINS.reduce(
+        (acc, plugin) => ({ ...acc, [plugin.id]: plugin.defaultEnabled }),
+        {} as Record<PluginId, boolean>,
+      ),
+  );
+  const [features, setFeatures] = useState<Record<HivemootFeature, boolean>>(
+    () =>
+      HIVEMOOT_FEATURES.reduce(
+        (acc, feature) => ({ ...acc, [feature.id]: feature.defaultEnabled }),
+        {} as Record<HivemootFeature, boolean>,
+      ),
+  );
+
+  const generatedConfig = useMemo(
+    () => buildGeneratedConfig({ provider, selectedPlugins, features }),
+    [features, provider, selectedPlugins],
+  );
+
+  function togglePlugin(plugin: PluginId) {
+    setSelectedPlugins((current) => {
+      const next = { ...current, [plugin]: !current[plugin] };
+      if (plugin === "github" && !next.github) {
+        setFeatures((currentFeatures) => ({
+          ...currentFeatures,
+          githubWorkflows: false,
+        }));
+      }
+      return next;
+    });
+  }
+
+  function toggleFeature(feature: HivemootFeature) {
+    if (feature === "githubWorkflows" && !selectedPlugins.github) {
+      return;
+    }
+    setFeatures((current) => ({ ...current, [feature]: !current[feature] }));
+  }
+
+  return (
+    <div className="flex flex-col gap-8 lg:flex-row lg:gap-10">
+      <StepNav activeStep={activeStep} onStepChange={setActiveStep} />
+
+      <section className="min-w-0 flex-1 space-y-4">
+        {auth && <AuthStatusBanner auth={auth} reason={reason} />}
+
+        <div id="local-agent-setup" className="rounded-xl border border-white/[0.06] bg-[#141414] p-6 sm:p-8">
+          {activeStep === 1 && (
+            <ToolStep provider={provider} onProviderChange={setProvider} />
+          )}
+          {activeStep === 2 && (
+            <PluginStep
+              selectedPlugins={selectedPlugins}
+              onTogglePlugin={togglePlugin}
+            />
+          )}
+          {activeStep === 3 && (
+            <HivemootStep
+              features={features}
+              githubEnabled={selectedPlugins.github}
+              onToggleFeature={toggleFeature}
+            />
+          )}
+          {activeStep === 4 && (
+            <ConfigStep
+              generatedConfig={generatedConfig}
+              features={features}
+              installationId={installationId}
+            />
+          )}
+
+          <StepActions activeStep={activeStep} onStepChange={setActiveStep} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/setup/SetupWizard.tsx
+++ b/web/src/app/setup/SetupWizard.tsx
@@ -92,15 +92,15 @@ function StepConnector({ fromStatus }: { fromStatus: StepStatus }) {
 function buildSteps(activeStep: 2 | 3): Step[] {
   if (activeStep === 3) {
     return [
-      { number: 1, label: "Connect GitHub", status: "complete" },
-      { number: 2, label: "Meet the Queen", status: "complete" },
-      { number: 3, label: "Launch your team", status: "active" },
+      { number: 1, label: "GitHub App", status: "complete" },
+      { number: 2, label: "AI key", status: "complete" },
+      { number: 3, label: "Run agents", status: "active" },
     ];
   }
   return [
-    { number: 1, label: "Connect GitHub", status: "complete" },
-    { number: 2, label: "Meet the Queen", status: "active" },
-    { number: 3, label: "Launch your team", status: "upcoming" },
+    { number: 1, label: "GitHub App", status: "complete" },
+    { number: 2, label: "AI key", status: "active" },
+    { number: 3, label: "Run agents", status: "upcoming" },
   ];
 }
 
@@ -145,11 +145,11 @@ function TerminalIcon({ className }: { className?: string }) {
   );
 }
 
-function RocketIcon({ className }: { className?: string }) {
+function KeyIcon({ className }: { className?: string }) {
   return (
     <svg
       className={className ?? "h-5 w-5"}
-      viewBox="0 0 16 16"
+      viewBox="0 0 20 20"
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
@@ -157,9 +157,10 @@ function RocketIcon({ className }: { className?: string }) {
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <path d="M8 12.5s-2 .5-4-1.5c0 0-.5-2 1.5-4C7.5 5 10 3 13 1c0 0-2 3.5-4 5.5-2 2-1 6-1 6Z" />
-      <path d="M5.5 10.5l-2 2" />
-      <path d="M10 6a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" />
+      <circle cx="7" cy="10" r="3" />
+      <line x1="10" y1="10" x2="17" y2="10" />
+      <line x1="14" y1="10" x2="14" y2="7" />
+      <line x1="17" y1="10" x2="17" y2="7" />
     </svg>
   );
 }
@@ -191,10 +192,11 @@ function Step3Content() {
   return (
     <div className="rounded-xl border border-white/[0.06] bg-[#141414] p-6 sm:p-8">
       <h2 className="text-lg font-semibold text-[#fafafa]">
-        Launch your team
+        Run your agents
       </h2>
       <p className="mt-2 text-sm leading-relaxed text-zinc-400">
-        Three things to get your agents working on your repo.
+        The website stores dashboard credentials. The agents still run from
+        your machine or server.
       </p>
 
       <div className="my-6 h-px bg-white/[0.06]" />
@@ -230,25 +232,32 @@ function Step3Content() {
           </div>
         </li>
 
-        {/* 2. Run your agents */}
+        {/* 2. Give agents credentials */}
         <li className="flex gap-3">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-honey-500/10">
-            <TerminalIcon className="h-4 w-4 text-honey-500" />
+            <KeyIcon className="h-4 w-4 text-honey-500" />
           </div>
           <div className="flex-1">
             <h3 className="text-sm font-medium text-[#fafafa]">
-              Run your agents
+              Give agents the keys they need
             </h3>
             <p className="mt-1 text-sm leading-relaxed text-zinc-400">
-              Clone the monorepo, set your target repo and API keys, then
-              start the container.
+              Put repo scope in <code className="rounded bg-white/[0.06] px-1.5 py-0.5 text-xs text-zinc-300">plugins.github.repos</code>, use a GitHub token file for repo work, a provider key file for model execution, and a Hivemoot Agent Token for dashboard task execution and health reporting.
             </p>
             <div className="mt-2 rounded-lg bg-white/[0.03] p-3">
               <pre className="overflow-x-auto text-xs leading-relaxed text-zinc-400">
-                <code>{`git clone https://github.com/hivemoot/hivemoot.git
-cd hivemoot/agent
-cp .env.example .env   # set TARGET_REPO + API keys
-docker compose run --rm hivemoot-agent`}</code>
+                <code>{`plugins:
+  github:
+    repos:
+      - owner/repo
+    token_file: !secret github_token
+  hivemoot:
+    token_file: !secret hivemoot_agent_token
+    health:
+      enabled: true
+      repo: owner/repo
+    tasks:
+      enabled: true`}</code>
               </pre>
             </div>
             <a
@@ -263,20 +272,24 @@ docker compose run --rm hivemoot-agent`}</code>
           </div>
         </li>
 
-        {/* 3. Watch them work */}
+        {/* 3. Start the container */}
         <li className="flex gap-3">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-honey-500/10">
-            <RocketIcon className="h-4 w-4 text-honey-500" />
+            <TerminalIcon className="h-4 w-4 text-honey-500" />
           </div>
           <div className="flex-1">
             <h3 className="text-sm font-medium text-[#fafafa]">
-              Watch them work
+              Start the runner
             </h3>
             <p className="mt-1 text-sm leading-relaxed text-zinc-400">
-              Your agents show up as real GitHub contributors — opening issues,
-              writing code, reviewing PRs. Check your repo&apos;s Issues and Pull
-              Requests to see them in action.
+              Mount your secrets directory and run one agent. Use
+              <code className="ml-1 rounded bg-white/[0.06] px-1.5 py-0.5 text-xs text-zinc-300">docker compose up</code> later for a long-running worker.
             </p>
+            <div className="mt-2 rounded-lg bg-white/[0.03] p-3">
+              <pre className="overflow-x-auto text-xs leading-relaxed text-zinc-400">
+                <code>{`docker compose run --rm -v ./secrets:/run/secrets:ro hivemoot-agent`}</code>
+              </pre>
+            </div>
           </div>
         </li>
       </ol>

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
+import SetupLocalFlow from "./SetupLocalFlow";
 import SetupWizard from "./SetupWizard";
 import { SESSION_TTL_SECONDS, SETUP_SESSION_COOKIE, getSetupSession } from "@/server/setup-session";
 import { getRedisClient } from "@/server/redis";
 import { validateEnv } from "@/server/env";
 
 export const metadata: Metadata = {
-  title: "Set up Hivemoot — Your AI Engineering Team",
+  title: "Set up Hivemoot — Local Agent Runner",
   description:
-    "Connect GitHub, add your API key, and launch your AI agent team in minutes.",
+    "Choose an agent CLI, enable plugins, and generate a local Hivemoot runner config.",
 };
 
 /**
@@ -62,155 +63,10 @@ function HoneycombDecoration({ className }: { className?: string }) {
   );
 }
 
-/** Step status determines visual treatment in the progress indicator. */
-type StepStatus = "complete" | "active" | "upcoming";
-
-interface Step {
-  number: number;
-  label: string;
-  status: StepStatus;
-}
-
-function buildSteps(isAuthorized: boolean): Step[] {
-  return [
-    { number: 1, label: "Connect GitHub", status: isAuthorized ? "complete" : "active" },
-    { number: 2, label: "Meet the Queen", status: isAuthorized ? "active" : "upcoming" },
-    { number: 3, label: "Launch your team", status: "upcoming" },
-  ];
-}
-
-function StepIndicator({ step }: { step: Step }) {
-  const isActive = step.status === "active";
-  const isComplete = step.status === "complete";
-  const isUpcoming = step.status === "upcoming";
-
-  return (
-    <li className="flex items-center gap-3">
-      {/* Step circle */}
-      <div
-        className={`
-          flex h-9 w-9 shrink-0 items-center justify-center rounded-full
-          text-sm font-semibold transition-colors
-          ${isActive ? "bg-honey-500 text-[#0a0a0a]" : ""}
-          ${isComplete ? "bg-honey-500/20 text-honey-400 ring-1 ring-honey-500/40" : ""}
-          ${isUpcoming ? "bg-white/5 text-zinc-500 ring-1 ring-white/10" : ""}
-        `}
-      >
-        {isComplete ? (
-          // Checkmark SVG for completed steps
-          <svg
-            className="h-4 w-4"
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <polyline points="3.5 8.5 6.5 11.5 12.5 4.5" />
-          </svg>
-        ) : (
-          step.number
-        )}
-      </div>
-
-      {/* Step label */}
-      <span
-        className={`
-          text-sm
-          ${isActive ? "font-medium text-[#fafafa]" : ""}
-          ${isComplete ? "text-honey-400" : ""}
-          ${isUpcoming ? "text-zinc-500" : ""}
-        `}
-      >
-        {step.label}
-      </span>
-    </li>
-  );
-}
-
-/** Connector line between steps in the progress indicator. */
-function StepConnector({ fromStatus }: { fromStatus: StepStatus }) {
-  const isActiveOrComplete =
-    fromStatus === "active" || fromStatus === "complete";
-
-  return (
-    <li aria-hidden="true" className="flex items-center pl-[17px]">
-      <div
-        className={`h-6 w-px ${isActiveOrComplete ? "bg-honey-500/30" : "bg-white/5"}`}
-      />
-    </li>
-  );
-}
-
 interface SearchParams {
   installation_id?: string;
   auth?: string;
   reason?: string;
-}
-
-/** Banner shown after the OAuth callback resolves. */
-function AuthStatusBanner({ auth, reason }: { auth: string; reason?: string }) {
-  if (auth === "ok") {
-    return (
-      <div className="mb-6 flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/5 px-4 py-3">
-        <svg className="h-4 w-4 shrink-0 text-green-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <polyline points="3.5 8.5 6.5 11.5 12.5 4.5" />
-        </svg>
-        <p className="text-sm text-green-400">GitHub authorization successful. Continue to Step 2.</p>
-      </div>
-    );
-  }
-  if (auth === "expired") {
-    return (
-      <div className="mb-6 flex items-center gap-2 rounded-lg border border-honey-500/20 bg-honey-500/5 px-4 py-3">
-        <svg className="h-4 w-4 shrink-0 text-honey-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <circle cx="8" cy="8" r="6" />
-          <line x1="8" y1="5" x2="8" y2="8.5" />
-          <circle cx="8" cy="11" r="0.5" fill="currentColor" />
-        </svg>
-        <p className="text-sm text-honey-400">Authorization could not be completed. Click below to try again.</p>
-      </div>
-    );
-  }
-  if (auth === "denied") {
-    return (
-      <div className="mb-6 flex items-center gap-2 rounded-lg border border-zinc-500/20 bg-zinc-500/5 px-4 py-3">
-        <p className="text-sm text-zinc-400">Authorization was cancelled. Click the button below to try again.</p>
-      </div>
-    );
-  }
-  if (auth === "not_installed") {
-    return (
-      <div className="mb-6 flex items-center gap-2 rounded-lg border border-honey-500/20 bg-honey-500/5 px-4 py-3">
-        <svg className="h-4 w-4 shrink-0 text-honey-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <circle cx="8" cy="8" r="6" />
-          <line x1="8" y1="5" x2="8" y2="8.5" />
-          <circle cx="8" cy="11" r="0.5" fill="currentColor" />
-        </svg>
-        <p className="text-sm text-honey-400">No Hivemoot installation found on your account. Install the app first, then come back here.</p>
-      </div>
-    );
-  }
-  if (auth === "forbidden") {
-    const message =
-      reason === "not_org_admin"
-        ? "You need to be an organization admin to configure Hivemoot for this installation."
-        : reason === "user_mismatch"
-          ? "The GitHub account you authorized does not match this installation."
-          : "You are not authorized to configure this installation.";
-    return (
-      <div className="mb-6 flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">
-        <svg className="h-4 w-4 shrink-0 text-red-400" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <line x1="4" y1="4" x2="12" y2="12" />
-          <line x1="12" y1="4" x2="4" y2="12" />
-        </svg>
-        <p className="text-sm text-red-400">{message}</p>
-      </div>
-    );
-  }
-  return null;
 }
 
 export default async function SetupPage({
@@ -227,7 +83,6 @@ export default async function SetupPage({
   const hasSession = !!sessionToken;
 
   const isAuthorized = auth === "ok" && hasSession;
-  const STEPS = buildSteps(isAuthorized);
 
   // Resolve actual session expiry from Redis so the client countdown is accurate.
   // Falls back to a freshly-computed window if Redis is unavailable.
@@ -262,7 +117,7 @@ export default async function SetupPage({
 
       {/* --- Navigation --- */}
       <nav className="relative z-10 border-b border-white/5">
-        <div className="mx-auto flex max-w-3xl items-center gap-2 px-6 py-4">
+        <div className="mx-auto flex max-w-5xl items-center gap-2 px-6 py-4">
           <Link
             href="/"
             className="text-sm font-semibold text-honey-500 transition-colors hover:text-honey-400"
@@ -277,15 +132,14 @@ export default async function SetupPage({
       </nav>
 
       {/* --- Main content --- */}
-      <main className="relative z-10 mx-auto max-w-3xl px-6 py-12">
+      <main className="relative z-10 mx-auto max-w-5xl px-6 py-12">
         {/* Page header */}
         <header className="mb-10">
           <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
-            Set up Hivemoot
+            Build your local runner
           </h1>
           <p className="mt-2 text-sm leading-relaxed text-zinc-400">
-            Connect your GitHub account, add your API key, and your agents
-            start contributing.
+            Pick a runtime, choose plugins, then copy the generated config.
           </p>
         </header>
 
@@ -296,93 +150,17 @@ export default async function SetupPage({
             initialExpiresAt={initialExpiresAt}
           />
         ) : (
-          /* Step 1: static server-rendered */
-          <div className="flex flex-col gap-8 sm:flex-row sm:gap-12">
-            <aside className="shrink-0 sm:w-56">
-              <ol className="flex flex-col" aria-label="Setup progress">
-                {STEPS.map((step, i) => (
-                  <div key={step.number}>
-                    <StepIndicator step={step} />
-                    {i < STEPS.length - 1 && (
-                      <StepConnector fromStatus={step.status} />
-                    )}
-                  </div>
-                ))}
-              </ol>
-            </aside>
-
-            <section className="flex flex-1 flex-col gap-6">
-              <div className="rounded-xl border border-white/[0.06] bg-[#141414] p-6 sm:p-8">
-                {auth && <AuthStatusBanner auth={auth} reason={reason} />}
-
-                <div className="mb-5 flex justify-center">
-                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/[0.06]">
-                    <svg
-                      className="h-7 w-7 text-[#fafafa]"
-                      viewBox="0 0 24 24"
-                      fill="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
-                    </svg>
-                  </div>
-                </div>
-
-                <div className="mb-6 text-center">
-                  <h2 className="text-lg font-semibold text-[#fafafa]">
-                    Connect your GitHub account
-                  </h2>
-                  <p className="mt-2 text-sm leading-relaxed text-zinc-400">
-                    Install the Hivemoot Bot on your repo. It manages your
-                    agent team — coordinating proposals, tracking votes, and
-                    merging approved changes (if you let it).
-                  </p>
-                </div>
-
-                {installationId ? (
-                  <Link
-                    href={`/api/auth/github/start?installation_id=${encodeURIComponent(installationId)}`}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-honey-500 px-5 py-3 text-sm font-semibold text-[#111114] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
-                  >
-                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
-                    </svg>
-                    Authorize with GitHub
-                  </Link>
-                ) : (
-                  <>
-                    <Link
-                      href="https://github.com/apps/hivemoot/installations/new"
-                      className="flex w-full items-center justify-center gap-2.5 rounded-lg bg-honey-500 px-5 py-3 text-sm font-semibold text-[#111114] transition-all hover:bg-honey-400 hover:shadow-lg hover:shadow-honey-500/20"
-                    >
-                      <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
-                      </svg>
-                      Install GitHub App
-                    </Link>
-
-                    <Link
-                      href="/api/auth/github/start-discover"
-                      className="mt-3 flex w-full items-center justify-center rounded-lg px-5 py-2.5 text-sm text-zinc-500 transition-colors hover:text-zinc-300"
-                    >
-                      Already installed? Authorize to continue
-                    </Link>
-                  </>
-                )}
-
-                <p className="mt-4 text-center text-xs leading-relaxed text-zinc-600">
-                  You&apos;ll be redirected to GitHub. After installation,
-                  you&apos;ll return here to finish setup.
-                </p>
-              </div>
-            </section>
-          </div>
+          <SetupLocalFlow
+            auth={auth}
+            reason={reason}
+            installationId={installationId}
+          />
         )}
       </main>
 
       {/* --- Footer --- */}
       <footer className="relative z-10 mt-16 border-t border-white/5">
-        <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-4">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
           <Link
             href="/"
             className="group flex items-center gap-1.5 text-xs text-zinc-500 transition-colors hover:text-zinc-300"

--- a/web/src/server/agent-token.ts
+++ b/web/src/server/agent-token.ts
@@ -2,12 +2,12 @@
  * Agent token lifecycle management.
  *
  * Tokens are 64-char hex strings (32 random bytes). On creation the raw token
- * is encrypted with the BYOK keyring and stored at `hive:agent-token:{installationId}`.
+ * is encrypted with the BYOK keyring and stored at `hive:agent-token:{scopeId}`.
  * A SHA-256 hash of the raw token is stored as a reverse index at
  * `agent-token-hash:{hash}` so incoming Bearer tokens can be resolved to an
- * installationId in O(1) without decrypting anything.
+ * installation/user scope in O(1) without decrypting anything.
  *
- * Only one active token per installation. Creating a new token revokes the old one.
+ * Only one active token per scope. Creating a new token revokes the old one.
  */
 
 import { randomBytes, createHash } from "crypto";

--- a/web/src/server/byok-store.ts
+++ b/web/src/server/byok-store.ts
@@ -1,7 +1,7 @@
 /**
  * Redis-backed BYOK envelope storage.
  *
- * Each installation gets one encrypted envelope at `hive:byok:{installationId}`.
+ * Each dashboard scope gets one encrypted envelope at `hive:byok:{scopeId}`.
  * The envelope holds the provider's API key in encrypted form plus non-sensitive
  * metadata (provider name, model, key fingerprint, status).
  */

--- a/web/src/server/setup-session.test.ts
+++ b/web/src/server/setup-session.test.ts
@@ -54,11 +54,27 @@ import {
   createOAuthState,
   validateOAuthState,
   createSetupSession,
+  createUserScopeId,
   getSetupSession,
+  isGitHubInstallationScope,
   isSessionFresh,
+  isUserScopeId,
   SESSION_TTL_SECONDS,
   SESSION_FRESHNESS_SECONDS,
 } from "./setup-session";
+
+describe("session scope helpers", () => {
+  it("creates stable user-scoped ids", () => {
+    expect(createUserScopeId(42)).toBe("user:42");
+  });
+
+  it("distinguishes GitHub installation scopes from user scopes", () => {
+    expect(isGitHubInstallationScope("12345")).toBe(true);
+    expect(isGitHubInstallationScope("user:42")).toBe(false);
+    expect(isUserScopeId("user:42")).toBe(true);
+    expect(isUserScopeId("12345")).toBe(false);
+  });
+});
 
 describe("createOAuthState", () => {
   it("returns a 64-char hex state string and state-binding nonce", async () => {

--- a/web/src/server/setup-session.ts
+++ b/web/src/server/setup-session.ts
@@ -7,8 +7,13 @@
  *    Validated on callback to prevent CSRF. Deleted after single use.
  *
  * 2. **Setup session token** — an opaque random token issued after successful
- *    OAuth + admin verification. Stored in Redis with a 24-hour TTL. Required
- *    on all subsequent /api/byok/* calls (Phase 3).
+ *    OAuth. Stored in Redis with a 24-hour TTL. Required on dashboard routes.
+ *
+ * Sessions are scoped either to a GitHub App installation id (numeric string)
+ * or to the authenticated GitHub user (`user:<id>`) when the user has not
+ * installed the GitHub App yet. Dashboard credentials, tasks, and health
+ * reporting can use either scope; GitHub repo automation requires a numeric
+ * installation scope.
  */
 
 import { randomBytes } from "crypto";
@@ -23,6 +28,7 @@ export const SESSION_FRESHNESS_SECONDS = 15 * 60;
 
 const STATE_KEY_PREFIX = "oauth-state:";
 const SESSION_KEY_PREFIX = "setup-session:";
+const USER_SCOPE_PREFIX = "user:";
 
 /**
  * Sentinel value used as the installationId in OAuth state when the user
@@ -30,6 +36,18 @@ const SESSION_KEY_PREFIX = "setup-session:";
  * and resolves the real installationId via `GET /user/installations`.
  */
 export const DISCOVER_SENTINEL = "discover";
+
+export function createUserScopeId(userId: number): string {
+  return `${USER_SCOPE_PREFIX}${userId}`;
+}
+
+export function isUserScopeId(scopeId: string): boolean {
+  return scopeId.startsWith(USER_SCOPE_PREFIX);
+}
+
+export function isGitHubInstallationScope(scopeId: string): boolean {
+  return /^\d+$/.test(scopeId);
+}
 
 interface OAuthStatePayload {
   installationId: string;
@@ -90,6 +108,11 @@ export async function validateOAuthState(
 }
 
 export interface SetupSessionPayload {
+  /**
+   * Dashboard scope id. Numeric strings are GitHub App installation ids.
+   * `user:<github-id>` means the user authenticated with GitHub OAuth but has
+   * not connected a GitHub App installation.
+   */
   installationId: string;
   userId: number;
   userLogin: string;


### PR DESCRIPTION
## Description

This change makes setup start with a local runner configurator instead of forcing GitHub App installation up front. Users can choose a provider CLI, enable runtime plugins, opt into Hivemoot reporting/tasks, and copy generated local config.

It also allows dashboard credentials, health reporting, and task execution to work from a user-scoped session when no GitHub App installation exists. GitHub App installation remains available for repo governance automation.

## Visual Changes

Before: setup immediately pushed users toward GitHub App installation.

After: setup walks through Tool, Plugins, Hivemoot, and Config steps, then generates `.env`, `hivemoot.yaml`, and secrets mapping.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test` passed with 604 passed, 1 skipped
- `http://localhost:3000/setup?auth=not_installed` returned 200