### PR TITLE
Phase B.1.d-i — auditAppend helper + REVOKE no-op spam guard + /api/whoami

### DIFF
--- a/web/src/app/api/whoami/route.test.ts
+++ b/web/src/app/api/whoami/route.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for GET /api/whoami — agent-token introspection.
+ *
+ * Covers:
+ *   - Unauthenticated request → 401 (delegated to middleware)
+ *   - Authenticated request → 200 with the snapshot shape
+ *   - lastUsedAt is read from :meta and surfaced in the response
+ *   - skipLastUsedAtWrite is passed through (no side effect on
+ *     the meta hash from the introspection itself)
+ *   - auth.success audit event emitted to the :auth stream
+ *   - POST /api/whoami → 405
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+  AGENT_AUTH_V1_ERROR: {
+    MISSING_BEARER: "agent_auth_v1_missing_bearer",
+    UNKNOWN_BEARER: "agent_auth_v1_unknown_bearer",
+    TOKEN_EXPIRED: "agent_auth_v1_token_expired",
+    MISSING_CAPABILITY: "agent_auth_v1_missing_capability",
+    SERVER_MISCONFIGURATION: "agent_auth_v1_server_misconfiguration",
+  },
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    envelopeMetaKey: real.envelopeMetaKey,
+  };
+});
+
+vi.mock("@/server/agent-token-v1-audit", () => ({
+  auditAppend: vi.fn(async () => undefined),
+}));
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import { GET, POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(token: string | null): NextRequest {
+  const headers = new Headers();
+  if (token !== null) headers.set("authorization", `Bearer ${token}`);
+  return new NextRequest("https://www.hivemoot.dev/api/whoami", {
+    method: "GET",
+    headers,
+  });
+}
+
+function makeAuthOk(overrides: Partial<{
+  installationId: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+}> = {}) {
+  const fakeRedis = {
+    hget: vi.fn(async (_key: string, _field: string) => "2026-04-27T12:00:00.000Z"),
+  };
+  return {
+    ok: true as const,
+    installationId: overrides.installationId ?? "12345",
+    name: overrides.name ?? "worker",
+    agent_role: overrides.agent_role ?? "drone",
+    capabilities: overrides.capabilities ?? [
+      "agent_health.report",
+      "tasks.claim",
+    ],
+    envelope: {
+      ciphertext: "base64-ciphertext",
+      iv: "base64-iv",
+      tag: "base64-tag",
+      keyVersion: "v1",
+      tokenHash: "0123456789abcdef",
+      fingerprint: overrides.fingerprint ?? "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "operator",
+      expiresAt: overrides.expiresAt ?? null,
+      name: overrides.name ?? "worker",
+      agent_role: overrides.agent_role ?? "drone",
+      capabilities: overrides.capabilities ?? [
+        "agent_health.report",
+        "tasks.claim",
+      ],
+    },
+    redis: fakeRedis as never,
+  };
+}
+
+function makeAuthFailure(status = 401) {
+  return {
+    ok: false as const,
+    response: NextResponse.json(
+      { code: "agent_auth_v1_missing_bearer", message: "denied" },
+      { status },
+    ),
+  };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedAuditAppend.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/whoami — unauthenticated", () => {
+  it("missing bearer → middleware's 401 surfaces directly", async () => {
+    mockedAuth.mockResolvedValue(makeAuthFailure(401));
+    const res = await GET(makeRequest(null));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/whoami — happy path", () => {
+  it("returns the full snapshot shape", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await GET(makeRequest("any-bearer"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      name: "worker",
+      agent_role: "drone",
+      installationId: "12345",
+      capabilities: ["agent_health.report", "tasks.claim"],
+      fingerprint: "01234567",
+      expiresAt: null,
+      lastUsedAt: "2026-04-27T12:00:00.000Z",
+    });
+  });
+
+  it("middleware called with requires=null + skipLastUsedAtWrite=true (snapshot has no side effects)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    await GET(makeRequest("any-bearer"));
+    expect(mockedAuth).toHaveBeenCalledTimes(1);
+    const opts = mockedAuth.mock.calls[0][1];
+    expect(opts.requires).toBeNull();
+    expect(opts.skipLastUsedAtWrite).toBe(true);
+  });
+
+  it("lastUsedAt: null when :meta has no entry yet (newly issued, never auth'd elsewhere)", async () => {
+    const auth = makeAuthOk();
+    (auth.redis as unknown as { hget: ReturnType<typeof vi.fn> }).hget =
+      vi.fn(async () => null);
+    mockedAuth.mockResolvedValue(auth);
+    const res = await GET(makeRequest("any-bearer"));
+    const body = await res.json();
+    expect(body.lastUsedAt).toBeNull();
+  });
+
+  it("emits auth.success to :auth stream via auditAppend", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    await GET(makeRequest("any-bearer"));
+    // auditAppend is fire-and-forget; allow microtask to flush
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockedAuditAppend).toHaveBeenCalledTimes(1);
+    const call = mockedAuditAppend.mock.calls[0][0];
+    expect(call.installationId).toBe("12345");
+    expect(call.entry.action).toBe("auth.success");
+    if (call.entry.action === "auth.success" || call.entry.action === "auth.failure") {
+      expect(call.entry.endpoint).toBe("GET /api/whoami");
+      expect(call.entry.required_capability).toBeNull();
+      expect(call.entry.outcome).toBe("ok");
+      // Security invariant: never log raw bearer
+      expect(call.entry.fingerprint).toBe("01234567");
+      expect("token" in call.entry).toBe(false);
+    }
+  });
+
+  it("survives :meta read failure — lastUsedAt becomes null but response still 200", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const auth = makeAuthOk();
+    (auth.redis as unknown as { hget: ReturnType<typeof vi.fn> }).hget =
+      vi.fn(async () => {
+        throw new Error("Redis blip");
+      });
+    mockedAuth.mockResolvedValue(auth);
+    const res = await GET(makeRequest("any-bearer"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.lastUsedAt).toBeNull();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "[whoami] meta read failed",
+      expect.any(Error),
+    );
+    consoleWarn.mockRestore();
+  });
+});
+
+describe("POST /api/whoami → 405", () => {
+  it("returns Method Not Allowed with Allow: GET", async () => {
+    const res = await POST();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET");
+  });
+});

