### PR TITLE
Fail-fast / clear errors for /notifications ops with App installation tokens

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/__init__.py
@@ -181,6 +181,39 @@ class GitHubPlugin:
                 errors.append(
                     f"plugins.github.token_file is empty: {cfg.token_file}"
                 )
+
+        # Subscriber mode is incompatible with /notifications-based
+        # watchers (mentions + review_requests). App installation
+        # tokens (ghs_*) cannot reach /notifications — GitHub returns
+        # 403 — so the underlying `hivemoot watch` command fails with
+        # a misleading "Could not determine GitHub user" error every
+        # poll cycle. Catch the misconfiguration at engine activation
+        # and point the operator at the App-token-compatible
+        # alternative (watch_new_prs polls /repos/{owner}/{repo}/pulls
+        # directly). See apiarist/DESIGN.md §12.3.7 for the full
+        # architectural rationale; the relevant nuance is that all
+        # App-authed agents share a single bot identity, so mention-
+        # based and review-request workflows need a routing layer
+        # (bot-mediated dispatch via the task queue, or label-based
+        # polling) rather than a CLI patch.
+        if cfg.token_source == "subscriber":
+            if cfg.watch_mentions:
+                errors.append(
+                    "plugins.github.watch_mentions: true is not supported "
+                    "with token_source: subscriber. App installation "
+                    "tokens cannot access /notifications. Use "
+                    "watch_new_prs (poll-based, App-token compatible) "
+                    "or set token_source: file."
+                )
+            if cfg.watch_review_requests:
+                errors.append(
+                    "plugins.github.watch_review_requests: true is not "
+                    "supported with token_source: subscriber. App "
+                    "installation tokens cannot access /notifications "
+                    "and cannot be assigned as PR reviewers. Use "
+                    "watch_new_prs (poll-based, App-token compatible) "
+                    "or set token_source: file."
+                )
         return errors
 
     def triggers(self) -> list[Trigger]:

--- a/agent/cli/tests/test_github_token_source_subscriber.py
+++ b/agent/cli/tests/test_github_token_source_subscriber.py
@@ -95,6 +95,70 @@ class ValidateTest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             GitHubConfig(repos=["a/b"], token_source="bogus")  # type: ignore[arg-type]
 
+    def test_subscriber_mode_rejects_watch_mentions(self) -> None:
+        """App tokens can't reach /notifications — fail-fast at validate."""
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"],
+            token_source="subscriber",
+            watch_mentions=True,
+        )
+        cfg = PluginConfig(name="github", typed=cfg_typed)
+        errors = plugin.validate(cfg)
+        self.assertTrue(
+            any(
+                "watch_mentions" in e and "subscriber" in e and "watch_new_prs" in e
+                for e in errors
+            ),
+            f"expected mentions+subscriber error pointing at watch_new_prs, got {errors}",
+        )
+
+    def test_subscriber_mode_rejects_watch_review_requests(self) -> None:
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"],
+            token_source="subscriber",
+            watch_review_requests=True,
+        )
+        cfg = PluginConfig(name="github", typed=cfg_typed)
+        errors = plugin.validate(cfg)
+        self.assertTrue(
+            any(
+                "watch_review_requests" in e and "subscriber" in e
+                for e in errors
+            ),
+            f"expected review-requests+subscriber error, got {errors}",
+        )
+
+    def test_subscriber_mode_allows_watch_new_prs(self) -> None:
+        """watch_new_prs is App-token compatible; should NOT error."""
+        plugin = GitHubPlugin()
+        cfg_typed = GitHubConfig(
+            repos=["acme/repo"],
+            token_source="subscriber",
+            watch_new_prs=True,
+        )
+        cfg = PluginConfig(name="github", typed=cfg_typed)
+        errors = plugin.validate(cfg)
+        self.assertEqual(errors, [])
+
+    def test_file_mode_still_allows_all_watch_types(self) -> None:
+        """The new fail-fast check is subscriber-mode-only."""
+        with tempfile.TemporaryDirectory() as tmp:
+            token_file = Path(tmp) / "tok"
+            token_file.write_text("ghp_x")
+            plugin = GitHubPlugin()
+            cfg_typed = GitHubConfig(
+                repos=["acme/repo"],
+                token_source="file",
+                token_file=token_file,
+                watch_mentions=True,
+                watch_review_requests=True,
+                watch_new_prs=True,
+            )
+            cfg = PluginConfig(name="github", typed=cfg_typed)
+            self.assertEqual(plugin.validate(cfg), [])
+
 
 # ── setup() in subscriber mode ────────────────────────────────────
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/ack.ts
+++ b/cli/src/commands/ack.ts
@@ -1,4 +1,5 @@
 import { CliError, type AckOptions } from "../config/types.js";
