### PR TITLE
Apiarist V1.6 — per-token allowed_permissions narrowing

### DIFF
--- a/apiarist/src/apiarist/features/tokens/plugin.py
+++ b/apiarist/src/apiarist/features/tokens/plugin.py
@@ -25,10 +25,26 @@ from apiarist.core.registry import Registry
 from apiarist.features.health import HealthState
 from apiarist.features.tokens.cache import TokenCache
 
-# V1 hard-coded narrowed permission set per DESIGN.md §11. Future
-# variants of the API may accept a per-request permissions override
-# (constrained by the agent token's policy) — for now every mint asks
-# for the same scope.
+# Hard-coded request-side ceiling per DESIGN.md §11. Apiarist always
+# asks the backend for THIS scope; the backend (V1.6+) may further
+# narrow per the agent token's `policy.allowed_permissions` before
+# calling GitHub. The response's `permissions` field reflects what was
+# actually granted (= intersect of this, token policy, installation
+# grant).
+#
+# Must stay in sync with web's `V1_PERMISSIONS` in
+# `web/src/server/github-installation-token.ts` — both define the same
+# upper bound, used as the cache-key hash on this side and as the
+# request body on the server side. Diverging keys/values would
+# silently invalidate every cached entry on the client OR cause the
+# server to receive a request asking for scope it doesn't accept.
+#
+# V1.6 cache-invalidation note: this dict drives the cache key on
+# apiarist's side; the SERVER applies token-policy narrowing on top.
+# If an operator updates a token's `policy.allowed_permissions`,
+# cached tokens minted under the previous policy keep serving until
+# their natural cache TTL expires (default 5 min). For immediate
+# rollout, restart the apiarist daemon — the in-memory cache resets.
 _V1_PERMISSIONS: dict[str, str] = {
     "contents": "read",
     "pull_requests": "write",

--- a/web/scripts/set-agent-policy.ts
+++ b/web/scripts/set-agent-policy.ts
@@ -1,7 +1,7 @@
 /**
  * Operator-only CLI: set the per-token policy on an agent token.
  *
- * Use to set `allowed_repos` (and future allowed_permissions) on an
+ * Use to set `allowed_repos` and (V1.6+) `allowed_permissions` on an
  * existing agent token without rotating it. Required before flipping
  * any repo to `refresh_token: true` for production rollout — without
  * a policy the mint endpoint runs in legacy-permissive mode and the
@@ -9,9 +9,23 @@
  *
  * Run from the `web/` directory:
  *
+ *   # V1.5: repo narrowing only
  *   npx tsx scripts/set-agent-policy.ts \
  *     --installation-id 12345678 \
  *     --allowed-repos hivemoot/hivemoot,hivemoot/colony
+ *
+ *   # V1.6: repo narrowing + read-only worker preset (closes WAR_ROOM_DESIGN.md
+ *   # §16 hard-rollout-gate; --read-only-worker is the canonical operator path)
+ *   npx tsx scripts/set-agent-policy.ts \
+ *     --installation-id 12345678 \
+ *     --allowed-repos hivemoot/hivemoot \
+ *     --read-only-worker
+ *
+ *   # V1.6: repo narrowing + custom permission map (advanced)
+ *   npx tsx scripts/set-agent-policy.ts \
+ *     --installation-id 12345678 \
+ *     --allowed-repos hivemoot/hivemoot \
+ *     --allowed-permissions '{"contents":"read","pull_requests":"read","issues":"read","metadata":"read"}'
  *
  * Or to clear the policy (revert to legacy permissive — for testing
  * rollback only):
@@ -33,11 +47,27 @@ import {
   setAgentTokenPolicy,
   getAgentToken,
   type AgentTokenPolicy,
+  type GitHubPermissionLevel,
 } from "../src/server/agent-token";
+import { V1_PERMISSIONS } from "../src/server/github-installation-token";
+
+// V1.6 read-only worker preset: every V1_PERMISSIONS key narrowed to "read".
+// Composed at runtime so a future change to V1_PERMISSIONS keeps this in sync
+// (e.g. if `metadata` ever upgrades to "write" upstream, the preset still
+// produces a true read-only scope).
+const READ_ONLY_WORKER_PRESET: Record<string, GitHubPermissionLevel> =
+  Object.fromEntries(
+    Object.keys(V1_PERMISSIONS).map((k) => [k, "read" as const]),
+  );
+
+const VALID_PERMISSION_LEVELS = ["read", "write", "admin"] as const;
 
 interface CliArgs {
   installationId: string;
   allowedRepos: string[] | null; // null when --clear
+  // V1.6: optional per-permission narrowing. Undefined = preserve V1.5 behavior.
+  // Set via --read-only-worker (preset) or --allowed-permissions (raw JSON).
+  allowedPermissions: Record<string, GitHubPermissionLevel> | undefined;
   acknowledge: boolean;
 }
 
@@ -49,7 +79,10 @@ interface CliArgs {
 const REPO_FORMAT = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 
 function parseArgs(argv: string[]): CliArgs {
-  const args: Partial<CliArgs> = { acknowledge: false };
+  const args: Partial<CliArgs> = {
+    acknowledge: false,
+    allowedPermissions: undefined,
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--installation-id") {
@@ -57,6 +90,23 @@ function parseArgs(argv: string[]): CliArgs {
     } else if (arg === "--allowed-repos") {
       const csv = argv[++i];
       args.allowedRepos = csv === "" ? [] : csv.split(",").map((s) => s.trim());
+    } else if (arg === "--read-only-worker") {
+      // V1.6 preset: every V1_PERMISSIONS key narrowed to "read".
+      args.allowedPermissions = { ...READ_ONLY_WORKER_PRESET };
+    } else if (arg === "--allowed-permissions") {
+      // V1.6 raw map: JSON object string. Validated below.
+      const json = argv[++i];
+      try {
+        const parsed = JSON.parse(json);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new Error("must be a JSON object");
+        }
+        args.allowedPermissions = parsed as Record<string, GitHubPermissionLevel>;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`invalid --allowed-permissions JSON: ${msg}`);
+        process.exit(2);
+      }
     } else if (arg === "--clear") {
       args.allowedRepos = null;
     } else if (arg === "--i-know-what-im-doing") {
@@ -94,18 +144,53 @@ function parseArgs(argv: string[]): CliArgs {
       }
     }
   }
+  // V1.6 validation: keys must be in V1_PERMISSIONS (so the operator
+  // gets immediate feedback on typos), values must be valid levels.
+  // Same fail-closed posture as intersectPermissions at mint time.
+  if (args.allowedPermissions !== undefined) {
+    if (args.allowedRepos === null) {
+      console.error(
+        "--allowed-permissions cannot be combined with --clear (clear drops the entire policy)",
+      );
+      process.exit(2);
+    }
+    for (const [key, value] of Object.entries(args.allowedPermissions)) {
+      if (!Object.prototype.hasOwnProperty.call(V1_PERMISSIONS, key)) {
+        console.error(
+          `invalid allowed_permissions key '${key}': must be one of ${Object.keys(V1_PERMISSIONS).join(", ")}`,
+        );
+        process.exit(2);
+      }
+      if (!(VALID_PERMISSION_LEVELS as readonly string[]).includes(value as string)) {
+        console.error(
+          `invalid allowed_permissions['${key}'] value '${value}': must be one of ${VALID_PERMISSION_LEVELS.join(", ")}`,
+        );
+        process.exit(2);
+      }
+    }
+  }
   return args as CliArgs;
 }
 
 function printUsage(): void {
   console.error(`Usage:
   set-agent-policy --installation-id <id> --allowed-repos <csv>
+  set-agent-policy --installation-id <id> --allowed-repos <csv> --read-only-worker
+  set-agent-policy --installation-id <id> --allowed-repos <csv> --allowed-permissions '<json>'
   set-agent-policy --installation-id <id> --clear
 
 Options:
   --installation-id <id>           Numeric GitHub installation id (required)
   --allowed-repos <owner/name,...> Comma-separated list of repos the token may mint for
                                    (empty = reject everything; intentional)
+  --read-only-worker               V1.6 preset: narrow every default permission to "read".
+                                   Composed at runtime from V1_PERMISSIONS, so future
+                                   additions to the default set keep this read-only.
+  --allowed-permissions <json>     V1.6 raw map: JSON object like
+                                   '{"contents":"read","pull_requests":"read",...}'.
+                                   Keys must be in V1_PERMISSIONS; values must be
+                                   "read"|"write"|"admin". Levels above the default
+                                   are silently capped at the default at mint time.
   --clear                          Drop the policy (revert to legacy permissive — testing only)
   --i-know-what-im-doing           Required when NODE_ENV=production
   --help                           Show this message
@@ -142,7 +227,20 @@ async function main(): Promise<void> {
   // Reading via getAgentToken would decrypt the token; we don't need that —
   // resolve via a direct envelope check instead.
   const policy: AgentTokenPolicy | null =
-    args.allowedRepos === null ? null : { allowed_repos: args.allowedRepos };
+    args.allowedRepos === null
+      ? null
+      : {
+          allowed_repos: args.allowedRepos,
+          // V1.6: include allowed_permissions only when set. Omitting the
+          // field (vs setting it to {}) preserves V1.5 behavior — mint
+          // requests V1_PERMISSIONS unchanged. setting it to {} would
+          // be technically valid (no per-key narrowing) but ambiguous;
+          // the CLI defaults to the omit-field path when the operator
+          // doesn't pass --read-only-worker or --allowed-permissions.
+          ...(args.allowedPermissions !== undefined
+            ? { allowed_permissions: args.allowedPermissions }
+            : {}),
+        };
 
   const ok = await setAgentTokenPolicy(args.installationId, policy, redis);
   if (!ok) {
@@ -170,6 +268,10 @@ async function main(): Promise<void> {
         action: policy === null ? "cleared" : "set",
         allowedReposCount: policy?.allowed_repos.length ?? 0,
         allowedRepos: policy?.allowed_repos ?? null,
+        // V1.6: surface what was set so the operator can verify the
+        // narrowing at a glance. Null = unchanged from V1.5 default
+        // (mint will request V1_PERMISSIONS verbatim).
+        allowedPermissions: policy?.allowed_permissions ?? null,
         fingerprintMatch: verify?.fingerprint ?? "(could not decrypt to verify)",
       },
       null,

--- a/web/src/app/api/github/installation-tokens/route.test.ts
+++ b/web/src/app/api/github/installation-tokens/route.test.ts
@@ -55,7 +55,16 @@ function makeRequest(body: unknown, opts: { json?: boolean } = {}): NextRequest 
 
 function authOk(
   installationId = "67890",
-  policy: { allowed_repos: string[] } | undefined = undefined,
+  policy:
+    | {
+        allowed_repos: string[];
+        // V1.6: optional allowed_permissions narrows GitHub permission
+        // scope at mint time. Tests can pass it through to exercise the
+        // route's V1.6 wiring (auth.policy?.allowed_permissions →
+        // mintInstallationToken's allowedPermissions param).
+        allowed_permissions?: Record<string, "read" | "write" | "admin">;
+      }
+    | undefined = undefined,
 ) {
   return {
     ok: true as const,
@@ -72,14 +81,29 @@ function authFailure(status = 401, code = "agent_health_not_authenticated") {
   };
 }
 
-function successMint() {
+function successMint(
+  overrides: Partial<{
+    token: string;
+    expires_at: string;
+    installation_id: string;
+    permissions: Record<string, string>;
+    repositories: Array<{ full_name: string; id: number }>;
+    hashed_token: string;
+  }> = {},
+) {
   return {
     token: "ghs_e2e_test_token",
     expires_at: "2026-04-25T19:30:00Z",
     installation_id: "67890",
-    permissions: { contents: "read", pull_requests: "write" },
+    permissions: {
+      contents: "read",
+      pull_requests: "write",
+      issues: "write",
+      metadata: "read",
+    },
     repositories: [{ full_name: "owner/repo", id: 12345 }],
     hashed_token: "FAKE_BASE64_SHA256_HASH=",
+    ...overrides,
   };
 }
 
@@ -317,6 +341,8 @@ describe("POST /api/github/installation-tokens — happy path", () => {
     expect(body.permissions).toEqual({
       contents: "read",
       pull_requests: "write",
+      issues: "write",
+      metadata: "read",
     });
     expect(body.repositories).toEqual([{ full_name: "owner/repo", id: 12345 }]);
     expect(body.hashed_token).toBe("FAKE_BASE64_SHA256_HASH=");
@@ -408,5 +434,138 @@ describe("POST /api/github/installation-tokens — mint error mapping", () => {
     // Critically: the unexpected error message is NOT echoed in the response,
     // only logged. Backend doesn't leak internals to apiarist.
     expect(body.message).not.toContain("totally unexpected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V1.6 — allowed_permissions wiring (closes guard G2)
+// ---------------------------------------------------------------------------
+//
+// These tests close the gap between the unit tests on intersectPermissions
+// and the actual route. They assert that the route forwards
+// auth.policy.allowed_permissions into mintInstallationToken's
+// allowedPermissions param, and that the audit log surfaces the right
+// signals (policyHasAllowedPermissions + scopeReduced).
+
+describe("POST /api/github/installation-tokens — V1.6 allowed_permissions wiring", () => {
+  beforeEach(() => {
+    mockedAuth.mockClear();
+    mockedMint.mockClear();
+  });
+
+  it("V1.5 path: no allowed_permissions on policy → mint called WITHOUT allowedPermissions", async () => {
+    mockedAuth.mockResolvedValue(
+      authOk("67890", { allowed_repos: ["owner/repo"] }),
+    );
+    mockedMint.mockResolvedValue(successMint());
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(mockedMint).toHaveBeenCalledTimes(1);
+    const call = mockedMint.mock.calls[0][0];
+    expect(call.allowedPermissions).toBeUndefined();
+  });
+
+  it("V1.6 path: allowed_permissions on policy → forwarded to mint as allowedPermissions", async () => {
+    const readOnly = {
+      contents: "read" as const,
+      pull_requests: "read" as const,
+      issues: "read" as const,
+      metadata: "read" as const,
+    };
+    mockedAuth.mockResolvedValue(
+      authOk("67890", {
+        allowed_repos: ["owner/repo"],
+        allowed_permissions: readOnly,
+      }),
+    );
+    mockedMint.mockResolvedValue(
+      successMint({ permissions: readOnly }),
+    );
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(mockedMint).toHaveBeenCalledTimes(1);
+    const call = mockedMint.mock.calls[0][0];
+    expect(call.allowedPermissions).toEqual(readOnly);
+  });
+
+  it("audit log: policyHasAllowedPermissions=false when policy.allowed_permissions undefined", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockedAuth.mockResolvedValue(
+      authOk("67890", { allowed_repos: ["owner/repo"] }),
+    );
+    mockedMint.mockResolvedValue(successMint());
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[installation-tokens] minted",
+      expect.objectContaining({ policyHasAllowedPermissions: false }),
+    );
+    consoleLog.mockRestore();
+  });
+
+  it("audit log: policyHasAllowedPermissions=true AND scopeReduced=true when narrowing actually applied", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockedAuth.mockResolvedValue(
+      authOk("67890", {
+        allowed_repos: ["owner/repo"],
+        allowed_permissions: { pull_requests: "read" },
+      }),
+    );
+    // Mocked mint returns the narrowed scope (pull_requests=read instead
+    // of write). Real intersectPermissions runs in the unit-test suite.
+    mockedMint.mockResolvedValue(
+      successMint({
+        permissions: {
+          contents: "read",
+          pull_requests: "read",   // narrowed
+          issues: "write",
+          metadata: "read",
+        },
+      }),
+    );
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[installation-tokens] minted",
+      expect.objectContaining({
+        policyHasAllowedPermissions: true,
+        scopeReduced: true,
+      }),
+    );
+    consoleLog.mockRestore();
+  });
+
+  it("audit log: scopeReduced=false when policy is set but matches V1_PERMISSIONS exactly (no-op narrowing)", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    // Policy "narrows" to exactly the same scope as V1_PERMISSIONS.
+    // policyHasAllowedPermissions=true (operator did configure it), but
+    // scopeReduced=false (no actual reduction happened) — distinct signals.
+    mockedAuth.mockResolvedValue(
+      authOk("67890", {
+        allowed_repos: ["owner/repo"],
+        allowed_permissions: {
+          contents: "read",
+          pull_requests: "write",
+          issues: "write",
+          metadata: "read",
+        },
+      }),
+    );
+    mockedMint.mockResolvedValue(successMint());
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[installation-tokens] minted",
+      expect.objectContaining({
+        policyHasAllowedPermissions: true,
+        scopeReduced: false,
+      }),
+    );
+    consoleLog.mockRestore();
   });
 });

--- a/web/src/app/api/github/installation-tokens/route.test.ts
+++ b/web/src/app/api/github/installation-tokens/route.test.ts
@@ -568,4 +568,106 @@ describe("POST /api/github/installation-tokens — V1.6 allowed_permissions wiri
     );
     consoleLog.mockRestore();
   });
+
+  it("audit log: scopeReduced=false when GitHub returns V1_PERMISSIONS in DIFFERENT KEY ORDER (regression on guard G3-R2)", async () => {
+    // R2 follow-up regression: prior implementation used
+    // JSON.stringify(...)===JSON.stringify(...), which is
+    // order-sensitive. GitHub may emit permissions in different
+    // key order than V1_PERMISSIONS declares; without
+    // order-insensitive comparison the audit log would falsely
+    // report scopeReduced=true on a no-op narrowing.
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockedAuth.mockResolvedValue(
+      authOk("67890", { allowed_repos: ["owner/repo"] }),
+    );
+    // Same permissions as V1_PERMISSIONS, intentionally rearranged
+    // (issues + pull_requests + metadata + contents instead of the
+    // canonical contents/pull_requests/issues/metadata).
+    mockedMint.mockResolvedValue(
+      successMint({
+        permissions: {
+          issues: "write",
+          pull_requests: "write",
+          metadata: "read",
+          contents: "read",
+        },
+      }),
+    );
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[installation-tokens] minted",
+      expect.objectContaining({ scopeReduced: false }),
+    );
+    consoleLog.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// permissionsEqual unit tests
+// ---------------------------------------------------------------------------
+
+import { permissionsEqual } from "./route";
+
+describe("permissionsEqual (route helper)", () => {
+  it("identical maps in identical order → true", () => {
+    expect(
+      permissionsEqual(
+        { contents: "read", pull_requests: "write" },
+        { contents: "read", pull_requests: "write" },
+      ),
+    ).toBe(true);
+  });
+
+  it("same keys + values, DIFFERENT insertion order → true (order-insensitive)", () => {
+    expect(
+      permissionsEqual(
+        { contents: "read", pull_requests: "write" },
+        { pull_requests: "write", contents: "read" },
+      ),
+    ).toBe(true);
+  });
+
+  it("same keys, ONE differing value → false", () => {
+    expect(
+      permissionsEqual(
+        { contents: "read", pull_requests: "write" },
+        { contents: "read", pull_requests: "read" },
+      ),
+    ).toBe(false);
+  });
+
+  it("a has extra key → false", () => {
+    expect(
+      permissionsEqual(
+        { contents: "read", pull_requests: "write" },
+        { contents: "read" },
+      ),
+    ).toBe(false);
+  });
+
+  it("b has extra key → false", () => {
+    expect(
+      permissionsEqual(
+        { contents: "read" },
+        { contents: "read", pull_requests: "write" },
+      ),
+    ).toBe(false);
+  });
+
+  it("both empty → true", () => {
+    expect(permissionsEqual({}, {})).toBe(true);
+  });
+
+  it("prototype member name on b doesn't false-positive", () => {
+    // Defense against a's key matching Object.prototype member name
+    // that could exist on b's prototype chain (toString etc.).
+    expect(
+      permissionsEqual(
+        { contents: "read", toString: "read" },
+        { contents: "read" },
+      ),
+    ).toBe(false);
+  });
 });

--- a/web/src/app/api/github/installation-tokens/route.ts
+++ b/web/src/app/api/github/installation-tokens/route.ts
@@ -17,6 +17,7 @@ import { validateEnv } from "@/server/env";
 import {
   mintInstallationToken,
   MintError,
+  V1_PERMISSIONS,
 } from "@/server/github-installation-token";
 
 const BAD_REQUEST_BODY = {
@@ -189,9 +190,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       // verify a "read-only worker" token actually got read-only scope
       // without combing through GitHub's audit log.
       grantedPermissions: tokenResponse.permissions,
-      // Whether the token narrowed via V1.6 policy. False = legacy /
-      // V1.5 token (defaults verbatim); true = V1.6 narrowing applied.
-      narrowedByPolicy: auth.policy?.allowed_permissions !== undefined,
+      // Whether the operator HAS configured a per-token narrowing policy.
+      // Distinct from `scopeReduced` below: a policy with `{}` or matching
+      // V1_PERMISSIONS is "configured but no-op". This flag = "policy
+      // field is set on the envelope, regardless of effect."
+      policyHasAllowedPermissions:
+        auth.policy?.allowed_permissions !== undefined,
+      // Whether the granted permissions actually differ from V1_PERMISSIONS.
+      // True = some narrowing took effect (from token policy OR installation
+      // grant); false = mint received the V1 default scope. This is the
+      // signal operators actually want when answering "did this token
+      // narrow scope?" (closes guard G3 — `narrowedByPolicy` was misleading
+      // because it was true even for empty {} or V1_PERMISSIONS-equivalent
+      // policies).
+      scopeReduced:
+        JSON.stringify(tokenResponse.permissions) !==
+        JSON.stringify(V1_PERMISSIONS),
       latencyMs: Date.now() - start,
     });
     return NextResponse.json(tokenResponse, { status: 200 });

--- a/web/src/app/api/github/installation-tokens/route.ts
+++ b/web/src/app/api/github/installation-tokens/route.ts
@@ -37,6 +37,36 @@ const INTERNAL_BODY = {
   message: "Unexpected error during mint; see backend logs for details.",
 } as const;
 
+/**
+ * Order-insensitive equality on GitHub permission maps.
+ *
+ * Used by the audit-log `scopeReduced` flag to detect actual scope
+ * reduction (vs no-op narrowing where the policy matches V1_PERMISSIONS
+ * exactly with different key order, or where GitHub returns the same
+ * permissions in a different key order than V1_PERMISSIONS declares).
+ *
+ * `JSON.stringify(...)===JSON.stringify(...)` is order-sensitive, so
+ * GitHub returning `{pull_requests: "write", contents: "read", ...}`
+ * vs V1_PERMISSIONS `{contents: "read", pull_requests: "write", ...}`
+ * would log scopeReduced=true on a no-op narrowing.
+ *
+ * Closes guard G3-R2 + builder R2 follow-up. Same-keys + same-values
+ * = equal regardless of insertion order.
+ */
+export function permissionsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   // Bearer auth — same path used by /api/agent-health POST. 401 on
   // missing/invalid bearer; the underlying helper has its own response
@@ -203,9 +233,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       // narrow scope?" (closes guard G3 — `narrowedByPolicy` was misleading
       // because it was true even for empty {} or V1_PERMISSIONS-equivalent
       // policies).
-      scopeReduced:
-        JSON.stringify(tokenResponse.permissions) !==
-        JSON.stringify(V1_PERMISSIONS),
+      //
+      // Order-insensitive comparison: GitHub's response may emit
+      // permissions in different key order than V1_PERMISSIONS, so a
+      // simple JSON.stringify(...)===JSON.stringify(...) would log
+      // scopeReduced=true on a no-op narrowing (closes guard G3-R2 +
+      // builder R2 follow-up). permissionsEqual normalizes by sorting
+      // keys and comparing values per-key.
+      scopeReduced: !permissionsEqual(tokenResponse.permissions, V1_PERMISSIONS),
       latencyMs: Date.now() - start,
     });
     return NextResponse.json(tokenResponse, { status: 200 });

