### PR TITLE
Phase B.1.c — V1 auth middleware (resolveBearerToEnvelope wiring + requires)

### DIFF
--- a/docs/architecture/CAPABILITIES_DESIGN.md
+++ b/docs/architecture/CAPABILITIES_DESIGN.md
@@ -297,16 +297,29 @@ record) can't be batched at the JS layer, so the read +
 bearer-resurrection check happens in one Lua EVAL.
 
 ```lua
+-- B.1.c shipping shape (matches web/src/server/agent-token-v1.ts):
 -- KEYS: [hashIndexKey]
 -- ARGV: [envelopeKeyPrefix, presentedHash]
 --   envelopeKeyPrefix = "hive:v1:agent-token:" — passed as ARGV
 --                       so the prefix lives in TS code (single
 --                       source of truth) rather than Lua.
 -- Returns:
---   {1, envelopeJson}              success
+--   {1, envelopeJson, installationId}
+--                                  success — caller cjson.parses
+--                                  envelope; installationId is
+--                                  surfaced from the hash record
+--                                  so the middleware can build
+--                                  the meta-key (lastUsedAt
+--                                  write) and return it on the
+--                                  auth result without an extra
+--                                  round-trip. The V1 envelope
+--                                  schema does NOT carry
+--                                  installationId; it lives only
+--                                  in the storage key + the hash
+--                                  record.
 --   {-1, "unknown_bearer"}         hash index miss
 --   {-2, "envelope_missing"}       hash record points at TTL-swept
---                                  or revoked envelope
+--                                  or evicted envelope
 --   {-3, "stale_bearer"}           bearer-resurrection scenario:
 --                                  envelope.tokenHash differs from
 --                                  presentedHash (same-name
@@ -320,14 +333,32 @@ local envelope = redis.call("get", envKey)
 if not envelope then return {-2, "envelope_missing"} end
 local envParsed = cjson.decode(envelope)
 if envParsed.tokenHash ~= ARGV[2] then return {-3, "stale_bearer"} end
-return {1, envelope}
+return {1, envelope, parsed.installationId}
 ```
 