--- a/web/src/app/api/whoami/route.test.ts
+++ b/web/src/app/api/whoami/route.test.ts
@@ -71,6 +71,14 @@ function makeAuthOk(overrides: Partial<{
   capabilities: string[];
   fingerprint: string;
   expiresAt: string | null;
+  // Mirrors AgentTokenPolicy from agent-token.ts: allowed_repos is
+  // required when policy is present (empty [] = reject all; field
+  // absence on envelope = legacy permissive). allowed_permissions
+  // is optional (V1.6+).
+  policy: {
+    allowed_repos: string[];
+    allowed_permissions?: Record<string, "read" | "write" | "admin">;
+  };
 }> = {}) {
   const fakeRedis = {
     hget: vi.fn(async (_key: string, _field: string) => "2026-04-27T12:00:00.000Z"),
@@ -100,6 +108,7 @@ function makeAuthOk(overrides: Partial<{
         "agent_health.report",
         "tasks.claim",
       ],
+      ...(overrides.policy ? { policy: overrides.policy } : {}),
     },
     redis: fakeRedis as never,
   };
@@ -146,6 +155,10 @@ describe("GET /api/whoami — happy path", () => {
       fingerprint: "01234567",
       expiresAt: null,
       lastUsedAt: "2026-04-27T12:00:00.000Z",
+      // Default makeAuthOk() does not set a policy — legacy / V1.5-pre
+      // tokens have no policy field on the envelope, so /whoami surfaces
+      // null rather than an empty object.
+      policy: null,
     });
   });
 
@@ -207,10 +220,155 @@ describe("GET /api/whoami — happy path", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Policy projection — V1.5 (allowedRepos) + V1.6 (allowedPermissions).
+//
+// Per CAPABILITIES_DESIGN.md §`/api/whoami` introspection endpoint, the
+// response includes a sanitized `policy` so operators can verify token
+// narrowing without having to query Redis directly.
+//
+// **WIRE SHAPE IS camelCase, STORAGE IS snake_case** — the handler
+// translates `envelope.policy.allowed_repos` → `policy.allowedRepos`
+// and `envelope.policy.allowed_permissions` → `policy.allowedPermissions`.
+// Tests below assert the camelCase wire shape; the helper feeds
+// snake_case (mirroring envelope storage) to exercise the translation.
+//
+// This describe block pins:
+//   1. legacy (no policy field on envelope) → response has policy: null
+//   2. V1.5 token (allowed_repos only) → response has allowedRepos,
+//      no allowedPermissions key
+//   3. V1.6 token (allowed_repos + allowed_permissions) → both round-trip
+//      under their camelCase names
+//   4. empty allowed_repos (intentional reject-all) → allowedRepos: []
+//   5. SECURITY: response NEVER contains envelope ciphertext / iv /
+//      tag / tokenHash / createdBy — only the sanitized projection
+//   6. SECURITY: response NEVER contains the snake_case keys themselves
+//      (would indicate a passthrough leak rather than projection)
+//
+// Note: there's no "V1.6-only" case in the type system — `policy.allowed_repos`
+// is required when `policy` is present (empty array is the canonical
+// reject-all). V1.6 is purely additive: it ADDS `allowed_permissions`
+// to an already-mandatory `allowed_repos`.
+// ---------------------------------------------------------------------------
+
+describe("GET /api/whoami — policy projection", () => {
+  it("envelope without policy field → response has policy: null", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await GET(makeRequest("any-bearer"));
+    const body = await res.json();
+    expect(body.policy).toBeNull();
+  });
+
+  it("V1.5 token (snake_case allowed_repos) → camelCase allowedRepos on wire, omits allowedPermissions", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        policy: { allowed_repos: ["hivemoot/foxstoria"] },
+      }),
+    );
+    const res = await GET(makeRequest("any-bearer"));
+    const body = await res.json();
+    expect(body.policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria"],
+    });
+    // Projection only copies present fields, so JSON.stringify
+    // does NOT emit allowedPermissions: undefined as a wire field.
+    expect("allowedPermissions" in body.policy).toBe(false);
+  });
+
+  it("V1.6 token (snake_case allowed_repos + allowed_permissions) → camelCase wire shape", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        policy: {
+          allowed_repos: ["hivemoot/foxstoria", "hivemoot/colony"],
+          allowed_permissions: { contents: "read", issues: "write" },
+        },
+      }),
+    );
+    const res = await GET(makeRequest("any-bearer"));
+    const body = await res.json();
+    expect(body.policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria", "hivemoot/colony"],
+      allowedPermissions: { contents: "read", issues: "write" },
+    });
+  });
+
+  it("intentional reject-all (allowed_repos: []) → allowedRepos: [] on wire", async () => {
+    // Per the AgentTokenPolicy doc: empty array is intentional — the
+    // token is provisioned but currently denied for all mints. /whoami
+    // must surface this faithfully so operators see the lockout state
+    // rather than confusing it with "policy not set".
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        policy: { allowed_repos: [] },
+      }),
+    );
+    const res = await GET(makeRequest("any-bearer"));
+    const body = await res.json();
+    expect(body.policy).toEqual({ allowedRepos: [] });
+  });
+
+  it("SECURITY: response never contains envelope crypto material, even when policy is present", async () => {
+    // Threat model: a sloppy projection (e.g. `...auth.envelope`) would
+    // leak ciphertext / iv / tag / tokenHash / createdBy through /whoami.
+    // Pin that the sanitized projection is the only path — by checking
+    // the literal serialized response for those substrings.
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        policy: {
+          allowed_repos: ["hivemoot/foxstoria"],
+          allowed_permissions: { contents: "read" },
+        },
+      }),
+    );
+    const res = await GET(makeRequest("any-bearer"));
+    const raw = await res.text();
+    expect(raw).not.toContain("ciphertext");
+    expect(raw).not.toContain("base64-ciphertext");
+    expect(raw).not.toContain("base64-iv");
+    expect(raw).not.toContain("base64-tag");
+    expect(raw).not.toContain("0123456789abcdef"); // tokenHash from envelope
+    expect(raw).not.toContain("createdBy");
+    expect(raw).not.toContain("operator");
+    // Sanity — the legitimate (camelCase) fields ARE there
+    expect(raw).toContain("allowedRepos");
+    expect(raw).toContain("allowedPermissions");
+    expect(raw).toContain("01234567"); // fingerprint is a legit field
+  });
+
+  it("SECURITY: response never contains snake_case storage keys (passthrough-leak detector)", async () => {
+    // Belt-and-suspenders for the storage→wire rename. If anyone
+    // accidentally spreads the envelope policy directly (`...policy`)
+    // instead of going through the projection, the snake_case keys
+    // would surface — this test fails loudly in that case.
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        policy: {
+          allowed_repos: ["hivemoot/foxstoria"],
+          allowed_permissions: { contents: "read" },
+        },
+      }),
+    );
+    const res = await GET(makeRequest("any-bearer"));
+    const raw = await res.text();
+    expect(raw).not.toContain("allowed_repos");
+    expect(raw).not.toContain("allowed_permissions");
+  });
+});
+
 describe("POST /api/whoami → 405", () => {
   it("returns Method Not Allowed with Allow: GET", async () => {
     const res = await POST();
     expect(res.status).toBe(405);
     expect(res.headers.get("allow")).toBe("GET");
+  });
+
+  it("uses code: method_not_allowed (not an auth error code) — drone R1 D1", async () => {
+    // Wrong-verb is not wrong-credentials, so reusing
+    // `agent_auth_v1_missing_bearer` would mislead clients into auth
+    // retries. Pin the semantic code.
+    const res = await POST();
+    const body = await res.json();
+    expect(body.code).toBe("method_not_allowed");
+    expect(body.code).not.toMatch(/agent_auth_v1_/);
   });
 });