+import { rejectAppInstallationToken } from "../github/auth-guard.js";
 import { markNotificationRead } from "../github/notifications.js";
 import { appendAck } from "../watch/state.js";
 
@@ -7,6 +8,10 @@ function log(message: string): void {
 }
 
 export async function ackCommand(key: string, options: AckOptions): Promise<void> {
+  // App installation tokens cannot PATCH /notifications/threads/:id —
+  // surface this with an actionable error before we touch GitHub.
+  rejectAppInstallationToken("ack");
+
   const colonIndex = key.indexOf(":");
   if (colonIndex < 1) {
     throw new CliError(

--- a/cli/src/commands/notifications-pull.ts
+++ b/cli/src/commands/notifications-pull.ts
@@ -1,4 +1,5 @@
 import { CliError } from "../config/types.js";
+import { rejectAppInstallationToken } from "../github/auth-guard.js";
 import { fetchNotificationsPull, type NotificationsPullResult } from "../github/fetch-notifications.js";
 
 export interface NotificationsPullOptions {
@@ -36,6 +37,11 @@ function formatResult(result: NotificationsPullResult): string {
 export async function notificationsPullCommand(
   options: NotificationsPullOptions,
 ): Promise<void> {
+  // App installation tokens cannot list /notifications — surface this
+  // before any backend call so the operator gets an actionable error
+  // instead of GitHub's raw 403.
+  rejectAppInstallationToken("notifications-pull");
+
   const rawReasons = options.reason ?? "*";
   const reasons = rawReasons
     .split(",")

--- a/cli/src/commands/watch.test.ts
+++ b/cli/src/commands/watch.test.ts
@@ -166,6 +166,80 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe("watchCommand — App installation token rejection", () => {
+  // App tokens (ghs_*) can't reach /notifications. The command must
+  // fail fast with an actionable message instead of letting
+  // fetchCurrentUser() emit the misleading "Could not determine
+  // GitHub user" error.
+  const originalGhToken = process.env.GH_TOKEN;
+  const originalGithubToken = process.env.GITHUB_TOKEN;
+
+  afterEach(() => {
+    if (originalGhToken === undefined) delete process.env.GH_TOKEN;
+    else process.env.GH_TOKEN = originalGhToken;
+    if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalGithubToken;
+  });
+
+  it("rejects ghs_-prefixed GH_TOKEN with GH_APP_TOKEN_UNSUPPORTED", async () => {
+    process.env.GH_TOKEN = "ghs_fake_installation_token_xyz";
+    delete process.env.GITHUB_TOKEN;
+
+    await expect(
+      watchCommand({ repo: "owner/repo", once: true }),
+    ).rejects.toMatchObject({
+      code: "GH_APP_TOKEN_UNSUPPORTED",
+    });
+
+    // Critically — fetchCurrentUser is NEVER called; we don't want
+    // the misleading "Could not determine GitHub user" path reachable.
+    expect(mockedFetchUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects ghs_-prefixed GITHUB_TOKEN when GH_TOKEN is unset", async () => {
+    delete process.env.GH_TOKEN;
+    process.env.GITHUB_TOKEN = "ghs_another_installation_token";
+
+    await expect(
+      watchCommand({ repo: "owner/repo", once: true }),
+    ).rejects.toMatchObject({
+      code: "GH_APP_TOKEN_UNSUPPORTED",
+    });
+  });
+
+  it("error message points operators at watch_new_prs as the App-compatible alternative", async () => {
+    process.env.GH_TOKEN = "ghs_xyz";
+    delete process.env.GITHUB_TOKEN;
+
+    let captured: CliError | undefined;
+    try {
+      await watchCommand({ repo: "owner/repo", once: true });
+    } catch (err) {
+      captured = err as CliError;
+    }
+    expect(captured).toBeDefined();
+    expect(captured?.message).toMatch(/watch_new_prs/);
+    expect(captured?.message).toMatch(/App installation tokens/);
+  });
+
+  it("does NOT reject a ghp_-prefixed PAT (file-mode legacy path stays intact)", async () => {
+    process.env.GH_TOKEN = "ghp_classic_pat_value";
+    delete process.env.GITHUB_TOKEN;
+
+    // Set up minimal mocks so the command proceeds past the
+    // ghs_-check into normal fetchCurrentUser flow.
+    mockedFetchUser.mockResolvedValue("test-user");
+    mockedFetchMentions.mockResolvedValue(makeConditionalResult([]));
+
+    await watchCommand({ repo: "owner/repo", once: true });
+
+    // The ghp_ token went through the normal path — fetchCurrentUser
+    // was reached. (Whether it succeeded or failed isn't the point;
+    // the App-token short-circuit didn't trigger.)
+    expect(mockedFetchUser).toHaveBeenCalled();
+  });
+});
+
 describe("watchCommand (--once mode)", () => {
   it("emits event to stdout without marking notification as read", async () => {
     const notification = makeNotification();

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -117,6 +117,31 @@ export async function watchCommand(options: WatchOptions): Promise<void> {
   const stateFile = options.stateFile ?? ".hivemoot-watch.json";
   const reasons = (options.reasons ?? "mention").split(",").map((r) => r.trim());
 
+  // App installation tokens (ghs_*) can't reach GitHub's
+  // /notifications API — it's user-scoped and returns 403 for App
+  // auth — so this command can't function with one. Detect the prefix
+  // and fail fast with an actionable message rather than letting
+  // fetchCurrentUser() emit the misleading "Could not determine
+  // GitHub user" error (which sounds like a token-validity bug).
+  // See apiarist DESIGN.md §12.3.7 for the App-token / notifications
+  // incompatibility background.
+  const tokenForAuth = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
+  if (tokenForAuth.startsWith("ghs_")) {
+    throw new CliError(
+      "App installation tokens (ghs_*) cannot access GitHub's " +
+        "/notifications API and so cannot be used with `hivemoot watch`. " +
+        "For App-token-compatible PR watching use the `watch_new_prs` " +
+        "trigger (polls /repos/{owner}/{repo}/pulls directly). " +
+        "Mention-based or review-request workflows for App tokens need " +
+        "a routing layer (bot-mediated dispatch via the task queue, or " +
+        "label-based polling) since all App-authed agents share the " +
+        "single bot identity. See apiarist/DESIGN.md §12.3.7 for the " +
+        "architectural rationale.",
+      "GH_APP_TOKEN_UNSUPPORTED",
+      2,
+    );
+  }
+
   // Resolve authenticated user login (used as agent name in events)
   let agent: string;
   try {

--- a/cli/src/commands/watch.ts
+++ b/cli/src/commands/watch.ts
@@ -1,5 +1,6 @@
 import type { WatchOptions } from "../config/types.js";
 import { CliError } from "../config/types.js";
+import { rejectAppInstallationToken } from "../github/auth-guard.js";
 import { fetchCurrentUser } from "../github/user.js";
 import type { CommentDetail } from "../github/notifications.js";
 import {
@@ -118,29 +119,12 @@ export async function watchCommand(options: WatchOptions): Promise<void> {
   const reasons = (options.reasons ?? "mention").split(",").map((r) => r.trim());
 
   // App installation tokens (ghs_*) can't reach GitHub's
-  // /notifications API — it's user-scoped and returns 403 for App
-  // auth — so this command can't function with one. Detect the prefix
-  // and fail fast with an actionable message rather than letting
-  // fetchCurrentUser() emit the misleading "Could not determine
-  // GitHub user" error (which sounds like a token-validity bug).
-  // See apiarist DESIGN.md §12.3.7 for the App-token / notifications
-  // incompatibility background.
-  const tokenForAuth = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
-  if (tokenForAuth.startsWith("ghs_")) {
-    throw new CliError(
-      "App installation tokens (ghs_*) cannot access GitHub's " +
-        "/notifications API and so cannot be used with `hivemoot watch`. " +
-        "For App-token-compatible PR watching use the `watch_new_prs` " +
-        "trigger (polls /repos/{owner}/{repo}/pulls directly). " +
-        "Mention-based or review-request workflows for App tokens need " +
-        "a routing layer (bot-mediated dispatch via the task queue, or " +
-        "label-based polling) since all App-authed agents share the " +
-        "single bot identity. See apiarist/DESIGN.md §12.3.7 for the " +
-        "architectural rationale.",
-      "GH_APP_TOKEN_UNSUPPORTED",
-      2,
-    );
-  }
+  // /notifications API — fail fast with an actionable message before
+  // letting fetchCurrentUser() emit the misleading "Could not determine
+  // GitHub user" error. Shared helper covers `watch`,
+  // `notifications-pull`, and `ack` uniformly. See apiarist
+  // DESIGN.md §12.3.7 for the App-token / notifications incompatibility.
+  rejectAppInstallationToken("watch");
 
   // Resolve authenticated user login (used as agent name in events)
   let agent: string;

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -264,6 +264,7 @@ export type ErrorCode =
   | "ROLE_NOT_FOUND"
   | "INVALID_CONFIG"
   | "RATE_LIMITED"
+  | "GH_APP_TOKEN_UNSUPPORTED"
   | "GH_ERROR";
 
 export class CliError extends Error {

--- a/cli/src/github/auth-guard.test.ts
+++ b/cli/src/github/auth-guard.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { CliError } from "../config/types.js";
+import { rejectAppInstallationToken } from "./auth-guard.js";
+
+describe("rejectAppInstallationToken", () => {
+  // Restore env vars after each test so we don't leak between cases
+  // (or with whatever the host environment had set).
+  const origGhToken = process.env.GH_TOKEN;
+  const origGithubToken = process.env.GITHUB_TOKEN;
+  afterEach(() => {
+    if (origGhToken === undefined) delete process.env.GH_TOKEN;
+    else process.env.GH_TOKEN = origGhToken;
+    if (origGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = origGithubToken;
+  });
+
+  it("rejects ghs_-prefixed GH_TOKEN with GH_APP_TOKEN_UNSUPPORTED", () => {
+    process.env.GH_TOKEN = "ghs_fake_installation_token_xyz";
+    delete process.env.GITHUB_TOKEN;
+
+    expect(() => rejectAppInstallationToken("watch")).toThrowError(
+      expect.objectContaining({ code: "GH_APP_TOKEN_UNSUPPORTED" }),
+    );
+  });
+
+  it("rejects ghs_-prefixed GITHUB_TOKEN when GH_TOKEN is unset", () => {
+    delete process.env.GH_TOKEN;
+    process.env.GITHUB_TOKEN = "ghs_another_one";
+
+    expect(() => rejectAppInstallationToken("ack")).toThrowError(
+      expect.objectContaining({ code: "GH_APP_TOKEN_UNSUPPORTED" }),
+    );
+  });
+
+  it("error message names the command and points at watch_new_prs", () => {
+    process.env.GH_TOKEN = "ghs_x";
+    delete process.env.GITHUB_TOKEN;
+
+    let captured: CliError | undefined;
+    try {
+      rejectAppInstallationToken("notifications-pull");
+    } catch (err) {
+      captured = err as CliError;
+    }
+    expect(captured).toBeDefined();
+    expect(captured?.message).toMatch(/hivemoot notifications-pull/);
+    expect(captured?.message).toMatch(/watch_new_prs/);
+    expect(captured?.message).toMatch(/App installation tokens/);
+    expect(captured?.exitCode).toBe(2);
+  });
+
+  it("does NOT reject a ghp_-prefixed PAT (legacy user PAT)", () => {
+    process.env.GH_TOKEN = "ghp_classic_pat";
+    delete process.env.GITHUB_TOKEN;
+    expect(() => rejectAppInstallationToken("watch")).not.toThrow();
+  });
+
+  it("does NOT reject a gho_-prefixed user-to-server OAuth token", () => {
+    process.env.GH_TOKEN = "gho_oauth_user_to_server";
+    delete process.env.GITHUB_TOKEN;
+    expect(() => rejectAppInstallationToken("watch")).not.toThrow();
+  });
+
+  it("does NOT reject when no token env is set (downstream error handles it)", () => {
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    // Empty token string doesn't match ghs_ prefix → passes guard.
+    // The downstream gh call will fail with auth error — which is the
+    // correct behavior (operator forgot to set the token).
+    expect(() => rejectAppInstallationToken("watch")).not.toThrow();
+  });
+
+  it("prefers GH_TOKEN over GITHUB_TOKEN when both are set", () => {
+    // Mirrors gh CLI's own precedence — GH_TOKEN wins. The guard
+    // should check the SAME token gh would actually use.
+    process.env.GH_TOKEN = "ghp_legacy_pat";
+    process.env.GITHUB_TOKEN = "ghs_app_installation";
+    expect(() => rejectAppInstallationToken("watch")).not.toThrow();
+  });
+});

--- a/cli/src/github/auth-guard.ts
+++ b/cli/src/github/auth-guard.ts
@@ -1,0 +1,45 @@
+import { CliError } from "../config/types.js";
+
+/**
+ * Reject GitHub App installation tokens (`ghs_*`) for commands that
+ * depend on user-scoped GitHub APIs (`/notifications`, `/user`, etc.).
+ *
+ * App installation tokens authenticate as the GitHub App rather than
+ * a user, so any endpoint scoped to "the authenticated user" returns
+ * `403 Resource not accessible by integration`. The downstream error
+ * is misleading — a token-validity-shaped error message for what is
+ * actually an API-incompatibility problem — so commands that touch
+ * these endpoints check for the prefix here and fail fast with an
+ * actionable message instead.
+ *
+ * Used by:
+ *   - `hivemoot watch`        (polls `/notifications`)
+ *   - `hivemoot notifications-pull`  (lists `/notifications`)
+ *   - `hivemoot ack`          (PATCHes `/notifications/threads/:id`)
+ *
+ * `ghp_` (classic PAT), `gho_` (OAuth user-to-server), `ghu_` (server-
+ * to-user), `ghr_` (refresh) all stay user-scoped and remain valid for
+ * `/notifications` — only `ghs_` is rejected.
+ *
+ * Architectural rationale lives in `apiarist/DESIGN.md` §12.3.7. The
+ * routing-layer alternatives (bot-mediated dispatch via the task queue,
+ * label-based polling) handle the use case App tokens can't cover.
+ */
+export function rejectAppInstallationToken(commandName: string): void {
+  const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
+  if (token.startsWith("ghs_")) {
+    throw new CliError(
+      `App installation tokens (ghs_*) cannot access GitHub's ` +
+        `/notifications API and so cannot be used with \`hivemoot ${commandName}\`. ` +
+        `For App-token-compatible PR watching use the \`watch_new_prs\` ` +
+        `trigger (polls /repos/{owner}/{repo}/pulls directly). ` +
+        `Mention-based or review-request workflows for App tokens need ` +
+        `a routing layer (bot-mediated dispatch via the task queue, or ` +
+        `label-based polling) since all App-authed agents share the ` +
+        `single bot identity. See apiarist/DESIGN.md §12.3.7 for the ` +
+        `architectural rationale.`,
+      "GH_APP_TOKEN_UNSUPPORTED",
+      2,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Two-surface follow-up to the apiarist V1 pilot (PR #490): turns the misleading runtime errors from the `hivemoot watch` CLI and the github plugin's notification-based watchers into honest configuration errors with actionable remediation, when running under App installation tokens (\`ghs_*\`).

Doesn't change the underlying constraint — App tokens fundamentally cannot reach GitHub's \`/notifications\` API (returns 403, user-scoped) and so cannot be used with mention or review-request watching. This PR just makes the failure mode explicit at the right layer instead of letting it surface as repeated stderr spam at runtime.

## Why this matters

When drone (apiarist V1 pilot, subscriber-mode auth) was deployed with the inherited \`watch_mentions: true\` + \`watch_review_requests: true\` defaults, the runtime emitted:

\`\`\`
[github-mention] poll failed: hivemoot watch exited 2:
  Error: Could not determine GitHub user. Ensure token is valid.
[github-review-request] poll failed: hivemoot watch exited 2:
  Error: Could not determine GitHub user. Ensure token is valid.
\`\`\`

…every 90 seconds. The error message reads as "token is broken" — but the token is *fine* (apiarist minted it successfully against GitHub), the *API endpoint* is what's incompatible. Operators who don't already know the App-token / notifications mismatch waste time investigating apiarist or the agent token before finding the real cause.

## What it looks like

**CLI — `hivemoot watch` invoked with an App token:**

Before:
\`\`\`
$ GH_TOKEN=ghs_xxx hivemoot watch --repo hivemoot/hivemoot
Error: Could not determine GitHub user. Ensure token is valid.
\`\`\`

After:
\`\`\`
$ GH_TOKEN=ghs_xxx hivemoot watch --repo hivemoot/hivemoot
Error: App installation tokens (ghs_*) cannot access GitHub's
/notifications API and so cannot be used with \`hivemoot watch\`.
For App-token-compatible PR watching use the \`watch_new_prs\`
trigger (polls /repos/{owner}/{repo}/pulls directly). Mention-based
or review-request workflows for App tokens need a routing layer
(bot-mediated dispatch via the task queue, or label-based polling)
since all App-authed agents share the single bot identity. See
apiarist/DESIGN.md §12.3.7 for the architectural rationale.

[exit code 2, error code: GH_APP_TOKEN_UNSUPPORTED]
\`\`\`

**Agent runtime — github plugin validate() with `token_source: subscriber + watch_mentions: true`:**

Before: deploys cleanly, container starts, \`watch_mentions\` polls fail every 90s with the same misleading "Could not determine GitHub user" — silent stderr spam, drone never receives events but the Fleet Summary still shows ✓.

After:
\`\`\`
[engine] FATAL: plugin 'github' validation failed:
  - plugins.github.watch_mentions: true is not supported with
    token_source: subscriber. App installation tokens cannot
    access /notifications. Use watch_new_prs (poll-based,
    App-token compatible) or set token_source: file.
  - plugins.github.watch_review_requests: true is not supported
    with token_source: subscriber. ...
\`\`\`

Container refuses to start; operator sees the misconfiguration at deploy time in deploy-apiary.sh's Fleet Summary STATUS column, not as ongoing log noise.

## Test plan

- [x] CLI: 4 new tests in \`cli/src/commands/watch.test.ts\` — verifies \`ghs_\`-prefixed \`GH_TOKEN\` AND \`GITHUB_TOKEN\` both trigger the rejection, that \`fetchCurrentUser()\` is NEVER called on the App-token path (so the misleading error is truly unreachable), that the error message points at \`watch_new_prs\`, and that \`ghp_\`-prefixed PATs continue through the legacy path. 823/823 CLI tests pass.
- [x] Agent runtime: 4 new tests in \`agent/cli/tests/test_github_token_source_subscriber.py\` — covers both subscriber-mode rejected combos (\`watch_mentions\`, \`watch_review_requests\`), the allowed case (\`watch_new_prs\` + subscriber), and the file-mode-still-allows-everything case. 491/491 agent tests pass.

## Doesn't fix

- App-token mention / review-request workflows. Those need a routing layer (bot-mediated dispatch or label-based polling) since all subscriber-mode agents share the single \`hivemoot[bot]\` identity — there's no per-agent identity at the GitHub layer to route mentions to. Designed in a separate V1.1 follow-up.