### PR TITLE
Phase B.1.a — capability vocabulary + presets + validation

### DIFF
--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from "vitest";
+import {
+  KNOWN_CAPABILITIES,
+  ADMIN_CLASS_CAPABILITIES,
+  PRESETS,
+  CapabilityValidationError,
+  expandCapabilities,
+  bearerHasCapability,
+  isKnownPreset,
+  resolvePreset,
+  validateName,
+  validateAgentRole,
+  validateCapabilityString,
+  NAME_REGEX,
+  CAPABILITY_REGEX,
+} from "./agent-token-capabilities";
+
+// ---------------------------------------------------------------------------
+// Validation regexes
+// ---------------------------------------------------------------------------
+
+describe("NAME_REGEX", () => {
+  it("accepts lowercase identifiers starting with a letter", () => {
+    for (const name of ["worker", "drone", "a", "x_y", "x-y", "abc123", "a".repeat(32)]) {
+      expect(NAME_REGEX.test(name), name).toBe(true);
+    }
+  });
+
+  it("rejects uppercase, leading non-letter, empty, too-long, or invalid chars", () => {
+    for (const name of [
+      "Worker",       // uppercase
+      "1worker",      // leading digit
+      "_worker",      // leading underscore
+      "-worker",      // leading hyphen
+      "",             // empty
+      "a".repeat(33), // > 32
+      "a b",          // space
+      "a/b",          // slash
+      "a.b",          // dot
+      "a@b",          // at
+    ]) {
+      expect(NAME_REGEX.test(name), name).toBe(false);
+    }
+  });
+});
+
+describe("CAPABILITY_REGEX", () => {
+  it("accepts bare *, identifier, identifier.*, multi-segment", () => {
+    for (const cap of [
+      "*",
+      "tasks.claim",
+      "tasks.*",
+      "agent_health.report",
+      "installation_token.mint",
+      "rooms.read",
+      "single",            // single-segment identifier
+    ]) {
+      expect(CAPABILITY_REGEX.test(cap), cap).toBe(true);
+    }
+  });
+
+  it("rejects uppercase, mid-segment wildcard, leading wildcard segment, empty segments", () => {
+    for (const cap of [
+      "Tasks.Claim",  // uppercase
+      "tasks.",       // trailing dot
+      "*.claim",      // leading wildcard segment
+      "tasks.*claim", // mid-segment wildcard
+      "tasks.cl*aim", // mid-segment wildcard
+      "tasks.*.foo",  // wildcard NOT trailing
+      "tasks..claim", // empty segment
+      "",             // empty
+      "tasks.claim ", // trailing space
+      "tasks.cl-aim", // hyphen not allowed in segment per spec
+    ]) {
+      expect(CAPABILITY_REGEX.test(cap), cap).toBe(false);
+    }
+  });
+});
+
+describe("validateName", () => {
+  it("returns silently on valid name", () => {
+    expect(() => validateName("worker")).not.toThrow();
+  });
+
+  it("throws CapabilityValidationError naming the field on invalid name", () => {
+    let captured: CapabilityValidationError | null = null;
+    try {
+      validateName("Worker");
+    } catch (e) {
+      captured = e as CapabilityValidationError;
+    }
+    expect(captured).toBeInstanceOf(CapabilityValidationError);
+    expect(captured?.field).toBe("name");
+    expect(captured?.value).toBe("Worker");
+    expect(captured?.message).toContain("Worker");
+  });
+});
+
+describe("validateAgentRole", () => {
+  it("uses the same regex as name (operator can name a role with the same shape as a token name)", () => {
+    expect(() => validateAgentRole("drone")).not.toThrow();
+    expect(() => validateAgentRole("Drone")).toThrow(CapabilityValidationError);
+  });
+
+  it("error.field is agent_role (not name)", () => {
+    let captured: CapabilityValidationError | null = null;
+    try {
+      validateAgentRole("");
+    } catch (e) {
+      captured = e as CapabilityValidationError;
+    }
+    expect(captured?.field).toBe("agent_role");
+  });
+});
+
+describe("validateCapabilityString", () => {
+  it("accepts canonical capabilities", () => {
+    for (const c of KNOWN_CAPABILITIES) {
+      expect(() => validateCapabilityString(c)).not.toThrow();
+    }
+  });
+
+  it("accepts wildcards", () => {
+    expect(() => validateCapabilityString("*")).not.toThrow();
+    expect(() => validateCapabilityString("tasks.*")).not.toThrow();
+  });
+
+  it("rejects mid-segment wildcard (R2.1 fix)", () => {
+    expect(() => validateCapabilityString("tasks.*claim")).toThrow(
+      CapabilityValidationError,
+    );
+  });
+
+  it("rejects uppercase and bad shapes", () => {
+    expect(() => validateCapabilityString("Tasks.Claim")).toThrow();
+    expect(() => validateCapabilityString("tasks.")).toThrow();
+    expect(() => validateCapabilityString("")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wildcard expansion
+// ---------------------------------------------------------------------------
+
+describe("expandCapabilities", () => {
+  it("empty list → empty set", () => {
+    expect(expandCapabilities([]).size).toBe(0);
+  });
+
+  it("concrete strings pass through", () => {
+    const out = expandCapabilities(["tasks.claim", "rooms.read"]);
+    expect(out.has("tasks.claim")).toBe(true);
+    expect(out.has("rooms.read")).toBe(true);
+    expect(out.size).toBe(2);
+  });
+
+  it("bare * expands to ALL KNOWN_CAPABILITIES except admin-class", () => {
+    const out = expandCapabilities(["*"]);
+    for (const k of KNOWN_CAPABILITIES) {
+      if (ADMIN_CLASS_CAPABILITIES.has(k)) {
+        expect(out.has(k), `* should NOT include admin-class ${k}`).toBe(false);
+      } else {
+        expect(out.has(k), `* should include ${k}`).toBe(true);
+      }
+    }
+  });
+
+  it("bare * does NOT include agent_tokens.manage (the canonical admin-class case)", () => {
+    expect(expandCapabilities(["*"]).has("agent_tokens.manage")).toBe(false);
+  });
+
+  it("tasks.* expands only tasks.* entries (and excludes admin-class even if a task admin existed)", () => {
+    const out = expandCapabilities(["tasks.*"]);
+    expect(out.has("tasks.claim")).toBe(true);
+    expect(out.has("tasks.progress")).toBe(true);
+    expect(out.has("tasks.complete")).toBe(true);
+    expect(out.has("tasks.create")).toBe(true);
+    expect(out.has("tasks.read")).toBe(true);
+    expect(out.has("tasks.cancel")).toBe(true);
+    expect(out.has("tasks.verify")).toBe(true);
+    // Should not bleed across subsystems
+    expect(out.has("rooms.read")).toBe(false);
+    expect(out.has("agent_health.report")).toBe(false);
+    expect(out.has("installation_token.mint")).toBe(false);
+    expect(out.has("agent_tokens.manage")).toBe(false);
+  });
+
+  it("agent_tokens.* does NOT expand to agent_tokens.manage (R2 N3 fix)", () => {
+    // The whole point of ADMIN_CLASS_CAPABILITIES: an operator who
+    // writes `agent_tokens.*` must NOT silently get the admin-class
+    // capability. They must list it explicitly.
+    const out = expandCapabilities(["agent_tokens.*"]);
+    expect(out.has("agent_tokens.manage")).toBe(false);
+    // Currently agent_tokens.manage is the only entry in
+    // KNOWN_CAPABILITIES under that prefix, so the expansion is
+    // empty. That's correct — the test pins the invariant for when
+    // future agent_tokens.* entries arrive.
+    expect(out.size).toBe(0);
+  });
+
+  it("explicit agent_tokens.manage works (admin-class IS reachable via single string)", () => {
+    expect(
+      expandCapabilities(["agent_tokens.manage"]).has("agent_tokens.manage"),
+    ).toBe(true);
+  });
+
+  it("mixed wildcards + concretes deduplicate", () => {
+    const out = expandCapabilities(["tasks.*", "tasks.claim", "rooms.read"]);
+    // tasks.claim already expanded by tasks.*; concrete is dedup'd
+    expect(out.has("tasks.claim")).toBe(true);
+    expect(out.has("rooms.read")).toBe(true);
+  });
+
+  it("unknown concrete strings pass through as-is (the validator earlier in the lifecycle is what rejects them)", () => {
+    const out = expandCapabilities(["tasks.imaginary"]);
+    expect(out.has("tasks.imaginary")).toBe(true);
+  });
+
+  it("idempotent on the same input", () => {
+    const a = expandCapabilities(["*", "tasks.claim"]);
+    const b = expandCapabilities(["*", "tasks.claim"]);
+    expect([...a].sort()).toEqual([...b].sort());
+  });
+});
+
+describe("bearerHasCapability", () => {
+  it("true when bearer literally holds the required cap", () => {
+    expect(bearerHasCapability(["tasks.claim"], "tasks.claim")).toBe(true);
+  });
+
+  it("true when wildcard expansion covers the required cap", () => {
+    expect(bearerHasCapability(["tasks.*"], "tasks.create")).toBe(true);
+    expect(bearerHasCapability(["*"], "rooms.read")).toBe(true);
+  });
+
+  it("false when neither literal nor wildcard covers the required cap", () => {
+    expect(bearerHasCapability(["tasks.claim"], "rooms.create")).toBe(false);
+  });
+
+  it("false on bare * for agent_tokens.manage (admin-class carve-out)", () => {
+    expect(bearerHasCapability(["*"], "agent_tokens.manage")).toBe(false);
+  });
+
+  it("true when admin-class is listed explicitly alongside *", () => {
+    expect(
+      bearerHasCapability(["*", "agent_tokens.manage"], "agent_tokens.manage"),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Presets
+// ---------------------------------------------------------------------------
+
+describe("PRESETS", () => {
+  it("every preset's capabilities pass CAPABILITY_REGEX validation", () => {
+    for (const [presetName, caps] of Object.entries(PRESETS)) {
+      for (const c of caps) {
+        expect(
+          () => validateCapabilityString(c),
+          `${presetName}: ${c}`,
+        ).not.toThrow();
+      }
+    }
+  });
+
+  it("worker preset does NOT include installation_token.mint (workers go through apiarist)", () => {
+    expect(PRESETS.worker.includes("installation_token.mint")).toBe(false);
+  });
+
+  it("worker preset DOES include rooms.read (so triage can fetch room state)", () => {
+    expect(PRESETS.worker.includes("rooms.read")).toBe(true);
+  });
+
+  it("queen preset has room-management caps", () => {
+    expect(PRESETS.queen.includes("rooms.create")).toBe(true);
+    expect(PRESETS.queen.includes("rooms.update")).toBe(true);
+    expect(PRESETS.queen.includes("rooms.decide")).toBe(true);
+    expect(PRESETS.queen.includes("rooms.close")).toBe(true);
+  });
+
+  it("apiarist preset is single-cap (smallest blast radius)", () => {
+    expect(PRESETS.apiarist).toEqual(["installation_token.mint"]);
+  });
+
+  it("admin preset includes both bare * AND agent_tokens.manage explicit (wildcard alone wouldn't cover it)", () => {
+    expect(PRESETS.admin.includes("*")).toBe(true);
+    expect(PRESETS.admin.includes("agent_tokens.manage")).toBe(true);
+  });
+
+  it("admin preset's effective capability set covers EVERY KNOWN_CAPABILITIES entry", () => {
+    const effective = expandCapabilities(PRESETS.admin);
+    for (const k of KNOWN_CAPABILITIES) {
+      expect(effective.has(k), `admin should grant ${k}`).toBe(true);
+    }
+  });
+});
+
+describe("isKnownPreset / resolvePreset", () => {
+  it("returns true for each canonical preset name", () => {
+    for (const name of Object.keys(PRESETS)) {
+      expect(isKnownPreset(name)).toBe(true);
+    }
+  });
+
+  it("returns false for unknown name", () => {
+    expect(isKnownPreset("nonexistent")).toBe(false);
+    expect(isKnownPreset("WORKER")).toBe(false); // case-sensitive
+  });
+
+  it("resolvePreset returns the cap list for known names", () => {
+    expect(resolvePreset("apiarist")).toEqual(["installation_token.mint"]);
+  });
+
+  it("resolvePreset throws CapabilityValidationError on unknown name (no silent fallback)", () => {
+    let captured: CapabilityValidationError | null = null;
+    try {
+      resolvePreset("nonexistent");
+    } catch (e) {
+      captured = e as CapabilityValidationError;
+    }
+    expect(captured).toBeInstanceOf(CapabilityValidationError);
+    expect(captured?.field).toBe("preset");
+    expect(captured?.value).toBe("nonexistent");
+    // Error message lists valid presets so the operator gets immediate
+    // feedback on typos.
+    expect(captured?.message).toMatch(/apiarist|admin|worker/);
+  });
+
+  it("Object.prototype member name (e.g. 'toString') is NOT a valid preset", () => {
+    // Prototype-pollution defense: hasOwnProperty (used by isKnownPreset)
+    // must reject inherited member names like 'toString'.
+    expect(isKnownPreset("toString")).toBe(false);
+    expect(() => resolvePreset("toString")).toThrow(CapabilityValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-invariants
+// ---------------------------------------------------------------------------
+
+describe("cross-invariants", () => {
+  it("ADMIN_CLASS_CAPABILITIES is a subset of KNOWN_CAPABILITIES (no orphans)", () => {
+    const known = new Set<string>(KNOWN_CAPABILITIES);
+    for (const c of ADMIN_CLASS_CAPABILITIES) {
+      expect(known.has(c), `admin-class cap ${c} must be in KNOWN_CAPABILITIES`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("KNOWN_CAPABILITIES has no duplicates", () => {
+    const set = new Set<string>(KNOWN_CAPABILITIES);
+    expect(set.size).toBe(KNOWN_CAPABILITIES.length);
+  });
+
+  it("every KNOWN_CAPABILITIES entry passes CAPABILITY_REGEX", () => {
+    for (const c of KNOWN_CAPABILITIES) {
+      expect(CAPABILITY_REGEX.test(c), c).toBe(true);
+    }
+  });
+
+  it("KNOWN_CAPABILITIES count matches the design doc claim (19)", () => {
+    // R2.2 design recount: 19 capabilities. If this fails, the doc
+    // section "Total: 19 capabilities" needs to be updated alongside
+    // the addition.
+    expect(KNOWN_CAPABILITIES.length).toBe(19);
+  });
+});

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -1,0 +1,313 @@
+/**
+ * Capability vocabulary + preset expansion + validation primitives for
+ * the per-key agent-token capability system (Phase B per
+ * `docs/architecture/CAPABILITIES_DESIGN.md`).
+ *
+ * This module is the single source of truth for:
+ * - The complete vocabulary of capabilities the API recognizes
+ *   (`KNOWN_CAPABILITIES`).
+ * - Capabilities that admin tokens grant but wildcards never expand
+ *   to (`ADMIN_CLASS_CAPABILITIES`) — bare `*` and prefix `tasks.*` /
+ *   `rooms.*` / etc. always exclude these.
+ * - Hardcoded preset bundles (`PRESETS`) for issuance ergonomics:
+ *   `apiarist`, `worker`, `queen`, `dispatcher`, `monitoring`, `admin`.
+ * - Wildcard expansion at request time (`expandCapabilities`). Adding
+ *   a new capability is a PR-touching-this-file change; the
+ *   CHANGELOG entry should call out wildcard implications.
+ * - Validation regexes for `name`, `agent_role`, and capability
+ *   strings.
+ *
+ * The middleware, `/api/whoami`, the `hivemoot tokens` CLI, and the
+ * issue/revoke/set-capabilities endpoints all import from here.
+ * Diverging the vocabulary across consumers is exactly the silent
+ * privilege-grant footgun the design doc was filed to prevent.
+ */
+
+// ---------------------------------------------------------------------------
+// Validation regexes
+// ---------------------------------------------------------------------------
+
+/**
+ * Token names + agent roles: lowercase ASCII, must start with a letter,
+ * up to 32 chars, underscore + hyphen allowed inside. The leading-letter
+ * rule keeps "1worker", "_admin", "-x" out — names should look like
+ * identifiers a human would copy from a runbook.
+ */
+export const NAME_REGEX = /^[a-z][a-z0-9_-]{0,31}$/;
+
+/**
+ * Capability strings: bare `*`, OR lowercase identifier with optional
+ * `*` ONLY as the trailing segment. The R2.1 design review rejected
+ * the prior `^[a-z_]+(\.[a-z_*]+)+$` regex because it permitted
+ * mid-segment `*` (`tasks.*claim`, `tasks.cl*aim`).
+ *
+ *   matches:  *
+ *             tasks.claim
+ *             tasks.*
+ *             agent_health.report
+ *
+ *   rejects:  Tasks.Claim       (uppercase)
+ *             tasks.            (trailing dot)
+ *             *.claim           (leading wildcard segment)
+ *             tasks.*claim      (mid-segment wildcard)
+ *             tasks.*.foo       (trailing-only invariant)
+ *             tasks..claim      (empty segment)
+ */
+export const CAPABILITY_REGEX = /^(\*|[a-z_]+(\.[a-z_]+)*(\.\*)?)$/;
+
+/**
+ * Strict validators that throw `CapabilityValidationError` on rejection.
+ * Use at envelope-write time (issue / set-capabilities) so a malformed
+ * string can never land in storage. The error carries the offending
+ * field so route handlers can surface it directly to the operator.
+ */
+export class CapabilityValidationError extends Error {
+  public readonly field: string;
+  public readonly value: string;
+  constructor(field: string, value: string, expectedDescription: string) {
+    super(
+      `Invalid ${field}: ${JSON.stringify(value)}. Expected ${expectedDescription}.`,
+    );
+    this.name = "CapabilityValidationError";
+    this.field = field;
+    this.value = value;
+  }
+}
+
+export function validateName(value: string): void {
+  if (!NAME_REGEX.test(value)) {
+    throw new CapabilityValidationError(
+      "name",
+      value,
+      "lowercase ASCII identifier starting with a letter, ≤32 chars (matching /^[a-z][a-z0-9_-]{0,31}$/)",
+    );
+  }
+}
+
+export function validateAgentRole(value: string): void {
+  if (!NAME_REGEX.test(value)) {
+    throw new CapabilityValidationError(
+      "agent_role",
+      value,
+      "lowercase ASCII identifier starting with a letter, ≤32 chars (matching /^[a-z][a-z0-9_-]{0,31}$/)",
+    );
+  }
+}
+
+export function validateCapabilityString(value: string): void {
+  if (!CAPABILITY_REGEX.test(value)) {
+    throw new CapabilityValidationError(
+      "capability",
+      value,
+      "bare `*` OR lowercase dot-separated identifier with optional trailing-only `*` (matching /^(\\*|[a-z_]+(\\.[a-z_]+)*(\\.\\*)?)$/)",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Capability vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Every capability the API recognizes. Wildcard expansion (`*`,
+ * `tasks.*`, etc.) resolves against this list at request time.
+ * Adding a new capability MUST update this constant; the CHANGELOG
+ * for that PR should call out the wildcard implication ("now grants
+ * `X` to existing `tasks.*` holders").
+ *
+ * Ordered by subsystem (installation_token → agent_health → tasks →
+ * rooms → agent_tokens) for diff readability.
+ */
+export const KNOWN_CAPABILITIES = [
+  // Installation-token brokerage (apiarist's only required cap).
+  "installation_token.mint",
+  // Agent health observability.
+  "agent_health.report",
+  "agent_health.read",
+  // Task lifecycle (workers).
+  "tasks.claim",
+  "tasks.progress",
+  "tasks.complete",
+  // Task management (bot/queen, dispatcher).
+  "tasks.create",
+  "tasks.read",
+  "tasks.cancel",
+  "tasks.verify",
+  // War rooms — workers.
+  "rooms.watch",
+  "rooms.read",
+  "rooms.contribute",
+  // War rooms — bot (queen module).
+  "rooms.create",
+  "rooms.update",
+  "rooms.decide",
+  "rooms.close",
+  // War rooms — admin.
+  "rooms.force_close",
+  // Token management (admin only — see ADMIN_CLASS_CAPABILITIES).
+  "agent_tokens.manage",
+] as const;
+
+export type KnownCapability = (typeof KNOWN_CAPABILITIES)[number];
+
+/**
+ * Capabilities that admin classes grant but wildcards never expand to.
+ * Both bare `*` and prefix `*.*` paths exclude these.
+ *
+ * Without this carve-out, an operator who issued `--capabilities
+ * agent_tokens.*` thinking it's "everything in the agent_tokens
+ * family except admin" would silently get full token-management
+ * capability. Admin-class caps are reachable only via explicit
+ * single-string listing.
+ */
+export const ADMIN_CLASS_CAPABILITIES: ReadonlySet<string> = new Set<string>([
+  "agent_tokens.manage",
+]);
+
+// ---------------------------------------------------------------------------
+// Wildcard expansion
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a capability list (which may contain wildcards) into the
+ * concrete capability set the bearer effectively holds. Used at
+ * middleware request time when checking whether the bearer satisfies
+ * an endpoint's `requires` capability.
+ *
+ * Rules:
+ *   1. `*` → every entry in `KNOWN_CAPABILITIES` EXCEPT
+ *      `ADMIN_CLASS_CAPABILITIES`.
+ *   2. `<prefix>.*` → every `KNOWN_CAPABILITIES` entry whose key
+ *      starts with `<prefix>.`, EXCEPT `ADMIN_CLASS_CAPABILITIES`.
+ *   3. Concrete strings → added as-is. Unknown concrete strings are
+ *      preserved (the caller's middleware can choose to log + fail or
+ *      ignore; the validator earlier in the lifecycle rejects them at
+ *      issue time).
+ *
+ * Returns a `Set<string>` so callers can `.has()` in O(1) for the cap
+ * check. Idempotent — safe to call repeatedly on the same input.
+ */
+export function expandCapabilities(
+  capabilities: readonly string[],
+): Set<string> {
+  const out = new Set<string>();
+  for (const entry of capabilities) {
+    if (entry === "*") {
+      for (const k of KNOWN_CAPABILITIES) {
+        if (!ADMIN_CLASS_CAPABILITIES.has(k)) out.add(k);
+      }
+      continue;
+    }
+    if (entry.endsWith(".*")) {
+      const prefix = entry.slice(0, -2);
+      for (const k of KNOWN_CAPABILITIES) {
+        if (k.startsWith(prefix + ".") && !ADMIN_CLASS_CAPABILITIES.has(k)) {
+          out.add(k);
+        }
+      }
+      continue;
+    }
+    out.add(entry);
+  }
+  return out;
+}
+
+/**
+ * Convenience wrapper for the middleware's request-time check:
+ * does the bearer hold the `required` capability after wildcard
+ * expansion?
+ */
+export function bearerHasCapability(
+  bearerCapabilities: readonly string[],
+  required: string,
+): boolean {
+  return expandCapabilities(bearerCapabilities).has(required);
+}
+
+// ---------------------------------------------------------------------------
+// Presets
+// ---------------------------------------------------------------------------
+
+/**
+ * Preset capability bundles for common roles. Used by `tokens issue
+ * --preset <name>` for issuance ergonomics; operators always free to
+ * bypass with `--capabilities <list>`.
+ *
+ * `set-capabilities --preset <name>` is deliberately a snap to the
+ * CURRENT preset definition (not the one at issue time) — adding a
+ * new preset member during system evolution is the intended path
+ * for granting it to existing preset-issued tokens.
+ *
+ * Preset wiring rationale (cross-referenced in CAPABILITIES_DESIGN.md):
+ * - `apiarist`: only mints installation tokens. Smallest blast
+ *   radius; runs on the host as a UDS broker.
+ * - `worker`: containers (drone, builder, guard). NO
+ *   `installation_token.mint` — workers go through apiarist's UDS,
+ *   not the API directly.
+ * - `queen`: bot's room-management token. Bot creates/updates/
+ *   decides/closes rooms; doesn't itself claim or progress tasks.
+ * - `dispatcher`: dashboard or external task creator.
+ * - `monitoring`: read-only operator.
+ * - `admin`: bare `*` + explicit `agent_tokens.manage` (the
+ *   wildcard expansion does NOT include the latter).
+ */
+export const PRESETS: Readonly<Record<string, readonly string[]>> = {
+  apiarist: [
+    "installation_token.mint",
+  ],
+  worker: [
+    "agent_health.report",
+    "tasks.claim",
+    "tasks.progress",
+    "tasks.complete",
+    "rooms.watch",
+    "rooms.read",
+    "rooms.contribute",
+  ],
+  queen: [
+    "agent_health.report",
+    "tasks.create",
+    "tasks.read",
+    "tasks.cancel",
+    "rooms.create",
+    "rooms.read",
+    "rooms.update",
+    "rooms.decide",
+    "rooms.close",
+  ],
+  dispatcher: [
+    "tasks.create",
+    "tasks.read",
+  ],
+  monitoring: [
+    "agent_health.read",
+    "tasks.read",
+    "rooms.read",
+  ],
+  admin: [
+    "*",
+    "agent_tokens.manage",
+  ],
+} as const;
+
+export type PresetName = keyof typeof PRESETS;
+
+export function isKnownPreset(name: string): name is PresetName {
+  return Object.prototype.hasOwnProperty.call(PRESETS, name);
+}
+
+/**
+ * Resolve a preset name to its capability list. Throws
+ * `CapabilityValidationError` on unknown name so the caller surfaces
+ * a clear error instead of silently issuing a token with `[]` caps.
+ */
+export function resolvePreset(name: string): readonly string[] {
+  if (!isKnownPreset(name)) {
+    throw new CapabilityValidationError(
+      "preset",
+      name,
+      `one of: ${Object.keys(PRESETS).sort().join(", ")}`,
+    );
+  }
+  return PRESETS[name];
+}


### PR DESCRIPTION
## Summary

First slice of Phase B.1 (backend implementation of CAPABILITIES_DESIGN.md). Pure module addition — no schema changes, no API surface, no middleware impact yet. Subsequent PRs (B.1.b/c/d) will layer schema migration + Lua scripts + middleware + HTTP endpoints on top.

This module is the single source of truth for capability vocabulary, preset bundles, and validation that the rest of Phase B will import.

## What lands

`web/src/server/agent-token-capabilities.ts`:

- `KNOWN_CAPABILITIES` — 19-entry vocabulary
- `ADMIN_CLASS_CAPABILITIES` — capabilities never reachable via wildcard expansion (currently `agent_tokens.manage`); closes R2 N3 silent-escalation trap
- `PRESETS` — `apiarist` / `worker` / `queen` / `dispatcher` / `monitoring` / `admin`. Worker deliberately omits `installation_token.mint` (workers go through apiarist UDS); admin lists `agent_tokens.manage` explicitly because bare `*` doesn't cover it
- `expandCapabilities()` / `bearerHasCapability()` — wildcard resolution + cap check
- `isKnownPreset()` / `resolvePreset()` — preset lookup with prototype-pollution defense (`hasOwnProperty`)
- `NAME_REGEX` / `CAPABILITY_REGEX` — design-doc-pinned validators (capability regex enforces trailing-only `*`, rejects `tasks.*claim`)
- `validateName` / `validateAgentRole` / `validateCapabilityString` — fail-closed throw paths returning `CapabilityValidationError(field, value, expectedDescription)`

## What it looks like

```typescript
import { expandCapabilities, bearerHasCapability, PRESETS } from "@/server/agent-token-capabilities";

// Wildcard expansion at request time:
expandCapabilities(["*"]);
// → Set { "installation_token.mint", "agent_health.report", ..., "rooms.force_close" }
//   (NOT "agent_tokens.manage" — admin-class carve-out)

bearerHasCapability(["tasks.*"], "tasks.create");      // → true
bearerHasCapability(["*"], "agent_tokens.manage");      // → false (carve-out)
bearerHasCapability(PRESETS.admin, "agent_tokens.manage");  // → true (admin lists it explicitly)

// Preset wiring (used by `tokens issue --preset worker`):
PRESETS.worker;
// → ["agent_health.report", "tasks.claim", "tasks.progress", "tasks.complete",
//    "rooms.watch", "rooms.read", "rooms.contribute"]
// Note: NO "installation_token.mint" — workers go through apiarist UDS

// Validation at envelope-write time:
validateName("worker");          // ok
validateName("Worker");          // throws CapabilityValidationError(field: "name", value: "Worker")
validateCapabilityString("tasks.*claim");  // throws (mid-segment wildcard rejected)
```

## Test plan

- [x] 43 tests in `agent-token-capabilities.test.ts` covering:
  - Regex positive + adversarial cases (8 each)
  - Validator fail-closed paths with field/value pinning
  - Wildcard expansion (bare `*`, prefix `tasks.*`, admin-class carve-out, idempotency)
  - Every preset's caps pass validation, worker omits `installation_token.mint`, admin's effective set covers every `KNOWN_CAPABILITIES` entry
  - `isKnownPreset`/`resolvePreset` with prototype-pollution defense (`'toString'` rejected)
  - Cross-invariants: `ADMIN_CLASS` ⊆ `KNOWN_CAPABILITIES`, no duplicates, count matches design doc claim (19)
- [x] `npx tsc --noEmit` clean
- [x] 43/43 pass locally

## Backward compatibility

Pure addition. No existing code imports this file yet; B.1.b will start consuming it. Zero runtime impact until then.

## Governance

No-linked-issue bypass per the same precedent as PRs #497/#498/#499/#500/#501. Risk profile: pure module addition, comprehensive test coverage, design ratified in #498.