--- a/web/src/app/api/whoami/route.ts
+++ b/web/src/app/api/whoami/route.ts
@@ -1,0 +1,112 @@
+/**
+ * GET /api/whoami — agent-token introspection.
+ *
+ * Returns the bearer's identity + capability snapshot for
+ * debugging / agent-startup logging. Per CAPABILITIES_DESIGN.md
+ * §`/api/whoami` introspection endpoint, this is a SNAPSHOT for
+ * debugging — agents MUST NOT cache this and skip the per-call
+ * middleware capability check on subsequent requests, because
+ * capabilities are mutable server-side via `set-capabilities`.
+ *
+ * Auth model: any valid bearer is accepted (`requires: null`).
+ * No capability is required to introspect oneself; that's the
+ * point. The endpoint does NOT update `lastUsedAt` (passes
+ * `skipLastUsedAtWrite: true`) — introspection should not have a
+ * side effect that bumps usage state and skews unused-token
+ * cleanup signals.
+ *
+ * Read side-effects:
+ *   - One additional Redis read for the `:meta` hash to surface
+ *     `lastUsedAt` in the response. Acceptable for an
+ *     introspection endpoint that's not on a hot path.
+ *
+ * Write side-effects:
+ *   - Audit log: emits `auth.success` to the per-installation
+ *     `:auth` stream (best-effort, fire-and-forget).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  authenticateAgentRequestV1,
+  AGENT_AUTH_V1_ERROR,
+} from "@/server/agent-token-v1-auth";
+import { envelopeMetaKey } from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+
+interface WhoamiResponse {
+  name: string;
+  agent_role: string;
+  installationId: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: null,
+    // /whoami is a snapshot endpoint — introspecting one's own
+    // identity should NOT bump lastUsedAt (closes hivemoot reviewer
+    // R2 #2 issue 4: a snapshot endpoint shouldn't have a side
+    // effect on usage state).
+    skipLastUsedAtWrite: true,
+  });
+  if (!auth.ok) return auth.response;
+
+  // Read lastUsedAt from the separate :meta hash. This is the
+  // canonical observability value — the middleware (when not
+  // skipped) writes here. /whoami specifically opts out of the
+  // write so the displayed value reflects the LAST authenticating
+  // request (not this introspection call).
+  let lastUsedAt: string | null = null;
+  try {
+    const metaKey = envelopeMetaKey(auth.installationId, auth.name);
+    lastUsedAt = await auth.redis.hget<string>(metaKey, "lastUsedAt");
+  } catch (err) {
+    // Best-effort — meta read failure shouldn't fail /whoami. The
+    // operator can still inspect everything else.
+    console.warn("[whoami] meta read failed", err);
+  }
+
+  // Best-effort audit emit (fire-and-forget). Doesn't await — a
+  // slow Redis XADD shouldn't extend the response.
+  void auditAppend({
+    redis: auth.redis,
+    installationId: auth.installationId,
+    entry: {
+      ts: new Date().toISOString(),
+      fingerprint: auth.envelope.fingerprint,
+      name: auth.name,
+      action: "auth.success",
+      endpoint: "GET /api/whoami",
+      required_capability: null,
+      outcome: "ok",
+    },
+  });
+
+  const body: WhoamiResponse = {
+    name: auth.name,
+    agent_role: auth.agent_role,
+    installationId: auth.installationId,
+    capabilities: auth.capabilities,
+    fingerprint: auth.envelope.fingerprint,
+    expiresAt: auth.envelope.expiresAt,
+    lastUsedAt,
+  };
+
+  return NextResponse.json(body, { status: 200 });
+}
+
+// Suppress the "Method Not Allowed" default by explicitly
+// rejecting non-GET methods. Helps operator triage when a script
+// accidentally POSTs a /whoami probe.
+export async function POST(): Promise<NextResponse> {
+  return NextResponse.json(
+    {
+      code: AGENT_AUTH_V1_ERROR.MISSING_BEARER,
+      message: "GET /api/whoami only — POST not supported",
+    },
+    { status: 405, headers: { Allow: "GET" } },
+  );
+}

--- a/web/src/app/api/whoami/route.ts
+++ b/web/src/app/api/whoami/route.ts
@@ -26,12 +26,37 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import {
-  authenticateAgentRequestV1,
-  AGENT_AUTH_V1_ERROR,
-} from "@/server/agent-token-v1-auth";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
 import { envelopeMetaKey } from "@/server/agent-token-v1";
 import { auditAppend } from "@/server/agent-token-v1-audit";
+
+/**
+ * Sanitized policy projection on the public wire shape.
+ *
+ * **Naming convention** — wire shape is **camelCase** (`allowedRepos`,
+ * `allowedPermissions`) per CAPABILITIES_DESIGN.md §`/api/whoami`
+ * introspection endpoint, while the underlying envelope storage is
+ * **snake_case** (`allowed_repos`, `allowed_permissions`) for backward
+ * compat with the V1.5 envelope shape. The handler is the translation
+ * layer — operators see camelCase, storage stays snake_case.
+ *
+ * Defined LOCALLY (not imported from `AgentTokenPolicy`) so that future
+ * additions to the storage type aren't auto-leaked through /whoami. The
+ * projection below is the only path to populate this type — adding a
+ * field here MUST be paired with an explicit copy + rename in the handler.
+ *
+ * Returned as `null` on the response when the envelope has no `policy`
+ * field at all (legacy / V1.5-pre tokens). When the policy field IS
+ * present, `allowedRepos` is always defined (empty `[]` is the
+ * intentional reject-all marker, per `AgentTokenPolicy`). The
+ * `allowedPermissions` field is V1.6+ and is omitted from the wire
+ * shape entirely when absent — operators see "no narrowing" rather
+ * than "narrowing: undefined".
+ */
+interface WhoamiPolicyView {
+  allowedRepos: string[];
+  allowedPermissions?: Record<string, string>;
+}
 
 interface WhoamiResponse {
   name: string;
@@ -41,6 +66,7 @@ interface WhoamiResponse {
   fingerprint: string;
   expiresAt: string | null;
   lastUsedAt: string | null;
+  policy: WhoamiPolicyView | null;
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -85,6 +111,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     },
   });
 