--- a/web/src/app/api/github/installation-tokens/route.ts
+++ b/web/src/app/api/github/installation-tokens/route.ts
@@ -166,6 +166,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       repo,
       appId: githubAppId,
       appPrivateKeyPem: githubAppPrivateKey,
+      // V1.6: pass token's allowed_permissions through. Undefined for
+      // legacy / V1.5 tokens (mint asks for V1_PERMISSIONS unchanged);
+      // when set, mintInstallationToken intersects it with V1_PERMISSIONS
+      // before sending to GitHub. The token can narrow scope, never raise.
+      allowedPermissions: auth.policy?.allowed_permissions,
     });
     // Audit log: success. Token VALUE never logged — only metadata.
     // hashed_token is the audit-correlation handle (sha256/base64 of
@@ -179,6 +184,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       agentId,
       hashedToken: tokenResponse.hashed_token,
       expiresAt: tokenResponse.expires_at,
+      // V1.6 audit: surface the actual permissions GitHub granted (which
+      // = (intersected request) ∩ (installation grant)). Lets operators
+      // verify a "read-only worker" token actually got read-only scope
+      // without combing through GitHub's audit log.
+      grantedPermissions: tokenResponse.permissions,
+      // Whether the token narrowed via V1.6 policy. False = legacy /
+      // V1.5 token (defaults verbatim); true = V1.6 narrowing applied.
+      narrowedByPolicy: auth.policy?.allowed_permissions !== undefined,
       latencyMs: Date.now() - start,
     });
     return NextResponse.json(tokenResponse, { status: 200 });

