### PR TITLE
opencode provider: pass --dangerously-skip-permissions in headless mode

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: python3 cli/tests/test_formatter.py
       - name: Verify engine and oneshot tests
         run: python3 cli/tests/test_engine.py
+      - name: Verify opencode provider argv (--dangerously-skip-permissions invariant)
+        run: python3 cli/tests/test_opencode_provider.py
       - name: Verify engine lifecycle contract tests
         run: python3 cli/tests/test_engine_lifecycle.py
       - name: Verify container lifecycle FSM (apiarist Phase L' invariants I1-I5)

--- a/agent/README.md
+++ b/agent/README.md
@@ -794,7 +794,7 @@ OPENROUTER_API_KEY_FILE=/run/secrets/openrouter_api_key
 | Codex | `--dangerously-bypass-approvals-and-sandbox` (no active Codex sandbox flag in `main`) | Container isolation plus your mounted workspace | `--full-auto` workspace-write path in [#224](https://github.com/hivemoot/hivemoot-agent/pull/224) |
 | Gemini | `--yolo` (this runtime does not configure Gemini policy/sandbox controls) | Container isolation plus your mounted workspace | Configure Gemini CLI `--sandbox`, `--approval-mode`, and `--policy` in runtime defaults |
 | Kilo | `kilo run --auto` (no provider-level deny list configured by this runtime) | Container isolation plus your mounted workspace | Depends on upstream/provider-specific capability support |
-| OpenCode | `opencode run` (no provider-level deny list configured by this runtime) | Container isolation plus your mounted workspace | Depends on upstream/provider-specific capability support |
+| OpenCode | `opencode run --dangerously-skip-permissions` (auto-approves anything not explicitly denied in operator's `opencode.json`; the deploy-staged config retains explicit `deny` patterns for `*.env` / `*.key` / `*.pem` / `*secret*` on read and `doom_loop` action) | Container isolation plus your mounted workspace; opencode's deny patterns layered on top | Pending: link to PR adding provider-level deny-list contract once OpenCode upstream surfaces a policy hook |
 
 When running Gemini against untrusted repositories, treat the container boundary as the primary runtime defense. Add external controls (for example, network egress restrictions and tightly scoped credentials) if exfiltration risk is a concern.
 

--- a/agent/cli/hivemoot_agent/providers/opencode.py
+++ b/agent/cli/hivemoot_agent/providers/opencode.py
@@ -24,6 +24,19 @@ def build_cmd(
 ) -> list[str]:
     combined = f"{system_prompt}\n\n{prompt}"
     cmd = ["opencode", "run"]
+    # Headless containers have no human to answer permission prompts, so
+    # opencode's default "ask" behavior on rules like external_directory
+    # silently blocks every gh/git invocation the agent attempts. The
+    # documented escape hatch is --dangerously-skip-permissions, which
+    # auto-approves anything the operator's opencode.json hasn't
+    # explicitly denied. The deny patterns in the deploy-staged config
+    # (*.env / *.key / *.pem / *secret* on read; doom_loop deny) stay
+    # in effect — only the "ask" cases get auto-approved. Container
+    # filesystem isolation (the docker mount set) is the real security
+    # boundary; opencode's interactive permission UI was layered on top
+    # for human-in-the-loop usage and doesn't fit the headless agent
+    # mode we run here.
+    cmd.append("--dangerously-skip-permissions")
     # Prefer OPENCODE_MODEL over the generic AGENT_MODEL passed as `model`.
     effective_model = os.environ.get(_MODEL_ENV, "") or model
     if effective_model:

--- a/agent/cli/tests/test_opencode_provider.py
+++ b/agent/cli/tests/test_opencode_provider.py
@@ -1,0 +1,127 @@
+"""Tests for ``hivemoot_agent.providers.opencode``.
+
+Pins the security-affecting argv composition: opencode is invoked with
+``--dangerously-skip-permissions`` so headless container runs don't get
+silently blocked by opencode's interactive permission "ask" prompts.
+
+Without this flag, drone (and any other opencode-backed agent) reaches
+``gh pr review`` and exits cleanly without posting because opencode
+treats the bash tool call as needing external_directory access, which
+defaults to "ask" → blocks in non-interactive mode. The flag is the
+documented opencode escape hatch; explicit deny patterns in the
+operator's opencode.json (``*.env`` / ``*.key`` / ``*.pem`` /
+``*secret*`` on read; ``doom_loop`` deny) remain in force.
+
+Test coverage:
+
+- ``--dangerously-skip-permissions`` is in argv (positional check —
+  must appear before the prompt body).
+- ``--model`` flag carried through when supplied.
+- ``OPENCODE_MODEL`` env override beats the ``model`` parameter
+  (existing behavior; pin against regression).
+- Prompt body is appended last so it's not interpreted as a flag.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.providers import opencode
+
+
+class OpenCodeBuildCmdTest(unittest.TestCase):
+    """Argv composition guarantees for the opencode provider."""
+
+    def setUp(self) -> None:
+        # OPENCODE_MODEL bleeds across tests; isolate.
+        self._orig_opencode_model = os.environ.pop("OPENCODE_MODEL", None)
+
+    def tearDown(self) -> None:
+        if self._orig_opencode_model is None:
+            os.environ.pop("OPENCODE_MODEL", None)
+        else:
+            os.environ["OPENCODE_MODEL"] = self._orig_opencode_model
+
+    def _build(self, **overrides) -> list[str]:
+        defaults = {
+            "prompt": "Review the PR.",
+            "system_prompt": "You are drone.",
+            "model": "zai/glm-5.1",
+            "mcp_config": "",
+            "session_id": "",
+        }
+        defaults.update(overrides)
+        return opencode.build_cmd(**defaults)
+
+    def test_dangerously_skip_permissions_in_argv(self) -> None:
+        """Security-affecting flag MUST be present so opencode auto-
+        approves in headless container mode (otherwise external_directory
+        rules silently block bash → no review ever posted)."""
+        argv = self._build()
+        self.assertIn(
+            "--dangerously-skip-permissions",
+            argv,
+            "opencode provider must invoke with --dangerously-skip-permissions; "
+            "without it, headless containers get silently blocked at gh/git "
+            "subprocess invocations",
+        )
+
+    def test_dangerously_skip_permissions_appears_before_prompt(self) -> None:
+        """Flag must precede the positional prompt argument so opencode's
+        argv parser treats it as a flag rather than message content."""
+        argv = self._build(prompt="REVIEW_PROMPT_BODY")
+        flag_idx = argv.index("--dangerously-skip-permissions")
+        # The combined "system_prompt\n\nprompt" string is the last positional
+        prompt_idx = next(
+            i for i, a in enumerate(argv) if "REVIEW_PROMPT_BODY" in a
+        )
+        self.assertLess(
+            flag_idx, prompt_idx,
+            "the security flag must come before the prompt positional",
+        )
+
+    def test_argv_starts_with_opencode_run(self) -> None:
+        argv = self._build()
+        self.assertEqual(argv[0], "opencode")
+        self.assertEqual(argv[1], "run")
+
+    def test_model_flag_carries_when_supplied(self) -> None:
+        argv = self._build(model="zai/glm-5.1")
+        self.assertIn("--model", argv)
+        idx = argv.index("--model")
+        self.assertEqual(argv[idx + 1], "zai/glm-5.1")
+
+    def test_no_model_flag_when_neither_param_nor_env_set(self) -> None:
+        argv = self._build(model="")
+        self.assertNotIn("--model", argv)
+
+    def test_opencode_model_env_overrides_model_parameter(self) -> None:
+        """Existing precedence: OPENCODE_MODEL env var beats the
+        generic AGENT_MODEL passed as the model parameter. Pin so a
+        future build_cmd refactor can't silently invert this."""
+        os.environ["OPENCODE_MODEL"] = "zai/glm-5.1"
+        argv = self._build(model="claude/opus-4-7")
+        idx = argv.index("--model")
+        self.assertEqual(
+            argv[idx + 1], "zai/glm-5.1",
+            "OPENCODE_MODEL env var should win over the model parameter",
+        )
+
+    def test_combined_prompt_is_last_positional(self) -> None:
+        """The combined system+user prompt is appended last so it can't
+        be re-interpreted as a flag value."""
+        argv = self._build(
+            prompt="USER_BODY",
+            system_prompt="SYSTEM_BODY",
+        )
+        last = argv[-1]
+        self.assertIn("SYSTEM_BODY", last)
+        self.assertIn("USER_BODY", last)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Drone V1 pilot follow-up. Drone runs the agent on incoming PRs cleanly through the apiarist mint chain + watch_new_prs polling + agent dispatch, but every run blocks at \`gh pr review\` with \`✗ bash failed\` and the user-rule trace from opencode (\`external_directory action ask\`). In headless containers with no human to answer permission prompts, \"ask\" silently blocks → drone never delivers a review.

opencode's documented escape hatch for non-interactive use is \`--dangerously-skip-permissions\`. Adds it to the opencode provider's \`build_cmd\`. Auto-approves anything not explicitly denied by the operator's \`opencode.json\` — the deny patterns shipped via apiary deploy (\`*.env\`, \`*.key\`, \`*.pem\`, \`*secret*\` on read; \`doom_loop\` deny) remain in force.

## What it looks like

Before:
\`\`\`
[engine] running agent (plugin=github, provider=opencode, mcp=yes)
[0m✗ [0mbash failed
Error: The user has specified a rule which prevents you from using this
specific tool call. Here are some of the relevant rules
[{\"permission\":\"*\",\"action\":\"allow\",\"pattern\":\"*\"},
 {\"permission\":\"external_directory\",\"pattern\":\"*\",\"action\":\"ask\"}, ...]
[engine] agent exit=0 stdout=545 stderr=33942
\`\`\`
Drone exits cleanly without posting a review. PR sits unreviewed.

After (expected):
\`\`\`
[engine] running agent (plugin=github, provider=opencode, mcp=yes)
[0m$ [0mgh pr review 497 --repo hivemoot/hivemoot --comment --body \"...\"
✓ Reviewed pull request hivemoot/hivemoot#497
[engine] agent exit=0 stdout=...
\`\`\`
Review lands on the PR.

## Why this is the right shape

opencode's permission system was built for human-in-the-loop usage where \"ask\" prompts a developer. Layered onto our headless container model, \"ask\" becomes \"silently fail\" because there's no developer to ask. The container filesystem isolation (docker mount set in \`build_standing_docker_run\`) is the real security boundary for what the agent can touch:

- Mounts (read-only): repo workspace, secrets, identity.md, opencode config, apiarist socket, plugins
- Mounts (read-write): \`/data\` (per-service workspace + state)
- Tmpfs: \`/tmp\` (size-limited, mode 1777)

Opencode's permission rules layered on top were producing false-blocks for every legitimate \`gh\` and \`git\` invocation. The flag is dramatically named (\`--dangerously-\`), but for our threat model — agent in a docker container with bind-mount restrictions and a read-only secrets dir — it's the appropriate setting.

Companion change: \`apiary\` repo \`c6c892a\` (already merged + deployed) flipped \`opencode.json\` \`external_directory: deny → allow\`. That alone wasn't sufficient because opencode merges built-in \`ask\` defaults at higher precedence than user config. \`--dangerously-skip-permissions\` is the only way to bypass them.

## Test plan

- [x] \`python3 -m unittest discover tests\` — 487/487 passing locally (no test changes; \`build_cmd\` flag composition isn't covered by existing tests)
- [ ] After deploy: open a fresh PR, watch drone log for \`gh pr review\` invocation succeeding, verify a drone review lands on the PR

## Follow-up

- Add a test for opencode \`build_cmd\` argv composition (asserting \`--dangerously-skip-permissions\` is present) so the next refactor of \`build_cmd\` doesn't regress this silently.