+  // Build sanitized policy projection. ONLY copy known V1.5/V1.6
+  // policy fields — never let the entire envelope leak through.
+  // Closes builder R1 on PR #505: the design doc requires policy
+  // visibility on /whoami so operators can verify token narrowing
+  // (allowedRepos for V1.5 mint scope, allowedPermissions for
+  // V1.6 GitHub-permission narrowing).
+  //
+  // **Snake_case → camelCase translation** is intentional and
+  // load-bearing. Storage shape is snake_case (envelope on Redis);
+  // wire shape is camelCase (per design doc §`/api/whoami`). Don't
+  // remove this rename or the public API drifts from the contract.
+  //
+  // `allowed_repos` is always defined when policy is set (empty []
+  // is the canonical reject-all marker), so it's copied directly.
+  // `allowed_permissions` is V1.6+ and conditionally spread to
+  // omit the key entirely when absent rather than emit
+  // `"allowedPermissions": null`.
+  const policy: WhoamiPolicyView | null = auth.envelope.policy
+    ? {
+        allowedRepos: auth.envelope.policy.allowed_repos,
+        ...(auth.envelope.policy.allowed_permissions !== undefined
+          ? { allowedPermissions: auth.envelope.policy.allowed_permissions }
+          : {}),
+      }
+    : null;
+
   const body: WhoamiResponse = {
     name: auth.name,
     agent_role: auth.agent_role,
@@ -93,6 +145,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     fingerprint: auth.envelope.fingerprint,
     expiresAt: auth.envelope.expiresAt,
     lastUsedAt,
+    policy,
   };
 
   return NextResponse.json(body, { status: 200 });
@@ -101,10 +154,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 // Suppress the "Method Not Allowed" default by explicitly
 // rejecting non-GET methods. Helps operator triage when a script
 // accidentally POSTs a /whoami probe.
