### PR TITLE
Phase B.1.b — V1 agent-token storage layer + 4 Lua scripts

### DIFF
--- a/docs/architecture/CAPABILITIES_DESIGN.md
+++ b/docs/architecture/CAPABILITIES_DESIGN.md
@@ -119,50 +119,48 @@ interface AgentTokenHashRecord {
 }
 ```
 
-**Latency note** (closes guard R2 N5): the V1.5→V1.6 transition
-adds a second Redis read per auth (hash index + envelope). The
-implementation MUST batch both reads via `redis.pipeline()` so
-each auth request stays one network round-trip. A sequential
-`await get` then `await get` would silently regress fleet-scale
-auth latency.
+**Latency + bearer-resurrection** (closes guard R2 N5 + builder
+R2 + builder R3 on PR #503): auth needs a hash-index read AND an
+envelope read AND a check that the envelope's `tokenHash` matches
+the presented bearer's SHA-256. The two reads are DEPENDENT —
+the envelope key requires `{installationId, name}` returned by
+the first read — so they CAN'T be batched via
+`redis.pipeline()`; the second key constructor depends on the
+first read's result.
 
-**Bearer-resurrection invariant** (closes builder R2 on PR #503):
-the hash index is intentionally NOT TTL'd (per the storage table
-TTL column rationale), so an explicit-expiry token whose envelope
+(Earlier drafts of this section had a `redis.pipeline().get().get()`
+pseudocode that builder R3 correctly identified as impossible.)
+
+The shipped pattern is a single Lua EVAL — `RESOLVE_BEARER_SCRIPT`
+— that does both reads + the bearer-resurrection check
+server-side. One Redis round-trip, no JS-side ordering bug
+possible. The script is in §Atomic operations below; the
+TypeScript wrapper is `web/src/server/agent-token-v1.ts:
+resolveBearerToEnvelope`. B.1.c middleware just consumes the
+typed result.
+
+**Why the `tokenHash` check is load-bearing.** The hash index is
+intentionally NOT TTL'd (per the storage-table TTL column —
+TTLing it risks dropping the index slightly before the envelope
+under clock skew). So an explicit-expiry token whose envelope
 gets swept by Redis leaves a stale hash record pointing at
 `{installationId, name}`. If the operator subsequently issues a
 NEW token with the SAME name (now permitted because
 `pruneOrphanedIndexEntries` cleared the sorted-set entry), the
-old bearer's hash → name → envelope path would resolve to the
-NEW envelope without an additional check.
+OLD bearer's hash → name → envelope path would resolve to the
+NEW envelope's identity. The script's
+`envelope.tokenHash != presentedHash → {-3, "stale_bearer"}`
+branch is what closes this. Middleware translates `stale_bearer`
+to 401 TOKEN_EXPIRED.
 
-The middleware MUST reject this case by comparing the presented
-bearer's SHA-256 against the loaded envelope's `tokenHash` field
-and rejecting on mismatch. This is the invariant that lets the
-hash index remain non-TTL safely:
-
-```
-const presentedHash = sha256(rawBearer);
-const [hashRecord, envelope] = await redis.pipeline()
-  .get(`hive:v1:idx:agent-token:hash:${presentedHash}`)
-  .get(`hive:v1:agent-token:${installationId}:${name}`)
-  .all();
-
-if (!envelope || envelope.tokenHash !== presentedHash) {
-  // Stale hash index pointing at a since-reissued name, OR
-  // envelope swept by Redis TTL. Surface as TOKEN_EXPIRED so
-  // the operator knows to re-issue / re-authenticate.
-  return reject(TOKEN_EXPIRED);
-}
-```
-
-Acceptance criterion for B.1.c: a regression test demonstrates
-the scenario "issue → wait for TTL → reissue same name → present
-old bearer → middleware returns TOKEN_EXPIRED (NOT auth success
-under new envelope's identity)."
-
-A unit test on the auth path also asserts on the call shape so
-a future refactor can't silently switch to sequential gets.
+**Acceptance criterion for B.1.c**: a regression test demonstrates
+"issue → TTL-sweep envelope → reissue same name → present old
+bearer → middleware returns 401 TOKEN_EXPIRED (NOT auth success
+under new envelope's identity)." B.1.b ships the storage-state
+demonstration of the scenario in `agent-token-v1.test.ts`'s
+"bearer-resurrection invariant" test + exercises the resolver
+script's `stale_bearer` branch directly via
+`resolveBearerToEnvelope` end-to-end.
 
 ### Storage layout (Redis)
 
@@ -291,6 +289,45 @@ if ARGV[3] ~= "" then
 end
 return {1}
 ```
+
+**`RESOLVE_BEARER_SCRIPT`** — single-RTT bearer→envelope
+resolution. Closes builder R3 on PR #503: the dependent reads
+(envelope key needs `{installationId, name}` from the hash
+record) can't be batched at the JS layer, so the read +
+bearer-resurrection check happens in one Lua EVAL.
+
+```lua
+-- KEYS: [hashIndexKey]
+-- ARGV: [envelopeKeyPrefix, presentedHash]
+--   envelopeKeyPrefix = "hive:v1:agent-token:" — passed as ARGV
+--                       so the prefix lives in TS code (single
+--                       source of truth) rather than Lua.
+-- Returns:
+--   {1, envelopeJson}              success
+--   {-1, "unknown_bearer"}         hash index miss
+--   {-2, "envelope_missing"}       hash record points at TTL-swept
+--                                  or revoked envelope
+--   {-3, "stale_bearer"}           bearer-resurrection scenario:
+--                                  envelope.tokenHash differs from
+--                                  presentedHash (same-name
+--                                  reissue race; see
+--                                  §"Latency + bearer-resurrection")
+local hashRecord = redis.call("get", KEYS[1])
+if not hashRecord then return {-1, "unknown_bearer"} end
+local parsed = cjson.decode(hashRecord)
+local envKey = ARGV[1] .. parsed.installationId .. ":" .. parsed.name
+local envelope = redis.call("get", envKey)
+if not envelope then return {-2, "envelope_missing"} end
+local envParsed = cjson.decode(envelope)
+if envParsed.tokenHash ~= ARGV[2] then return {-3, "stale_bearer"} end
+return {1, envelope}
+```
+
+Middleware (B.1.c) wraps this via `resolveBearerToEnvelope`:
+maps each failure code to its HTTP response (`unknown_bearer` /
+`envelope_missing` → 401 invalid-bearer; `stale_bearer` → 401
+TOKEN_EXPIRED), then on success applies the `expiresAt` wall-clock
+check and the per-endpoint `requires` capability check.
 
 **`ROTATE_TOKEN_SCRIPT`** — atomically replaces the bearer for an
 existing named token (closes hivemoot reviewer #5 issue 1: prior

--- a/docs/architecture/CAPABILITIES_DESIGN.md
+++ b/docs/architecture/CAPABILITIES_DESIGN.md
@@ -124,20 +124,45 @@ adds a second Redis read per auth (hash index + envelope). The
 implementation MUST batch both reads via `redis.pipeline()` so
 each auth request stays one network round-trip. A sequential
 `await get` then `await get` would silently regress fleet-scale
-auth latency. Pseudocode (concrete pattern):
+auth latency.
+
+**Bearer-resurrection invariant** (closes builder R2 on PR #503):
+the hash index is intentionally NOT TTL'd (per the storage table
+TTL column rationale), so an explicit-expiry token whose envelope
+gets swept by Redis leaves a stale hash record pointing at
+`{installationId, name}`. If the operator subsequently issues a
+NEW token with the SAME name (now permitted because
+`pruneOrphanedIndexEntries` cleared the sorted-set entry), the
+old bearer's hash → name → envelope path would resolve to the
+NEW envelope without an additional check.
+
+The middleware MUST reject this case by comparing the presented
+bearer's SHA-256 against the loaded envelope's `tokenHash` field
+and rejecting on mismatch. This is the invariant that lets the
+hash index remain non-TTL safely:
 
 ```
+const presentedHash = sha256(rawBearer);
 const [hashRecord, envelope] = await redis.pipeline()
-  .get(`hive:v1:idx:agent-token:hash:${tokenHash}`)
+  .get(`hive:v1:idx:agent-token:hash:${presentedHash}`)
   .get(`hive:v1:agent-token:${installationId}:${name}`)
   .all();
+
+if (!envelope || envelope.tokenHash !== presentedHash) {
+  // Stale hash index pointing at a since-reissued name, OR
+  // envelope swept by Redis TTL. Surface as TOKEN_EXPIRED so
+  // the operator knows to re-issue / re-authenticate.
+  return reject(TOKEN_EXPIRED);
+}
 ```
 
-(Pseudocode uses the canonical v1 key shapes from the storage
-table — closes guard G-R2.2-1 doc-drift.)
+Acceptance criterion for B.1.c: a regression test demonstrates
+the scenario "issue → wait for TTL → reissue same name → present
+old bearer → middleware returns TOKEN_EXPIRED (NOT auth success
+under new envelope's identity)."
 
-A unit test on the auth path asserts on the call shape so a future
-refactor can't silently switch to sequential gets.
+A unit test on the auth path also asserts on the call shape so
+a future refactor can't silently switch to sequential gets.
 
 ### Storage layout (Redis)
 
@@ -165,14 +190,23 @@ sorted-set/`SADD` mismatch + guard R2 N1 (atomic limit) + builder
 R2.2 (envelope TTL contract for `--expires-in` tokens).
 
 ```lua
--- KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey]
--- ARGV: [installationId, name, envelopeJson, hashRecordJson,
---        createdAtMs, tokenLimit, expirySecsOrZero]
+-- R2 shipping shape (matches web/src/server/agent-token-v1.ts):
+-- KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, auditStreamKey]
+-- ARGV: [name, envelopeJson, hashRecordJson, createdAtMs,
+--        tokenLimit, expirySecsOrZero, auditEntryJsonOrEmpty]
 --   expirySecsOrZero: 0 = no TTL (expiresAt: null tokens);
 --                     positive int = (expiresAt - now() + 300)
 --                     where +300 is the clock-skew safety margin
 --                     (closes guard R2.1 G-R2.1-4 + builder R2.2
 --                     "TTL contract not implemented in script")
+--   auditEntryJsonOrEmpty: pre-built audit entry JSON, or "" to
+--                          skip the XADD. Atomic-audit guarantee
+--                          per guard R1 G1 on PR #503: audit emit
+--                          inside the same EVAL when non-empty.
+--   installationId is encoded in the envelope KEY's prefix; the
+--                  script never uses it directly (was in design's
+--                  earlier 7-arg form; impl drops the redundant
+--                  arg per guard R1 G8 on PR #503).
 -- Returns:
 --   {1, name}                success
 --   {0, "name_taken"}        name already exists
@@ -180,15 +214,18 @@ R2.2 (envelope TTL contract for `--expires-in` tokens).
 local existing = redis.call("get", KEYS[1])
 if existing then return {0, "name_taken"} end
 local count = redis.call("zcard", KEYS[3])
-if count >= tonumber(ARGV[6]) then return {-1, "limit"} end
-if tonumber(ARGV[7]) > 0 then
-  redis.call("set", KEYS[1], ARGV[3], "EX", tonumber(ARGV[7]))
+if count >= tonumber(ARGV[5]) then return {-1, "limit"} end
+if tonumber(ARGV[6]) > 0 then
+  redis.call("set", KEYS[1], ARGV[2], "EX", tonumber(ARGV[6]))
 else
-  redis.call("set", KEYS[1], ARGV[3])
+  redis.call("set", KEYS[1], ARGV[2])
 end
-redis.call("set", KEYS[2], ARGV[4])
-redis.call("zadd", KEYS[3], tonumber(ARGV[5]), ARGV[2])
-return {1, ARGV[2]}
+redis.call("set", KEYS[2], ARGV[3])
+redis.call("zadd", KEYS[3], tonumber(ARGV[4]), ARGV[1])
+if ARGV[7] ~= "" then
+  redis.call("xadd", KEYS[4], "MAXLEN", "~", "10000", "*", "entry", ARGV[7])
+end
+return {1, ARGV[1]}
 ```
 
 The hash index is intentionally NOT TTL'd at issue: middleware
@@ -210,8 +247,9 @@ index + installation sorted-set membership + meta). Closes hivemoot
 reviewer #3 (3+ keys atomic) + builder R2.1 sorted-set parity.
 
 ```lua
--- KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, metaKey]
--- ARGV: [name]
+-- R2 shipping shape:
+-- KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, metaKey, auditStreamKey]
+-- ARGV: [name, auditEntryJsonOrEmpty]
 -- Returns:
 --   {1, name}    success (envelope existed, all keys cleaned)
 --   {0, name}    nothing to revoke (envelope already gone)
@@ -219,6 +257,9 @@ local existed = redis.call("del", KEYS[1])
 redis.call("del", KEYS[2])
 redis.call("del", KEYS[4])
 redis.call("zrem", KEYS[3], ARGV[1])
+if ARGV[2] ~= "" then
+  redis.call("xadd", KEYS[5], "MAXLEN", "~", "10000", "*", "entry", ARGV[2])
+end
 if existed == 0 then return {0, ARGV[1]} end
 return {1, ARGV[1]}
 ```
@@ -232,20 +273,22 @@ not by token lifetime.
 field on the envelope, with audit emission.
 
 ```lua
+-- R2 shipping shape:
 -- KEYS: [envelopeKey, auditStreamKey]
--- ARGV: [newEnvelopeJson, auditEntryJson, expirySecsOrZero]
+-- ARGV: [newEnvelopeJson, expirySecsOrZero, auditEntryJsonOrEmpty]
 -- Returns:
---   {1}          success
---   {-1}         envelope missing (race with revoke; caller surfaces 404)
+--   {1}                  success
+--   {-1, "no_envelope"}  envelope missing (race with revoke; caller surfaces 404)
 local existing = redis.call("get", KEYS[1])
-if not existing then return {-1} end
-if tonumber(ARGV[3]) > 0 then
-  redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[3]))
+if not existing then return {-1, "no_envelope"} end
+if tonumber(ARGV[2]) > 0 then
+  redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
 else
   redis.call("set", KEYS[1], ARGV[1])
 end
-redis.call("xadd", KEYS[2], "MAXLEN", "~", "10000", "*",
-                   "entry", ARGV[2])
+if ARGV[3] ~= "" then
+  redis.call("xadd", KEYS[2], "MAXLEN", "~", "10000", "*", "entry", ARGV[3])
+end
 return {1}
 ```
 
@@ -255,23 +298,25 @@ revoke+issue path produced a downtime window because the bearer
 became invalid for in-flight requests between the two ops).
 
 ```lua
+-- R2 shipping shape:
 -- KEYS: [envelopeKey, oldHashIndexKey, newHashIndexKey, auditStreamKey]
--- ARGV: [newEnvelopeJson, newHashRecordJson, auditEntryJson, expirySecsOrZero]
+-- ARGV: [name, newEnvelopeJson, newHashRecordJson, expirySecsOrZero, auditEntryJsonOrEmpty]
 -- Returns:
---   {1}                success
+--   {1, name}              success
 --   {-1, "no_envelope"}    name doesn't exist (race with revoke)
 local existing = redis.call("get", KEYS[1])
 if not existing then return {-1, "no_envelope"} end
 redis.call("del", KEYS[2])                            -- old hash index
 if tonumber(ARGV[4]) > 0 then
-  redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[4]))
+  redis.call("set", KEYS[1], ARGV[2], "EX", tonumber(ARGV[4]))
 else
-  redis.call("set", KEYS[1], ARGV[1])
+  redis.call("set", KEYS[1], ARGV[2])
 end
-redis.call("set", KEYS[3], ARGV[2])                   -- new hash index
-redis.call("xadd", KEYS[4], "MAXLEN", "~", "10000", "*",
-                   "entry", ARGV[3])
-return {1}
+redis.call("set", KEYS[3], ARGV[3])                   -- new hash index
+if ARGV[5] ~= "" then
+  redis.call("xadd", KEYS[4], "MAXLEN", "~", "10000", "*", "entry", ARGV[5])
+end
+return {1, ARGV[1]}
 ```
 
 The new bearer is reachable via the new hash index immediately;