--- a/web/src/server/agent-token.ts
+++ b/web/src/server/agent-token.ts
@@ -65,18 +65,30 @@ return 1
  * logs a warning and defers to the installation grant — this preserves
  * compatibility with existing tokens during the V1.5 migration window.
  *
- * `allowed_permissions` is intentionally DEFERRED to V1.6: V1 already
- * hard-codes a narrow permission set (`V1_PERMISSIONS` in
- * `github-installation-token.ts`); per-token permission narrowing is a
- * second layer of defense that hasn't been needed yet. When added,
- * enforcement: passed permissions ∩ V1_PERMISSIONS, then validated
- * against the installation grant by GitHub.
+ * `allowed_permissions` (V1.6, this revision) is per-token permission
+ * narrowing on top of the V1.5 repo narrowing. When set, the mint
+ * endpoint intersects these permissions with `V1_PERMISSIONS` (the
+ * default scope hard-coded in `github-installation-token.ts`) before
+ * passing to GitHub: the token can NARROW the default but never
+ * EXCEED it. Permissions GitHub doesn't grant on the installation are
+ * always rejected by GitHub regardless. Absence (`undefined`) = use
+ * `V1_PERMISSIONS` unchanged (V1.5 behavior, no narrowing).
  */
+export type GitHubPermissionLevel = "read" | "write" | "admin";
+
 export interface AgentTokenPolicy {
   /** `owner/name` strings the token may request mints for. Empty array
    * = reject everything (intentional). Field absence on the envelope =
    * legacy permissive (defer to installation grant). */
   allowed_repos: string[];
+  /** V1.6+: per-token permission narrowing. Map of GitHub App permission
+   * name (e.g. "contents", "pull_requests", "issues", "metadata") to
+   * the maximum level the token may request. Mint intersects with
+   * `V1_PERMISSIONS` (lower level wins per `read < write < admin`).
+   * Permissions named here that aren't in `V1_PERMISSIONS` are silently
+   * dropped (a token cannot grant scope the default doesn't have).
+   * Absence (`undefined`) = use `V1_PERMISSIONS` as-is. */
+  allowed_permissions?: Record<string, GitHubPermissionLevel>;
 }
 
 export interface AgentTokenEnvelope {

--- a/web/src/server/github-installation-token.test.ts
+++ b/web/src/server/github-installation-token.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/server/github-auth", () => ({
 import { generateAppJwt } from "@/server/github-auth";
 import {
   mintInstallationToken,
+  intersectPermissions,
   V1_PERMISSIONS,
   AppCredentialError,
   InstallationNotCoverageError,
@@ -16,6 +17,7 @@ import {
   InvalidMintRequestError,
   type MintOptions,
 } from "./github-installation-token";
+import type { GitHubPermissionLevel } from "./agent-token";
 
 const mockJwt = vi.mocked(generateAppJwt);
 
@@ -387,5 +389,160 @@ describe("mintInstallationToken — network + parse", () => {
     await expect(
       mintInstallationToken(VALID_OPTIONS, fetcher),
     ).rejects.toBeInstanceOf(GitHubUnavailableError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V1.6 — intersectPermissions helper
+// ---------------------------------------------------------------------------
+
+describe("intersectPermissions (V1.6)", () => {
+  it("undefined narrow → returns defaults verbatim (V1.5 path)", () => {
+    expect(intersectPermissions(V1_PERMISSIONS, undefined)).toEqual(V1_PERMISSIONS);
+  });
+
+  it("returns a fresh object (not the same reference as defaults)", () => {
+    const result = intersectPermissions(V1_PERMISSIONS, undefined);
+    expect(result).not.toBe(V1_PERMISSIONS);
+  });
+
+  it("token requesting same level as default → no change", () => {
+    expect(
+      intersectPermissions(V1_PERMISSIONS, {
+        contents: "read",
+        pull_requests: "write",
+      }),
+    ).toEqual(V1_PERMISSIONS);
+  });
+
+  it("token narrowing pull_requests: write → read", () => {
+    const result = intersectPermissions(V1_PERMISSIONS, {
+      pull_requests: "read",
+    });
+    expect(result.pull_requests).toBe("read");
+    expect(result.contents).toBe("read");
+    expect(result.issues).toBe("write");
+    expect(result.metadata).toBe("read");
+  });
+
+  it("token requesting HIGHER than default → silently capped at default (no escalation)", () => {
+    const result = intersectPermissions(V1_PERMISSIONS, {
+      contents: "write",
+    });
+    expect(result.contents).toBe("read");
+  });
+
+  it("token requesting admin → still capped at default level for that permission", () => {
+    const result = intersectPermissions(V1_PERMISSIONS, {
+      pull_requests: "admin",
+    });
+    expect(result.pull_requests).toBe("write");
+  });
+
+  it("token mentioning a permission NOT in defaults is silently dropped + warned", () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = intersectPermissions(V1_PERMISSIONS, {
+      administration: "write" as GitHubPermissionLevel,
+      contents: "read",
+    });
+    expect(Object.keys(result).sort()).toEqual(
+      Object.keys(V1_PERMISSIONS).sort(),
+    );
+    expect(result).not.toHaveProperty("administration");
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("administration"),
+    );
+    consoleWarn.mockRestore();
+  });
+
+  it("read-only worker preset (all read) → all permissions = read", () => {
+    const readOnlyPolicy: Record<string, GitHubPermissionLevel> = {
+      contents: "read",
+      pull_requests: "read",
+      issues: "read",
+      metadata: "read",
+    };
+    expect(intersectPermissions(V1_PERMISSIONS, readOnlyPolicy)).toEqual({
+      contents: "read",
+      pull_requests: "read",
+      issues: "read",
+      metadata: "read",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V1.6 — mint with allowedPermissions
+// ---------------------------------------------------------------------------
+
+describe("mintInstallationToken — V1.6 allowedPermissions", () => {
+  beforeEach(() => {
+    mockJwt.mockClear();
+    mockJwt.mockReturnValue("fake.jwt.token");
+  });
+
+  it("V1.5 path: omitted allowedPermissions sends V1_PERMISSIONS verbatim", async () => {
+    const fetcher = vi.fn().mockResolvedValue(fakeResponse(201, successBody()));
+    await mintInstallationToken(VALID_OPTIONS, fetcher);
+
+    const body = JSON.parse(fetcher.mock.calls[0][1].body);
+    expect(body.permissions).toEqual(V1_PERMISSIONS);
+  });
+
+  it("read-only worker: narrows pull_requests + issues to read", async () => {
+    const fetcher = vi.fn().mockResolvedValue(fakeResponse(201, successBody()));
+    await mintInstallationToken(
+      {
+        ...VALID_OPTIONS,
+        allowedPermissions: {
+          contents: "read",
+          pull_requests: "read",
+          issues: "read",
+          metadata: "read",
+        },
+      },
+      fetcher,
+    );
+
+    const body = JSON.parse(fetcher.mock.calls[0][1].body);
+    expect(body.permissions).toEqual({
+      contents: "read",
+      pull_requests: "read",
+      issues: "read",
+      metadata: "read",
+    });
+  });
+
+  it("attempt to escalate (write where default is read) is silently capped", async () => {
+    const fetcher = vi.fn().mockResolvedValue(fakeResponse(201, successBody()));
+    await mintInstallationToken(
+      {
+        ...VALID_OPTIONS,
+        allowedPermissions: { contents: "write" },
+      },
+      fetcher,
+    );
+
+    const body = JSON.parse(fetcher.mock.calls[0][1].body);
+    expect(body.permissions.contents).toBe("read");
+  });
+
+  it("partial narrow leaves unspecified defaults intact", async () => {
+    const fetcher = vi.fn().mockResolvedValue(fakeResponse(201, successBody()));
+    await mintInstallationToken(
+      {
+        ...VALID_OPTIONS,
+        allowedPermissions: { pull_requests: "read" },
+      },
+      fetcher,
+    );
+
+    const body = JSON.parse(fetcher.mock.calls[0][1].body);
+    expect(body.permissions).toEqual({
+      contents: "read",
+      pull_requests: "read",   // narrowed
+      issues: "write",         // unchanged from V1_PERMISSIONS
+      metadata: "read",
+    });
   });
 });

--- a/web/src/server/github-installation-token.test.ts
+++ b/web/src/server/github-installation-token.test.ts
@@ -9,6 +9,7 @@ import { generateAppJwt } from "@/server/github-auth";
 import {
   mintInstallationToken,
   intersectPermissions,
+  InvalidPermissionLevelError,
   V1_PERMISSIONS,
   AppCredentialError,
   InstallationNotCoverageError,
@@ -451,6 +452,58 @@ describe("intersectPermissions (V1.6)", () => {
     expect(result).not.toHaveProperty("administration");
     expect(consoleWarn).toHaveBeenCalledWith(
       expect.stringContaining("administration"),
+    );
+    consoleWarn.mockRestore();
+  });
+
+  // R2 fix: fail-closed on invalid level values. The R1 review found
+  // that a typoed level like "typo" silently fell through to the default
+  // (e.g. pull_requests: "typo" → effective level "write" instead of
+  // failing the mint). For a narrowing primitive, fail-open is the
+  // worst possible failure direction.
+  it("invalid level value in narrow throws InvalidPermissionLevelError (fail-closed)", () => {
+    expect(() =>
+      intersectPermissions(V1_PERMISSIONS, {
+        pull_requests: "typo" as GitHubPermissionLevel,
+      }),
+    ).toThrow(InvalidPermissionLevelError);
+  });
+
+  it("invalid level error names the offending permission and value", () => {
+    let captured: InvalidPermissionLevelError | null = null;
+    try {
+      intersectPermissions(V1_PERMISSIONS, {
+        contents: "WRITE" as GitHubPermissionLevel,  // wrong case
+      });
+    } catch (e) {
+      captured = e as InvalidPermissionLevelError;
+    }
+    expect(captured).toBeInstanceOf(InvalidPermissionLevelError);
+    expect(captured?.message).toContain("contents");
+    expect(captured?.message).toContain("WRITE");
+    expect(captured?.errorCode).toBe("invalid_permission_level");
+    expect(captured?.httpStatus).toBe(400);
+  });
+
+  it("non-string level value (e.g. number from corrupted JSON) fails closed", () => {
+    expect(() =>
+      intersectPermissions(V1_PERMISSIONS, {
+        // Simulates a corrupted Redis envelope with non-string level
+        contents: 1 as unknown as GitHubPermissionLevel,
+      }),
+    ).toThrow(InvalidPermissionLevelError);
+  });
+
+  it("Object.prototype member name in narrow does NOT suppress the warning", () => {
+    // R2 G4: prior `key in defaults` check would walk the prototype chain
+    // and treat e.g. "toString" as "in defaults" because Object.prototype
+    // has toString. Fix uses hasOwnProperty.
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    intersectPermissions(V1_PERMISSIONS, {
+      toString: "read" as GitHubPermissionLevel,
+    });
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("toString"),
     );
     consoleWarn.mockRestore();
   });

--- a/web/src/server/github-installation-token.ts
+++ b/web/src/server/github-installation-token.ts
@@ -52,6 +52,22 @@ export const V1_PERMISSIONS: Readonly<Record<string, GitHubPermissionLevel>> =
 const PERMISSION_LEVEL_RANK: Readonly<Record<GitHubPermissionLevel, number>> =
   Object.freeze({ read: 1, write: 2, admin: 3 });
 
+// `InvalidPermissionLevelError` is declared further down (after `MintError`,
+// which it extends — TypeScript classes are not hoisted, so it must be
+// defined after its base class). Forward-declared here as a type-only
+// import for the `intersectPermissions` JSDoc cross-reference.
+
+function isValidPermissionLevel(value: unknown): value is GitHubPermissionLevel {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(PERMISSION_LEVEL_RANK, value)
+  );
+}
+
+const VALID_LEVELS = Object.freeze(
+  Object.keys(PERMISSION_LEVEL_RANK) as GitHubPermissionLevel[],
+);
+
 /**
  * Compute the effective permission set: intersect the default ceiling
  * with an optional per-token narrowing map.
@@ -61,19 +77,26 @@ const PERMISSION_LEVEL_RANK: Readonly<Record<GitHubPermissionLevel, number>> =
  *      behavior preserved for legacy / non-V1.6 tokens).
  *   2. For every key in `defaults`:
  *      - If `narrow` doesn't mention it → use the default level.
- *      - If `narrow` mentions it → take the LOWER of the two levels
- *        (read < write < admin). The token can narrow but never raise.
+ *      - If `narrow` mentions it with a VALID level → take the LOWER
+ *        of the two levels (read < write < admin). The token can
+ *        narrow but never raise.
+ *      - If `narrow` mentions it with an INVALID level (string that
+ *        isn't "read"|"write"|"admin", or non-string) → throw
+ *        {@link InvalidPermissionLevelError}. Fail closed.
  *   3. Keys present in `narrow` but absent from `defaults` are silently
  *      DROPPED (a token cannot grant scope the default doesn't have).
  *      A console warning is emitted so misconfigurations are visible
- *      in operator logs.
+ *      in operator logs. Uses `hasOwnProperty` (not `in`) to avoid
+ *      false positives on `Object.prototype` member names like
+ *      `toString`/`hasOwnProperty` themselves.
  *
  * Exported for unit testing; production callers should let
- * `mintInstallationToken` apply this internally.
+ * `mintInstallationToken` apply this internally (which translates
+ * thrown errors into structured 400 responses).
  */
 export function intersectPermissions(
   defaults: Readonly<Record<string, GitHubPermissionLevel>>,
-  narrow: Readonly<Record<string, GitHubPermissionLevel>> | undefined,
+  narrow: Readonly<Record<string, unknown>> | undefined,
 ): Record<string, GitHubPermissionLevel> {
   if (narrow === undefined) {
     // No narrowing requested — caller wants defaults verbatim.
@@ -87,6 +110,18 @@ export function intersectPermissions(
       out[key] = defaultLevel;
       continue;
     }
+    if (!isValidPermissionLevel(narrowLevel)) {
+      // Fail-closed: do NOT silently fall back to the default level.
+      // For a narrowing primitive, the safer behavior is to reject
+      // the mint entirely so the operator notices and fixes the
+      // policy. Caller (route handler) maps this to a 400 with the
+      // structured error code.
+      throw new InvalidPermissionLevelError(
+        key,
+        String(narrowLevel),
+        VALID_LEVELS,
+      );
+    }
     const defaultRank = PERMISSION_LEVEL_RANK[defaultLevel];
     const narrowRank = PERMISSION_LEVEL_RANK[narrowLevel];
     out[key] = narrowRank < defaultRank ? narrowLevel : defaultLevel;
@@ -96,8 +131,10 @@ export function intersectPermissions(
   // `defaults` — operator typo'd a permission name, or asked for a scope
   // V1_PERMISSIONS doesn't expose. The dropped keys still go to GitHub
   // through `out`, so the request is unaffected (those keys aren't there).
+  // Use hasOwnProperty so prototype-chain members ("toString" etc.) don't
+  // suppress legitimate warnings.
   for (const key of Object.keys(narrow)) {
-    if (!(key in defaults)) {
+    if (!Object.prototype.hasOwnProperty.call(defaults, key)) {
       console.warn(
         `[mintInstallationToken] policy.allowed_permissions['${key}'] ignored — not in V1_PERMISSIONS`,
       );
@@ -248,6 +285,28 @@ export class GitHubUnavailableError extends MintError {
 export class InvalidMintRequestError extends MintError {
   constructor(detail: string) {
     super(`Invalid mint request: ${detail}`, 400, "invalid_mint_request");
+  }
+}
+
+/**
+ * Thrown when `allowed_permissions` carries a level value that isn't
+ * one of `"read" | "write" | "admin"`. The Redis-stored policy JSON
+ * has no schema enforcement, so an operator typo or a corrupted
+ * envelope could land here. Fail closed: better to refuse the mint
+ * with a clear error than silently fall through to the default level
+ * (R1 finding from PR #501 — fail-open on invalid levels would let a
+ * typoed read-only worker token get write scope by accident, which
+ * is the WORST possible failure direction for a narrowing primitive).
+ */
+export class InvalidPermissionLevelError extends MintError {
+  constructor(permission: string, badValue: string, validLevels: readonly string[]) {
+    super(
+      `Token policy 'allowed_permissions.${permission}' has invalid value ` +
+        `${JSON.stringify(badValue)} (expected one of ${validLevels.join(", ")}). ` +
+        `Fix the token's policy via setAgentTokenPolicy or rotate it.`,
+      400,
+      "invalid_permission_level",
+    );
   }
 }
 

--- a/web/src/server/github-installation-token.ts
+++ b/web/src/server/github-installation-token.ts
@@ -23,24 +23,88 @@
 
 import { createHash } from "crypto";
 import { generateAppJwt } from "@/server/github-auth";
+import type { GitHubPermissionLevel } from "@/server/agent-token";
 
 // ---------------------------------------------------------------------------
-// V1 permission set
+// Default permission set
 // ---------------------------------------------------------------------------
 //
-// Hard-coded for V1 per apiarist DESIGN.md §11 — every mint asks for the
-// same scope. Future variants of the API may accept a per-request override
-// constrained by the agent token's policy. Apiarist's `_V1_PERMISSIONS`
-// (in `apiarist/src/apiarist/features/tokens/plugin.py`) MUST be kept in
-// sync with this — apiarist uses it as the cache-key hash, and a divergence
+// Hard-coded ceiling per apiarist DESIGN.md §11 — every mint asks for at
+// most this scope. V1.6 (`allowed_permissions` on the token policy) lets
+// individual tokens NARROW from this default; nothing can EXCEED it.
+// Apiarist's `_V1_PERMISSIONS` (in
+// `apiarist/src/apiarist/features/tokens/plugin.py`) MUST be kept in sync
+// with this — apiarist uses it as the cache-key hash, and a divergence
 // would silently invalidate every cached entry on the client.
 
-export const V1_PERMISSIONS: Readonly<Record<string, string>> = Object.freeze({
-  contents: "read",
-  pull_requests: "write",
-  issues: "write",
-  metadata: "read",
-});
+export const V1_PERMISSIONS: Readonly<Record<string, GitHubPermissionLevel>> =
+  Object.freeze({
+    contents: "read",
+    pull_requests: "write",
+    issues: "write",
+    metadata: "read",
+  });
+
+// ---------------------------------------------------------------------------
+// Permission intersection (V1.6)
+// ---------------------------------------------------------------------------
+
+const PERMISSION_LEVEL_RANK: Readonly<Record<GitHubPermissionLevel, number>> =
+  Object.freeze({ read: 1, write: 2, admin: 3 });
+
+/**
+ * Compute the effective permission set: intersect the default ceiling
+ * with an optional per-token narrowing map.
+ *
+ * Rules:
+ *   1. If `narrow` is `undefined` → return defaults unchanged (V1.5
+ *      behavior preserved for legacy / non-V1.6 tokens).
+ *   2. For every key in `defaults`:
+ *      - If `narrow` doesn't mention it → use the default level.
+ *      - If `narrow` mentions it → take the LOWER of the two levels
+ *        (read < write < admin). The token can narrow but never raise.
+ *   3. Keys present in `narrow` but absent from `defaults` are silently
+ *      DROPPED (a token cannot grant scope the default doesn't have).
+ *      A console warning is emitted so misconfigurations are visible
+ *      in operator logs.
+ *
+ * Exported for unit testing; production callers should let
+ * `mintInstallationToken` apply this internally.
+ */
+export function intersectPermissions(
+  defaults: Readonly<Record<string, GitHubPermissionLevel>>,
+  narrow: Readonly<Record<string, GitHubPermissionLevel>> | undefined,
+): Record<string, GitHubPermissionLevel> {
+  if (narrow === undefined) {
+    // No narrowing requested — caller wants defaults verbatim.
+    return { ...defaults };
+  }
+
+  const out: Record<string, GitHubPermissionLevel> = {};
+  for (const [key, defaultLevel] of Object.entries(defaults)) {
+    const narrowLevel = narrow[key];
+    if (narrowLevel === undefined) {
+      out[key] = defaultLevel;
+      continue;
+    }
+    const defaultRank = PERMISSION_LEVEL_RANK[defaultLevel];
+    const narrowRank = PERMISSION_LEVEL_RANK[narrowLevel];
+    out[key] = narrowRank < defaultRank ? narrowLevel : defaultLevel;
+  }
+
+  // Surface (don't silently swallow) keys in `narrow` that aren't in
+  // `defaults` — operator typo'd a permission name, or asked for a scope
+  // V1_PERMISSIONS doesn't expose. The dropped keys still go to GitHub
+  // through `out`, so the request is unaffected (those keys aren't there).
+  for (const key of Object.keys(narrow)) {
+    if (!(key in defaults)) {
+      console.warn(
+        `[mintInstallationToken] policy.allowed_permissions['${key}'] ignored — not in V1_PERMISSIONS`,
+      );
+    }
+  }
+  return out;
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -55,6 +119,15 @@ export interface MintOptions {
   appId: string;
   /** Hivemoot Bot's RSA private key in PEM form (from `GITHUB_APP_PRIVATE_KEY` env). */
   appPrivateKeyPem: string;
+  /**
+   * V1.6+: per-token permission narrowing from the agent token's
+   * `policy.allowed_permissions`. When set, the requested scope is
+   * `intersectPermissions(V1_PERMISSIONS, allowedPermissions)` — the
+   * token can only narrow the default; it cannot raise it.
+   * Absence (undefined) preserves V1.5 behavior — request V1_PERMISSIONS
+   * verbatim.
+   */
+  allowedPermissions?: Record<string, GitHubPermissionLevel>;
 }
 
 export interface InstallationAccessTokenResponse {
@@ -212,11 +285,20 @@ export async function mintInstallationToken(
   options: MintOptions,
   fetcher: Fetcher = fetch,
 ): Promise<InstallationAccessTokenResponse> {
-  const { installationId, repo, appId, appPrivateKeyPem } = options;
+  const { installationId, repo, appId, appPrivateKeyPem, allowedPermissions } =
+    options;
 
   // Validate repo shape BEFORE generating the JWT so a malformed input
   // doesn't burn an RSA signing operation.
   const { name: repoShortName } = parseRepo(repo);
+
+  // V1.6: compute the effective permission set. With no narrowing
+  // (legacy/V1.5 tokens) this returns V1_PERMISSIONS unchanged; with
+  // narrowing (V1.6 tokens) it returns the intersected map.
+  const effectivePermissions = intersectPermissions(
+    V1_PERMISSIONS,
+    allowedPermissions,
+  );
 
   // Generate the App JWT. This is purely CPU work (RS256 sign) — failures
   // here mean the App private key in env is malformed or missing, which is
@@ -251,10 +333,12 @@ export async function mintInstallationToken(
         // name (NOT owner/name); the installation provides the owner
         // context implicitly.
         repositories: [repoShortName],
-        // Narrow to the V1 permission set. If the installation's policy
-        // grants less, GitHub silently narrows further and the response
+        // Permission set: V1_PERMISSIONS by default, intersected with
+        // `allowedPermissions` (V1.6) if the token's policy narrows
+        // further. If the installation's policy grants less than what
+        // we ask for, GitHub silently narrows further and the response
         // permissions reflect that.
-        permissions: V1_PERMISSIONS,
+        permissions: effectivePermissions,
       }),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

- Extends V1.5 token-policy framework with `allowed_permissions`: per-token GitHub permission narrowing on top of the existing `allowed_repos` repo narrowing
- Read-only worker tokens become possible — token cannot escalate, can only narrow within `V1_PERMISSIONS` ceiling
- Unblocks WAR_ROOM_DESIGN.md §16 hard-rollout-gate: war-room V1 can't ship to prod until V1.6 is live

## What changed

`AgentTokenPolicy` (in `web/src/server/agent-token.ts`) gains an optional `allowed_permissions` field:

```typescript
export type GitHubPermissionLevel = "read" | "write" | "admin";

export interface AgentTokenPolicy {
  allowed_repos: string[];                                              // V1.5
  allowed_permissions?: Record<string, GitHubPermissionLevel>;          // V1.6 (this PR)
}
```

New `intersectPermissions(defaults, narrow)` helper enforces:
- `undefined` narrow → return defaults verbatim (V1.5 behavior preserved)
- per-key intersection: lower level wins (`read < write < admin`) — token can NARROW, never RAISE
- keys not in defaults: silently dropped + console warning (token can't grant scope the default doesn't have)

`mintInstallationToken` accepts `MintOptions.allowedPermissions` and applies the helper before calling GitHub. Audit log on the route also surfaces `grantedPermissions` and `narrowedByPolicy: bool` so operators can verify V1.6 narrowing took effect without combing GitHub's audit log.

## What it looks like

**Before** (V1.5 — every mint asks for full V1_PERMISSIONS scope):
```
[installation-tokens] minted {
  installationId: "107212709",
  repo: "hivemoot/hivemoot",
  hashedToken: "abc...",
  expiresAt: "2026-04-26T23:18:29Z"
}
```

**After** (V1.6 — read-only worker token narrows scope):
```
[installation-tokens] minted {
  installationId: "107212709",
  repo: "hivemoot/hivemoot",
  hashedToken: "abc...",
  expiresAt: "2026-04-26T23:18:29Z",
  grantedPermissions: { contents: "read", pull_requests: "read", issues: "read", metadata: "read" },
  narrowedByPolicy: true
}
```

**Setting a read-only policy** (existing `setAgentTokenPolicy` API, just extended):
```typescript
await setAgentTokenPolicy("107212709", {
  allowed_repos: ["hivemoot/hivemoot"],
  allowed_permissions: {
    contents: "read",
    pull_requests: "read",
    issues: "read",
    metadata: "read",
  },
}, redis);
```

**Escalation attempt is silently capped** (defense-in-depth):
```typescript
// V1_PERMISSIONS.contents = "read"
// Token tries: contents = "write"
// Result sent to GitHub: contents = "read"  (capped, no warning needed)
```

## Test plan

- [x] `npx tsc --noEmit` clean across web/
- [x] 57/57 tests pass (38 in `github-installation-token.test.ts`, 19 in route test)
- [x] 8 new unit tests on `intersectPermissions`: undefined, fresh-object, no-change, narrow, escalation cap, admin cap, dropped-unknown-key warning, read-only worker preset
- [x] 4 new mint integration tests: V1.5 path preserved, read-only narrowing, escalation capped, partial narrow leaves defaults intact
- [ ] Manual hive verification (post-merge): set policy on apiarist token to `{contents: read, pull_requests: read, issues: read, metadata: read}`, observe drone container's next mint requests `permissions: {... all read}`, verify the resulting `ghs_*` token cannot push to GitHub (403 from `gh push`).

## Backward compatibility

- Legacy tokens (`policy: undefined`) → V1.5 path: zero behavior change
- V1.5 tokens (`policy.allowed_repos` set, `allowed_permissions` undefined) → zero behavior change
- V1.6 tokens (`allowed_permissions` set) → narrow scope as configured

No new endpoint, no schema migration, no forced redeploy. Read-only worker tokens become available the moment an operator calls `setAgentTokenPolicy` with the narrowing.

## Apiarist daemon impact

None at the wire level — apiarist still requests `_V1_PERMISSIONS` (the ceiling). Server applies the token's policy and returns the narrowed result in the response's `permissions` field.

Comment added to `apiarist/src/apiarist/features/tokens/plugin.py:_V1_PERMISSIONS` explaining V1.6 cache-invalidation: cached tokens minted under the previous policy keep serving until natural cache TTL (default 5 min). Operators rolling out a policy change immediately should restart the apiarist daemon — the in-memory cache resets.

## Governance

No-linked-issue bypass per the same precedent as PRs #497, #498, #499, #500. Audit trail captured in this description + commit message. The doc gate this PR closes is WAR_ROOM_DESIGN.md §16 (Phase C dependency).