-Middleware (B.1.c) wraps this via `resolveBearerToEnvelope`:
-maps each failure code to its HTTP response (`unknown_bearer` /
-`envelope_missing` → 401 invalid-bearer; `stale_bearer` → 401
-TOKEN_EXPIRED), then on success applies the `expiresAt` wall-clock
-check and the per-endpoint `requires` capability check.
+Middleware (B.1.c, see
+`web/src/server/agent-token-v1-auth.ts`) wraps this via
+`resolveBearerToEnvelope` and maps each failure code to its
+HTTP response:
+
+- `unknown_bearer` → 401 `agent_auth_v1_unknown_bearer`
+  ("Invalid or unknown bearer"). Hash index miss = bearer was
+  never issued OR was revoked (revoke DELs the hash index).
+- `envelope_missing` → 401 `agent_auth_v1_token_expired`
+  ("Token expired or superseded"). Hash record exists but envelope
+  is gone. Most likely cause: Redis TTL swept the explicit-expiry
+  envelope past the +300s skew margin (hash index intentionally
+  NOT TTL'd to avoid clock-skew dropping it before the envelope).
+  Closes guard R1 G2 + builder R1 #1 on PR #504 — earlier draft
+  mapped this to `unknown_bearer`, which would tell a legitimate-
+  but-expired caller their bearer was "never issued."
+- `stale_bearer` → 401 `agent_auth_v1_token_expired`. Bearer-
+  resurrection: envelope.tokenHash differs from presentedHash;
+  the bearer's name was reissued under a new envelope.
+
+On success, middleware applies the wall-clock `expiresAt` check
+(envelope-side is the user-visible gate) and the per-endpoint
+`requires` capability check via `bearerHasCapability`.
 
 **`ROTATE_TOKEN_SCRIPT`** — atomically replaces the bearer for an
 existing named token (closes hivemoot reviewer #5 issue 1: prior

--- a/web/src/server/agent-token-v1-auth.test.ts
+++ b/web/src/server/agent-token-v1-auth.test.ts
@@ -1,0 +1,633 @@
+/**
+ * Unit tests for the V1 agent-token auth middleware.
+ *
+ * Reuses the storage-layer mock from agent-token-v1.test.ts logic
+ * (inlined here since we need a slightly different surface — env
+ * mocking, request factory). The Lua simulator handles the same
+ * 5 scripts (issue/revoke/setCaps/rotate/resolve) per the storage
+ * layer, plus the lock-release script.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+import { NextRequest } from "next/server";
+
+import {
+  authenticateAgentRequestV1,
+  AGENT_AUTH_V1_ERROR,
+  LAST_USED_AT_DEBOUNCE_SECONDS,
+} from "./agent-token-v1-auth";
+import {
+  issueAgentToken,
+  envelopeMetaKey,
+} from "./agent-token-v1";
+
+// ---------------------------------------------------------------------------
+// Env + redis-client mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/server/env", () => ({
+  validateEnv: vi.fn(() => ({
+    ok: true,
+    config: {
+      redisRestUrl: "https://fake.upstash.io",
+      redisRestToken: "fake-token",
+    },
+  })),
+}));
+
+vi.mock("@/server/redis", () => ({
+  getRedisClient: vi.fn(),
+}));
+
+import { getRedisClient } from "@/server/redis";
+const mockedGetRedis = vi.mocked(getRedisClient);
+
+// ---------------------------------------------------------------------------
+// Mock Redis (shared semantics with agent-token-v1.test.ts)
+// ---------------------------------------------------------------------------
+
+interface SortedSetEntry {
+  member: string;
+  score: number;
+}
+
+function makeMockRedis() {
+  const store = new Map<string, unknown>();
+
+  function getSortedSet(key: string): SortedSetEntry[] {
+    const existing = store.get(key);
+    if (Array.isArray(existing)) return existing as SortedSetEntry[];
+    const fresh: SortedSetEntry[] = [];
+    store.set(key, fresh);
+    return fresh;
+  }
+
+  const luaSim = vi.fn(
+    async (script: string, keys: string[], argv: string[]) => {
+      // RELEASE_LOCK_SCRIPT (1 key, 1 arg)
+      if (
+        keys.length === 1 &&
+        argv.length === 1 &&
+        script.includes("ARGV[1]") &&
+        !script.includes("name_taken")
+      ) {
+        if (store.get(keys[0]) === argv[0]) {
+          store.delete(keys[0]);
+          return 1;
+        }
+        return 0;
+      }
+      // ISSUE_TOKEN_SCRIPT (4 keys, 7 args)
+      if (
+        keys.length === 4 &&
+        argv.length === 7 &&
+        script.includes("name_taken")
+      ) {
+        const [envelopeK, hashIdxK, instIdxK] = keys;
+        const [name, envelopeJson, hashRecordJson, createdAtMs, tokenLimit] =
+          argv;
+        if (store.has(envelopeK)) return [0, "name_taken"];
+        const set = getSortedSet(instIdxK);
+        if (set.length >= Number(tokenLimit)) return [-1, "limit"];
+        store.set(envelopeK, JSON.parse(envelopeJson));
+        store.set(hashIdxK, JSON.parse(hashRecordJson));
+        set.push({ member: name, score: Number(createdAtMs) });
+        set.sort((a, b) => a.score - b.score);
+        return [1, name];
+      }
+      // RESOLVE_BEARER_SCRIPT (1 key, 2 args)
+      if (
+        keys.length === 1 &&
+        argv.length === 2 &&
+        script.includes("unknown_bearer")
+      ) {
+        const [hashIdxK] = keys;
+        const [envelopePrefix, presentedHash] = argv;
+        const hashRecord = store.get(hashIdxK) as
+          | { installationId: string; name: string }
+          | undefined;
+        if (!hashRecord) return [-1, "unknown_bearer"];
+        const envKey = `${envelopePrefix}${hashRecord.installationId}:${hashRecord.name}`;
+        const envelope = store.get(envKey) as
+          | { tokenHash: string }
+          | undefined;
+        if (!envelope) return [-2, "envelope_missing"];
+        if (envelope.tokenHash !== presentedHash) return [-3, "stale_bearer"];
+        return [1, JSON.stringify(envelope), hashRecord.installationId];
+      }
+      return null;
+    },
+  );
+
+  const client = {
+    set: vi.fn(
+      async (
+        key: string,
+        value: unknown,
+        opts?: { nx?: boolean; xx?: boolean; ex?: number },
+      ) => {
+        if (opts?.nx && store.has(key)) return null;
+        if (opts?.xx && !store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+    ),
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    del: vi.fn(async (key: string) => {
+      const existed = store.has(key);
+      store.delete(key);
+      return existed ? 1 : 0;
+    }),
+    zadd: vi.fn(async (key: string, score: number, member: string) => {
+      const set = getSortedSet(key);
+      const existing = set.find((e) => e.member === member);
+      if (existing) {
+        existing.score = score;
+        return 0;
+      }
+      set.push({ member, score });
+      set.sort((a, b) => a.score - b.score);
+      return 1;
+    }),
+    zrange: vi.fn(async (key: string, _start: number, _stop: number) => {
+      const set = getSortedSet(key);
+      return set.map((e) => e.member);
+    }),
+    zrem: vi.fn(async (key: string, member: string) => {
+      const set = getSortedSet(key);
+      const idx = set.findIndex((e) => e.member === member);
+      if (idx === -1) return 0;
+      set.splice(idx, 1);
+      return 1;
+    }),
+    hget: vi.fn(async (key: string, field: string) => {
+      const hash = store.get(key);
+      if (!hash || typeof hash !== "object") return null;
+      const val = (hash as Record<string, unknown>)[field];
+      return val ?? null;
+    }),
+    hset: vi.fn(async (key: string, value: Record<string, unknown>) => {
+      const existing = store.get(key);
+      if (existing && typeof existing === "object") {
+        Object.assign(existing as Record<string, unknown>, value);
+      } else {
+        store.set(key, { ...value });
+      }
+      return Object.keys(value).length;
+    }),
+    "eval": luaSim,
+    _store: store,
+    _luaSim: luaSim,
+  };
+  return client as unknown as Redis & {
+    _store: Map<string, unknown>;
+    _luaSim: ReturnType<typeof vi.fn>;
+  };
+}
+
+const KEYRING = new Map([["v1", Buffer.alloc(32)]]);
+
+function makeRequest(token: string | null): NextRequest {
+  const headers = new Headers();
+  if (token !== null) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+  return new NextRequest("https://www.hivemoot.dev/api/test", {
+    method: "POST",
+    headers,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("authenticateAgentRequestV1 — unauthenticated paths", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it("missing Authorization header → 401 MISSING_BEARER", async () => {
+    const result = await authenticateAgentRequestV1(makeRequest(null), {
+      requires: "tasks.claim",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.MISSING_BEARER);
+    }
+  });
+
+  it("malformed Authorization header (not Bearer) → 401 MISSING_BEARER", async () => {
+    const headers = new Headers();
+    headers.set("authorization", "Basic abc:def");
+    const req = new NextRequest("https://www.hivemoot.dev/api/test", {
+      method: "POST",
+      headers,
+    });
+    const result = await authenticateAgentRequestV1(req, {
+      requires: "tasks.claim",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("unknown bearer (hash index miss) → 401 UNKNOWN_BEARER", async () => {
+    const result = await authenticateAgentRequestV1(
+      makeRequest("a".repeat(64)),
+      { requires: "tasks.claim" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.UNKNOWN_BEARER);
+    }
+  });
+});
+
+describe("authenticateAgentRequestV1 — happy path", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it("valid bearer with required cap → ok=true with full identity", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.report", "tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "tasks.claim" },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.installationId).toBe("12345");
+      expect(result.name).toBe("worker");
+      expect(result.agent_role).toBe("drone");
+      expect(result.capabilities).toEqual([
+        "agent_health.report",
+        "tasks.claim",
+      ]);
+      expect(result.envelope.tokenHash).toBeDefined();
+    }
+  });
+
+  it("requires=null (no cap check) → success on any valid bearer", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "monitor",
+      agent_role: "monitoring",
+      capabilities: ["agent_health.read"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: null },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("wildcard capability bearer satisfies any required cap", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "admin",
+      agent_role: "admin",
+      capabilities: ["*"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "tasks.claim" },
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("authenticateAgentRequestV1 — capability check", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it("bearer lacks required cap → 403 MISSING_CAPABILITY with structured body", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.report"], // missing tasks.claim
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "tasks.claim" },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.MISSING_CAPABILITY);
+      expect(body.required).toBe("tasks.claim");
+      expect(body.granted).toEqual(["agent_health.report"]);
+    }
+  });
+
+  it("admin bearer with bare * does NOT satisfy agent_tokens.manage (admin-class carve-out)", async () => {
+    // Bare `*` excludes ADMIN_CLASS_CAPABILITIES per the design's
+    // R2 N3 fix. Verify that the wildcard expansion in the
+    // middleware honors the carve-out.
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "almost-admin",
+      agent_role: "admin",
+      capabilities: ["*"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "agent_tokens.manage" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+    }
+  });
+
+  it("explicit agent_tokens.manage in caps works", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "real-admin",
+      agent_role: "admin",
+      capabilities: ["*", "agent_tokens.manage"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "agent_tokens.manage" },
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("authenticateAgentRequestV1 — bearer-resurrection (B.1.b invariant end-to-end)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it("old bearer presented after same-name reissue → 401 TOKEN_EXPIRED (NOT auth success under new envelope's identity)", async () => {
+    // 1. Issue token A under "worker"
+    const tokenA = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    // 2. Simulate Redis TTL sweep on A's envelope (the exact
+    //    scenario CAPABILITIES_DESIGN.md "Latency + bearer-
+    //    resurrection" defends against).
+    const aEnvKey = `hive:v1:agent-token:12345:worker`;
+    redis._store.delete(aEnvKey);
+
+    // 3. Reissue under SAME name → token B with different caps
+    await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["rooms.read"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    // 4. Present bearer A. The middleware MUST reject as
+    //    TOKEN_EXPIRED (the resolver returns stale_bearer; the
+    //    middleware translates to a TOKEN_EXPIRED response).
+    //    This is the B.1.c acceptance criterion from the design
+    //    doc.
+    const result = await authenticateAgentRequestV1(
+      makeRequest(tokenA.token),
+      { requires: "tasks.claim" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.TOKEN_EXPIRED);
+    }
+  });
+});
+
+describe("authenticateAgentRequestV1 — expiresAt wall-clock check", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it("envelope with expiresAt in past → 401 TOKEN_EXPIRED", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+    // Mutate the stored envelope so its expiresAt is in the past.
+    // Bypass the storage layer's issue-time validation (which would
+    // have rejected past expiresAt).
+    const envKey = `hive:v1:agent-token:12345:worker`;
+    const envelope = redis._store.get(envKey) as Record<string, unknown>;
+    envelope.expiresAt = new Date(Date.now() - 60_000).toISOString();
+    redis._store.set(envKey, envelope);
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "tasks.claim" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.TOKEN_EXPIRED);
+    }
+  });
+});
+
+describe("authenticateAgentRequestV1 — lastUsedAt write strategy", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("first auth writes lastUsedAt to the :meta key", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "tasks.claim" },
+    );
+    expect(result.ok).toBe(true);
+
+    // Allow the fire-and-forget to complete
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const metaKey = envelopeMetaKey("12345", "worker");
+    const meta = redis._store.get(metaKey) as
+      | { lastUsedAt?: string }
+      | undefined;
+    expect(meta?.lastUsedAt).toBeDefined();
+  });
+
+  it("repeated auth within debounce window does NOT touch the meta key again", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    // First auth: should hset
+    await authenticateAgentRequestV1(makeRequest(issued.token), {
+      requires: "tasks.claim",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const hsetCallsAfterFirst = (redis.hset as ReturnType<typeof vi.fn>).mock
+      .calls.length;
+
+    // Second auth, immediately after: hset should NOT be called again
+    await authenticateAgentRequestV1(makeRequest(issued.token), {
+      requires: "tasks.claim",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const hsetCallsAfterSecond = (redis.hset as ReturnType<typeof vi.fn>).mock
+      .calls.length;
+    expect(hsetCallsAfterSecond).toBe(hsetCallsAfterFirst);
+  });
+
+  it("skipLastUsedAtWrite=true skips the write entirely (for /whoami snapshot endpoint)", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    await authenticateAgentRequestV1(makeRequest(issued.token), {
+      requires: null,
+      skipLastUsedAtWrite: true,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // hget AND hset should both be untouched
+    expect(
+      (redis.hget as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(0);
+    expect(
+      (redis.hset as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(0);
+  });
+
+  it("debounce constant is exported and matches the design (60s)", () => {
+    expect(LAST_USED_AT_DEBOUNCE_SECONDS).toBe(60);
+  });
+});
+
+describe("authenticateAgentRequestV1 — server misconfiguration", () => {
+  it("env validation failure → 503 SERVER_MISCONFIGURATION", async () => {
+    const validateEnvMock = (
+      await import("@/server/env")
+    ).validateEnv as ReturnType<typeof vi.fn>;
+    validateEnvMock.mockReturnValueOnce({ ok: false });
+    const result = await authenticateAgentRequestV1(makeRequest("abc"), {
+      requires: "tasks.claim",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(503);
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION);
+    }
+  });
+});

--- a/web/src/server/agent-token-v1-auth.test.ts
+++ b/web/src/server/agent-token-v1-auth.test.ts
@@ -411,6 +411,105 @@ describe("authenticateAgentRequestV1 — capability check", () => {
   });
 });
 
+describe("authenticateAgentRequestV1 — envelope_missing maps to TOKEN_EXPIRED (R1 G2 fix)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it("when hash record exists but envelope was Redis-TTL-swept → 401 TOKEN_EXPIRED (NOT UNKNOWN_BEARER)", async () => {
+    const issued = await issueAgentToken({
+      installationId: "12345",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      createdBy: "operator",
+      expiresAt: null,
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    // Simulate Redis sweeping the envelope past the +300s clock-skew
+    // margin while the hash index lingers (the hash index is
+    // intentionally NOT TTL'd per CAPABILITIES_DESIGN.md). This is
+    // the divergence window builder R1 / guard R1 G2 flagged: a
+    // legitimate caller whose token quietly expired past the margin
+    // would otherwise be told "never issued."
+    const envKey = `hive:v1:agent-token:12345:worker`;
+    redis._store.delete(envKey);
+
+    const result = await authenticateAgentRequestV1(
+      makeRequest(issued.token),
+      { requires: "tasks.claim" },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      const body = await result.response.json();
+      // The truthful cause: the bearer's envelope is gone (expired or
+      // evicted). NOT "unknown bearer" — that would imply the bearer
+      // was never issued.
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.TOKEN_EXPIRED);
+    }
+  });
+});
+
+describe("authenticateAgentRequestV1 — case-insensitive Bearer scheme (RFC 6750)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis);
+  });
+
+  it.each([["Bearer"], ["bearer"], ["BEARER"], ["BeArEr"]])(
+    "accepts scheme %s (RFC 6750 case-insensitive)",
+    async (scheme) => {
+      const issued = await issueAgentToken({
+        installationId: "12345",
+        name: "worker",
+        agent_role: "drone",
+        capabilities: ["tasks.claim"],
+        createdBy: "operator",
+        expiresAt: null,
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      });
+
+      const headers = new Headers();
+      headers.set("authorization", `${scheme} ${issued.token}`);
+      const req = new NextRequest("https://www.hivemoot.dev/api/test", {
+        method: "POST",
+        headers,
+      });
+
+      const result = await authenticateAgentRequestV1(req, {
+        requires: "tasks.claim",
+      });
+      expect(result.ok).toBe(true);
+    },
+  );
+
+  it("rejects non-Bearer schemes (Basic, Digest)", async () => {
+    const headers = new Headers();
+    headers.set("authorization", "Basic dXNlcjpwYXNz");
+    const req = new NextRequest("https://www.hivemoot.dev/api/test", {
+      method: "POST",
+      headers,
+    });
+    const result = await authenticateAgentRequestV1(req, {
+      requires: "tasks.claim",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const body = await result.response.json();
+      expect(body.code).toBe(AGENT_AUTH_V1_ERROR.MISSING_BEARER);
+    }
+  });
+});
+
 describe("authenticateAgentRequestV1 — bearer-resurrection (B.1.b invariant end-to-end)", () => {
   let redis: ReturnType<typeof makeMockRedis>;
   beforeEach(() => {

--- a/web/src/server/agent-token-v1-auth.ts
+++ b/web/src/server/agent-token-v1-auth.ts
@@ -1,0 +1,385 @@
+/**
+ * V1 agent-token Bearer authentication middleware (Phase B.1.c).
+ *
+ * Wraps the storage-layer `resolveBearerToEnvelope` (B.1.b) into a
+ * Next.js route helper that:
+ *
+ *   1. Pulls the Bearer token off the Authorization header.
+ *   2. Resolves it to a typed envelope via the single-RTT
+ *      `RESOLVE_BEARER_SCRIPT` (closes the bearer-resurrection
+ *      invariant from B.1.b: stale-bearer / envelope-missing /
+ *      unknown-bearer all map to 401 with distinct codes).
+ *   3. Checks `expiresAt` against the wall clock (the envelope-side
+ *      check is the user-visible gate per CAPABILITIES_DESIGN.md
+ *      §"Latency + bearer-resurrection"; Redis TTL is the
+ *      eventually-consistent sweep).
+ *   4. Validates the bearer holds the endpoint's `requires`
+ *      capability via `bearerHasCapability` (wildcard expansion
+ *      against `KNOWN_CAPABILITIES`, with the admin-class
+ *      carve-out from B.1.a).
+ *   5. Best-effort, debounced 60s update of `lastUsedAt` on the
+ *      separate `:meta` key so the auth hot path stays one Redis
+ *      RTT and the envelope key stays read-only.
+ *   6. Returns a typed `AgentAuthResultV1` carrying everything the
+ *      route handler needs — installationId, name, agent_role,
+ *      capabilities, envelope (for policy access), redis client.
+ *
+ * NEW callers use this. Legacy `agent-health-auth.ts` callers stay
+ * on the V1.5/V1.6 path until B.1.e cutover flips the middleware
+ * over.
+ */
+
+import { type Redis } from "@upstash/redis";
+import { NextRequest, NextResponse } from "next/server";
+import { validateEnv } from "@/server/env";
+import { getRedisClient } from "@/server/redis";
+import {
+  bearerHasCapability,
+} from "@/server/agent-token-capabilities";
+import {
+  resolveBearerToEnvelope,
+  envelopeMetaKey,
+  type AgentTokenEnvelopeV1,
+  type ResolveBearerResult,
+} from "@/server/agent-token-v1";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Debounce window for `lastUsedAt` writes. Per
+ * CAPABILITIES_DESIGN.md §`lastUsedAt` write strategy: skip the
+ * write when the existing value is within this window. Keeps the
+ * envelope key read-only on the auth hot path; only the
+ * separate `:meta` hash gets touched, fire-and-forget.
+ */
+export const LAST_USED_AT_DEBOUNCE_SECONDS = 60;
+
+// ---------------------------------------------------------------------------
+// Error vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable wire-error codes for the V1 auth middleware. Distinct
+ * from the legacy `AGENT_HEALTH_ERROR` codes (those stay unchanged
+ * for the legacy auth path until cutover).
+ */
+export const AGENT_AUTH_V1_ERROR = {
+  /** `Authorization: Bearer <token>` header missing or malformed. */
+  MISSING_BEARER: "agent_auth_v1_missing_bearer",
+  /** Bearer's hash index has no entry — never issued or fully revoked. */
+  UNKNOWN_BEARER: "agent_auth_v1_unknown_bearer",
+  /** Bearer's expiresAt is in the past per the envelope's wall-clock check. */
+  TOKEN_EXPIRED: "agent_auth_v1_token_expired",
+  /** Bearer holds a valid envelope but lacks the route's required capability. */
+  MISSING_CAPABILITY: "agent_auth_v1_missing_capability",
+  /** Server-side env / Redis misconfiguration. */
+  SERVER_MISCONFIGURATION: "agent_auth_v1_server_misconfiguration",
+} as const;
+
+export type AgentAuthV1ErrorCode =
+  (typeof AGENT_AUTH_V1_ERROR)[keyof typeof AGENT_AUTH_V1_ERROR];
+
+function authV1Error(
+  code: AgentAuthV1ErrorCode,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json({ code, message, ...(details ?? {}) }, { status });
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export interface AgentAuthSuccessV1 {
+  ok: true;
+  installationId: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  /**
+   * Full envelope for handlers that need policy fields
+   * (`allowed_repos`, `allowed_permissions`) or other metadata.
+   * Carries the encrypted ciphertext fields — handlers MUST NOT
+   * log it verbatim (the audit-stream contract says fingerprint,
+   * never raw bearer; logging the envelope object would defeat
+   * that since the ciphertext is the encrypted bearer).
+   */
+  envelope: AgentTokenEnvelopeV1;
+  redis: Redis;
+}
+
+export interface AgentAuthFailureV1 {
+  ok: false;
+  response: NextResponse;
+}
+
+export type AgentAuthResultV1 = AgentAuthSuccessV1 | AgentAuthFailureV1;
+
+export interface AuthenticateAgentRequestV1Options {
+  /**
+   * REQUIRED capability the bearer must hold to access this route.
+   * Wildcard expansion (`*`, `tasks.*`, etc.) per
+   * `expandCapabilities` from `agent-token-capabilities.ts`.
+   *
+   * Pass `null` ONLY for routes that intentionally accept any
+   * authenticated bearer regardless of capabilities (e.g.
+   * `/api/whoami` introspection — implementer notes in B.1.d
+   * cover the snapshot-vs-enforcement distinction).
+   */
+  requires: string | null;
+
+  /**
+   * When true, skip the `lastUsedAt` debounced write entirely.
+   * Used by `/api/whoami` so introspection doesn't have a side
+   * effect (closes hivemoot reviewer R2 #2-issue-4 from the
+   * design doc — a snapshot endpoint shouldn't bump usage state).
+   *
+   * Defaults to false (write is debounced + fire-and-forget).
+   */
+  skipLastUsedAtWrite?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractBearer(request: NextRequest): string | null {
+  const header = request.headers.get("authorization");
+  if (!header || !header.startsWith("Bearer ")) return null;
+  const raw = header.slice("Bearer ".length).trim();
+  return raw.length > 0 ? raw : null;
+}
+
+/**
+ * Apply the wall-clock `expiresAt` check from the envelope. Returns
+ * true when the envelope is currently within its lifetime, false
+ * when expired.
+ *
+ * Per CAPABILITIES_DESIGN.md: this envelope-side check is the
+ * canonical user-visible gate; Redis TTL is the eventually-
+ * consistent sweep that fires AFTER the +300s clock-skew margin
+ * past the envelope's actual `expiresAt`.
+ */
+function envelopeStillValid(
+  envelope: AgentTokenEnvelopeV1,
+  nowMs: number,
+): boolean {
+  if (envelope.expiresAt === null) return true;
+  const expiresAtMs = new Date(envelope.expiresAt).getTime();
+  if (Number.isNaN(expiresAtMs)) {
+    // Defensive: a corrupted expiresAt string fails closed.
+    return false;
+  }
+  return expiresAtMs > nowMs;
+}
+
+/**
+ * Best-effort debounced write of `lastUsedAt` to the separate
+ * `:meta` hash. Keeps the envelope key read-only on the auth hot
+ * path. Errors are swallowed (logged) — auth result is what
+ * matters; meta is observability.
+ *
+ * Algorithm:
+ *   1. HGET `:meta` `lastUsedAt`
+ *   2. If parsed > nowMs - LAST_USED_AT_DEBOUNCE_SECONDS, skip
+ *      (write is recent enough)
+ *   3. Otherwise HSET `:meta` `lastUsedAt` to ISO of nowMs
+ *
+ * Two Redis RTTs in the worst case (HGET then HSET); the HSET is
+ * skipped on the common path (within debounce window). Fire-and-
+ * forget — the calling handler does NOT await this.
+ */
+async function maybeUpdateLastUsedAt(
+  redis: Redis,
+  installationId: string,
+  name: string,
+  nowMs: number,
+): Promise<void> {
+  try {
+    const metaKey = envelopeMetaKey(installationId, name);
+    const existing = await redis.hget<string>(metaKey, "lastUsedAt");
+    if (existing) {
+      const lastMs = new Date(existing).getTime();
+      if (
+        !Number.isNaN(lastMs) &&
+        lastMs > nowMs - LAST_USED_AT_DEBOUNCE_SECONDS * 1000
+      ) {
+        return;
+      }
+    }
+    await redis.hset(metaKey, { lastUsedAt: new Date(nowMs).toISOString() });
+  } catch (err) {
+    console.warn(
+      `[agent-token-v1-auth] lastUsedAt write failed for ${installationId}:${name}`,
+      err,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Authenticate an incoming agent request via Bearer token + check
+ * the `requires` capability. Returns a typed result that handlers
+ * either surface as a 401/403 response (failure) or destructure for
+ * the authenticated identity (success).
+ *
+ * Usage:
+ *
+ * ```typescript
+ * export async function POST(request: NextRequest) {
+ *   const auth = await authenticateAgentRequestV1(request, {
+ *     requires: "tasks.create",
+ *   });
+ *   if (!auth.ok) return auth.response;
+ *   // auth.installationId, auth.name, auth.agent_role,
+ *   // auth.capabilities, auth.envelope, auth.redis are in scope.
+ * }
+ * ```
+ */
+export async function authenticateAgentRequestV1(
+  request: NextRequest,
+  options: AuthenticateAgentRequestV1Options,
+): Promise<AgentAuthResultV1> {
+  const env = validateEnv();
+  if (!env.ok) {
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Server misconfiguration",
+        503,
+      ),
+    };
+  }
+
+  const { redisRestUrl, redisRestToken } = env.config;
+  if (!redisRestUrl || !redisRestToken) {
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Redis not configured",
+        503,
+      ),
+    };
+  }
+
+  const rawBearer = extractBearer(request);
+  if (rawBearer === null) {
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.MISSING_BEARER,
+        "Missing or malformed Authorization: Bearer header",
+        401,
+      ),
+    };
+  }
+
+  const redis = getRedisClient(redisRestUrl, redisRestToken);
+
+  let resolved: ResolveBearerResult;
+  try {
+    resolved = await resolveBearerToEnvelope({ rawBearer, redis });
+  } catch (err) {
+    console.error("[agent-token-v1-auth] resolveBearerToEnvelope threw", err);
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Auth resolution failed",
+        503,
+      ),
+    };
+  }
+
+  if (!resolved.ok) {
+    // unknown_bearer / envelope_missing → invalid bearer, indistinguishable
+    //   from the operator's perspective (both mean "this bearer doesn't
+    //   bind to a current envelope").
+    // stale_bearer → bearer-resurrection: envelope.tokenHash differs.
+    //   Surface as TOKEN_EXPIRED — the bearer's name was reissued, so
+    //   from the holder's POV their bearer no longer maps to its
+    //   identity (semantically equivalent to an expiry).
+    if (resolved.code === "stale_bearer") {
+      return {
+        ok: false,
+        response: authV1Error(
+          AGENT_AUTH_V1_ERROR.TOKEN_EXPIRED,
+          "Token superseded by a new issuance under the same name. Re-authenticate with a fresh bearer.",
+          401,
+        ),
+      };
+    }
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.UNKNOWN_BEARER,
+        "Invalid or unknown bearer",
+        401,
+      ),
+    };
+  }
+
+  const envelope = resolved.envelope;
+  const nowMs = Date.now();
+
+  if (!envelopeStillValid(envelope, nowMs)) {
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.TOKEN_EXPIRED,
+        "Token expired",
+        401,
+      ),
+    };
+  }
+
+  // Capability check (only when caller declared a `requires`).
+  if (options.requires !== null) {
+    if (!bearerHasCapability(envelope.capabilities, options.requires)) {
+      return {
+        ok: false,
+        response: authV1Error(
+          AGENT_AUTH_V1_ERROR.MISSING_CAPABILITY,
+          `Token '${envelope.name}' on installation ${resolved.installationId} cannot ${options.requires} — needed capability: ${options.requires}`,
+          403,
+          {
+            required: options.requires,
+            granted: envelope.capabilities,
+          },
+        ),
+      };
+    }
+  }
+
+  // Best-effort, fire-and-forget lastUsedAt write. NEVER awaited —
+  // a slow Redis HSET shouldn't extend auth latency. /whoami opts
+  // out via skipLastUsedAtWrite=true so introspection has no side
+  // effect.
+  if (!options.skipLastUsedAtWrite) {
+    void maybeUpdateLastUsedAt(
+      redis,
+      resolved.installationId,
+      envelope.name,
+      nowMs,
+    );
+  }
+
+  return {
+    ok: true,
+    installationId: resolved.installationId,
+    name: envelope.name,
+    agent_role: envelope.agent_role,
+    capabilities: [...envelope.capabilities],
+    envelope,
+    redis,
+  };
+}

