### PR TITLE
docs(apiarist): add hashed_token to mint example

### DIFF
--- a/apiarist/DESIGN.md
+++ b/apiarist/DESIGN.md
@@ -615,6 +615,7 @@ infrastructure isn't there yet.
 {
   "token": "ghs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "expires_at": "2026-04-24T18:30:00Z",
+  "hashed_token": "9pY3KbXp5RfXYqjpFoJoCFQVLkv4XfV2sZqK8iCJ7WI=",
   "installation_id": "67890",
   "permissions": {
     "contents": "read",


### PR DESCRIPTION
## Summary

Adds `hashed_token` to the §11 successful mint response example in `apiarist/DESIGN.md`.

This follows up on the PR #489 review thread: the shipped route, §3 diagram, and §11 audit-hash prose all document `hashed_token`, but the JSON example still omitted it after the rebase.

## Before / after

Before: the example listed `token`, `expires_at`, `installation_id`, `permissions`, and `repositories`.

After: the example also lists `hashed_token`, matching the actual response shape and audit-hash prose.

## Verification

- Documentation-only change; verified the rendered source diff locally.

Refs #489.



Closes #665