+//
+// The code is `method_not_allowed` (not an auth error code) — using
+// `agent_auth_v1_missing_bearer` here would be misleading since the
+// failure mode is wrong-verb, not wrong-credentials. Closes drone R1
+// non-blocking observation D1 on PR #505.
 export async function POST(): Promise<NextResponse> {
   return NextResponse.json(
     {
-      code: AGENT_AUTH_V1_ERROR.MISSING_BEARER,
+      code: "method_not_allowed",
       message: "GET /api/whoami only — POST not supported",
     },
     { status: 405, headers: { Allow: "GET" } },

--- a/web/src/server/agent-token-v1-audit.test.ts
+++ b/web/src/server/agent-token-v1-audit.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+
+import {
+  auditAppend,
+  buildAuditEntryJson,
+  auditStreamKey,
+  authStreamKey,
+  AUDIT_STREAM_MAXLEN,
+  AUTH_STREAM_MAXLEN,
+  type AuditMutationEntry,
+  type AuditAuthEntry,
+} from "./agent-token-v1-audit";
+
+// ---------------------------------------------------------------------------
+// Mock Redis
+// ---------------------------------------------------------------------------
+//
+// Captures Lua-script invocations and decodes the XADD shape.
+
+function makeMockRedis() {
+  const xaddCalls: Array<{ key: string; maxlen: number; entryJson: string }> = [];
+
+  const luaSim = vi.fn(
+    async (script: string, keys: string[], argv: string[]) => {
+      // XADD_AUDIT_SCRIPT: 1 key, 2 args
+      if (
+        keys.length === 1 &&
+        argv.length === 2 &&
+        script.includes('redis.call("xadd"')
+      ) {
+        xaddCalls.push({
+          key: keys[0],
+          maxlen: Number(argv[0]),
+          entryJson: argv[1],
+        });
+        return "1234567890-0";
+      }
+      return null;
+    },
+  );
+
+  return {
+    "eval": luaSim,
+    _xaddCalls: xaddCalls,
+    _luaSim: luaSim,
+  } as unknown as Redis & {
+    _xaddCalls: typeof xaddCalls;
+    _luaSim: ReturnType<typeof vi.fn>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stream key helpers
+// ---------------------------------------------------------------------------
+
+describe("auditStreamKey + authStreamKey", () => {
+  it("auditStreamKey uses the :audit suffix on the v1 envelope prefix", () => {
+    expect(auditStreamKey("12345")).toBe(
+      "hive:v1:agent-token:12345:audit",
+    );
+  });
+
+  it("authStreamKey uses the :auth suffix on the v1 envelope prefix", () => {
+    expect(authStreamKey("12345")).toBe(
+      "hive:v1:agent-token:12345:auth",
+    );
+  });
+
+  it("the two streams are distinct (closes guard R2 N2 — separate trim budgets)", () => {
+    expect(auditStreamKey("12345")).not.toBe(authStreamKey("12345"));
+  });
+});
+
+describe("MAXLEN constants match the design doc retention math", () => {
+  it("AUDIT_STREAM_MAXLEN = 10000 (mutations effectively unbounded at <10/day)", () => {
+    expect(AUDIT_STREAM_MAXLEN).toBe(10000);
+  });
+
+  it("AUTH_STREAM_MAXLEN = 100000 (hours-to-days at single-Hive load)", () => {
+    expect(AUTH_STREAM_MAXLEN).toBe(100000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auditAppend — routing + content
+// ---------------------------------------------------------------------------
+
+describe("auditAppend — mutation events route to :audit stream", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it.each([
+    ["issue"],
+    ["revoke"],
+    ["set_capabilities"],
+    ["rotate"],
+    ["bootstrap"],
+  ] as const)(
+    "%s → :audit stream with AUDIT_STREAM_MAXLEN",
+    async (action) => {
+      const entry: AuditMutationEntry = {
+        ts: new Date().toISOString(),
+        fingerprint: "abcd1234",
+        name: "worker",
+        action,
+        actor: "operator",
+      };
+      await auditAppend({
+        redis,
+        installationId: "12345",
+        entry,
+      });
+      expect(redis._xaddCalls).toHaveLength(1);
+      expect(redis._xaddCalls[0].key).toBe(auditStreamKey("12345"));
+      expect(redis._xaddCalls[0].maxlen).toBe(AUDIT_STREAM_MAXLEN);
+      const parsed = JSON.parse(redis._xaddCalls[0].entryJson);
+      expect(parsed.action).toBe(action);
+    },
+  );
+});
+
+describe("auditAppend — auth events route to :auth stream", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it.each([["auth.success"], ["auth.failure"]] as const)(
+    "%s → :auth stream with AUTH_STREAM_MAXLEN",
+    async (action) => {
+      const entry: AuditAuthEntry = {
+        ts: new Date().toISOString(),
+        fingerprint: "abcd1234",
+        name: "worker",
+        action,
+        endpoint: "GET /api/whoami",
+        required_capability: null,
+        outcome: "ok",
+      };
+      await auditAppend({
+        redis,
+        installationId: "12345",
+        entry,
+      });
+      expect(redis._xaddCalls).toHaveLength(1);
+      expect(redis._xaddCalls[0].key).toBe(authStreamKey("12345"));
+      expect(redis._xaddCalls[0].maxlen).toBe(AUTH_STREAM_MAXLEN);
+    },
+  );
+});
+
+describe("auditAppend — security: never logs raw bearer", () => {
+  it("AuditEntry shape has no `token` field — only fingerprint", () => {
+    const entry: AuditMutationEntry = {
+      ts: new Date().toISOString(),
+      fingerprint: "abcd1234",
+      name: "worker",
+      action: "issue",
+      actor: "operator",
+    };
+    const json = buildAuditEntryJson(entry);
+    expect(json).not.toMatch(/"token"\s*:/);
+    expect(json).toContain('"fingerprint":"abcd1234"');
+  });
+});
+
+describe("auditAppend — failure mode (best-effort, never throws)", () => {
+  it("Redis errors are caught, logged, and don't propagate", async () => {
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    const failingRedis = {
+      "eval": vi.fn(async () => {
+        throw new Error("simulated Redis outage");
+      }),
+    } as unknown as Redis;
+
+    const entry: AuditMutationEntry = {
+      ts: new Date().toISOString(),
+      fingerprint: "abcd1234",
+      name: "worker",
+      action: "issue",
+      actor: "operator",
+    };
+
+    await expect(
+      auditAppend({
+        redis: failingRedis,
+        installationId: "12345",
+        entry,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("auditAppend failed"),
+      expect.any(Error),
+    );
+    consoleWarn.mockRestore();
+  });
+});
+
+describe("buildAuditEntryJson — symmetric with auditAppend payload", () => {
+  it("produces the same JSON string the script would receive", () => {
+    const entry: AuditMutationEntry = {
+      ts: "2026-04-27T13:00:00.000Z",
+      fingerprint: "abcd1234",
+      name: "worker",
+      action: "set_capabilities",
+      actor: "admin-token",
+      detail: { from: ["tasks.claim"], to: ["tasks.claim", "rooms.read"] },
+    };
+    const json = buildAuditEntryJson(entry);
+    const parsed = JSON.parse(json);
+    expect(parsed.action).toBe("set_capabilities");
+    expect(parsed.detail.from).toEqual(["tasks.claim"]);
+    expect(parsed.detail.to).toEqual(["tasks.claim", "rooms.read"]);
+  });
+});

--- a/web/src/server/agent-token-v1-audit.ts
+++ b/web/src/server/agent-token-v1-audit.ts
@@ -1,0 +1,217 @@
+/**
+ * Audit-stream emit helper for the V1 agent-token system (Phase B.1.d-i).
+ *
+ * Per CAPABILITIES_DESIGN.md §Audit log, audit emit is split into
+ * two streams per installation:
+ *
+ *   - `:audit` (mutations) — issue / revoke / set_capabilities /
+ *     rotate / bootstrap. Bounded by `MAXLEN ~10000`. At <10
+ *     mutations/day this is effectively unbounded (V1 retention).
+ *   - `:auth`  (auth events) — auth.success / auth.failure. Bounded
+ *     by `MAXLEN ~100000`. Hours-to-days at single-Hive load. The
+ *     split prevents high-volume auth events from displacing
+ *     low-volume mutation events that operators actually care about
+ *     for forensics.
+ *
+ * **Security: never log raw bearers.** Audit entries carry the
+ * SHA-256 fingerprint (first 8 hex chars of `tokenHash`) for
+ * correlation, never the raw bearer or the full hash. The
+ * `AuditEntry` type below enforces this — there is no `token`
+ * field; the closest approximation is `fingerprint` which is
+ * already plaintext metadata in storage.
+ *
+ * Wiring contract:
+ *
+ *   - For ISSUE / REVOKE / SET_CAPABILITIES / ROTATE: callers
+ *     build an `AuditEntry` and pass it as JSON via the script's
+ *     `auditEntryJsonOrEmpty` ARGV slot. The script does the XADD
+ *     atomically with the storage write (closes the lost-audit
+ *     window guard R1 G1 was protecting against).
+ *
+ *   - For BOOTSTRAP / WHOAMI / auth.success / auth.failure: caller
+ *     uses `auditAppend(...)` directly (no Lua script wraps the
+ *     event-source for these — they live in route handlers and
+ *     the middleware).
+ */
+
+import { type Redis } from "@upstash/redis";
+import {
+  ENVELOPE_PREFIX,
+} from "@/server/agent-token-v1";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AUDIT_SUFFIX = ":audit";
+const AUTH_SUFFIX = ":auth";
+
+/**
+ * Per CAPABILITIES_DESIGN.md §Audit log retention math:
+ *
+ *   - Mutations stream: 10,000 entries. At <10 mutations/day this
+ *     is effectively unbounded; the trim is a safety net.
+ *   - Auth stream: 100,000 entries. Hours-to-days at single-Hive
+ *     load (1 RPS auth → ~28h retention).
+ *
+ * `~` prefix is Redis's "approximate trim" mode — slightly more
+ * efficient because it lets Redis trim at radix-tree node
+ * boundaries rather than exact counts. The ~10x slack is
+ * acceptable for an audit log that's bounded by config.
+ */
+export const AUDIT_STREAM_MAXLEN = 10000;
+export const AUTH_STREAM_MAXLEN = 100000;
+
+// ---------------------------------------------------------------------------
+// Stream key helpers
+// ---------------------------------------------------------------------------
+
+/** `hive:v1:agent-token:{installationId}:audit` — mutations stream. */
+export function auditStreamKey(installationId: string): string {
+  return `${ENVELOPE_PREFIX}${installationId}${AUDIT_SUFFIX}`;
+}
+
+/** `hive:v1:agent-token:{installationId}:auth` — auth events stream. */
+export function authStreamKey(installationId: string): string {
+  return `${ENVELOPE_PREFIX}${installationId}${AUTH_SUFFIX}`;
+}
+
+// ---------------------------------------------------------------------------
+// Entry shapes
+// ---------------------------------------------------------------------------
+
+/** Event classes that emit to the `:audit` (mutations) stream. */
+export type AuditMutationAction =
+  | "issue"
+  | "revoke"
+  | "set_capabilities"
+  | "rotate"
+  | "bootstrap";
+
+/** Event classes that emit to the `:auth` (auth events) stream. */
+export type AuditAuthAction = "auth.success" | "auth.failure";
+
+interface BaseAuditEntry {
+  /** Server-side timestamp (ISO 8601 UTC). */
+  ts: string;
+  /** First 8 hex chars of the bearer's SHA-256. NEVER raw bearer. */
+  fingerprint: string;
+  /** Token name (`name` field on the envelope). Empty for bootstrap
+   * (the bootstrap admin token's name is created in the same call
+   * that emits the event). */
+  name: string;
+  /** Optional client metadata. */
+  client_ip?: string;
+}
+
+export interface AuditMutationEntry extends BaseAuditEntry {
+  action: AuditMutationAction;
+  /** Operator who initiated the action — admin token's name when
+   * called via the API; "dashboard" when called via cookie auth
+   * (bootstrap path). */
+  actor: string;
+  /** Optional structured detail. JSON.stringify'd inside the entry
+   * for the stream. Use cases:
+   *   - issue: `{capabilities, agent_role, expiresAt}`
+   *   - set_capabilities: `{from: [...], to: [...]}`
+   *   - rotate: `{}` (no narrative needed beyond the action itself)
+   *   - revoke: `{reason?}`
+   */
+  detail?: Record<string, unknown>;
+}
+
+export interface AuditAuthEntry extends BaseAuditEntry {
+  action: AuditAuthAction;
+  /** API endpoint that triggered the auth check, e.g.
+   * `"GET /api/whoami"` or `"POST /api/tasks/claim"`. */
+  endpoint: string;
+  /** Capability the route required (or null when route is
+   * intentionally cap-less, e.g. /api/whoami). */
+  required_capability: string | null;
+  /** "ok" | "missing_bearer" | "unknown_bearer" | "token_expired"
+   * | "missing_capability" | "server_misconfiguration" — the
+   * stable wire-error code from `AGENT_AUTH_V1_ERROR` minus the
+   * `agent_auth_v1_` prefix, OR "ok" on success. */
+  outcome: string;
+}
+
+export type AuditEntry = AuditMutationEntry | AuditAuthEntry;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Lua wrapper for `XADD ... MAXLEN ~ N * entry <json>`. Sidesteps
+ * the variation in Upstash Redis SDK xadd/xtrim surface area by
+ * letting the Redis server do the canonical command directly.
+ *
+ * KEYS: [streamKey]
+ * ARGV: [maxlen, entryJson]
+ * Returns: the new stream entry ID (string) on success.
+ */
+const XADD_AUDIT_SCRIPT = `
+return redis.call("xadd", KEYS[1], "MAXLEN", "~", tonumber(ARGV[1]), "*", "entry", ARGV[2])
+`;
+
+/**
+ * Emit an audit entry to the appropriate stream. Routes the event
+ * to the mutations stream (`:audit`) or auth stream (`:auth`)
+ * based on the action class, applying the right MAXLEN trim.
+ *
+ * Best-effort: failures are logged but do not throw. The audit
+ * stream is observability state; a Redis hiccup on XADD shouldn't
+ * fail the operator's actual mutation.
+ *
+ * For ISSUE / REVOKE / SET_CAPABILITIES / ROTATE, the storage
+ * layer's Lua scripts handle the audit XADD atomically with the
+ * storage write — callers there pass the audit-entry JSON via
+ * the script's `auditEntryJsonOrEmpty` ARGV slot. This function
+ * is for paths that DON'T have a wrapping script (BOOTSTRAP,
+ * /api/whoami auth events, etc.).
+ *
+ * Returns void — fire-and-forget by design.
+ */
+export async function auditAppend(args: {
+  redis: Redis;
+  installationId: string;
+  entry: AuditEntry;
+}): Promise<void> {
+  try {
+    const isMutation = isMutationAction(args.entry.action);
+    const streamKey = isMutation
+      ? auditStreamKey(args.installationId)
+      : authStreamKey(args.installationId);
+    const maxlen = isMutation ? AUDIT_STREAM_MAXLEN : AUTH_STREAM_MAXLEN;
+    await args.redis.eval(
+      XADD_AUDIT_SCRIPT,
+      [streamKey],
+      [String(maxlen), JSON.stringify(args.entry)],
+    );
+  } catch (err) {
+    console.warn(
+      `[agent-token-v1-audit] auditAppend failed for ${args.installationId} action=${args.entry.action}`,
+      err,
+    );
+  }
+}
+
+/**
+ * Build a structured audit entry as JSON for passing into one of
+ * the storage-layer scripts' `auditEntryJsonOrEmpty` ARGV slot.
+ * Convenience wrapper around `JSON.stringify(entry)` so the
+ * caller's call site is symmetric with `auditAppend(...)`.
+ */
+export function buildAuditEntryJson(entry: AuditEntry): string {
+  return JSON.stringify(entry);
+}
+
+function isMutationAction(action: string): action is AuditMutationAction {
+  return (
+    action === "issue" ||
+    action === "revoke" ||
+    action === "set_capabilities" ||
+    action === "rotate" ||
+    action === "bootstrap"
+  );
+}

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { type Redis } from "@upstash/redis";
 
 import { createHash } from "crypto";
+import { readFileSync } from "fs";
 import {
   // Public API under test
   issueAgentToken,
@@ -487,6 +488,30 @@ describe("revokeAgentToken", () => {
       redis,
     });
     expect(removed).toBe(false);
+  });
+
+  it("does NOT XADD to audit stream on no-op revoke (closes guard PR #504 non-blocking #5: audit-spam guard)", async () => {
+    // The mock's REVOKE branch follows the script logic: only emit
+    // when ARGV[2] is non-empty AND existed > 0. Since the storage
+    // layer doesn't call this path with an audit entry yet (B.1.d
+    // wires structured entries), we verify the script's no-op
+    // branch in isolation by counting eval calls before and after a
+    // revoke against a nonexistent name. With the audit-spam guard,
+    // the script returns {0, name} without doing the XADD even if
+    // ARGV[2] were non-empty — preventing an agent_tokens.manage
+    // holder from spamming `revoke nonexistent-name` to push real
+    // audit entries past the MAXLEN ~10000 trim.
+    //
+    // Direct guarantee: REVOKE_TOKEN_SCRIPT body now reads:
+    //   if ARGV[2] ~= "" and existed > 0 then xadd ... end
+    // (was: `if ARGV[2] ~= "" then xadd ... end` — vulnerable to spam)
+    const script = readFileSync(
+      __dirname + "/agent-token-v1.ts",
+      "utf8",
+    );
+    expect(script).toMatch(/if ARGV\[2\] ~= "" and existed > 0 then/);
+    // Defensive: make sure the unguarded form is gone
+    expect(script).not.toMatch(/if ARGV\[2\] ~= "" then\n  redis\.call\("xadd"/);
   });
 
   it("rejects invalid name without making any Redis writes", async () => {

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -90,7 +90,7 @@ export const DEFAULT_TOKEN_LIMIT_PER_INSTALLATION = 20;
  */
 export const ENVELOPE_TTL_SKEW_MARGIN_SECONDS = 300;
 
-const ENVELOPE_PREFIX = "hive:v1:agent-token:";
+export const ENVELOPE_PREFIX = "hive:v1:agent-token:";
 const HASH_INDEX_PREFIX = "hive:v1:idx:agent-token:hash:";
 const INSTALLATION_INDEX_PREFIX = "hive:v1:idx:agent-token:installation:";
 const META_SUFFIX = ":meta";
@@ -312,7 +312,12 @@ local existed = redis.call("del", KEYS[1])
 redis.call("del", KEYS[2])
 redis.call("del", KEYS[4])
 redis.call("zrem", KEYS[3], ARGV[1])
-if ARGV[2] ~= "" then
+-- Audit emit ONLY on actual revoke (existed > 0) — closes guard R1
+-- non-blocking #5 on PR #504: an agent_tokens.manage holder calling
+-- revoke against a nonexistent name was previously emitting an audit
+-- entry per call, which would let them spam real entries past the
+-- :audit stream's MAXLEN ~10000 trim and push out genuine forensics.
+if ARGV[2] ~= "" and existed > 0 then
   redis.call("xadd", KEYS[5], "MAXLEN", "~", "10000", "*", "entry", ARGV[2])
 end
 if existed == 0 then return {0, ARGV[1]} end


### PR DESCRIPTION
## Summary

First slice of Phase B.1.d (HTTP endpoints). Smallest reviewable unit: ships the audit-emit helper that subsequent endpoint slices will use, the long-standing REVOKE audit-spam guard from PR #504 non-blocking #5, and the first user-facing endpoint (`/api/whoami` introspection).

## Security implications (surfaced first per security-first principle)

- **`AuditEntry` shape has NO `token` field** — only `fingerprint` (first 8 hex chars of `tokenHash`). Type-level + runtime test pin this. The audit log is "fingerprint, never raw bearer."
- **REVOKE audit-spam guard**: previously a `agent_tokens.manage` holder could spam `revoke nonexistent-name` and emit one audit entry per call, eventually pushing real audit entries past the `MAXLEN ~10000` trim. R2 fix gates the XADD on `existed > 0` so no-op revokes produce no audit entry.
- **`/whoami` opts out of `lastUsedAt` write** via `skipLastUsedAtWrite: true` — the snapshot endpoint shouldn't have a side effect that bumps usage state and skews unused-token cleanup signals.
- **`/whoami` JSDoc reaffirms**: this is a SNAPSHOT for debugging; agents MUST NOT cache and skip the per-call middleware capability check (capabilities are mutable server-side via `set-capabilities`).

## What lands

`web/src/server/agent-token-v1-audit.ts` (new):
- `auditAppend({redis, installationId, entry})` — fire-and-forget XADD via Lua wrapper. Routes to `:audit` (mutations) vs `:auth` (auth events) stream by action class.
- `auditStreamKey()` / `authStreamKey()` — stream-key helpers.
- `AuditMutationEntry` / `AuditAuthEntry` types — pin the fingerprint-not-bearer + structured-detail contract.
- `buildAuditEntryJson(entry)` — convenience for callers passing via the storage scripts' `auditEntryJsonOrEmpty` ARGV slot.
- `AUDIT_STREAM_MAXLEN = 10000`, `AUTH_STREAM_MAXLEN = 100000` (matches CAPABILITIES_DESIGN.md retention math).

`web/src/server/agent-token-v1.ts`:
- `ENVELOPE_PREFIX` exported (was internal) so the audit module can build stream keys from the same prefix.
- `REVOKE_TOKEN_SCRIPT` XADD gated on `ARGV[2] ~= "" and existed > 0` (audit-spam guard).

`web/src/app/api/whoami/route.ts` (new):
- GET: returns `{name, agent_role, installationId, capabilities, fingerprint, expiresAt, lastUsedAt}` per CAPABILITIES_DESIGN.md.
- Uses middleware with `requires: null, skipLastUsedAtWrite: true`.
- Reads `lastUsedAt` from `:meta` separately.
- Emits `auth.success` to `:auth` stream via `auditAppend`.
- Survives `:meta` read failure — falls back to `lastUsedAt: null`, response stays 200.
- POST returns 405 with `Allow: GET`.

## What it looks like

```bash
$ curl -H "Authorization: Bearer hmt_xxx" https://www.hivemoot.dev/api/whoami
{
  "name": "worker",
  "agent_role": "drone",
  "installationId": "12345",
  "capabilities": ["agent_health.report", "tasks.claim", "rooms.read", "rooms.contribute"],
  "fingerprint": "01234567",
  "expiresAt": null,
  "lastUsedAt": "2026-04-27T12:00:00.000Z"
}
```

## Test plan

- [x] **96/96** V1 tests pass (52 storage + 22 middleware + 15 audit + 7 whoami)
- [x] `npx tsc --noEmit` clean
- [x] 15 audit tests (key helpers, MAXLEN constants, mutation routing × 5 actions, auth routing × 2 actions, security invariant `no token field`, failure mode best-effort, JSON build symmetry)
- [x] 7 whoami tests (unauthenticated 401, full snapshot shape, middleware opts, lastUsedAt: null on first auth, auth.success emit, survives meta read failure, POST → 405)
- [x] 1 new storage regression test pinning the REVOKE audit-spam guard via file-read regex assertion

## What this PR DOESN'T do (deferred)

- **B.1.d-ii**: read + mutation endpoints (POST issue, DELETE revoke, set-capabilities, rotate, GET list/show) + wires `auditAppend` into storage-script call sites
- **B.1.d-iii**: bootstrap dashboard route (cookie auth, 24h admin token expiry per CAPABILITIES_DESIGN.md §Bootstrap path)

## Backward compatibility

Pure addition. `/whoami` is a new endpoint; `auditAppend` is opt-in (legacy auth path doesn't call it; B.1.d-ii will wire it into the new endpoints). `REVOKE_TOKEN_SCRIPT` change is invisible at the API surface — tightens the audit guarantee, doesn't change existing behavior.

## Governance

No-linked-issue bypass per the same precedent as PRs #497-#504.