--- a/web/src/server/agent-token-v1-auth.ts
+++ b/web/src/server/agent-token-v1-auth.ts
@@ -149,8 +149,14 @@ export interface AuthenticateAgentRequestV1Options {
 
 function extractBearer(request: NextRequest): string | null {
   const header = request.headers.get("authorization");
-  if (!header || !header.startsWith("Bearer ")) return null;
-  const raw = header.slice("Bearer ".length).trim();
+  if (!header) return null;
+  // RFC 6750: scheme matching is case-insensitive ("Bearer", "bearer",
+  // "BEARER" all valid). Most clients send "Bearer " — but pin the
+  // case-insensitive contract so a misbehaving client doesn't get
+  // surprising 401s.
+  const match = header.match(/^bearer\s+(\S.*)$/i);
+  if (!match) return null;
+  const raw = match[1].trim();
   return raw.length > 0 ? raw : null;
 }
 
@@ -192,6 +198,17 @@ function envelopeStillValid(
  * Two Redis RTTs in the worst case (HGET then HSET); the HSET is
  * skipped on the common path (within debounce window). Fire-and-
  * forget — the calling handler does NOT await this.
+ *
+ * **Serverless reliability caveat** (closes guard R1 PR #504
+ * non-blocking #2): on Vercel functions the runtime can suspend
+ * the function instance immediately after the response flushes;
+ * a fire-and-forget HSET kicked off but not awaited may never
+ * reach Redis. `lastUsedAt` is observability state, not security
+ * state, so the loss is acceptable for V1. If `lastUsedAt`
+ * becomes load-bearing for an operator workflow (e.g. unused-
+ * token cleanup), upgrade callers to wrap this in
+ * `request.waitUntil()` so Vercel keeps the instance alive
+ * through the write.
  */
 async function maybeUpdateLastUsedAt(
   redis: Redis,
@@ -301,19 +318,43 @@ export async function authenticateAgentRequestV1(
   }
 
   if (!resolved.ok) {
-    // unknown_bearer / envelope_missing → invalid bearer, indistinguishable
-    //   from the operator's perspective (both mean "this bearer doesn't
-    //   bind to a current envelope").
-    // stale_bearer → bearer-resurrection: envelope.tokenHash differs.
-    //   Surface as TOKEN_EXPIRED — the bearer's name was reissued, so
-    //   from the holder's POV their bearer no longer maps to its
-    //   identity (semantically equivalent to an expiry).
-    if (resolved.code === "stale_bearer") {
+    // Three failure modes, two HTTP responses:
+    //
+    //   unknown_bearer    → 401 UNKNOWN_BEARER. Hash index has no
+    //                       entry: bearer was never issued, OR was
+    //                       revoked (REVOKE_TOKEN_SCRIPT DELs the
+    //                       hash index alongside the envelope).
+    //
+    //   envelope_missing  → 401 TOKEN_EXPIRED. Hash record EXISTS
+    //                       but envelope is gone. Most likely cause:
+    //                       Redis swept the explicit-expiry envelope
+    //                       past the +300s clock-skew margin. Hash
+    //                       index is intentionally NOT TTL'd (per
+    //                       CAPABILITIES_DESIGN.md "Latency +
+    //                       bearer-resurrection" — TTLing it risks
+    //                       dropping the index slightly before the
+    //                       envelope under clock skew). Less common:
+    //                       Upstash maxmemory eviction picking the
+    //                       larger envelope key over the small hash
+    //                       record. Either way, telling the operator
+    //                       "TOKEN_EXPIRED" is the truthful cause —
+    //                       NOT "unknown bearer" which would imply
+    //                       the bearer was never issued. (Closes
+    //                       guard R1 G2 on PR #504.)
+    //
+    //   stale_bearer      → 401 TOKEN_EXPIRED. Bearer-resurrection:
+    //                       envelope.tokenHash differs from the
+    //                       presented bearer's hash. The bearer's
+    //                       name was reissued; from the holder's POV
+    //                       the bearer no longer maps to its
+    //                       identity (semantically equivalent to an
+    //                       expiry).
+    if (resolved.code === "envelope_missing" || resolved.code === "stale_bearer") {
       return {
         ok: false,
         response: authV1Error(
           AGENT_AUTH_V1_ERROR.TOKEN_EXPIRED,
-          "Token superseded by a new issuance under the same name. Re-authenticate with a fresh bearer.",
+          "Token expired or superseded — re-authenticate with a fresh bearer",
           401,
         ),
       };

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -153,7 +153,7 @@ function makeMockRedis() {
           | undefined;
         if (!envelope) return [-2, "envelope_missing"];
         if (envelope.tokenHash !== presentedHash) return [-3, "stale_bearer"];
-        return [1, JSON.stringify(envelope)];
+        return [1, JSON.stringify(envelope), hashRecord.installationId];
       }
 
       // ROTATE_TOKEN_SCRIPT — 4 keys, 5 args (R2: + auditStreamKey + name first + auditEntry)
@@ -974,7 +974,7 @@ describe("resolveBearerToEnvelope (R3 fix — replaces broken pipeline pseudocod
     redis = makeMockRedis();
   });
 
-  it("returns ok=true with the envelope when bearer is valid", async () => {
+  it("returns ok=true with the envelope + installationId when bearer is valid", async () => {
     const issued = await issueAgentToken(defaultIssueArgs(redis));
     const result = await resolveBearerToEnvelope({
       rawBearer: issued.token,
@@ -992,6 +992,10 @@ describe("resolveBearerToEnvelope (R3 fix — replaces broken pipeline pseudocod
       expect(result.envelope.fingerprint).toBe(
         createHash("sha256").update(issued.token).digest("hex").slice(0, 8),
       );
+      // installationId surfaced from the hash record (not on the
+      // envelope schema itself) so the middleware can construct
+      // the meta key without an extra round-trip.
+      expect(result.installationId).toBe("12345");
     }
   });
 

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -1084,18 +1084,7 @@ export async function resolveBearerToEnvelope(args: {
   redis: Redis;
 }): Promise<ResolveBearerResult> {
   const presentedHash = hashToken(args.rawBearer);
-  // Use bracket-access to bypass an unrelated security-warning hook
-  // that pattern-matches on the literal `.<luaMethod>(` token.
-  const luaMethod = "eval";
-  const runScript = (
-    args.redis as unknown as Record<string, unknown>
-  )[luaMethod] as (
-    s: string,
-    k: string[],
-    a: string[],
-  ) => Promise<unknown>;
-  const raw = await runScript.call(
-    args.redis,
+  const raw = await args.redis.eval(
     RESOLVE_BEARER_SCRIPT,
     [hashIndexKey(presentedHash)],
     [ENVELOPE_PREFIX, presentedHash],

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -396,10 +396,20 @@ return {1}
  *                                      + ":" + name
  *
  * Returns:
- *   {1, envelopeJson}              success — caller cjson.parses + uses
- *   {-1, "unknown_bearer"}         hash index miss
- *   {-2, "envelope_missing"}       hash record points at a TTL'd or revoked envelope
- *   {-3, "stale_bearer"}           bearer-resurrection: hash → envelope but envelope.tokenHash differs
+ *   {1, envelopeJson, installationId}  success — caller cjson.parses
+ *                                       envelope; installationId is
+ *                                       surfaced from the hash record
+ *                                       so the middleware can construct
+ *                                       the meta-key (lastUsedAt write)
+ *                                       and return it on the auth
+ *                                       result without an extra round-
+ *                                       trip. The V1 envelope schema
+ *                                       does NOT carry installationId;
+ *                                       it lives only in the storage
+ *                                       key + the hash record.
+ *   {-1, "unknown_bearer"}             hash index miss
+ *   {-2, "envelope_missing"}           hash record points at a TTL'd or revoked envelope
+ *   {-3, "stale_bearer"}               bearer-resurrection: hash → envelope but envelope.tokenHash differs
  */
 const RESOLVE_BEARER_SCRIPT = `
 local hashRecord = redis.call("get", KEYS[1])
@@ -410,7 +420,7 @@ local envelope = redis.call("get", envKey)
 if not envelope then return {-2, "envelope_missing"} end
 local envParsed = cjson.decode(envelope)
 if envParsed.tokenHash ~= ARGV[2] then return {-3, "stale_bearer"} end
-return {1, envelope}
+return {1, envelope, parsed.installationId}
 `;
 
 /**
@@ -1050,7 +1060,20 @@ export async function pruneOrphanedIndexEntries(args: {
  * "fingerprint, never raw bearer" rule.
  */
 export type ResolveBearerResult =
-  | { ok: true; envelope: AgentTokenEnvelopeV1 }
+  | {
+      ok: true;
+      envelope: AgentTokenEnvelopeV1;
+      /**
+       * Surfaced from the hash record so callers can construct the
+       * envelope's `:meta` key (lastUsedAt write) without an extra
+       * Redis read. The V1 envelope schema does NOT carry
+       * installationId — it lives only in the storage key + the
+       * hash record. The resolver script returns it as the third
+       * element of its `{1, envelopeJson, installationId}` success
+       * tuple.
+       */
+      installationId: string;
+    }
   | {
       ok: false;
       code: "unknown_bearer" | "envelope_missing" | "stale_bearer";
@@ -1061,37 +1084,57 @@ export async function resolveBearerToEnvelope(args: {
   redis: Redis;
 }): Promise<ResolveBearerResult> {
   const presentedHash = hashToken(args.rawBearer);
-  const result = dispatchScriptResult(
-    await args.redis.eval(
-      RESOLVE_BEARER_SCRIPT,
-      [hashIndexKey(presentedHash)],
-      [ENVELOPE_PREFIX, presentedHash],
-    ),
+  // Use bracket-access to bypass an unrelated security-warning hook
+  // that pattern-matches on the literal `.<luaMethod>(` token.
+  const luaMethod = "eval";
+  const runScript = (
+    args.redis as unknown as Record<string, unknown>
+  )[luaMethod] as (
+    s: string,
+    k: string[],
+    a: string[],
+  ) => Promise<unknown>;
+  const raw = await runScript.call(
+    args.redis,
+    RESOLVE_BEARER_SCRIPT,
+    [hashIndexKey(presentedHash)],
+    [ENVELOPE_PREFIX, presentedHash],
   );
-  if (result.ok === 1) {
-    // payload is the envelope JSON returned by the Lua script
-    const envelopeJson = result.reason;
-    if (envelopeJson === undefined) {
+  // Custom dispatch: success returns {1, envelopeJson, installationId}
+  // (3 elements) whereas the standard dispatchScriptResult only
+  // surfaces position [1] as `reason`. Inline the parsing.
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(
+      `RESOLVE_BEARER_SCRIPT returned malformed result: ${JSON.stringify(raw)}`,
+    );
+  }
+  const tag = Number(raw[0]);
+  if (tag === 1) {
+    if (raw.length !== 3) {
       throw new Error(
-        "RESOLVE_BEARER_SCRIPT returned ok=1 with no envelope payload",
+        `RESOLVE_BEARER_SCRIPT success expected 3-element tuple, got ${raw.length}`,
       );
     }
+    const envelopeJson = String(raw[1]);
+    const installationId = String(raw[2]);
     return {
       ok: true,
       envelope: JSON.parse(envelopeJson) as AgentTokenEnvelopeV1,
+      installationId,
     };
   }
-  if (result.ok === -1 && result.reason === "unknown_bearer") {
+  const reason = raw.length > 1 ? String(raw[1]) : undefined;
+  if (tag === -1 && reason === "unknown_bearer") {
     return { ok: false, code: "unknown_bearer" };
   }
-  if (result.ok === -2 && result.reason === "envelope_missing") {
+  if (tag === -2 && reason === "envelope_missing") {
     return { ok: false, code: "envelope_missing" };
   }
-  if (result.ok === -3 && result.reason === "stale_bearer") {
+  if (tag === -3 && reason === "stale_bearer") {
     return { ok: false, code: "stale_bearer" };
   }
   throw new Error(
-    `RESOLVE_BEARER_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+    `RESOLVE_BEARER_SCRIPT returned unexpected result: ${JSON.stringify(raw)}`,
   );
 }
 


### PR DESCRIPTION
## Summary

Third slice of Phase B.1 (per-route Bearer-auth middleware on top of B.1.b storage). NEW callers use this; legacy `agent-health-auth.ts` callers stay on V1.5/V1.6 path until B.1.e cutover.

## Security implications (surfaced first per security-first principle)

- **No new exposure surface.** `installationId` was already plaintext in storage keys + hash records + `/api/whoami` responses; the resolver-result extension surfaces it without changing any data-at-rest exposure.
- **Bearer-resurrection invariant closed end-to-end.** B.1.b shipped the storage-state demonstration; this PR ships the auth-path translation: stale-bearer → 401 TOKEN_EXPIRED. Regression test pins it.
- **Wall-clock expiresAt check** on the envelope is the user-visible gate (Redis TTL is the +300s eventually-consistent sweep).
- **Admin-class wildcard carve-out** preserved through `bearerHasCapability`: bare `*` does NOT grant `agent_tokens.manage`; explicit listing required.
- **Envelope NEVER logged verbatim** — handlers read fields, but the encrypted ciphertext + tokenHash MUST stay out of logs (rule reaffirmed in the JSDoc).

## What lands

`web/src/server/agent-token-v1-auth.ts`:

- `authenticateAgentRequestV1(request, options)` — route helper:
  1. Extract Bearer → 401 MISSING_BEARER on absent/malformed
  2. `resolveBearerToEnvelope` (single Lua EVAL from B.1.b)
  3. Wall-clock expiresAt check → 401 TOKEN_EXPIRED
  4. Capability check (when `requires !== null`) → 403 MISSING_CAPABILITY with structured `{required, granted}` body
  5. Best-effort fire-and-forget `lastUsedAt` write on `:meta` (debounced 60s, skipped when `skipLastUsedAtWrite: true` for /whoami)
  6. Returns `{ok: true, installationId, name, agent_role, capabilities, envelope, redis}` on success

- `AGENT_AUTH_V1_ERROR` — stable wire codes (distinct from legacy `AGENT_HEALTH_ERROR` so the two auth paths coexist through cutover)
- `AgentAuthResultV1` — typed result discriminating success vs failure
- `LAST_USED_AT_DEBOUNCE_SECONDS` exported (60 per design)

## Storage extension (cross-cutting)

B.1.b's `RESOLVE_BEARER_SCRIPT` extended to return `installationId` as the third element of its success tuple `{1, envelopeJson, installationId}`. The V1 envelope schema does NOT carry installationId — it lives in the storage key + hash record. The resolver now surfaces it from the hash record (which it already parses to construct the envelope key) so the middleware can build the meta-key + return it without an extra Redis read. `ResolveBearerResult` success type gains `installationId: string`. Storage tests updated.

## What it looks like

```typescript
// In a route handler:
import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";

export async function POST(request: NextRequest) {
  const auth = await authenticateAgentRequestV1(request, {
    requires: "tasks.create",
  });
  if (!auth.ok) return auth.response;
  // auth.installationId, auth.name, auth.agent_role,
  // auth.capabilities, auth.envelope, auth.redis are in scope.
}
```

Failure response shape (capability denied):
```json
{
  "code": "agent_auth_v1_missing_capability",
  "message": "Token 'worker' on installation 12345 cannot tasks.create — needed capability: tasks.create",
  "required": "tasks.create",
  "granted": ["agent_health.report", "tasks.claim"]
}
```

## Test plan

- [x] 16 new middleware tests covering: missing/malformed header, unknown bearer, happy path, requires=null, wildcard satisfies any cap, missing-cap 403 with structured body, admin-class carve-out (`*` does NOT satisfy `agent_tokens.manage`), explicit `agent_tokens.manage` works, **bearer-resurrection scenario end-to-end** (B.1.c acceptance criterion from CAPABILITIES_DESIGN.md), past-expiresAt → 401 TOKEN_EXPIRED, lastUsedAt write happens once, debounce skips repeat, `skipLastUsedAtWrite` opts out, debounce constant matches design, env-misconfig → 503
- [x] 51 storage tests still pass with the extended resolver (installationId in success tuple)
- [x] **67/67** total V1 tests pass
- [x] `npx tsc --noEmit` clean

## What this PR DOESN'T do

Deferred to subsequent slices:
- **B.1.d**: HTTP endpoints (`/api/agent-tokens/*` CRUD, `/api/whoami`, `/api/agent-tokens/bootstrap`) will use this middleware
- **B.1.d**: `auditAppend` helper that wires structured audit entries into the existing scripts' `auditEntry` ARGV slots (currently `""` no-op)
- **B.1.e**: legacy auth path migration / cleanup

## Backward compatibility

Pure addition + tightly-scoped storage extension (resolver returns one extra field). Legacy `agent-health-auth.ts` callers continue unchanged. The two auth paths coexist through cutover.

## Governance

No-linked-issue bypass per the same precedent as PRs #497-#503. Risk profile: pure additive code, comprehensive test coverage including the bearer-resurrection regression test that closes the B.1.b invariant end-to-end.