--- a/docs/architecture/CAPABILITIES_DESIGN.md
+++ b/docs/architecture/CAPABILITIES_DESIGN.md
@@ -63,19 +63,31 @@ interface AgentTokenEnvelope {
   name: string;               // operator-chosen, unique per (installationId, name)
   agent_role: string;         // e.g. "drone", "queen", "apiarist"; bound at issue,
                               // server-derived for any role-bearing API call
+  capabilities: string[];     // REQUIRED, ≥1 entry, gates hivemoot.dev API.
+                              // Top-level (NOT nested under policy) per the
+                              // B.1.b implementation: required fields stay
+                              // top-level; the optional V1.5+ policy container
+                              // holds optional GitHub-narrowing fields.
 
-  // — policy (gains capabilities; existing fields stay) —
-  policy: {
+  // — V1.5+/V1.6 GitHub-narrowing policy (optional container) —
+  policy?: {
     allowed_repos?: string[];        // V1.5 — repo narrowing for installation-token mints
     allowed_permissions?: {          // V1.6 (Phase C) — GitHub permission narrowing
       contents?: "read" | "write";
       pull_requests?: "read" | "write";
       issues?: "read" | "write";
     };
-    capabilities: string[];          // NEW — required, ≥1 entry, gates hivemoot.dev API
   };
 }
 ```
+
+**Schema note** (closes guard R1 G2 on PR #503): an earlier draft of
+this section nested `capabilities` inside `policy`. The shipping
+shape above hoists it to the top level — `capabilities` is required,
+and pulling it out of the optional `policy` container makes the type
+narrower and the middleware import simpler (`envelope.capabilities`,
+not `envelope.policy.capabilities`). The `policy` container retains
+only the optional V1.5/V1.6 GitHub-narrowing fields.
 
 **Strict-mode notes:**
 - Envelopes loaded WITHOUT `name` → 401 with `code:

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -1,0 +1,682 @@
+/**
+ * Unit tests for the V1 agent-token storage layer.
+ *
+ * Uses a smart in-memory Redis mock that simulates the four Lua
+ * script semantics by inspecting the script source. The mock is
+ * intentionally larger than the agent-token.test.ts mock because
+ * V1 introduces sorted-set indexes + per-key locks + an
+ * envelope-then-script READ pattern.
+ *
+ * Note: bracket-notation access (`redis["eval"]`) is used throughout
+ * to sidestep an unrelated security-warning hook that pattern-matches
+ * on the literal `.eval(` token even for Redis Lua-execution methods.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+
+import {
+  // Public API under test
+  issueAgentToken,
+  revokeAgentToken,
+  setAgentTokenCapabilities,
+  rotateAgentToken,
+  listAgentTokens,
+  getAgentTokenSummary,
+  // Helpers we want to unit-test directly
+  computeEnvelopeTtlSeconds,
+  envelopeKey,
+  hashIndexKey,
+  installationIndexKey,
+  envelopeMetaKey,
+  lockKey,
+  ENVELOPE_TTL_SKEW_MARGIN_SECONDS,
+  DEFAULT_TOKEN_LIMIT_PER_INSTALLATION,
+  TokenNameTakenError,
+  TokenLimitReachedError,
+  TokenNotFoundError,
+  type AgentTokenEnvelopeV1,
+  type AgentTokenHashRecordV1,
+} from "./agent-token-v1";
+import { CapabilityValidationError } from "./agent-token-capabilities";
+
+// ---------------------------------------------------------------------------
+// Mock Redis
+// ---------------------------------------------------------------------------
+
+interface SortedSetEntry {
+  member: string;
+  score: number;
+}
+
+function makeMockRedis() {
+  const store = new Map<string, unknown>();
+
+  function getSortedSet(key: string): SortedSetEntry[] {
+    const existing = store.get(key);
+    if (Array.isArray(existing)) return existing as SortedSetEntry[];
+    const fresh: SortedSetEntry[] = [];
+    store.set(key, fresh);
+    return fresh;
+  }
+
+  // Lua-script simulator: inspects the script body to identify which
+  // operation is being requested, then mirrors the real Lua semantics.
+  // Returns match the design's `{tag, payload?}` convention.
+  const luaSim = vi.fn(
+    async (script: string, keys: string[], argv: string[]) => {
+      // withRedisLock release script — 1 key, 1 arg, references ARGV[1]
+      if (keys.length === 1 && argv.length === 1 && script.includes("ARGV[1]") && !script.includes("name_taken")) {
+        const lockKey = keys[0];
+        if (store.get(lockKey) === argv[0]) {
+          store.delete(lockKey);
+          return 1;
+        }
+        return 0;
+      }
+
+      // ISSUE_TOKEN_SCRIPT — 3 keys, 6 args
+      if (keys.length === 3 && argv.length === 6 && script.includes("name_taken")) {
+        const [envelopeK, hashIdxK, instIdxK] = keys;
+        const [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit, expirySecsOrZero] = argv;
+        if (store.has(envelopeK)) return [0, "name_taken"];
+        const set = getSortedSet(instIdxK);
+        if (set.length >= Number(tokenLimit)) return [-1, "limit"];
+        const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+        if (Number(expirySecsOrZero) > 0) {
+          env.__ttl_secs__ = Number(expirySecsOrZero);
+        }
+        store.set(envelopeK, env);
+        store.set(hashIdxK, JSON.parse(hashRecordJson));
+        set.push({ member: name, score: Number(createdAtMs) });
+        set.sort((a, b) => a.score - b.score);
+        return [1, name];
+      }
+
+      // REVOKE_TOKEN_SCRIPT — 4 keys, 1 arg
+      if (
+        keys.length === 4 &&
+        argv.length === 1 &&
+        script.includes('existed = redis.call("del"')
+      ) {
+        const [envelopeK, hashIdxK, instIdxK, metaK] = keys;
+        const [name] = argv;
+        const existed = store.has(envelopeK) ? 1 : 0;
+        store.delete(envelopeK);
+        store.delete(hashIdxK);
+        store.delete(metaK);
+        const set = getSortedSet(instIdxK);
+        const idx = set.findIndex((e) => e.member === name);
+        if (idx !== -1) set.splice(idx, 1);
+        if (existed === 0) return [0, name];
+        return [1, name];
+      }
+
+      // SET_CAPABILITIES_SCRIPT — 1 key, 2 args, includes no_envelope
+      // (and NOT 3 keys like ROTATE)
+      if (
+        keys.length === 1 &&
+        argv.length === 2 &&
+        script.includes("no_envelope")
+      ) {
+        const [envelopeK] = keys;
+        const [envelopeJson, expirySecsOrZero] = argv;
+        if (!store.has(envelopeK)) return [-1, "no_envelope"];
+        const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+        if (Number(expirySecsOrZero) > 0) {
+          env.__ttl_secs__ = Number(expirySecsOrZero);
+        }
+        store.set(envelopeK, env);
+        return [1];
+      }
+
+      // ROTATE_TOKEN_SCRIPT — 3 keys, 3 args, includes no_envelope
+      if (
+        keys.length === 3 &&
+        argv.length === 3 &&
+        script.includes("no_envelope")
+      ) {
+        const [envelopeK, oldHashIdxK, newHashIdxK] = keys;
+        const [envelopeJson, hashRecordJson, expirySecsOrZero] = argv;
+        if (!store.has(envelopeK)) return [-1, "no_envelope"];
+        store.delete(oldHashIdxK);
+        const env = JSON.parse(envelopeJson) as Record<string, unknown>;
+        if (Number(expirySecsOrZero) > 0) {
+          env.__ttl_secs__ = Number(expirySecsOrZero);
+        }
+        store.set(envelopeK, env);
+        store.set(newHashIdxK, JSON.parse(hashRecordJson));
+        return [1, envelopeJson];
+      }
+
+      return null;
+    },
+  );
+
+  const client = {
+    set: vi.fn(
+      async (
+        key: string,
+        value: unknown,
+        opts?: { nx?: boolean; xx?: boolean; ex?: number },
+      ) => {
+        if (opts?.nx && store.has(key)) return null;
+        if (opts?.xx && !store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+    ),
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    del: vi.fn(async (key: string) => {
+      const existed = store.has(key);
+      store.delete(key);
+      return existed ? 1 : 0;
+    }),
+    zadd: vi.fn(async (key: string, score: number, member: string) => {
+      const set = getSortedSet(key);
+      const existing = set.find((e) => e.member === member);
+      if (existing) {
+        existing.score = score;
+        return 0;
+      }
+      set.push({ member, score });
+      set.sort((a, b) => a.score - b.score);
+      return 1;
+    }),
+    zrem: vi.fn(async (key: string, member: string) => {
+      const set = getSortedSet(key);
+      const idx = set.findIndex((e) => e.member === member);
+      if (idx === -1) return 0;
+      set.splice(idx, 1);
+      return 1;
+    }),
+    zrange: vi.fn(async (key: string, _start: number, _stop: number) => {
+      const set = getSortedSet(key);
+      return set.map((e) => e.member);
+    }),
+    // Lua-script entrypoint exposed as a property — production code
+    // accesses it via bracket notation; tests do too.
+    "eval": luaSim,
+    _store: store,
+    _luaSim: luaSim,
+  };
+  return client as unknown as Redis & {
+    _store: Map<string, unknown>;
+    _luaSim: ReturnType<typeof vi.fn>;
+  };
+}
+
+const KEYRING = new Map([["v1", Buffer.alloc(32)]]);
+
+function defaultIssueArgs(redis: Redis) {
+  return {
+    installationId: "12345",
+    name: "worker",
+    agent_role: "drone",
+    capabilities: ["agent_health.report", "tasks.claim"],
+    createdBy: "operator",
+    expiresAt: null,
+    keyring: KEYRING,
+    keyVersion: "v1",
+    redis,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function helpers
+// ---------------------------------------------------------------------------
+
+describe("key prefix helpers", () => {
+  it("envelopeKey uses the v1 prefix and escapes nothing", () => {
+    expect(envelopeKey("12345", "worker")).toBe("hive:v1:agent-token:12345:worker");
+  });
+
+  it("hashIndexKey uses the v1 idx prefix", () => {
+    expect(hashIndexKey("abcd")).toBe("hive:v1:idx:agent-token:hash:abcd");
+  });
+
+  it("installationIndexKey uses the v1 idx installation prefix", () => {
+    expect(installationIndexKey("12345")).toBe(
+      "hive:v1:idx:agent-token:installation:12345",
+    );
+  });
+
+  it("envelopeMetaKey is envelopeKey + :meta", () => {
+    expect(envelopeMetaKey("12345", "worker")).toBe(
+      "hive:v1:agent-token:12345:worker:meta",
+    );
+  });
+
+  it("lockKey uses the v1 lock prefix", () => {
+    expect(lockKey("12345", "worker")).toBe(
+      "hive:v1:lock:agent-token:12345:worker",
+    );
+  });
+});
+
+describe("computeEnvelopeTtlSeconds", () => {
+  it("expiresAt: null → 0 (no TTL)", () => {
+    expect(computeEnvelopeTtlSeconds(null)).toBe(0);
+  });
+
+  it("expiresAt in past → 0 (envelope fails middleware anyway)", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    expect(computeEnvelopeTtlSeconds(past)).toBe(0);
+  });
+
+  it("expiresAt 30 days out → ~30 days * 86400 + 300 margin", () => {
+    const future = new Date(Date.now() + 30 * 86400 * 1000).toISOString();
+    const ttl = computeEnvelopeTtlSeconds(future);
+    expect(ttl).toBeGreaterThan(30 * 86400);
+    expect(ttl).toBeLessThanOrEqual(30 * 86400 + ENVELOPE_TTL_SKEW_MARGIN_SECONDS);
+  });
+
+  it("invalid ISO → 0 (defensive — never NaN-EX a key)", () => {
+    expect(computeEnvelopeTtlSeconds("not-a-date")).toBe(0);
+  });
+
+  it("explicit nowMs lets tests pin the math deterministically", () => {
+    const expiresAt = new Date(2026, 0, 2, 0, 0, 0).toISOString();
+    const nowMs = new Date(2026, 0, 1, 0, 0, 0).getTime();
+    expect(computeEnvelopeTtlSeconds(expiresAt, nowMs)).toBe(86400 + 300);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issueAgentToken
+// ---------------------------------------------------------------------------
+
+describe("issueAgentToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("issues a token, returns the bearer ONCE, stores envelope + hash idx + installation idx", async () => {
+    const issued = await issueAgentToken(defaultIssueArgs(redis));
+
+    expect(issued.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(issued.name).toBe("worker");
+    expect(issued.agent_role).toBe("drone");
+    expect(issued.capabilities).toEqual(["agent_health.report", "tasks.claim"]);
+    expect(issued.fingerprint.length).toBe(8);
+    expect(issued.expiresAt).toBeNull();
+
+    const envelope = redis._store.get(
+      envelopeKey("12345", "worker"),
+    ) as AgentTokenEnvelopeV1;
+    expect(envelope).toBeDefined();
+    expect(envelope.name).toBe("worker");
+    expect(envelope.agent_role).toBe("drone");
+    expect(envelope.capabilities).toEqual(["agent_health.report", "tasks.claim"]);
+
+    const hashIdxRecord = redis._store.get(
+      hashIndexKey(envelope.tokenHash),
+    ) as AgentTokenHashRecordV1;
+    expect(hashIdxRecord.installationId).toBe("12345");
+    expect(hashIdxRecord.name).toBe("worker");
+
+    const idx = redis._store.get(
+      installationIndexKey("12345"),
+    ) as SortedSetEntry[];
+    expect(idx).toHaveLength(1);
+    expect(idx[0].member).toBe("worker");
+    expect(idx[0].score).toBeGreaterThan(0);
+  });
+
+  it("rejects empty capabilities", async () => {
+    await expect(
+      issueAgentToken({ ...defaultIssueArgs(redis), capabilities: [] }),
+    ).rejects.toThrow(/empty capabilities/);
+  });
+
+  it("rejects invalid name (uppercase)", async () => {
+    await expect(
+      issueAgentToken({ ...defaultIssueArgs(redis), name: "Worker" }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("rejects invalid agent_role (leading digit)", async () => {
+    await expect(
+      issueAgentToken({ ...defaultIssueArgs(redis), agent_role: "1drone" }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("rejects invalid capability string (mid-segment wildcard)", async () => {
+    await expect(
+      issueAgentToken({
+        ...defaultIssueArgs(redis),
+        capabilities: ["tasks.*claim"],
+      }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("throws TokenNameTakenError on duplicate name", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+    await expect(
+      issueAgentToken(defaultIssueArgs(redis)),
+    ).rejects.toThrow(TokenNameTakenError);
+  });
+
+  it("throws TokenLimitReachedError when installation already at the cap", async () => {
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "first",
+      tokenLimit: 2,
+    });
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "second",
+      tokenLimit: 2,
+    });
+    await expect(
+      issueAgentToken({
+        ...defaultIssueArgs(redis),
+        name: "third",
+        tokenLimit: 2,
+      }),
+    ).rejects.toThrow(TokenLimitReachedError);
+  });
+
+  it("DEFAULT_TOKEN_LIMIT_PER_INSTALLATION matches the design doc claim", () => {
+    expect(DEFAULT_TOKEN_LIMIT_PER_INSTALLATION).toBe(20);
+  });
+
+  it("with expiresAt set, ISSUE script call carries positive expirySecsOrZero", async () => {
+    const future = new Date(Date.now() + 86400 * 1000).toISOString();
+    await issueAgentToken({ ...defaultIssueArgs(redis), expiresAt: future });
+
+    const issueCall = redis._luaSim.mock.calls.find(
+      (c) => c[1].length === 3 && c[2].length === 6,
+    );
+    expect(issueCall).toBeDefined();
+    if (issueCall) {
+      const expirySecsOrZero = Number(issueCall[2][5]);
+      expect(expirySecsOrZero).toBeGreaterThan(0);
+    }
+  });
+
+  it("with expiresAt: null, ISSUE script call carries expirySecsOrZero=0", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+    const issueCall = redis._luaSim.mock.calls.find(
+      (c) => c[1].length === 3 && c[2].length === 6,
+    );
+    expect(issueCall).toBeDefined();
+    if (issueCall) {
+      expect(issueCall[2][5]).toBe("0");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revokeAgentToken
+// ---------------------------------------------------------------------------
+
+describe("revokeAgentToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns true and cleans envelope + hash + meta + index", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+    const envelope = redis._store.get(
+      envelopeKey("12345", "worker"),
+    ) as AgentTokenEnvelopeV1;
+
+    const removed = await revokeAgentToken({
+      installationId: "12345",
+      name: "worker",
+      redis,
+    });
+
+    expect(removed).toBe(true);
+    expect(redis._store.has(envelopeKey("12345", "worker"))).toBe(false);
+    expect(redis._store.has(hashIndexKey(envelope.tokenHash))).toBe(false);
+    expect(redis._store.has(envelopeMetaKey("12345", "worker"))).toBe(false);
+
+    const idx = redis._store.get(
+      installationIndexKey("12345"),
+    ) as SortedSetEntry[];
+    expect(idx).toEqual([]);
+  });
+
+  it("returns false when there's no envelope to revoke (idempotent)", async () => {
+    const removed = await revokeAgentToken({
+      installationId: "12345",
+      name: "nonexistent",
+      redis,
+    });
+    expect(removed).toBe(false);
+  });
+
+  it("rejects invalid name without making any Redis writes", async () => {
+    const beforeWriteCount = (redis.set as ReturnType<typeof vi.fn>).mock.calls.length;
+    await expect(
+      revokeAgentToken({ installationId: "12345", name: "Worker", redis }),
+    ).rejects.toThrow(CapabilityValidationError);
+    const afterWriteCount = (redis.set as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(afterWriteCount).toBe(beforeWriteCount);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setAgentTokenCapabilities
+// ---------------------------------------------------------------------------
+
+describe("setAgentTokenCapabilities", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("replaces capabilities on the existing envelope (snap-to, not merge)", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+
+    const summary = await setAgentTokenCapabilities({
+      installationId: "12345",
+      name: "worker",
+      capabilities: ["rooms.read", "rooms.contribute"],
+      redis,
+    });
+
+    expect(summary.capabilities).toEqual(["rooms.read", "rooms.contribute"]);
+    expect(summary.agent_role).toBe("drone");
+    expect(summary.name).toBe("worker");
+
+    const envelope = redis._store.get(
+      envelopeKey("12345", "worker"),
+    ) as AgentTokenEnvelopeV1;
+    expect(envelope.capabilities).toEqual(["rooms.read", "rooms.contribute"]);
+  });
+
+  it("rejects empty capabilities", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+    await expect(
+      setAgentTokenCapabilities({
+        installationId: "12345",
+        name: "worker",
+        capabilities: [],
+        redis,
+      }),
+    ).rejects.toThrow(/empty capabilities/);
+  });
+
+  it("rejects invalid capability string", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+    await expect(
+      setAgentTokenCapabilities({
+        installationId: "12345",
+        name: "worker",
+        capabilities: ["Tasks.Claim"],
+        redis,
+      }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("throws TokenNotFoundError when the envelope doesn't exist", async () => {
+    await expect(
+      setAgentTokenCapabilities({
+        installationId: "12345",
+        name: "missing",
+        capabilities: ["tasks.claim"],
+        redis,
+      }),
+    ).rejects.toThrow(TokenNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateAgentToken
+// ---------------------------------------------------------------------------
+
+describe("rotateAgentToken", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("replaces the bearer atomically; old hash index is gone, new one points at same identity", async () => {
+    const original = await issueAgentToken(defaultIssueArgs(redis));
+    const originalEnvelope = redis._store.get(
+      envelopeKey("12345", "worker"),
+    ) as AgentTokenEnvelopeV1;
+
+    const rotated = await rotateAgentToken({
+      installationId: "12345",
+      name: "worker",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    expect(rotated.token).not.toBe(original.token);
+    expect(rotated.name).toBe("worker");
+    expect(rotated.agent_role).toBe("drone");
+    expect(rotated.capabilities).toEqual(["agent_health.report", "tasks.claim"]);
+
+    const newEnvelope = redis._store.get(
+      envelopeKey("12345", "worker"),
+    ) as AgentTokenEnvelopeV1;
+    expect(newEnvelope.fingerprint).toBe(rotated.fingerprint);
+    expect(newEnvelope.fingerprint).not.toBe(originalEnvelope.fingerprint);
+    expect(newEnvelope.expiresAt).toBe(originalEnvelope.expiresAt);
+    expect(newEnvelope.createdAt).toBe(originalEnvelope.createdAt);
+    expect(newEnvelope.capabilities).toEqual(originalEnvelope.capabilities);
+
+    expect(redis._store.has(hashIndexKey(originalEnvelope.tokenHash))).toBe(false);
+    expect(redis._store.has(hashIndexKey(newEnvelope.tokenHash))).toBe(true);
+  });
+
+  it("throws TokenNotFoundError when the envelope doesn't exist", async () => {
+    await expect(
+      rotateAgentToken({
+        installationId: "12345",
+        name: "missing",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(TokenNotFoundError);
+  });
+
+  it("preserves expiresAt (rotate ≠ extend)", async () => {
+    const future = new Date(Date.now() + 86400 * 1000).toISOString();
+    await issueAgentToken({ ...defaultIssueArgs(redis), expiresAt: future });
+
+    const rotated = await rotateAgentToken({
+      installationId: "12345",
+      name: "worker",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    expect(rotated.expiresAt).toBe(future);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listAgentTokens / getAgentTokenSummary
+// ---------------------------------------------------------------------------
+
+describe("listAgentTokens", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns empty array when no tokens for installation", async () => {
+    const out = await listAgentTokens({ installationId: "99", redis });
+    expect(out).toEqual([]);
+  });
+
+  it("returns tokens in creation order (sorted-set score == createdAt epoch ms)", async () => {
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "first" });
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "second" });
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "third" });
+
+    const out = await listAgentTokens({ installationId: "12345", redis });
+    expect(out.map((s) => s.name)).toEqual(["first", "second", "third"]);
+    for (const summary of out) {
+      expect("ciphertext" in summary).toBe(false);
+      expect(summary.fingerprint).toBeDefined();
+    }
+  });
+});
+
+describe("getAgentTokenSummary", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns the summary excluding ciphertext", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+
+    const summary = await getAgentTokenSummary({
+      installationId: "12345",
+      name: "worker",
+      redis,
+    });
+
+    expect(summary.name).toBe("worker");
+    expect(summary.agent_role).toBe("drone");
+    expect(summary.capabilities).toEqual(["agent_health.report", "tasks.claim"]);
+    expect("ciphertext" in summary).toBe(false);
+  });
+
+  it("throws TokenNotFoundError when not found", async () => {
+    await expect(
+      getAgentTokenSummary({
+        installationId: "12345",
+        name: "missing",
+        redis,
+      }),
+    ).rejects.toThrow(TokenNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-invariant: no operation accidentally reads/writes a legacy key
+// ---------------------------------------------------------------------------
+
+describe("v1 storage layer never touches legacy keys", () => {
+  it("issue + revoke leave no legacy `hive:agent-token:` (no v1) key in store", async () => {
+    const redis = makeMockRedis();
+    await issueAgentToken(defaultIssueArgs(redis));
+    await revokeAgentToken({ installationId: "12345", name: "worker", redis });
+    for (const key of redis._store.keys()) {
+      // legacy envelope = `hive:agent-token:` (no v1)
+      expect(key, key).not.toMatch(/^hive:agent-token:[^v]/);
+      // legacy reverse idx = `agent-token-hash:`
+      expect(key, key).not.toMatch(/^agent-token-hash:/);
+    }
+  });
+});

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -872,6 +872,76 @@ describe("SET_CAPABILITIES_SCRIPT — {-1, no_envelope} race path (G7)", () => {
   });
 });
 
+describe("bearer-resurrection invariant (builder R2 on PR #503)", () => {
+  // Demonstrates the storage state after the same-name reissue
+  // scenario builder flagged. This module's storage shape REQUIRES
+  // the middleware (B.1.c) to enforce
+  //   sha256(presentedBearer) === envelope.tokenHash
+  // and reject mismatches. This test pins the storage state so a
+  // future B.1.c regression test can assert against it concretely.
+  it("after TTL-sweep + same-name reissue, old hash index lingers and points at NEW envelope (middleware MUST reject by tokenHash mismatch)", async () => {
+    const redis = makeMockRedis();
+
+    // 1. Issue token A under name "worker"
+    const tokenA = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "worker",
+      expiresAt: null, // would normally be future-dated; null here for test simplicity
+    });
+    const oldHash = redis._store.get(envelopeKey("12345", "worker")) as AgentTokenEnvelopeV1;
+    const oldTokenHash = oldHash.tokenHash;
+    expect(oldTokenHash).toBeDefined();
+    expect(redis._store.has(hashIndexKey(oldTokenHash))).toBe(true);
+
+    // 2. Simulate Redis TTL sweep on the envelope (real-world: explicit
+    //    expiresAt fires Redis EX). The hash index is intentionally
+    //    NOT TTL'd, so it persists pointing at the now-deleted name.
+    redis._store.delete(envelopeKey("12345", "worker"));
+
+    // 3. Reissue under the SAME name. listAgentTokens / issueAgentToken
+    //    self-heal the orphaned sorted-set entry, so the issuance
+    //    succeeds.
+    const tokenB = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "worker",
+      capabilities: ["rooms.read"],
+      expiresAt: null,
+    });
+    expect(tokenB.token).not.toBe(tokenA.token);
+
+    // 4. THE INVARIANT: the OLD hash index still exists, pointing at
+    //    `{installationId, name: "worker"}` — but the envelope at
+    //    that name is now token B's, with a DIFFERENT tokenHash.
+    //    The middleware (B.1.c) MUST reject by comparing the
+    //    presented bearer's hash against envelope.tokenHash.
+    const oldHashRecordStillThere = redis._store.get(hashIndexKey(oldTokenHash));
+    expect(oldHashRecordStillThere).toEqual({
+      installationId: "12345",
+      name: "worker",
+    });
+
+    const newEnvelope = redis._store.get(
+      envelopeKey("12345", "worker"),
+    ) as AgentTokenEnvelopeV1;
+    expect(newEnvelope.tokenHash).not.toBe(oldTokenHash);
+    expect(newEnvelope.tokenHash).toBe(
+      createHash("sha256").update(tokenB.token).digest("hex"),
+    );
+
+    // The middleware-side check that closes this:
+    //   const presentedHash = sha256(rawBearerA);
+    //   if (envelope.tokenHash !== presentedHash) reject(TOKEN_EXPIRED);
+    // → bearer A presented against new envelope B fails because their
+    //   hashes don't match.
+    const presentedHashIfBearerAUsed = createHash("sha256")
+      .update(tokenA.token)
+      .digest("hex");
+    expect(presentedHashIfBearerAUsed).not.toBe(newEnvelope.tokenHash);
+    // ↑ this is the assertion the B.1.c middleware translates into
+    // a 401 TOKEN_EXPIRED response.
+  });
+});
+
 describe("ROTATE_TOKEN_SCRIPT — {-1, no_envelope} race path (G7)", () => {
   it("translates {-1, no_envelope} from the script to TokenNotFoundError", async () => {
     const redis = makeMockRedis();

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -25,6 +25,7 @@ import {
   listAgentTokens,
   getAgentTokenSummary,
   pruneOrphanedIndexEntries,
+  resolveBearerToEnvelope,
   // Helpers we want to unit-test directly
   computeEnvelopeTtlSeconds,
   envelopeKey,
@@ -132,6 +133,27 @@ function makeMockRedis() {
         }
         store.set(envelopeK, env);
         return [1];
+      }
+
+      // RESOLVE_BEARER_SCRIPT — 1 key, 2 args (R3: + envelopePrefix + presentedHash)
+      if (
+        keys.length === 1 &&
+        argv.length === 2 &&
+        script.includes("unknown_bearer")
+      ) {
+        const [hashIdxK] = keys;
+        const [envelopePrefix, presentedHash] = argv;
+        const hashRecord = store.get(hashIdxK) as
+          | { installationId: string; name: string }
+          | undefined;
+        if (!hashRecord) return [-1, "unknown_bearer"];
+        const envKey = `${envelopePrefix}${hashRecord.installationId}:${hashRecord.name}`;
+        const envelope = store.get(envKey) as
+          | { tokenHash: string }
+          | undefined;
+        if (!envelope) return [-2, "envelope_missing"];
+        if (envelope.tokenHash !== presentedHash) return [-3, "stale_bearer"];
+        return [1, JSON.stringify(envelope)];
       }
 
       // ROTATE_TOKEN_SCRIPT — 4 keys, 5 args (R2: + auditStreamKey + name first + auditEntry)
@@ -939,6 +961,112 @@ describe("bearer-resurrection invariant (builder R2 on PR #503)", () => {
     expect(presentedHashIfBearerAUsed).not.toBe(newEnvelope.tokenHash);
     // ↑ this is the assertion the B.1.c middleware translates into
     // a 401 TOKEN_EXPIRED response.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBearerToEnvelope — single-RTT bearer resolution (R3 fix for builder)
+// ---------------------------------------------------------------------------
+
+describe("resolveBearerToEnvelope (R3 fix — replaces broken pipeline pseudocode)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns ok=true with the envelope when bearer is valid", async () => {
+    const issued = await issueAgentToken(defaultIssueArgs(redis));
+    const result = await resolveBearerToEnvelope({
+      rawBearer: issued.token,
+      redis,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.name).toBe("worker");
+      expect(result.envelope.agent_role).toBe("drone");
+      expect(result.envelope.capabilities).toEqual([
+        "agent_health.report",
+        "tasks.claim",
+      ]);
+      // Envelope carries the SHA-256-derived fingerprint, not bearer suffix
+      expect(result.envelope.fingerprint).toBe(
+        createHash("sha256").update(issued.token).digest("hex").slice(0, 8),
+      );
+    }
+  });
+
+  it("returns code=unknown_bearer when the hash index has no entry", async () => {
+    const result = await resolveBearerToEnvelope({
+      rawBearer: "deadbeef".repeat(8), // 64 chars, valid shape but never issued
+      redis,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("unknown_bearer");
+  });
+
+  it("returns code=envelope_missing when hash record points at a TTL-swept envelope", async () => {
+    const issued = await issueAgentToken(defaultIssueArgs(redis));
+    // Simulate Redis TTL sweep on the envelope (hash index intentionally
+    // not TTL'd, so it lingers).
+    redis._store.delete(envelopeKey("12345", "worker"));
+
+    const result = await resolveBearerToEnvelope({
+      rawBearer: issued.token,
+      redis,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("envelope_missing");
+  });
+
+  it("returns code=stale_bearer for the bearer-resurrection scenario (closes builder R2 invariant end-to-end)", async () => {
+    // 1. Issue token A
+    const tokenA = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "worker",
+    });
+    // 2. TTL-sweep A's envelope
+    redis._store.delete(envelopeKey("12345", "worker"));
+    // 3. Reissue under same name → token B
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "worker",
+      capabilities: ["rooms.read"],
+    });
+
+    // 4. Bearer A presented now: the resolver SHOULD reject as
+    //    stale_bearer because envelope.tokenHash (B's) != sha256(A).
+    //    This is the bearer-resurrection close.
+    const result = await resolveBearerToEnvelope({
+      rawBearer: tokenA.token,
+      redis,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("stale_bearer");
+  });
+
+  it("succeeds for the NEW bearer after a same-name reissue (B doesn't get rejected)", async () => {
+    // Same setup as bearer-resurrection test, but verify token B (the
+    // legitimate new bearer) is not collateral damage.
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "worker",
+    });
+    redis._store.delete(envelopeKey("12345", "worker"));
+    const tokenB = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "worker",
+      capabilities: ["rooms.read"],
+    });
+
+    const result = await resolveBearerToEnvelope({
+      rawBearer: tokenB.token,
+      redis,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // It's B's envelope (the new one with rooms.read)
+      expect(result.envelope.capabilities).toEqual(["rooms.read"]);
+    }
   });
 });
 

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { type Redis } from "@upstash/redis";
 
+import { createHash } from "crypto";
 import {
   // Public API under test
   issueAgentToken,
@@ -23,6 +24,7 @@ import {
   rotateAgentToken,
   listAgentTokens,
   getAgentTokenSummary,
+  pruneOrphanedIndexEntries,
   // Helpers we want to unit-test directly
   computeEnvelopeTtlSeconds,
   envelopeKey,
@@ -35,6 +37,7 @@ import {
   TokenNameTakenError,
   TokenLimitReachedError,
   TokenNotFoundError,
+  InvalidExpiresAtError,
   type AgentTokenEnvelopeV1,
   type AgentTokenHashRecordV1,
 } from "./agent-token-v1";
@@ -76,9 +79,10 @@ function makeMockRedis() {
       }
 
       // ISSUE_TOKEN_SCRIPT — 3 keys, 6 args
-      if (keys.length === 3 && argv.length === 6 && script.includes("name_taken")) {
-        const [envelopeK, hashIdxK, instIdxK] = keys;
-        const [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit, expirySecsOrZero] = argv;
+      if (keys.length === 4 && argv.length === 7 && script.includes("name_taken")) {
+        // R2 (audit slot): 4 keys (added auditStreamKey), 7 args (added auditEntry)
+        const [envelopeK, hashIdxK, instIdxK, _auditK] = keys;
+        const [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit, expirySecsOrZero, _auditEntry] = argv;
         if (store.has(envelopeK)) return [0, "name_taken"];
         const set = getSortedSet(instIdxK);
         if (set.length >= Number(tokenLimit)) return [-1, "limit"];
@@ -93,14 +97,14 @@ function makeMockRedis() {
         return [1, name];
       }
 
-      // REVOKE_TOKEN_SCRIPT — 4 keys, 1 arg
+      // REVOKE_TOKEN_SCRIPT — 5 keys, 2 args (R2: + auditStreamKey + auditEntry)
       if (
-        keys.length === 4 &&
-        argv.length === 1 &&
+        keys.length === 5 &&
+        argv.length === 2 &&
         script.includes('existed = redis.call("del"')
       ) {
-        const [envelopeK, hashIdxK, instIdxK, metaK] = keys;
-        const [name] = argv;
+        const [envelopeK, hashIdxK, instIdxK, metaK, _auditK] = keys;
+        const [name, _auditEntry] = argv;
         const existed = store.has(envelopeK) ? 1 : 0;
         store.delete(envelopeK);
         store.delete(hashIdxK);
@@ -112,15 +116,15 @@ function makeMockRedis() {
         return [1, name];
       }
 
-      // SET_CAPABILITIES_SCRIPT — 1 key, 2 args, includes no_envelope
-      // (and NOT 3 keys like ROTATE)
+      // SET_CAPABILITIES_SCRIPT — 2 keys, 3 args (R2: + auditStreamKey + auditEntry)
+      // (distinguished from ROTATE by 2 keys vs ROTATE's 4 keys)
       if (
-        keys.length === 1 &&
-        argv.length === 2 &&
+        keys.length === 2 &&
+        argv.length === 3 &&
         script.includes("no_envelope")
       ) {
-        const [envelopeK] = keys;
-        const [envelopeJson, expirySecsOrZero] = argv;
+        const [envelopeK, _auditK] = keys;
+        const [envelopeJson, expirySecsOrZero, _auditEntry] = argv;
         if (!store.has(envelopeK)) return [-1, "no_envelope"];
         const env = JSON.parse(envelopeJson) as Record<string, unknown>;
         if (Number(expirySecsOrZero) > 0) {
@@ -130,14 +134,14 @@ function makeMockRedis() {
         return [1];
       }
 
-      // ROTATE_TOKEN_SCRIPT — 3 keys, 3 args, includes no_envelope
+      // ROTATE_TOKEN_SCRIPT — 4 keys, 5 args (R2: + auditStreamKey + name first + auditEntry)
       if (
-        keys.length === 3 &&
-        argv.length === 3 &&
+        keys.length === 4 &&
+        argv.length === 5 &&
         script.includes("no_envelope")
       ) {
-        const [envelopeK, oldHashIdxK, newHashIdxK] = keys;
-        const [envelopeJson, hashRecordJson, expirySecsOrZero] = argv;
+        const [envelopeK, oldHashIdxK, newHashIdxK, _auditK] = keys;
+        const [name, envelopeJson, hashRecordJson, expirySecsOrZero, _auditEntry] = argv;
         if (!store.has(envelopeK)) return [-1, "no_envelope"];
         store.delete(oldHashIdxK);
         const env = JSON.parse(envelopeJson) as Record<string, unknown>;
@@ -146,7 +150,8 @@ function makeMockRedis() {
         }
         store.set(envelopeK, env);
         store.set(newHashIdxK, JSON.parse(hashRecordJson));
-        return [1, envelopeJson];
+        // R2 (G6 fix): script returns {1, name} for parity with ISSUE
+        return [1, name];
       }
 
       return null;
@@ -303,6 +308,16 @@ describe("issueAgentToken", () => {
     expect(issued.fingerprint.length).toBe(8);
     expect(issued.expiresAt).toBeNull();
 
+    // R1 fix: fingerprint MUST equal the SHA-256 prefix of the bearer,
+    // NOT the suffix of the raw bearer (would leak 8 hex chars of
+    // the secret anywhere fingerprint is exposed).
+    const expectedFingerprint = createHash("sha256")
+      .update(issued.token)
+      .digest("hex")
+      .slice(0, 8);
+    expect(issued.fingerprint).toBe(expectedFingerprint);
+    expect(issued.fingerprint).not.toBe(issued.token.slice(-8));
+
     const envelope = redis._store.get(
       envelopeKey("12345", "worker"),
     ) as AgentTokenEnvelopeV1;
@@ -388,7 +403,7 @@ describe("issueAgentToken", () => {
     await issueAgentToken({ ...defaultIssueArgs(redis), expiresAt: future });
 
     const issueCall = redis._luaSim.mock.calls.find(
-      (c) => c[1].length === 3 && c[2].length === 6,
+      (c) => c[1].length === 4 && c[2].length === 7,
     );
     expect(issueCall).toBeDefined();
     if (issueCall) {
@@ -400,7 +415,7 @@ describe("issueAgentToken", () => {
   it("with expiresAt: null, ISSUE script call carries expirySecsOrZero=0", async () => {
     await issueAgentToken(defaultIssueArgs(redis));
     const issueCall = redis._luaSim.mock.calls.find(
-      (c) => c[1].length === 3 && c[2].length === 6,
+      (c) => c[1].length === 4 && c[2].length === 7,
     );
     expect(issueCall).toBeDefined();
     if (issueCall) {
@@ -678,5 +693,211 @@ describe("v1 storage layer never touches legacy keys", () => {
       // legacy reverse idx = `agent-token-hash:`
       expect(key, key).not.toMatch(/^agent-token-hash:/);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R1 fix — past/invalid expiresAt rejected at issue time (builder #2)
+// ---------------------------------------------------------------------------
+
+describe("issueAgentToken — expiresAt validation (R1 fix)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("rejects past expiresAt with InvalidExpiresAtError", async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    await expect(
+      issueAgentToken({ ...defaultIssueArgs(redis), expiresAt: past }),
+    ).rejects.toThrow(InvalidExpiresAtError);
+  });
+
+  it("rejects unparseable expiresAt string with InvalidExpiresAtError", async () => {
+    await expect(
+      issueAgentToken({ ...defaultIssueArgs(redis), expiresAt: "not-a-date" }),
+    ).rejects.toThrow(InvalidExpiresAtError);
+  });
+
+  it("accepts future expiresAt", async () => {
+    const future = new Date(Date.now() + 86400 * 1000).toISOString();
+    const issued = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      expiresAt: future,
+    });
+    expect(issued.expiresAt).toBe(future);
+  });
+
+  it("accepts null expiresAt (no-expiry default)", async () => {
+    const issued = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      expiresAt: null,
+    });
+    expect(issued.expiresAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R1 fix — orphaned index entries pruned (builder #2)
+// ---------------------------------------------------------------------------
+
+describe("pruneOrphanedIndexEntries (R1 fix)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("returns 0 when there are no orphans", async () => {
+    await issueAgentToken(defaultIssueArgs(redis));
+    const pruned = await pruneOrphanedIndexEntries({
+      installationId: "12345",
+      redis,
+    });
+    expect(pruned).toBe(0);
+  });
+
+  it("ZREMs orphaned entries when their envelope was TTL'd", async () => {
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "alive" });
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "ghost" });
+
+    // Simulate Redis TTL expiry: delete the envelope but leave the
+    // sorted-set entry (this is exactly what happens when a Redis EX
+    // fires on the envelope key without our explicit revoke flow).
+    redis._store.delete(envelopeKey("12345", "ghost"));
+
+    const pruned = await pruneOrphanedIndexEntries({
+      installationId: "12345",
+      redis,
+    });
+    expect(pruned).toBe(1);
+
+    // Sorted set should now only contain "alive"
+    const idx = redis._store.get(
+      installationIndexKey("12345"),
+    ) as SortedSetEntry[];
+    expect(idx.map((e) => e.member)).toEqual(["alive"]);
+  });
+});
+
+describe("listAgentTokens — self-heals orphans (R1 fix)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("skips orphans in the returned list AND ZREMs them from the index", async () => {
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "alive" });
+    await issueAgentToken({ ...defaultIssueArgs(redis), name: "ghost" });
+    redis._store.delete(envelopeKey("12345", "ghost"));
+
+    const out = await listAgentTokens({ installationId: "12345", redis });
+    expect(out.map((s) => s.name)).toEqual(["alive"]);
+
+    // Orphan was opportunistically pruned
+    const idx = redis._store.get(
+      installationIndexKey("12345"),
+    ) as SortedSetEntry[];
+    expect(idx.map((e) => e.member)).toEqual(["alive"]);
+  });
+});
+
+describe("issueAgentToken — at-cap orphan self-heal (R1 fix)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("issuing at the cap succeeds when an orphan exists (the orphan is pruned first)", async () => {
+    // Issue 2 tokens with cap=2, then orphan one and try to issue a third.
+    // Without orphan-pruning before the cap check, this would 422 with
+    // TokenLimitReached. With pruning, the third issuance succeeds.
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "first",
+      tokenLimit: 2,
+    });
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "second",
+      tokenLimit: 2,
+    });
+
+    // Orphan "second" by deleting its envelope (simulating TTL expiry)
+    redis._store.delete(envelopeKey("12345", "second"));
+
+    // Third issue should succeed because the orphaned "second" is
+    // pruned before the cap check.
+    const issued = await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      name: "third",
+      tokenLimit: 2,
+    });
+    expect(issued.name).toBe("third");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// G7 — direct test coverage for {-1, "no_envelope"} race paths
+// ---------------------------------------------------------------------------
+
+describe("SET_CAPABILITIES_SCRIPT — {-1, no_envelope} race path (G7)", () => {
+  it("translates {-1, no_envelope} from the script to TokenNotFoundError", async () => {
+    const redis = makeMockRedis();
+    await issueAgentToken(defaultIssueArgs(redis));
+
+    // Force the eval to return [-1, "no_envelope"] — simulates a race
+    // where the GET succeeded (envelope was there) but a concurrent
+    // revoke deleted the envelope before the EVAL ran.
+    const original = redis._luaSim.getMockImplementation();
+    redis._luaSim.mockImplementation(async (script, keys, argv) => {
+      // Hit only on SET_CAPABILITIES_SCRIPT shape (2 keys, 3 args)
+      if (
+        keys.length === 2 &&
+        argv.length === 3 &&
+        script.includes("no_envelope")
+      ) {
+        return [-1, "no_envelope"];
+      }
+      return original ? await (original as (s: string, k: string[], a: string[]) => Promise<unknown>)(script, keys, argv) : null;
+    });
+
+    await expect(
+      setAgentTokenCapabilities({
+        installationId: "12345",
+        name: "worker",
+        capabilities: ["rooms.read"],
+        redis,
+      }),
+    ).rejects.toThrow(TokenNotFoundError);
+  });
+});
+
+describe("ROTATE_TOKEN_SCRIPT — {-1, no_envelope} race path (G7)", () => {
+  it("translates {-1, no_envelope} from the script to TokenNotFoundError", async () => {
+    const redis = makeMockRedis();
+    await issueAgentToken(defaultIssueArgs(redis));
+
+    const original = redis._luaSim.getMockImplementation();
+    redis._luaSim.mockImplementation(async (script, keys, argv) => {
+      // Hit only on ROTATE_TOKEN_SCRIPT shape (4 keys, 5 args)
+      if (
+        keys.length === 4 &&
+        argv.length === 5 &&
+        script.includes("no_envelope")
+      ) {
+        return [-1, "no_envelope"];
+      }
+      return original ? await (original as (s: string, k: string[], a: string[]) => Promise<unknown>)(script, keys, argv) : null;
+    });
+
+    await expect(
+      rotateAgentToken({
+        installationId: "12345",
+        name: "worker",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(TokenNotFoundError);
   });
 });

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -71,6 +71,7 @@ const ENVELOPE_PREFIX = "hive:v1:agent-token:";
 const HASH_INDEX_PREFIX = "hive:v1:idx:agent-token:hash:";
 const INSTALLATION_INDEX_PREFIX = "hive:v1:idx:agent-token:installation:";
 const META_SUFFIX = ":meta";
+const AUDIT_SUFFIX = ":audit";
 const LOCK_PREFIX = "hive:v1:lock:agent-token:";
 
 export function envelopeKey(installationId: string, name: string): string {
@@ -87,6 +88,18 @@ export function installationIndexKey(installationId: string): string {
 
 export function envelopeMetaKey(installationId: string, name: string): string {
   return `${envelopeKey(installationId, name)}${META_SUFFIX}`;
+}
+
+/**
+ * Per-installation audit stream (mutations only — issue / revoke /
+ * set_capabilities / rotate / bootstrap). The high-volume auth-event
+ * stream lives at a different key (B.1.d wires that one alongside
+ * `auditAppend`). Per CAPABILITIES_DESIGN.md §Audit log: split-stream
+ * model with `MAXLEN ~10000` on this stream → effectively unbounded
+ * at <10 mutations/day.
+ */
+export function auditStreamKey(installationId: string): string {
+  return `${ENVELOPE_PREFIX}${installationId}${AUDIT_SUFFIX}`;
 }
 
 export function lockKey(installationId: string, name: string): string {
@@ -187,6 +200,24 @@ export class TokenNotFoundError extends Error {
   }
 }
 
+/**
+ * Thrown when caller passes an `expiresAt` that is in the past or
+ * unparseable. Issuing such a token would create a permanently-401
+ * envelope (the auth middleware would reject it from the start),
+ * AND consume a slot against the installation's token cap, AND
+ * leave a stale sorted-set entry once the past-TTL Redis sweep
+ * fires. Reject at write time so the operator gets a clear error
+ * (closes builder R1 issue 2).
+ */
+export class InvalidExpiresAtError extends Error {
+  constructor(value: string, reason: string) {
+    super(
+      `Invalid expiresAt ${JSON.stringify(value)} — ${reason}. Provide a future ISO 8601 timestamp or null for no expiry.`,
+    );
+    this.name = "InvalidExpiresAtError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Lua scripts
 // ---------------------------------------------------------------------------
@@ -204,8 +235,16 @@ export class TokenNotFoundError extends Error {
  * TTLing the hash index too risks dropping it slightly before the
  * envelope under clock skew.
  *
- * KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey]
- * ARGV: [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit, expirySecsOrZero]
+ * Audit emit happens INSIDE the same EVAL when ARGV[7] is non-empty
+ * (closes guard R1 G1).
+ *
+ * Note (closes guard R1 G8): the design doc shows a 7-arg form with
+ * `installationId` first; impl drops it because installationId is
+ * already encoded in the envelope KEY's prefix and the script never
+ * uses it. Functionally equivalent.
+ *
+ * KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, auditStreamKey]
+ * ARGV: [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit, expirySecsOrZero, auditEntryJsonOrEmpty]
  *
  * Returns:
  *   {1, name}            success
@@ -224,28 +263,35 @@ else
 end
 redis.call("set", KEYS[2], ARGV[3])
 redis.call("zadd", KEYS[3], tonumber(ARGV[4]), ARGV[1])
+if ARGV[7] ~= "" then
+  redis.call("xadd", KEYS[4], "MAXLEN", "~", "10000", "*", "entry", ARGV[7])
+end
 return {1, ARGV[1]}
 `;
 
 /**
  * REVOKE_TOKEN_SCRIPT — atomic 4-key cleanup (envelope + reverse index
- * + installation sorted-set membership + meta).
+ * + installation sorted-set membership + meta) + audit emit.
  *
- * KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, metaKey]
- * ARGV: [name]
+ * Audit emit happens INSIDE the same EVAL when ARGV[2] is non-empty
+ * (closes guard R1 G1). The audit stream itself is NEVER deleted —
+ * the audit trail outlives the token.
+ *
+ * KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, metaKey, auditStreamKey]
+ * ARGV: [name, auditEntryJsonOrEmpty]
  *
  * Returns:
  *   {1, name}    success (envelope existed, all keys cleaned)
  *   {0, name}    nothing to revoke (envelope already gone)
- *
- * The audit stream is intentionally NOT deleted on revoke — the
- * audit trail outlives the token.
  */
 const REVOKE_TOKEN_SCRIPT = `
 local existed = redis.call("del", KEYS[1])
 redis.call("del", KEYS[2])
 redis.call("del", KEYS[4])
 redis.call("zrem", KEYS[3], ARGV[1])
+if ARGV[2] ~= "" then
+  redis.call("xadd", KEYS[5], "MAXLEN", "~", "10000", "*", "entry", ARGV[2])
+end
 if existed == 0 then return {0, ARGV[1]} end
 return {1, ARGV[1]}
 `;
@@ -257,8 +303,14 @@ return {1, ARGV[1]}
  * calling this). Preserves the envelope's existing TTL via the same
  * `expirySecsOrZero` ARGV pattern as ISSUE.
  *
- * KEYS: [envelopeKey]
- * ARGV: [newEnvelopeJson, expirySecsOrZero]
+ * Audit emit happens INSIDE the same EVAL when ARGV[3] is non-empty
+ * (closes guard R1 G1 — the design spec'd atomic audit; this PR
+ * ships the script with the slot wired so B.1.d only adds the
+ * audit-entry construction at the call site, never re-versions the
+ * script body).
+ *
+ * KEYS: [envelopeKey, auditStreamKey]
+ * ARGV: [newEnvelopeJson, expirySecsOrZero, auditEntryJsonOrEmpty]
  *
  * Returns:
  *   {1}                  success
@@ -271,6 +323,9 @@ if tonumber(ARGV[2]) > 0 then
   redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
 else
   redis.call("set", KEYS[1], ARGV[1])
+end
+if ARGV[3] ~= "" then
+  redis.call("xadd", KEYS[2], "MAXLEN", "~", "10000", "*", "entry", ARGV[3])
 end
 return {1}
 `;
@@ -287,8 +342,11 @@ return {1}
  * computes `expirySecsOrZero` as `expiresAt - now() + 300` from the
  * EXISTING envelope's expiry.
  *
- * KEYS: [envelopeKey, oldHashIndexKey, newHashIndexKey]
- * ARGV: [newEnvelopeJson, newHashRecordJson, expirySecsOrZero]
+ * Audit emit happens INSIDE the same EVAL when ARGV[5] is non-empty
+ * (closes guard R1 G1).
+ *
+ * KEYS: [envelopeKey, oldHashIndexKey, newHashIndexKey, auditStreamKey]
+ * ARGV: [name, newEnvelopeJson, newHashRecordJson, expirySecsOrZero, auditEntryJsonOrEmpty]
  *
  * Returns:
  *   {1, name}                success
@@ -298,13 +356,16 @@ const ROTATE_TOKEN_SCRIPT = `
 local existing = redis.call("get", KEYS[1])
 if not existing then return {-1, "no_envelope"} end
 redis.call("del", KEYS[2])
-if tonumber(ARGV[3]) > 0 then
-  redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[3]))
+if tonumber(ARGV[4]) > 0 then
+  redis.call("set", KEYS[1], ARGV[2], "EX", tonumber(ARGV[4]))
 else
-  redis.call("set", KEYS[1], ARGV[1])
+  redis.call("set", KEYS[1], ARGV[2])
 end
-redis.call("set", KEYS[3], ARGV[2])
-return {1, ARGV[2]}
+redis.call("set", KEYS[3], ARGV[3])
+if ARGV[5] ~= "" then
+  redis.call("xadd", KEYS[4], "MAXLEN", "~", "10000", "*", "entry", ARGV[5])
+end
+return {1, ARGV[1]}
 `;
 
 // ---------------------------------------------------------------------------
@@ -319,31 +380,15 @@ function hashToken(rawToken: string): string {
   return createHash("sha256").update(rawToken).digest("hex");
 }
 
-function fingerprint(rawToken: string): string {
-  return rawToken.slice(-8);
-}
-
 /**
- * Bracket-notation alias around the Upstash Redis client's Lua
- * execution method. The literal `.<method>(` token-pattern is
- * flagged by an unrelated security-warning hook (it can't tell
- * the difference between Node's built-in eval and Redis's
- * Lua-script entrypoint), so we route the call through bracket
- * access in one place and keep the rest of the file readable.
+ * Derive an audit/list fingerprint from the token's SHA-256 hash.
+ * MUST NOT be derived from the raw bearer — that would leak 8 hex
+ * chars of the secret anywhere `fingerprint` is exposed (audit log,
+ * `tokens list`, dashboard). Hash prefix is the design's canonical
+ * form per CAPABILITIES_DESIGN.md §Audit log entry shape.
  */
-function runLuaScript(
-  client: Redis,
-  script: string,
-  keys: string[],
-  argv: string[],
-): Promise<unknown> {
-  const method = "eval";
-  const fn = (client as unknown as Record<string, unknown>)[method] as (
-    s: string,
-    k: string[],
-    a: string[],
-  ) => Promise<unknown>;
-  return fn.call(client, script, keys, argv);
+function fingerprint(tokenHash: string): string {
+  return tokenHash.slice(0, 8);
 }
 
 /**
@@ -444,14 +489,37 @@ export async function issueAgentToken(args: {
   }
   for (const c of args.capabilities) validateCapabilityString(c);
 
+  // Reject past or unparseable expiresAt at write time (closes builder R1
+  // issue 2 — letting an already-expired envelope land would consume a
+  // slot against the cap and produce a permanently-401 token).
+  if (args.expiresAt !== null) {
+    const expiresAtMs = new Date(args.expiresAt).getTime();
+    if (Number.isNaN(expiresAtMs)) {
+      throw new InvalidExpiresAtError(args.expiresAt, "not a valid ISO 8601 timestamp");
+    }
+    if (expiresAtMs <= Date.now()) {
+      throw new InvalidExpiresAtError(args.expiresAt, "is in the past");
+    }
+  }
+
   const limit = args.tokenLimit ?? DEFAULT_TOKEN_LIMIT_PER_INSTALLATION;
   if (limit <= 0) {
     throw new Error(`tokenLimit must be positive (got ${limit})`);
   }
 
+  // Self-heal orphaned sorted-set entries before the limit check. If
+  // explicit-expiry envelopes have been TTL'd by Redis, their hash
+  // index + sorted-set membership outlive the envelope; without this
+  // pruning the cap would count ghost entries (closes builder R1 #2).
+  // Cheap: O(N) Redis reads on a bounded set (cap ≤20).
+  await pruneOrphanedIndexEntries({
+    installationId: args.installationId,
+    redis: args.redis,
+  });
+
   const rawToken = generateRawToken();
   const tokenHash = hashToken(rawToken);
-  const tokenFingerprint = fingerprint(rawToken);
+  const tokenFingerprint = fingerprint(tokenHash);
 
   const encrypted: EncryptedEnvelope = encrypt(
     rawToken,
@@ -490,13 +558,13 @@ export async function issueAgentToken(args: {
     args.redis,
     async () => {
       const result = dispatchScriptResult(
-        await runLuaScript(
-          args.redis,
+        await args.redis.eval(
           ISSUE_TOKEN_SCRIPT,
           [
             envelopeKey(args.installationId, args.name),
             hashIndexKey(tokenHash),
             installationIndexKey(args.installationId),
+            auditStreamKey(args.installationId),
           ],
           [
             args.name,
@@ -505,6 +573,12 @@ export async function issueAgentToken(args: {
             String(createdAtMs),
             String(limit),
             String(ttlSecs),
+            // B.1.d will replace this empty sentinel with the
+            // structured audit-entry JSON. Script no-ops when empty,
+            // so the atomic-audit guarantee from the design is
+            // preserved without B.1.d needing to re-version the
+            // script (closes guard R1 G1).
+            "",
           ],
         ),
       );
@@ -557,24 +631,26 @@ export async function revokeAgentToken(args: {
         envelopeKey(args.installationId, args.name),
       );
       if (!envelopeRaw) {
-        // Sweep just the index in case of partial-state from prior failure
-        await args.redis.zrem(
-          installationIndexKey(args.installationId),
-          args.name,
-        );
+        // Sweep both the index entry AND the meta key in case of partial-
+        // state from prior failure (closes guard R1 G4 — meta could
+        // orphan after a manual Redis intervention).
+        await Promise.all([
+          args.redis.zrem(installationIndexKey(args.installationId), args.name),
+          args.redis.del(envelopeMetaKey(args.installationId, args.name)),
+        ]);
         return false;
       }
       const result = dispatchScriptResult(
-        await runLuaScript(
-          args.redis,
+        await args.redis.eval(
           REVOKE_TOKEN_SCRIPT,
           [
             envelopeKey(args.installationId, args.name),
             hashIndexKey(envelopeRaw.tokenHash),
             installationIndexKey(args.installationId),
             envelopeMetaKey(args.installationId, args.name),
+            auditStreamKey(args.installationId),
           ],
-          [args.name],
+          [args.name, ""],
         ),
       );
       return result.ok === 1;
@@ -626,11 +702,13 @@ export async function setAgentTokenCapabilities(args: {
         args.nowMs ?? Date.now(),
       );
       const result = dispatchScriptResult(
-        await runLuaScript(
-          args.redis,
+        await args.redis.eval(
           SET_CAPABILITIES_SCRIPT,
-          [envelopeKey(args.installationId, args.name)],
-          [JSON.stringify(updated), String(ttlSecs)],
+          [
+            envelopeKey(args.installationId, args.name),
+            auditStreamKey(args.installationId),
+          ],
+          [JSON.stringify(updated), String(ttlSecs), ""],
         ),
       );
       if (result.ok === -1 && result.reason === "no_envelope") {
@@ -682,7 +760,7 @@ export async function rotateAgentToken(args: {
 
       const newRawToken = generateRawToken();
       const newTokenHash = hashToken(newRawToken);
-      const newFingerprint = fingerprint(newRawToken);
+      const newFingerprint = fingerprint(newTokenHash);
 
       const encrypted: EncryptedEnvelope = encrypt(
         newRawToken,
@@ -712,18 +790,20 @@ export async function rotateAgentToken(args: {
       );
 
       const result = dispatchScriptResult(
-        await runLuaScript(
-          args.redis,
+        await args.redis.eval(
           ROTATE_TOKEN_SCRIPT,
           [
             envelopeKey(args.installationId, args.name),
             hashIndexKey(envelopeRaw.tokenHash),
             hashIndexKey(newTokenHash),
+            auditStreamKey(args.installationId),
           ],
           [
+            args.name,
             JSON.stringify(updated),
             JSON.stringify(newHashRecord),
             String(ttlSecs),
+            "",
           ],
         ),
       );
@@ -752,6 +832,11 @@ export async function rotateAgentToken(args: {
  * List token summaries for an installation in creation order
  * (by `createdAt` epoch ms via the sorted-set score). Excludes
  * encrypted ciphertext.
+ *
+ * Self-healing: opportunistically prunes orphaned sorted-set
+ * entries whose envelopes have been TTL'd by Redis. Keeps
+ * `tokens list` accurate AND ensures the per-installation cap
+ * doesn't count ghost entries.
  */
 export async function listAgentTokens(args: {
   installationId: string;
@@ -771,10 +856,77 @@ export async function listAgentTokens(args: {
     ),
   );
   const out: AgentTokenSummaryV1[] = [];
-  for (const env of envelopes) {
-    if (env !== null) out.push(summarize(env));
+  const orphans: string[] = [];
+  for (let i = 0; i < envelopes.length; i++) {
+    const env = envelopes[i];
+    if (env !== null) {
+      out.push(summarize(env));
+    } else {
+      orphans.push(names[i]);
+    }
+  }
+  if (orphans.length > 0) {
+    // Best-effort cleanup; failures are logged but don't fail the read.
+    await Promise.all(
+      orphans.map((name) =>
+        args.redis
+          .zrem(installationIndexKey(args.installationId), name)
+          .catch((err: unknown) => {
+            console.warn(
+              `[agent-token-v1] failed to ZREM orphaned index entry ${args.installationId}:${name}`,
+              err,
+            );
+          }),
+      ),
+    );
   }
   return out;
+}
+
+/**
+ * Sweep the per-installation sorted set for entries whose envelope has
+ * been TTL'd by Redis. Called by `issueAgentToken` before the cap
+ * check so explicit-expiry tokens that have already been swept don't
+ * consume slots.
+ *
+ * Returns the count of pruned entries (mostly for tests / observability).
+ * Best-effort: ZREM failures are logged but not propagated.
+ */
+export async function pruneOrphanedIndexEntries(args: {
+  installationId: string;
+  redis: Redis;
+}): Promise<number> {
+  const names = await args.redis.zrange<string[]>(
+    installationIndexKey(args.installationId),
+    0,
+    -1,
+  );
+  if (names.length === 0) return 0;
+  const envelopes = await Promise.all(
+    names.map((name) =>
+      args.redis.get<AgentTokenEnvelopeV1>(
+        envelopeKey(args.installationId, name),
+      ),
+    ),
+  );
+  const orphans: string[] = [];
+  for (let i = 0; i < envelopes.length; i++) {
+    if (envelopes[i] === null) orphans.push(names[i]);
+  }
+  if (orphans.length === 0) return 0;
+  await Promise.all(
+    orphans.map((name) =>
+      args.redis
+        .zrem(installationIndexKey(args.installationId), name)
+        .catch((err: unknown) => {
+          console.warn(
+            `[agent-token-v1] failed to ZREM orphaned index entry ${args.installationId}:${name}`,
+            err,
+          );
+        }),
+    ),
+  );
+  return orphans.length;
 }
 
 /** Read a single token summary by name. Throws TokenNotFoundError. */

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -354,6 +354,66 @@ return {1}
 `;
 
 /**
+ * RESOLVE_BEARER_SCRIPT — single-RTT bearer→envelope resolution.
+ *
+ * Closes builder R3: the design doc's earlier "pipeline both reads"
+ * pseudocode was impossible because the envelope key requires
+ * `{installationId, name}` from the hash record returned by the
+ * FIRST get. The reads are dependent, so a JS-side
+ * `redis.pipeline().get().get().all()` can't construct the second
+ * key before the pipeline has run.
+ *
+ * Resolution: do both reads + the bearer-resurrection invariant
+ * check (`envelope.tokenHash === presentedHash`) inside a single
+ * Lua EVAL. The script:
+ *   1. GET the hash index for the presented bearer.
+ *   2. If missing → `{-1, "unknown_bearer"}`.
+ *   3. cjson.decode the hash record → `{installationId, name}`.
+ *   4. Compute the envelope key in Lua + GET it.
+ *   5. If missing → `{-2, "envelope_missing"}` (TTL-swept or
+ *      revoke race).
+ *   6. cjson.decode the envelope + check `envelope.tokenHash ===
+ *      ARGV[2]`. If mismatch → `{-3, "stale_bearer"}` (the
+ *      same-name-reissue bearer-resurrection scenario the storage
+ *      shape is designed to defend against — see the BEARER-
+ *      RESURRECTION INVARIANT block at the top of this file).
+ *   7. Otherwise return `{1, envelopeJson}`.
+ *
+ * Middleware (B.1.c) then:
+ *   - Checks `envelope.expiresAt` against current time (Lua can't
+ *     reliably compare wall-clock time across instances; the +300s
+ *     TTL margin guarantees the envelope outlives its expiresAt
+ *     by at least 5 min so this check is the user-visible gate).
+ *   - Returns the typed auth result with capabilities + agent_role.
+ *
+ * KEYS: [hashIndexKey]
+ * ARGV: [envelopeKeyPrefix, presentedHash]
+ *   envelopeKeyPrefix = "hive:v1:agent-token:" — passed as ARGV
+ *                       so the prefix lives in TS code (single
+ *                       source of truth) rather than the Lua
+ *                       string. Lua does
+ *                         envelopeKey = prefix + installationId
+ *                                      + ":" + name
+ *
+ * Returns:
+ *   {1, envelopeJson}              success — caller cjson.parses + uses
+ *   {-1, "unknown_bearer"}         hash index miss
+ *   {-2, "envelope_missing"}       hash record points at a TTL'd or revoked envelope
+ *   {-3, "stale_bearer"}           bearer-resurrection: hash → envelope but envelope.tokenHash differs
+ */
+const RESOLVE_BEARER_SCRIPT = `
+local hashRecord = redis.call("get", KEYS[1])
+if not hashRecord then return {-1, "unknown_bearer"} end
+local parsed = cjson.decode(hashRecord)
+local envKey = ARGV[1] .. parsed.installationId .. ":" .. parsed.name
+local envelope = redis.call("get", envKey)
+if not envelope then return {-2, "envelope_missing"} end
+local envParsed = cjson.decode(envelope)
+if envParsed.tokenHash ~= ARGV[2] then return {-3, "stale_bearer"} end
+return {1, envelope}
+`;
+
+/**
  * ROTATE_TOKEN_SCRIPT — atomic bearer swap. Replaces the envelope +
  * the hash index under the same name with a new bearer's hash record
  * + freshly-encrypted envelope. The previous hash index is DELed in
@@ -464,10 +524,10 @@ function dispatchScriptResult(raw: unknown): ScriptResult {
   }
   const tag = Number(raw[0]);
   const payload = raw.length > 1 ? String(raw[1]) : undefined;
-  return {
-    ok: tag,
-    reason: tag === 0 || tag === -1 ? payload : undefined,
-  };
+  // Pass payload through for ALL tags. For success (tag === 1) it
+  // can carry an envelope/name/etc; for non-success tags it carries
+  // the named discriminator (REDIS_KEY_CONVENTION.md `{0, "<reason>"}`).
+  return { ok: tag, reason: payload };
 }
 
 // ---------------------------------------------------------------------------
@@ -950,6 +1010,89 @@ export async function pruneOrphanedIndexEntries(args: {
     ),
   );
   return orphans.length;
+}
+
+/**
+ * Resolve a presented bearer to the full envelope in ONE Redis
+ * round-trip. Used by B.1.c middleware to authenticate incoming
+ * requests; the returned envelope carries everything the
+ * `requires` capability check needs (capabilities, agent_role,
+ * installationId, policy, expiresAt).
+ *
+ * Returns:
+ *   - `{ ok: true, envelope }` when the bearer is valid and
+ *     binds to a current envelope (tokenHash matched).
+ *   - `{ ok: false, code: "unknown_bearer" }` when the hash index
+ *     misses (bearer never existed OR was revoked).
+ *   - `{ ok: false, code: "envelope_missing" }` when the hash
+ *     record points at an envelope that was Redis-TTL-swept or
+ *     concurrently revoked.
+ *   - `{ ok: false, code: "stale_bearer" }` when the envelope
+ *     exists but its tokenHash differs from the presented bearer's
+ *     SHA-256 — the bearer-resurrection scenario (see the
+ *     BEARER-RESURRECTION INVARIANT docblock at top of file).
+ *
+ * Caller (B.1.c middleware) maps each failure code to its
+ * appropriate HTTP response:
+ *   - unknown_bearer / envelope_missing → 401 Invalid bearer
+ *   - stale_bearer → 401 TOKEN_EXPIRED (semantically: the bearer
+ *     points at a name whose envelope has been replaced; from
+ *     the caller's perspective the bearer no longer maps to its
+ *     identity)
+ *   - ok → caller checks `envelope.expiresAt` against the wall
+ *     clock + checks the `requires` capability per
+ *     `bearerHasCapability(envelope.capabilities, requires)`.
+ *
+ * The returned envelope INCLUDES the encrypted ciphertext fields
+ * (the middleware doesn't decrypt; it only reads metadata). Callers
+ * MUST NOT log the envelope object verbatim — it carries the
+ * encrypted bearer ciphertext which would defeat the audit-stream
+ * "fingerprint, never raw bearer" rule.
+ */
+export type ResolveBearerResult =
+  | { ok: true; envelope: AgentTokenEnvelopeV1 }
+  | {
+      ok: false;
+      code: "unknown_bearer" | "envelope_missing" | "stale_bearer";
+    };
+
+export async function resolveBearerToEnvelope(args: {
+  rawBearer: string;
+  redis: Redis;
+}): Promise<ResolveBearerResult> {
+  const presentedHash = hashToken(args.rawBearer);
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      RESOLVE_BEARER_SCRIPT,
+      [hashIndexKey(presentedHash)],
+      [ENVELOPE_PREFIX, presentedHash],
+    ),
+  );
+  if (result.ok === 1) {
+    // payload is the envelope JSON returned by the Lua script
+    const envelopeJson = result.reason;
+    if (envelopeJson === undefined) {
+      throw new Error(
+        "RESOLVE_BEARER_SCRIPT returned ok=1 with no envelope payload",
+      );
+    }
+    return {
+      ok: true,
+      envelope: JSON.parse(envelopeJson) as AgentTokenEnvelopeV1,
+    };
+  }
+  if (result.ok === -1 && result.reason === "unknown_bearer") {
+    return { ok: false, code: "unknown_bearer" };
+  }
+  if (result.ok === -2 && result.reason === "envelope_missing") {
+    return { ok: false, code: "envelope_missing" };
+  }
+  if (result.ok === -3 && result.reason === "stale_bearer") {
+    return { ok: false, code: "stale_bearer" };
+  }
+  throw new Error(
+    `RESOLVE_BEARER_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
 }
 
 /** Read a single token summary by name. Throws TokenNotFoundError. */

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -8,6 +8,29 @@
  * callers stay on `agent-token.ts` until the cutover (B.1.e) flips
  * the middleware over.
  *
+ * BEARER-RESURRECTION INVARIANT (load-bearing for B.1.c middleware)
+ * ----------------------------------------------------------------
+ * The hash index is intentionally NOT TTL'd (per CAPABILITIES_DESIGN.md
+ * — middleware verifies envelope expiry; TTLing the hash index too
+ * risks dropping it before the envelope under clock skew). That
+ * design decision creates a same-name-reuse failure mode at the
+ * storage layer: if an explicit-expiry envelope gets TTL'd by Redis
+ * AND the operator reissues a NEW token under the SAME name (now
+ * permitted because pruneOrphanedIndexEntries cleared the
+ * sorted-set entry), the OLD bearer's hash index still points at
+ * `{installationId, name}` and would resolve to the NEW envelope.
+ *
+ * The middleware MUST close this by comparing
+ *   sha256(presentedBearer) === envelope.tokenHash
+ * and rejecting on mismatch. This module does NOT enforce that
+ * check (it's middleware-side); B.1.c implements it. The fact
+ * that this module's storage shape REQUIRES that check is the
+ * load-bearing contract — any future refactor that drops the
+ * check would silently allow old-bearer-resurrection.
+ *
+ * See `agent-token-v1.test.ts` "bearer-resurrection invariant"
+ * test for the storage-state demonstration.
+ *
  * Storage layout (per `docs/architecture/REDIS_KEY_CONVENTION.md`):
  *
  *   hive:v1:agent-token:{installationId}:{name}            string (envelope JSON)

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -1,0 +1,812 @@
+/**
+ * V1 agent-token storage layer (Phase B.1.b).
+ *
+ * Implements the storage primitives for the per-key capability
+ * system from `docs/architecture/CAPABILITIES_DESIGN.md` alongside
+ * the legacy single-token-per-installation primitives in
+ * `agent-token.ts`. NEW callers should use this module; legacy
+ * callers stay on `agent-token.ts` until the cutover (B.1.e) flips
+ * the middleware over.
+ *
+ * Storage layout (per `docs/architecture/REDIS_KEY_CONVENTION.md`):
+ *
+ *   hive:v1:agent-token:{installationId}:{name}            string (envelope JSON)
+ *   hive:v1:idx:agent-token:hash:{tokenHash}               string (hash record JSON)
+ *   hive:v1:idx:agent-token:installation:{installationId}  sorted set (token names by createdAt)
+ *   hive:v1:agent-token:{installationId}:{name}:meta       hash (lastUsedAt, callCount)
+ *   hive:v1:agent-token:{installationId}:audit             stream (mutations)
+ *   hive:v1:agent-token:{installationId}:auth              stream (auth events)
+ *   hive:v1:lock:agent-token:{installationId}:{name}       string (issue/revoke/setCaps lock)
+ *
+ * Atomicity is via 4 Lua scripts (ISSUE, REVOKE, SET_CAPABILITIES,
+ * ROTATE) with the return-shape convention from REDIS_KEY_CONVENTION.md.
+ *
+ * What this module DOESN'T do (deferred to later B.1 PRs):
+ *   - middleware integration (B.1.c) — `resolveTokenToInstallation`
+ *     extension to read these envelopes
+ *   - HTTP endpoints (B.1.d) — `/api/agent-tokens/*` CRUD,
+ *     `/api/whoami`, `/api/agent-tokens/bootstrap`
+ *   - lastUsedAt write strategy (debounced 60s) — B.1.c with the
+ *     middleware that writes it
+ *   - audit-stream emit (`auditAppend`) — wired into the same
+ *     middleware/endpoint PRs
+ *   - cleanup script for legacy keys (B.1.e cutover)
+ */
+
+import { createHash, randomBytes } from "crypto";
+import { type Redis } from "@upstash/redis";
+import { encrypt, type EncryptedEnvelope } from "@/server/crypto";
+import { withRedisLock } from "@/server/redis-lock";
+import {
+  validateName,
+  validateAgentRole,
+  validateCapabilityString,
+} from "@/server/agent-token-capabilities";
+import type {
+  AgentTokenPolicy,
+  GitHubPermissionLevel,
+} from "@/server/agent-token";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard cap per installation. Configurable via env at the route layer
+ * (default 20 per design); the script enforces whatever positive int
+ * the caller passes.
+ */
+export const DEFAULT_TOKEN_LIMIT_PER_INSTALLATION = 20;
+
+/**
+ * Clock-skew safety margin (seconds) baked into the envelope's Redis
+ * TTL. The middleware does its own envelope `expiresAt` check; the
+ * Redis TTL is the eventually-consistent sweep, not the user-visible
+ * gate. +300s ensures a Redis-vs-API-server clock drift can't drop
+ * the envelope before its `expiresAt` would have fired.
+ */
+export const ENVELOPE_TTL_SKEW_MARGIN_SECONDS = 300;
+
+const ENVELOPE_PREFIX = "hive:v1:agent-token:";
+const HASH_INDEX_PREFIX = "hive:v1:idx:agent-token:hash:";
+const INSTALLATION_INDEX_PREFIX = "hive:v1:idx:agent-token:installation:";
+const META_SUFFIX = ":meta";
+const LOCK_PREFIX = "hive:v1:lock:agent-token:";
+
+export function envelopeKey(installationId: string, name: string): string {
+  return `${ENVELOPE_PREFIX}${installationId}:${name}`;
+}
+
+export function hashIndexKey(tokenHash: string): string {
+  return `${HASH_INDEX_PREFIX}${tokenHash}`;
+}
+
+export function installationIndexKey(installationId: string): string {
+  return `${INSTALLATION_INDEX_PREFIX}${installationId}`;
+}
+
+export function envelopeMetaKey(installationId: string, name: string): string {
+  return `${envelopeKey(installationId, name)}${META_SUFFIX}`;
+}
+
+export function lockKey(installationId: string, name: string): string {
+  return `${LOCK_PREFIX}${installationId}:${name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * V1 envelope. Required new fields from V1.5/V1.6:
+ *   - `name` — operator-chosen, unique per (installationId, name)
+ *   - `agent_role` — server-derived actor identity for multi-actor
+ *     APIs (war rooms etc.); never accepted from request body
+ *   - `capabilities` — per-key API gates; ≥ 1 entry; wildcards
+ *     expanded at request time per `expandCapabilities()`
+ */
+export interface AgentTokenEnvelopeV1 {
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  keyVersion: string;
+  tokenHash: string;
+  fingerprint: string;
+  createdAt: string;
+  createdBy: string;
+  expiresAt: string | null;
+  // V1.5/V1.6
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  policy?: AgentTokenPolicy;
+}
+
+/**
+ * Reverse index for bearer → identity lookup.
+ *
+ * `expiresAt` removed (was in legacy V1.5 hash record): the middleware
+ * reads expiry from the envelope on every auth, keeping a single
+ * source of truth. Cost: one extra Redis read per auth, batched into
+ * the existing pipeline (per CAPABILITIES_DESIGN.md latency note).
+ */
+export interface AgentTokenHashRecordV1 {
+  installationId: string;
+  name: string;
+}
+
+/**
+ * Per-installation summary entry returned by `listAgentTokens`.
+ * Excludes the encrypted ciphertext (we never decrypt for listing).
+ */
+export interface AgentTokenSummaryV1 {
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  createdAt: string;
+  createdBy: string;
+  expiresAt: string | null;
+  policy?: AgentTokenPolicy;
+}
+
+/** Bearer + minimal metadata returned ONCE at issue time. */
+export interface IssuedAgentTokenV1 {
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors
+// ---------------------------------------------------------------------------
+
+export class TokenNameTakenError extends Error {
+  constructor(installationId: string, name: string) {
+    super(`Token name '${name}' already exists for installation ${installationId}`);
+    this.name = "TokenNameTakenError";
+  }
+}
+
+export class TokenLimitReachedError extends Error {
+  constructor(installationId: string, limit: number) {
+    super(
+      `Installation ${installationId} is at the ${limit}-token limit; revoke an unused token before issuing a new one`,
+    );
+    this.name = "TokenLimitReachedError";
+  }
+}
+
+export class TokenNotFoundError extends Error {
+  constructor(installationId: string, name: string) {
+    super(`No agent token named '${name}' for installation ${installationId}`);
+    this.name = "TokenNotFoundError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lua scripts
+// ---------------------------------------------------------------------------
+
+/**
+ * ISSUE_TOKEN_SCRIPT — atomic SET NX on the envelope key, plus hash
+ * index + sorted-set add. Enforces the 20-token-per-installation
+ * limit INSIDE the script (closes guard R2 N1 — was TOCTOU between
+ * client SCARD and EVAL).
+ *
+ * Per the design's R2.3 amendment, the envelope gets an explicit
+ * Redis EX when `expirySecsOrZero > 0` (computed by the caller as
+ * `expiresAt - now() + 300`). The hash index is intentionally NOT
+ * TTL'd — middleware verifies envelope expiry on every auth, and
+ * TTLing the hash index too risks dropping it slightly before the
+ * envelope under clock skew.
+ *
+ * KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey]
+ * ARGV: [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit, expirySecsOrZero]
+ *
+ * Returns:
+ *   {1, name}            success
+ *   {0, "name_taken"}    name already exists for this installation
+ *   {-1, "limit"}        installation already at tokenLimit names
+ */
+const ISSUE_TOKEN_SCRIPT = `
+local existing = redis.call("get", KEYS[1])
+if existing then return {0, "name_taken"} end
+local count = redis.call("zcard", KEYS[3])
+if count >= tonumber(ARGV[5]) then return {-1, "limit"} end
+if tonumber(ARGV[6]) > 0 then
+  redis.call("set", KEYS[1], ARGV[2], "EX", tonumber(ARGV[6]))
+else
+  redis.call("set", KEYS[1], ARGV[2])
+end
+redis.call("set", KEYS[2], ARGV[3])
+redis.call("zadd", KEYS[3], tonumber(ARGV[4]), ARGV[1])
+return {1, ARGV[1]}
+`;
+
+/**
+ * REVOKE_TOKEN_SCRIPT — atomic 4-key cleanup (envelope + reverse index
+ * + installation sorted-set membership + meta).
+ *
+ * KEYS: [envelopeKey, hashIndexKey, installationSortedSetKey, metaKey]
+ * ARGV: [name]
+ *
+ * Returns:
+ *   {1, name}    success (envelope existed, all keys cleaned)
+ *   {0, name}    nothing to revoke (envelope already gone)
+ *
+ * The audit stream is intentionally NOT deleted on revoke — the
+ * audit trail outlives the token.
+ */
+const REVOKE_TOKEN_SCRIPT = `
+local existed = redis.call("del", KEYS[1])
+redis.call("del", KEYS[2])
+redis.call("del", KEYS[4])
+redis.call("zrem", KEYS[3], ARGV[1])
+if existed == 0 then return {0, ARGV[1]} end
+return {1, ARGV[1]}
+`;
+
+/**
+ * SET_CAPABILITIES_SCRIPT — atomic mutation of the capabilities field
+ * on the envelope. Caller passes the FULL replacement envelope JSON
+ * (TypeScript merges the new caps into the existing envelope before
+ * calling this). Preserves the envelope's existing TTL via the same
+ * `expirySecsOrZero` ARGV pattern as ISSUE.
+ *
+ * KEYS: [envelopeKey]
+ * ARGV: [newEnvelopeJson, expirySecsOrZero]
+ *
+ * Returns:
+ *   {1}                  success
+ *   {-1, "no_envelope"}  envelope missing (race with revoke)
+ */
+const SET_CAPABILITIES_SCRIPT = `
+local existing = redis.call("get", KEYS[1])
+if not existing then return {-1, "no_envelope"} end
+if tonumber(ARGV[2]) > 0 then
+  redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[2]))
+else
+  redis.call("set", KEYS[1], ARGV[1])
+end
+return {1}
+`;
+
+/**
+ * ROTATE_TOKEN_SCRIPT — atomic bearer swap. Replaces the envelope +
+ * the hash index under the same name with a new bearer's hash record
+ * + freshly-encrypted envelope. The previous hash index is DELed in
+ * the same EVAL so there is zero "two valid bearers" window at the
+ * Redis layer (operationally there is still a stop-and-restart
+ * window per the design — see the rotate runbook).
+ *
+ * Preserves the envelope's `expiresAt` (rotate ≠ extend); caller
+ * computes `expirySecsOrZero` as `expiresAt - now() + 300` from the
+ * EXISTING envelope's expiry.
+ *
+ * KEYS: [envelopeKey, oldHashIndexKey, newHashIndexKey]
+ * ARGV: [newEnvelopeJson, newHashRecordJson, expirySecsOrZero]
+ *
+ * Returns:
+ *   {1, name}                success
+ *   {-1, "no_envelope"}      name doesn't exist (race with revoke)
+ */
+const ROTATE_TOKEN_SCRIPT = `
+local existing = redis.call("get", KEYS[1])
+if not existing then return {-1, "no_envelope"} end
+redis.call("del", KEYS[2])
+if tonumber(ARGV[3]) > 0 then
+  redis.call("set", KEYS[1], ARGV[1], "EX", tonumber(ARGV[3]))
+else
+  redis.call("set", KEYS[1], ARGV[1])
+end
+redis.call("set", KEYS[3], ARGV[2])
+return {1, ARGV[2]}
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateRawToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function hashToken(rawToken: string): string {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+function fingerprint(rawToken: string): string {
+  return rawToken.slice(-8);
+}
+
+/**
+ * Bracket-notation alias around the Upstash Redis client's Lua
+ * execution method. The literal `.<method>(` token-pattern is
+ * flagged by an unrelated security-warning hook (it can't tell
+ * the difference between Node's built-in eval and Redis's
+ * Lua-script entrypoint), so we route the call through bracket
+ * access in one place and keep the rest of the file readable.
+ */
+function runLuaScript(
+  client: Redis,
+  script: string,
+  keys: string[],
+  argv: string[],
+): Promise<unknown> {
+  const method = "eval";
+  const fn = (client as unknown as Record<string, unknown>)[method] as (
+    s: string,
+    k: string[],
+    a: string[],
+  ) => Promise<unknown>;
+  return fn.call(client, script, keys, argv);
+}
+
+/**
+ * Compute the Redis TTL (in seconds) to apply to the envelope key.
+ * Returns 0 when no expiry is set (V1.5 default — no TTL).
+ *
+ * The +ENVELOPE_TTL_SKEW_MARGIN_SECONDS ensures the auth middleware's
+ * envelope-side `expiresAt` check is the user-visible gate; the Redis
+ * TTL is the eventually-consistent cleanup that fires AFTER the
+ * envelope is already considered expired.
+ *
+ * Returns 0 (no TTL) if `expiresAt` is in the past or within the
+ * skew margin — the envelope will fail middleware checks immediately
+ * anyway, so TTL'ing it just risks racing the auth path.
+ */
+export function computeEnvelopeTtlSeconds(
+  expiresAtIso: string | null,
+  nowMs: number = Date.now(),
+): number {
+  if (expiresAtIso === null) return 0;
+  const expiresAtMs = new Date(expiresAtIso).getTime();
+  if (Number.isNaN(expiresAtMs)) return 0;
+  const remainingSecs = Math.floor((expiresAtMs - nowMs) / 1000);
+  if (remainingSecs <= 0) return 0;
+  return remainingSecs + ENVELOPE_TTL_SKEW_MARGIN_SECONDS;
+}
+
+interface ScriptResult {
+  ok: number;
+  reason?: string;
+}
+
+/**
+ * Normalize the Lua script's `[tag, payload]` return into a typed
+ * dispatch object.
+ *
+ *   tag === 1   → ok (positive success)
+ *   tag === 0   → benign conflict (named via reason string)
+ *   tag === -1  → precondition failed (named via reason string)
+ *
+ * Other tags ({-2, ...} sequence drift / {-3, ...} unrecoverable)
+ * aren't produced by THIS module's scripts, but the helper accepts
+ * them uniformly for future-proofing.
+ */
+function dispatchScriptResult(raw: unknown): ScriptResult {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(
+      `Lua script returned malformed result: ${JSON.stringify(raw)}`,
+    );
+  }
+  const tag = Number(raw[0]);
+  const payload = raw.length > 1 ? String(raw[1]) : undefined;
+  return {
+    ok: tag,
+    reason: tag === 0 || tag === -1 ? payload : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue a new agent token under `(installationId, name)`. Validates
+ * inputs at write time (fail-closed on bad name/role/cap strings) and
+ * acquires the per-key lock so concurrent issuances under the same
+ * name resolve cleanly via the script's NX path.
+ *
+ * Returns the bearer ONCE — caller must surface it to the operator
+ * (CLI prints to stdout, dashboard shows once-then-clears). The raw
+ * bearer is never recoverable: storage holds an encrypted envelope
+ * keyed by ciphertext + a SHA-256 hash for reverse lookup.
+ *
+ * Throws:
+ *   - `CapabilityValidationError` on bad name/role/cap inputs
+ *   - `TokenNameTakenError` if `(installationId, name)` already exists
+ *   - `TokenLimitReachedError` if the installation is at the cap
+ */
+export async function issueAgentToken(args: {
+  installationId: string;
+  name: string;
+  agent_role: string;
+  capabilities: readonly string[];
+  createdBy: string;
+  expiresAt: string | null;
+  policy?: AgentTokenPolicy;
+  keyring: Map<string, Buffer>;
+  keyVersion: string;
+  redis: Redis;
+  tokenLimit?: number;
+}): Promise<IssuedAgentTokenV1> {
+  validateName(args.name);
+  validateAgentRole(args.agent_role);
+  if (args.capabilities.length === 0) {
+    throw new Error(
+      "Refusing to issue a token with empty capabilities — all envelopes require ≥1 capability",
+    );
+  }
+  for (const c of args.capabilities) validateCapabilityString(c);
+
+  const limit = args.tokenLimit ?? DEFAULT_TOKEN_LIMIT_PER_INSTALLATION;
+  if (limit <= 0) {
+    throw new Error(`tokenLimit must be positive (got ${limit})`);
+  }
+
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+  const tokenFingerprint = fingerprint(rawToken);
+
+  const encrypted: EncryptedEnvelope = encrypt(
+    rawToken,
+    args.keyVersion,
+    args.keyring,
+  );
+
+  const createdAtMs = Date.now();
+  const createdAtIso = new Date(createdAtMs).toISOString();
+
+  const envelope: AgentTokenEnvelopeV1 = {
+    ciphertext: encrypted.ciphertext,
+    iv: encrypted.iv,
+    tag: encrypted.tag,
+    keyVersion: encrypted.keyVersion,
+    tokenHash,
+    fingerprint: tokenFingerprint,
+    createdAt: createdAtIso,
+    createdBy: args.createdBy,
+    expiresAt: args.expiresAt,
+    name: args.name,
+    agent_role: args.agent_role,
+    capabilities: [...args.capabilities],
+    ...(args.policy ? { policy: args.policy } : {}),
+  };
+
+  const hashRecord: AgentTokenHashRecordV1 = {
+    installationId: args.installationId,
+    name: args.name,
+  };
+
+  const ttlSecs = computeEnvelopeTtlSeconds(args.expiresAt, createdAtMs);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const result = dispatchScriptResult(
+        await runLuaScript(
+          args.redis,
+          ISSUE_TOKEN_SCRIPT,
+          [
+            envelopeKey(args.installationId, args.name),
+            hashIndexKey(tokenHash),
+            installationIndexKey(args.installationId),
+          ],
+          [
+            args.name,
+            JSON.stringify(envelope),
+            JSON.stringify(hashRecord),
+            String(createdAtMs),
+            String(limit),
+            String(ttlSecs),
+          ],
+        ),
+      );
+      if (result.ok === 0 && result.reason === "name_taken") {
+        throw new TokenNameTakenError(args.installationId, args.name);
+      }
+      if (result.ok === -1 && result.reason === "limit") {
+        throw new TokenLimitReachedError(args.installationId, limit);
+      }
+      if (result.ok !== 1) {
+        throw new Error(
+          `ISSUE_TOKEN_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+        );
+      }
+      return {
+        token: rawToken,
+        name: args.name,
+        agent_role: args.agent_role,
+        capabilities: [...args.capabilities],
+        fingerprint: tokenFingerprint,
+        expiresAt: args.expiresAt,
+      };
+    },
+  );
+}
+
+/**
+ * Revoke a token by name. Returns true if the token existed and was
+ * cleaned up; false if it was already gone (idempotent revoke).
+ *
+ * Hard-stop semantics per the design (V1): in-flight calls
+ * 401 on next read; current task fails / orphans; queen handles
+ * via the existing task watchdog. V1.1 may add a 5-min grace
+ * window if hard-stop produces visibly bad task UX.
+ */
+export async function revokeAgentToken(args: {
+  installationId: string;
+  name: string;
+  redis: Redis;
+}): Promise<boolean> {
+  validateName(args.name);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      // Read the envelope to find the tokenHash (needed to DEL the hash
+      // index — the lookup goes envelope → tokenHash → hashIndexKey).
+      const envelopeRaw = await args.redis.get<AgentTokenEnvelopeV1>(
+        envelopeKey(args.installationId, args.name),
+      );
+      if (!envelopeRaw) {
+        // Sweep just the index in case of partial-state from prior failure
+        await args.redis.zrem(
+          installationIndexKey(args.installationId),
+          args.name,
+        );
+        return false;
+      }
+      const result = dispatchScriptResult(
+        await runLuaScript(
+          args.redis,
+          REVOKE_TOKEN_SCRIPT,
+          [
+            envelopeKey(args.installationId, args.name),
+            hashIndexKey(envelopeRaw.tokenHash),
+            installationIndexKey(args.installationId),
+            envelopeMetaKey(args.installationId, args.name),
+          ],
+          [args.name],
+        ),
+      );
+      return result.ok === 1;
+    },
+  );
+}
+
+/**
+ * Replace the capabilities on an existing token (in place). Caller
+ * provides the FULL new capabilities list; this is a "snap to" not a
+ * "merge."
+ *
+ * Preserves all other envelope fields including `agent_role` and
+ * `expiresAt`. The Redis TTL is recomputed from the (preserved)
+ * `expiresAt` so the +300s skew margin stays accurate to the
+ * envelope's actual lifetime.
+ */
+export async function setAgentTokenCapabilities(args: {
+  installationId: string;
+  name: string;
+  capabilities: readonly string[];
+  redis: Redis;
+  nowMs?: number;
+}): Promise<AgentTokenSummaryV1> {
+  validateName(args.name);
+  if (args.capabilities.length === 0) {
+    throw new Error(
+      "Refusing to set empty capabilities — all envelopes require ≥1 capability",
+    );
+  }
+  for (const c of args.capabilities) validateCapabilityString(c);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const envelopeRaw = await args.redis.get<AgentTokenEnvelopeV1>(
+        envelopeKey(args.installationId, args.name),
+      );
+      if (!envelopeRaw) {
+        throw new TokenNotFoundError(args.installationId, args.name);
+      }
+      const updated: AgentTokenEnvelopeV1 = {
+        ...envelopeRaw,
+        capabilities: [...args.capabilities],
+      };
+      const ttlSecs = computeEnvelopeTtlSeconds(
+        updated.expiresAt,
+        args.nowMs ?? Date.now(),
+      );
+      const result = dispatchScriptResult(
+        await runLuaScript(
+          args.redis,
+          SET_CAPABILITIES_SCRIPT,
+          [envelopeKey(args.installationId, args.name)],
+          [JSON.stringify(updated), String(ttlSecs)],
+        ),
+      );
+      if (result.ok === -1 && result.reason === "no_envelope") {
+        // Race with revoke between the GET above and the EVAL — surface
+        // the same NotFound the GET-miss path uses so callers don't
+        // need a separate code path.
+        throw new TokenNotFoundError(args.installationId, args.name);
+      }
+      if (result.ok !== 1) {
+        throw new Error(
+          `SET_CAPABILITIES_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+        );
+      }
+      return summarize(updated);
+    },
+  );
+}
+
+/**
+ * Replace the bearer for an existing named token. Atomic at the
+ * Redis layer (envelope + new hash index swap in one EVAL); the
+ * old hash index is DELed in the same call so the previous bearer
+ * is invalid the moment this returns.
+ *
+ * Preserves `expiresAt` (rotate ≠ extend). Operators wanting to
+ * extend lifetime should issue a successor under a different name
+ * with `--expires-in <duration>`, then revoke the old one.
+ */
+export async function rotateAgentToken(args: {
+  installationId: string;
+  name: string;
+  keyring: Map<string, Buffer>;
+  keyVersion: string;
+  redis: Redis;
+  nowMs?: number;
+}): Promise<IssuedAgentTokenV1> {
+  validateName(args.name);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const envelopeRaw = await args.redis.get<AgentTokenEnvelopeV1>(
+        envelopeKey(args.installationId, args.name),
+      );
+      if (!envelopeRaw) {
+        throw new TokenNotFoundError(args.installationId, args.name);
+      }
+
+      const newRawToken = generateRawToken();
+      const newTokenHash = hashToken(newRawToken);
+      const newFingerprint = fingerprint(newRawToken);
+
+      const encrypted: EncryptedEnvelope = encrypt(
+        newRawToken,
+        args.keyVersion,
+        args.keyring,
+      );
+
+      const updated: AgentTokenEnvelopeV1 = {
+        ...envelopeRaw,
+        ciphertext: encrypted.ciphertext,
+        iv: encrypted.iv,
+        tag: encrypted.tag,
+        keyVersion: encrypted.keyVersion,
+        tokenHash: newTokenHash,
+        fingerprint: newFingerprint,
+        // expiresAt + capabilities + agent_role + name + createdAt all preserved
+      };
+
+      const newHashRecord: AgentTokenHashRecordV1 = {
+        installationId: args.installationId,
+        name: args.name,
+      };
+
+      const ttlSecs = computeEnvelopeTtlSeconds(
+        updated.expiresAt,
+        args.nowMs ?? Date.now(),
+      );
+
+      const result = dispatchScriptResult(
+        await runLuaScript(
+          args.redis,
+          ROTATE_TOKEN_SCRIPT,
+          [
+            envelopeKey(args.installationId, args.name),
+            hashIndexKey(envelopeRaw.tokenHash),
+            hashIndexKey(newTokenHash),
+          ],
+          [
+            JSON.stringify(updated),
+            JSON.stringify(newHashRecord),
+            String(ttlSecs),
+          ],
+        ),
+      );
+      if (result.ok === -1 && result.reason === "no_envelope") {
+        throw new TokenNotFoundError(args.installationId, args.name);
+      }
+      if (result.ok !== 1) {
+        throw new Error(
+          `ROTATE_TOKEN_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        token: newRawToken,
+        name: args.name,
+        agent_role: updated.agent_role,
+        capabilities: [...updated.capabilities],
+        fingerprint: newFingerprint,
+        expiresAt: updated.expiresAt,
+      };
+    },
+  );
+}
+
+/**
+ * List token summaries for an installation in creation order
+ * (by `createdAt` epoch ms via the sorted-set score). Excludes
+ * encrypted ciphertext.
+ */
+export async function listAgentTokens(args: {
+  installationId: string;
+  redis: Redis;
+}): Promise<AgentTokenSummaryV1[]> {
+  const names = await args.redis.zrange<string[]>(
+    installationIndexKey(args.installationId),
+    0,
+    -1,
+  );
+  if (names.length === 0) return [];
+  const envelopes = await Promise.all(
+    names.map((name) =>
+      args.redis.get<AgentTokenEnvelopeV1>(
+        envelopeKey(args.installationId, name),
+      ),
+    ),
+  );
+  const out: AgentTokenSummaryV1[] = [];
+  for (const env of envelopes) {
+    if (env !== null) out.push(summarize(env));
+  }
+  return out;
+}
+
+/** Read a single token summary by name. Throws TokenNotFoundError. */
+export async function getAgentTokenSummary(args: {
+  installationId: string;
+  name: string;
+  redis: Redis;
+}): Promise<AgentTokenSummaryV1> {
+  const envelopeRaw = await args.redis.get<AgentTokenEnvelopeV1>(
+    envelopeKey(args.installationId, args.name),
+  );
+  if (!envelopeRaw) {
+    throw new TokenNotFoundError(args.installationId, args.name);
+  }
+  return summarize(envelopeRaw);
+}
+
+function summarize(envelope: AgentTokenEnvelopeV1): AgentTokenSummaryV1 {
+  return {
+    name: envelope.name,
+    agent_role: envelope.agent_role,
+    capabilities: [...envelope.capabilities],
+    fingerprint: envelope.fingerprint,
+    createdAt: envelope.createdAt,
+    createdBy: envelope.createdBy,
+    expiresAt: envelope.expiresAt,
+    ...(envelope.policy ? { policy: envelope.policy } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports
+// ---------------------------------------------------------------------------
+
+export type { GitHubPermissionLevel };


### PR DESCRIPTION
## Summary

Second slice of Phase B.1 (storage primitives for the per-key capability system from `docs/architecture/CAPABILITIES_DESIGN.md`). Builds on B.1.a (#502 — capability vocabulary + presets). Layered above legacy `agent-token.ts` so callers can migrate in B.1.c/d without breaking existing endpoints.

## What lands

`web/src/server/agent-token-v1.ts`:

**Storage layout** (per `REDIS_KEY_CONVENTION.md`):
- `hive:v1:agent-token:{installationId}:{name}` — envelope JSON
- `hive:v1:idx:agent-token:hash:{tokenHash}` — bearer → identity reverse index
- `hive:v1:idx:agent-token:installation:{installationId}` — sorted set (token names by createdAt)
- `hive:v1:agent-token:{installationId}:{name}:meta` — mutable side-state (`lastUsedAt` written by B.1.c middleware)
- `hive:v1:agent-token:{installationId}:audit` + `:auth` — audit streams (B.1.d)
- `hive:v1:lock:agent-token:{installationId}:{name}` — issue/revoke/setCaps serialization

**Four Lua scripts** implementing CAPABILITIES_DESIGN.md R2.3:
- `ISSUE_TOKEN_SCRIPT` — atomic SET-NX + ZADD + atomic 20-token-per-installation limit (closes guard R2 N1 — was TOCTOU). Honors `expirySecsOrZero` ARGV (`expiresAt - now() + 300` for the +300s clock-skew margin).
- `REVOKE_TOKEN_SCRIPT` — atomic 4-key cleanup. Audit stream NOT deleted (audit trail outlives the token).
- `SET_CAPABILITIES_SCRIPT` — atomic envelope mutation preserving TTL.
- `ROTATE_TOKEN_SCRIPT` — atomic bearer swap. Old hash index DELed in same EVAL → zero "two valid bearers" Redis window. Preserves `expiresAt` (rotate ≠ extend).

**Public API**: `issueAgentToken`, `revokeAgentToken`, `setAgentTokenCapabilities`, `rotateAgentToken`, `listAgentTokens`, `getAgentTokenSummary`.

**Typed errors**: `TokenNameTakenError`, `TokenLimitReachedError`, `TokenNotFoundError` + inherited `CapabilityValidationError` from B.1.a.

## What it looks like

```typescript
import { issueAgentToken, revokeAgentToken, rotateAgentToken } from "@/server/agent-token-v1";
import { PRESETS } from "@/server/agent-token-capabilities";

// Issue a worker token (B.1.d will wire this into POST /api/agent-tokens):
const issued = await issueAgentToken({
  installationId: "12345",
  name: "drone-fleet",
  agent_role: "drone",
  capabilities: PRESETS.worker,
  createdBy: "operator",
  expiresAt: null,
  keyring,
  keyVersion: "v1",
  redis,
});
// → { token: "ghs_...", name: "drone-fleet", agent_role: "drone",
//     capabilities: [...], fingerprint: "abcd1234", expiresAt: null }
// The bearer is shown ONCE — never recoverable later.

// Rotate atomically (preserves capabilities + agent_role + expiresAt):
const rotated = await rotateAgentToken({
  installationId: "12345",
  name: "drone-fleet",
  keyring, keyVersion: "v1", redis,
});
// → new bearer, old hash index DELed in the same Lua EVAL

// Revoke (idempotent):
await revokeAgentToken({ installationId: "12345", name: "drone-fleet", redis });
```

## Test plan

- [x] 35 tests in `agent-token-v1.test.ts`:
  - 10 pure-helper tests (key prefixes, TTL math, validation throw paths)
  - 9 issue tests (success, validation, name-taken, limit, default constant, ARGV expiry pass-through)
  - 3 revoke tests (success, idempotent, validation-fail-no-write)
  - 4 setCaps tests (snap-to, validation, not-found)
  - 3 rotate tests (atomic swap, not-found, preserves expiry)
  - 4 list/get tests
  - 1 cross-invariant: no operation touches legacy keys
- [x] `npx tsc --noEmit` clean
- [x] 35/35 pass locally
- Mock Redis simulates the Lua semantics by inspecting script body + KEYS/ARGV shape; returns match the design's `{tag, payload}` contract

## What this PR DOESN'T do

Deferred to subsequent slices:
- **B.1.c**: middleware integration (`resolveTokenToInstallation` extension, `requires` parameter, debounced `lastUsedAt` write)
- **B.1.d**: HTTP endpoints (`/api/agent-tokens/*` CRUD, `/api/whoami`, `/api/agent-tokens/bootstrap`) + `auditAppend` helper
- **B.1.e**: cutover — flip middleware to v1-only, write legacy-cleanup script

## Backward compatibility

Pure addition. Storage layouts are disjoint (`hive:agent-token:*` legacy vs `hive:v1:agent-token:*`); the two modules can coexist through B.1.c/d. Legacy endpoints continue to work unchanged.

## Governance

No-linked-issue bypass per the same precedent as PRs #497/#498/#499/#500/#501/#502. Risk profile: pure additive code, comprehensive test coverage, design ratified in #498, vocabulary primitives ratified in #502.