### PR TITLE
Phase B.1.d-ii — agent-token mutation/read endpoints + carry-forwards

### DIFF
--- a/web/src/app/api/agent-tokens/[name]/rotate/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/rotate/route.test.ts
@@ -39,6 +39,7 @@ import {
 import {
   rotateAgentToken,
   TokenNotFoundError,
+  TokenExpiredForMutationError,
 } from "@/server/agent-token-v1";
 import { auditAppend } from "@/server/agent-token-v1-audit";
 import { POST } from "./route";
@@ -156,7 +157,7 @@ describe("POST /api/agent-tokens/{name}/rotate", () => {
     expect(body.message).toMatch(/Old bearer is already invalid/);
   });
 
-  it("auditEntry passed with action=rotate + operator's fingerprint", async () => {
+  it("auditContext passed with operator identity (storage builds entry with old + new fingerprints)", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
     mockedKeyring.mockReturnValue(makeKeyringOk());
     mockedRotate.mockResolvedValue({
@@ -169,10 +170,73 @@ describe("POST /api/agent-tokens/{name}/rotate", () => {
     });
     await POST(makeRequest(), makeContext("worker"));
     const callArgs = mockedRotate.mock.calls[0][0];
-    expect(callArgs.auditEntry?.action).toBe("rotate");
-    expect(callArgs.auditEntry?.fingerprint).toBe("deadbeef"); // operator's
-    expect(callArgs.auditEntry?.name).toBe("worker"); // subject
-    expect(callArgs.auditEntry?.actor).toBe("admin"); // operator's name
+    expect(callArgs.auditContext).toBeDefined();
+    expect(callArgs.auditContext?.operator.fingerprint).toBe("deadbeef");
+    expect(callArgs.auditContext?.operator.name).toBe("admin");
+    // Storage builds the entry with detail.fingerprint_old +
+    // fingerprint_new from the locked envelope state.
+  });
+
+  it("rotate response surfaces preserved policy (B2 regression)", async () => {
+    // Closes #506 builder R1 #2: previously rotate always returned
+    // policy: null, falsely advertising policy-narrowed tokens as
+    // legacy-permissive. Storage now round-trips policy on
+    // IssuedAgentTokenV1 from the existing envelope.
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockResolvedValue({
+      token: "hmt_rotated",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "newfp001",
+      expiresAt: null,
+      policy: {
+        allowed_repos: ["hivemoot/foxstoria"],
+        allowed_permissions: { contents: "read" },
+      },
+    });
+    const res = await POST(makeRequest(), makeContext("worker"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria"],
+      allowedPermissions: { contents: "read" },
+    });
+  });
+
+  it("rotate response policy: null when token genuinely has no policy", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockResolvedValue({
+      token: "hmt_rotated",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "newfp001",
+      expiresAt: null,
+      // no policy field
+    });
+    const res = await POST(makeRequest(), makeContext("worker"));
+    const body = await res.json();
+    expect(body.policy).toBeNull();
+  });
+
+  it("expired-target rotate → 410 TOKEN_EXPIRED_FOR_MUTATION (B1)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockRejectedValue(
+      new TokenExpiredForMutationError(
+        "12345",
+        "old-worker",
+        "2026-04-26T00:00:00.000Z",
+      ),
+    );
+    const res = await POST(makeRequest(), makeContext("old-worker"));
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_token_expired_for_mutation");
+    expect(body.expiredAt).toBe("2026-04-26T00:00:00.000Z");
   });
 
   it("token not found → 404 TOKEN_NOT_FOUND", async () => {

--- a/web/src/app/api/agent-tokens/[name]/rotate/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/rotate/route.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for POST /api/agent-tokens/{name}/rotate. Phase B.1.d-ii.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+  loadV1MintKeyring: vi.fn(),
+  AGENT_AUTH_V1_ERROR: {
+    MISSING_BEARER: "agent_auth_v1_missing_bearer",
+    UNKNOWN_BEARER: "agent_auth_v1_unknown_bearer",
+    TOKEN_EXPIRED: "agent_auth_v1_token_expired",
+    MISSING_CAPABILITY: "agent_auth_v1_missing_capability",
+    SERVER_MISCONFIGURATION: "agent_auth_v1_server_misconfiguration",
+  },
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    rotateAgentToken: vi.fn(),
+  };
+});
+
+vi.mock("@/server/agent-token-v1-audit", () => ({
+  auditAppend: vi.fn(async () => undefined),
+}));
+
+import {
+  authenticateAgentRequestV1,
+  loadV1MintKeyring,
+} from "@/server/agent-token-v1-auth";
+import {
+  rotateAgentToken,
+  TokenNotFoundError,
+} from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedKeyring = vi.mocked(loadV1MintKeyring);
+const mockedRotate = vi.mocked(rotateAgentToken);
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    "https://www.hivemoot.dev/api/agent-tokens/worker/rotate",
+    {
+      method: "POST",
+      headers: { authorization: "Bearer hmt_admin" },
+    },
+  );
+}
+
+function makeAuthOk(overrides: { name?: string } = {}) {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: overrides.name ?? "admin",
+    agent_role: "admin",
+    capabilities: ["agent_tokens.manage"],
+    envelope: {
+      ciphertext: "ct",
+      iv: "iv",
+      tag: "tag",
+      keyVersion: "v1",
+      tokenHash: "deadbeef00000000",
+      fingerprint: "deadbeef",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "bootstrap",
+      expiresAt: null,
+      name: overrides.name ?? "admin",
+      agent_role: "admin",
+      capabilities: ["agent_tokens.manage"],
+    },
+    redis: {} as never,
+  };
+}
+
+function makeKeyringOk() {
+  return {
+    ok: true as const,
+    keyring: new Map<string, Buffer>([["v1", Buffer.alloc(32)]]),
+    keyVersion: "v1",
+  };
+}
+
+function makeContext(name: string) {
+  return { params: Promise.resolve({ name }) };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedKeyring.mockReset();
+  mockedRotate.mockReset();
+  mockedAuditAppend.mockReset();
+});
+
+describe("POST /api/agent-tokens/{name}/rotate", () => {
+  it("auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "denied" }, { status: 403 }),
+    });
+    const res = await POST(makeRequest(), makeContext("worker"));
+    expect(res.status).toBe(403);
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+
+  it("self-rotate → 409 SELF_OP_REFUSED", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk({ name: "self-admin" }));
+    const res = await POST(makeRequest(), makeContext("self-admin"));
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("agent_tokens_v1_self_op_refused");
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+
+  it("keyring misconfigured → 503 surfaces", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue({
+      ok: false,
+      response: NextResponse.json(
+        { code: "agent_auth_v1_server_misconfiguration" },
+        { status: 503 },
+      ),
+    });
+    const res = await POST(makeRequest(), makeContext("worker"));
+    expect(res.status).toBe(503);
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+
+  it("happy path → 200 with new bearer + same caps + ONCE message", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockResolvedValue({
+      token: "hmt_rotated_bearer",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.report", "tasks.claim"],
+      fingerprint: "newfp001",
+      expiresAt: "2026-05-27T10:00:00.000Z",
+    });
+    const res = await POST(makeRequest(), makeContext("worker"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("hmt_rotated_bearer");
+    expect(body.fingerprint).toBe("newfp001");
+    expect(body.capabilities).toEqual(["agent_health.report", "tasks.claim"]);
+    expect(body.message).toMatch(/ONCE/);
+    expect(body.message).toMatch(/Old bearer is already invalid/);
+  });
+
+  it("auditEntry passed with action=rotate + operator's fingerprint", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockResolvedValue({
+      token: "hmt_rotated",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "newfp001",
+      expiresAt: null,
+    });
+    await POST(makeRequest(), makeContext("worker"));
+    const callArgs = mockedRotate.mock.calls[0][0];
+    expect(callArgs.auditEntry?.action).toBe("rotate");
+    expect(callArgs.auditEntry?.fingerprint).toBe("deadbeef"); // operator's
+    expect(callArgs.auditEntry?.name).toBe("worker"); // subject
+    expect(callArgs.auditEntry?.actor).toBe("admin"); // operator's name
+  });
+
+  it("token not found → 404 TOKEN_NOT_FOUND", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockRejectedValue(new TokenNotFoundError("12345", "missing"));
+    const res = await POST(makeRequest(), makeContext("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("emits auth.success audit", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockResolvedValue({
+      token: "hmt_rotated",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "newfp001",
+      expiresAt: null,
+    });
+    await POST(makeRequest(), makeContext("worker"));
+    await new Promise((resolve) => setImmediate(resolve));
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    if (entry.action === "auth.success" || entry.action === "auth.failure") {
+      expect(entry.endpoint).toBe("POST /api/agent-tokens/{name}/rotate");
+    }
+  });
+
+  it("SECURITY: response never contains operator's tokenHash", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedRotate.mockResolvedValue({
+      token: "hmt_rotated",
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "newfp001",
+      expiresAt: null,
+    });
+    const res = await POST(makeRequest(), makeContext("worker"));
+    const raw = await res.text();
+    expect(raw).not.toContain("deadbeef00000000"); // operator's tokenHash
+    expect(raw).not.toContain("ciphertext");
+  });
+});

--- a/web/src/app/api/agent-tokens/[name]/rotate/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/rotate/route.ts
@@ -32,7 +32,6 @@ import {
 import { rotateAgentToken } from "@/server/agent-token-v1";
 import { auditAppend } from "@/server/agent-token-v1-audit";
 import {
-  buildMutationAuditEntry,
   projectV1ResponsePolicy,
   mapV1StorageErrorToResponse,
   v1Error,
@@ -83,22 +82,10 @@ export async function POST(
   const keyringResult = loadV1MintKeyring();
   if (!keyringResult.ok) return keyringResult.response;
 
-  // For audit detail, capture the OLD fingerprint so investigators
-  // can correlate the rotation with prior `auth.success` entries
-  // tied to that fingerprint. We don't have the new fingerprint
-  // until inside the storage function — that lands in the response
-  // payload (and can be reconstructed from the next auth.success
-  // event for the same name).
-  const auditEntry = buildMutationAuditEntry({
-    action: "rotate",
-    operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
-    subjectName: name,
-    // No `detail` — rotate is "swap bearer, preserve everything
-    // else" and the new fingerprint is observable via the response
-    // and the next auth.success in the same installation's :auth
-    // stream. Empty detail keeps the audit row compact.
-  });
-
+  // Storage builds the audit entry internally with both the OLD
+  // and NEW fingerprints in detail (read inside the lock; new is
+  // computed before the script runs). Closes #506 builder R1 #3
+  // and gives investigators a clean correlation point.
   try {
     const issued = await rotateAgentToken({
       installationId: auth.installationId,
@@ -106,7 +93,9 @@ export async function POST(
       keyring: keyringResult.keyring,
       keyVersion: keyringResult.keyVersion,
       redis: auth.redis,
-      auditEntry,
+      auditContext: {
+        operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
+      },
     });
 
     void auditAppend({
@@ -123,18 +112,12 @@ export async function POST(
       },
     });
 
-    // Preserved policy comes from the OLD envelope — rotate doesn't
-    // mutate policy. Read it from the auth context's envelope view
-    // by way of a separate read isn't worth it; the response just
-    // omits policy on rotate (caller can GET /api/agent-tokens/{name}
-    // afterwards if they want the full snapshot). For now we stage
-    // policy: null — rotation doesn't claim to surface it.
-    //
-    // Actually — surface it for operator clarity. We can fetch the
-    // post-rotate summary in the same call's wake. But that's an
-    // extra Redis RTT for a frontend convenience. Compromise:
-    // include it as null and document that callers wanting the full
-    // post-rotate snapshot should call GET /api/agent-tokens/{name}.
+    // The preserved policy is now surfaced from `IssuedAgentTokenV1`
+    // (closes #506 builder R1 #2 — was previously `null` regardless,
+    // falsely advertising policy-narrowed tokens as legacy-permissive).
+    // `issued.policy` is undefined for envelopes that genuinely had
+    // no policy; `projectV1ResponsePolicy(undefined)` correctly
+    // returns null in that case.
     const responseBody: RotateResponse = {
       token: issued.token,
       name: issued.name,
@@ -142,11 +125,9 @@ export async function POST(
       capabilities: issued.capabilities,
       fingerprint: issued.fingerprint,
       expiresAt: issued.expiresAt,
-      // IssuedAgentTokenV1 doesn't carry policy; surface null and
-      // tell callers to fetch the show endpoint for the full picture.
-      policy: projectV1ResponsePolicy(null),
+      policy: projectV1ResponsePolicy(issued.policy ?? null),
       message:
-        "New bearer is shown ONCE — store it securely now. Old bearer is already invalid. Call GET /api/agent-tokens/{name} for the full post-rotate snapshot (incl. policy).",
+        "New bearer is shown ONCE — store it securely now. Old bearer is already invalid.",
     };
     return NextResponse.json(responseBody, { status: 200 });
   } catch (err) {

--- a/web/src/app/api/agent-tokens/[name]/rotate/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/rotate/route.ts
@@ -1,0 +1,159 @@
+/**
+ * POST /api/agent-tokens/{name}/rotate — atomic bearer rotation
+ * for an existing named token.
+ *
+ * Auth: bearer with `agent_tokens.manage`.
+ *
+ * No body required. The storage layer (`rotateAgentToken`) generates
+ * a new bearer + token-hash, swaps the encrypted ciphertext on the
+ * envelope, and DELes the OLD hash-index entry — all in one Lua
+ * EVAL — so the previous bearer is invalid the moment this returns.
+ *
+ * Preserves: `name`, `agent_role`, `capabilities`, `expiresAt`,
+ * `policy`. (Rotate ≠ extend; rotate ≠ re-cap. Operators wanting
+ * to extend lifetime should issue a successor under a different
+ * name with the desired `expiresIn`, then revoke the old one.)
+ *
+ * Response shape mirrors POST /api/agent-tokens (issue): the new
+ * bearer is shown ONCE.
+ *
+ * **Self-rotate guard**: refuses to rotate the bearer's own token —
+ * the in-flight request would 401 the operator on next call (the
+ * old bearer's hash-index DEL kills any retry). Operators should
+ * issue a fresh successor admin token via POST /api/agent-tokens
+ * and revoke this one separately.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  authenticateAgentRequestV1,
+  loadV1MintKeyring,
+} from "@/server/agent-token-v1-auth";
+import { rotateAgentToken } from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import {
+  buildMutationAuditEntry,
+  projectV1ResponsePolicy,
+  mapV1StorageErrorToResponse,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+  type V1ResponsePolicyView,
+} from "@/server/agent-token-v1-routes";
+
+const REQUIRED_CAPABILITY = "agent_tokens.manage";
+
+interface RotateResponse {
+  /** New raw bearer. Shown ONCE — same contract as POST /api/agent-tokens. */
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  /** New fingerprint (changes on rotation since fingerprint is
+   * derived from the new tokenHash prefix per #503 R1 fix). */
+  fingerprint: string;
+  /** Preserved from the original envelope — rotate doesn't touch
+   * expiresAt. Operators wanting to extend lifetime should issue
+   * a successor + revoke. */
+  expiresAt: string | null;
+  /** Preserved from the original envelope. */
+  policy: V1ResponsePolicyView | null;
+  message: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ name: string }> },
+): Promise<NextResponse> {
+  const { name } = await context.params;
+
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: REQUIRED_CAPABILITY,
+  });
+  if (!auth.ok) return auth.response;
+
+  if (auth.name === name) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.SELF_OP_REFUSED,
+      "Refusing to rotate the bearer's own token — the old hash-index DEL would 401 your next call. Issue a successor via POST /api/agent-tokens, switch to it, then call rotate or revoke against this one.",
+      409,
+      { name },
+    );
+  }
+
+  const keyringResult = loadV1MintKeyring();
+  if (!keyringResult.ok) return keyringResult.response;
+
+  // For audit detail, capture the OLD fingerprint so investigators
+  // can correlate the rotation with prior `auth.success` entries
+  // tied to that fingerprint. We don't have the new fingerprint
+  // until inside the storage function — that lands in the response
+  // payload (and can be reconstructed from the next auth.success
+  // event for the same name).
+  const auditEntry = buildMutationAuditEntry({
+    action: "rotate",
+    operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
+    subjectName: name,
+    // No `detail` — rotate is "swap bearer, preserve everything
+    // else" and the new fingerprint is observable via the response
+    // and the next auth.success in the same installation's :auth
+    // stream. Empty detail keeps the audit row compact.
+  });
+
+  try {
+    const issued = await rotateAgentToken({
+      installationId: auth.installationId,
+      name,
+      keyring: keyringResult.keyring,
+      keyVersion: keyringResult.keyVersion,
+      redis: auth.redis,
+      auditEntry,
+    });
+
+    void auditAppend({
+      redis: auth.redis,
+      installationId: auth.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: auth.envelope.fingerprint,
+        name: auth.name,
+        action: "auth.success",
+        endpoint: "POST /api/agent-tokens/{name}/rotate",
+        required_capability: REQUIRED_CAPABILITY,
+        outcome: "ok",
+      },
+    });
+
+    // Preserved policy comes from the OLD envelope — rotate doesn't
+    // mutate policy. Read it from the auth context's envelope view
+    // by way of a separate read isn't worth it; the response just
+    // omits policy on rotate (caller can GET /api/agent-tokens/{name}
+    // afterwards if they want the full snapshot). For now we stage
+    // policy: null — rotation doesn't claim to surface it.
+    //
+    // Actually — surface it for operator clarity. We can fetch the
+    // post-rotate summary in the same call's wake. But that's an
+    // extra Redis RTT for a frontend convenience. Compromise:
+    // include it as null and document that callers wanting the full
+    // post-rotate snapshot should call GET /api/agent-tokens/{name}.
+    const responseBody: RotateResponse = {
+      token: issued.token,
+      name: issued.name,
+      agent_role: issued.agent_role,
+      capabilities: issued.capabilities,
+      fingerprint: issued.fingerprint,
+      expiresAt: issued.expiresAt,
+      // IssuedAgentTokenV1 doesn't carry policy; surface null and
+      // tell callers to fetch the show endpoint for the full picture.
+      policy: projectV1ResponsePolicy(null),
+      message:
+        "New bearer is shown ONCE — store it securely now. Old bearer is already invalid. Call GET /api/agent-tokens/{name} for the full post-rotate snapshot (incl. policy).",
+    };
+    return NextResponse.json(responseBody, { status: 200 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "POST /api/agent-tokens/{name}/rotate",
+      installationId: auth.installationId,
+      name,
+    });
+  }
+}

--- a/web/src/app/api/agent-tokens/[name]/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/route.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for GET /api/agent-tokens/{name} (show) and
+ * DELETE /api/agent-tokens/{name} (revoke). Phase B.1.d-ii.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+  AGENT_AUTH_V1_ERROR: {
+    MISSING_BEARER: "agent_auth_v1_missing_bearer",
+    UNKNOWN_BEARER: "agent_auth_v1_unknown_bearer",
+    TOKEN_EXPIRED: "agent_auth_v1_token_expired",
+    MISSING_CAPABILITY: "agent_auth_v1_missing_capability",
+    SERVER_MISCONFIGURATION: "agent_auth_v1_server_misconfiguration",
+  },
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    getAgentTokenSummary: vi.fn(),
+    revokeAgentToken: vi.fn(),
+  };
+});
+
+vi.mock("@/server/agent-token-v1-audit", () => ({
+  auditAppend: vi.fn(async () => undefined),
+}));
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getAgentTokenSummary,
+  revokeAgentToken,
+  TokenNotFoundError,
+} from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import { GET, DELETE } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedShow = vi.mocked(getAgentTokenSummary);
+const mockedRevoke = vi.mocked(revokeAgentToken);
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+function makeRequest(method: "GET" | "DELETE"): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/agent-tokens/worker", {
+    method,
+    headers: { authorization: "Bearer hmt_admin" },
+  });
+}
+
+function makeAuthOk(overrides: { name?: string } = {}) {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: overrides.name ?? "admin",
+    agent_role: "admin",
+    capabilities: ["agent_tokens.manage"],
+    envelope: {
+      ciphertext: "ct",
+      iv: "iv",
+      tag: "tag",
+      keyVersion: "v1",
+      tokenHash: "deadbeef00000000",
+      fingerprint: "deadbeef",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "bootstrap",
+      expiresAt: null,
+      name: overrides.name ?? "admin",
+      agent_role: "admin",
+      capabilities: ["agent_tokens.manage"],
+    },
+    redis: {} as never,
+  };
+}
+
+function makeAuthFailure(status = 401) {
+  return {
+    ok: false as const,
+    response: NextResponse.json({ code: "denied" }, { status }),
+  };
+}
+
+function makeContext(name: string) {
+  return { params: Promise.resolve({ name }) };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedShow.mockReset();
+  mockedRevoke.mockReset();
+  mockedAuditAppend.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/agent-tokens/{name}
+// ---------------------------------------------------------------------------
+
+describe("GET /api/agent-tokens/{name}", () => {
+  it("invalid name format → 400 INVALID_NAME (path validation)", async () => {
+    // Should not even reach auth — boundary validation first.
+    const res = await GET(makeRequest("GET"), makeContext("Worker!"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+    expect(mockedAuth).not.toHaveBeenCalled();
+  });
+
+  it("auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue(makeAuthFailure(403));
+    const res = await GET(makeRequest("GET"), makeContext("worker"));
+    expect(res.status).toBe(403);
+    expect(mockedShow).not.toHaveBeenCalled();
+  });
+
+  it("happy path → 200 with camelCase wire-shape summary", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.report", "tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+      policy: {
+        allowed_repos: ["hivemoot/foxstoria"],
+        allowed_permissions: { contents: "read" },
+      },
+    });
+    const res = await GET(makeRequest("GET"), makeContext("worker"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe("worker");
+    expect(body.policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria"],
+      allowedPermissions: { contents: "read" },
+    });
+  });
+
+  it("token not found → 404 TOKEN_NOT_FOUND with name", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockRejectedValue(new TokenNotFoundError("12345", "missing"));
+    const res = await GET(makeRequest("GET"), makeContext("missing"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_token_not_found");
+    expect(body.name).toBe("missing");
+  });
+
+  it("emits auth.success audit", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    await GET(makeRequest("GET"), makeContext("worker"));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockedAuditAppend).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/agent-tokens/{name}
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/agent-tokens/{name}", () => {
+  it("auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue(makeAuthFailure(403));
+    const res = await DELETE(makeRequest("DELETE"), makeContext("worker"));
+    expect(res.status).toBe(403);
+    expect(mockedRevoke).not.toHaveBeenCalled();
+  });
+
+  it("self-revoke (auth.name === path name) → 409 SELF_OP_REFUSED", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk({ name: "self-admin" }));
+    const res = await DELETE(makeRequest("DELETE"), makeContext("self-admin"));
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("agent_tokens_v1_self_op_refused");
+    expect(mockedRevoke).not.toHaveBeenCalled();
+  });
+
+  it("happy path → 200 { revoked: true, name }", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedRevoke.mockResolvedValue(true);
+    const res = await DELETE(makeRequest("DELETE"), makeContext("worker"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ revoked: true, name: "worker" });
+  });
+
+  it("idempotent revoke (already gone) → 404 TOKEN_NOT_FOUND with name", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedRevoke.mockResolvedValue(false);
+    const res = await DELETE(makeRequest("DELETE"), makeContext("worker"));
+    expect(res.status).toBe(404);
+    expect((await res.json()).code).toBe("agent_tokens_v1_token_not_found");
+  });
+
+  it("auditEntry passed to storage with action=revoke + operator's fingerprint", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedRevoke.mockResolvedValue(true);
+    await DELETE(makeRequest("DELETE"), makeContext("worker"));
+    const callArgs = mockedRevoke.mock.calls[0][0];
+    expect(callArgs.auditEntry).toBeDefined();
+    expect(callArgs.auditEntry?.action).toBe("revoke");
+    expect(callArgs.auditEntry?.fingerprint).toBe("deadbeef");
+    expect(callArgs.auditEntry?.name).toBe("worker"); // subject
+    expect(callArgs.auditEntry?.actor).toBe("admin"); // operator
+  });
+
+  it("emits auth.success audit", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedRevoke.mockResolvedValue(true);
+    await DELETE(makeRequest("DELETE"), makeContext("worker"));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockedAuditAppend).toHaveBeenCalled();
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    if (entry.action === "auth.success" || entry.action === "auth.failure") {
+      expect(entry.endpoint).toBe("DELETE /api/agent-tokens/{name}");
+    }
+  });
+});

--- a/web/src/app/api/agent-tokens/[name]/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/route.test.ts
@@ -205,16 +205,14 @@ describe("DELETE /api/agent-tokens/{name}", () => {
     expect((await res.json()).code).toBe("agent_tokens_v1_token_not_found");
   });
 
-  it("auditEntry passed to storage with action=revoke + operator's fingerprint", async () => {
+  it("auditContext passed to storage with operator identity (storage builds entry)", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
     mockedRevoke.mockResolvedValue(true);
     await DELETE(makeRequest("DELETE"), makeContext("worker"));
     const callArgs = mockedRevoke.mock.calls[0][0];
-    expect(callArgs.auditEntry).toBeDefined();
-    expect(callArgs.auditEntry?.action).toBe("revoke");
-    expect(callArgs.auditEntry?.fingerprint).toBe("deadbeef");
-    expect(callArgs.auditEntry?.name).toBe("worker"); // subject
-    expect(callArgs.auditEntry?.actor).toBe("admin"); // operator
+    expect(callArgs.auditContext).toBeDefined();
+    expect(callArgs.auditContext?.operator.fingerprint).toBe("deadbeef");
+    expect(callArgs.auditContext?.operator.name).toBe("admin");
   });
 
   it("emits auth.success audit", async () => {

--- a/web/src/app/api/agent-tokens/[name]/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/route.ts
@@ -25,7 +25,6 @@ import {
 } from "@/server/agent-token-capabilities";
 import { auditAppend } from "@/server/agent-token-v1-audit";
 import {
-  buildMutationAuditEntry,
   projectV1TokenSummary,
   mapV1StorageErrorToResponse,
   v1Error,
@@ -142,18 +141,16 @@ export async function DELETE(
     );
   }
 
-  const auditEntry = buildMutationAuditEntry({
-    action: "revoke",
-    operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
-    subjectName: nameCheck.name,
-  });
-
   try {
     const revoked = await revokeAgentToken({
       installationId: auth.installationId,
       name: nameCheck.name,
       redis: auth.redis,
-      auditEntry,
+      // Storage builds the audit entry internally with the revoked
+      // envelope's fingerprint (read inside the lock).
+      auditContext: {
+        operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
+      },
     });
 
     void auditAppend({

--- a/web/src/app/api/agent-tokens/[name]/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/route.ts
@@ -1,0 +1,192 @@
+/**
+ * GET    /api/agent-tokens/{name} — fetch a single token's summary
+ * DELETE /api/agent-tokens/{name} — revoke a token by name
+ *
+ * Both require `agent_tokens.manage` (admin/operator capability).
+ *
+ * Revoke is idempotent at the storage layer (`revokeAgentToken`
+ * returns false if the token was already gone). The route surfaces
+ * the same 404 the GET-miss path uses for the missing case so
+ * clients don't need a separate code path. Hard-stop semantics
+ * per CAPABILITIES_DESIGN.md §"Graceful revocation": in-flight
+ * calls 401 on next read; current task fails / orphans; queen
+ * handles via the existing task watchdog.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getAgentTokenSummary,
+  revokeAgentToken,
+} from "@/server/agent-token-v1";
+import {
+  validateName,
+  CapabilityValidationError,
+} from "@/server/agent-token-capabilities";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import {
+  buildMutationAuditEntry,
+  projectV1TokenSummary,
+  mapV1StorageErrorToResponse,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+  type V1TokenSummaryView,
+} from "@/server/agent-token-v1-routes";
+
+const REQUIRED_CAPABILITY = "agent_tokens.manage";
+
+/** Validate the `[name]` path param at the boundary so route handlers
+ * don't pass random strings to the storage layer. Throws are mapped
+ * to a 400 INVALID_NAME response. */
+function validatePathName(rawName: string): { ok: true; name: string } | { ok: false; response: NextResponse } {
+  try {
+    validateName(rawName);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      return {
+        ok: false,
+        response: v1Error(
+          AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+          err.message,
+          400,
+          { field: err.field, value: err.value },
+        ),
+      };
+    }
+    throw err;
+  }
+  return { ok: true, name: rawName };
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/agent-tokens/{name}
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ name: string }> },
+): Promise<NextResponse> {
+  const { name: rawName } = await context.params;
+  const nameCheck = validatePathName(rawName);
+  if (!nameCheck.ok) return nameCheck.response;
+
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: REQUIRED_CAPABILITY,
+  });
+  if (!auth.ok) return auth.response;
+
+  try {
+    const summary = await getAgentTokenSummary({
+      installationId: auth.installationId,
+      name: nameCheck.name,
+      redis: auth.redis,
+    });
+
+    void auditAppend({
+      redis: auth.redis,
+      installationId: auth.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: auth.envelope.fingerprint,
+        name: auth.name,
+        action: "auth.success",
+        endpoint: "GET /api/agent-tokens/{name}",
+        required_capability: REQUIRED_CAPABILITY,
+        outcome: "ok",
+      },
+    });
+
+    const responseBody: V1TokenSummaryView = projectV1TokenSummary(summary);
+    return NextResponse.json(responseBody, { status: 200 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "GET /api/agent-tokens/{name}",
+      installationId: auth.installationId,
+      name: nameCheck.name,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/agent-tokens/{name}
+// ---------------------------------------------------------------------------
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ name: string }> },
+): Promise<NextResponse> {
+  const { name: rawName } = await context.params;
+  const nameCheck = validatePathName(rawName);
+  if (!nameCheck.ok) return nameCheck.response;
+
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: REQUIRED_CAPABILITY,
+  });
+  if (!auth.ok) return auth.response;
+
+  // **Self-revoke guard**: an admin token revoking ITSELF would
+  // 401 in-flight requests including any retry by the operator.
+  // The bootstrap path (B.1.d-iv) is the recovery, but we make the
+  // trap explicit by returning 409 with a clear message rather than
+  // silently completing. Note: this only catches name-equality;
+  // operators could still revoke OTHER admin tokens that they
+  // happened to also hold (and lock themselves out via that path,
+  // which is intentional per the design's "deliberate-rotation"
+  // discipline).
+  if (auth.name === nameCheck.name) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.SELF_OP_REFUSED,
+      "Refusing to revoke the bearer's own token — would lock you out mid-flight. Issue a successor admin token, switch to it, then revoke this one.",
+      409,
+      { name: nameCheck.name },
+    );
+  }
+
+  const auditEntry = buildMutationAuditEntry({
+    action: "revoke",
+    operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
+    subjectName: nameCheck.name,
+  });
+
+  try {
+    const revoked = await revokeAgentToken({
+      installationId: auth.installationId,
+      name: nameCheck.name,
+      redis: auth.redis,
+      auditEntry,
+    });
+
+    void auditAppend({
+      redis: auth.redis,
+      installationId: auth.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: auth.envelope.fingerprint,
+        name: auth.name,
+        action: "auth.success",
+        endpoint: "DELETE /api/agent-tokens/{name}",
+        required_capability: REQUIRED_CAPABILITY,
+        outcome: "ok",
+      },
+    });
+
+    if (!revoked) {
+      // Idempotent at storage layer, but surface 404 to API clients
+      // — operators want to know if their `revoke` was a no-op so
+      // they can investigate (typo? already revoked?).
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.TOKEN_NOT_FOUND,
+        `No agent token named '${nameCheck.name}' found for this installation (already revoked or never existed).`,
+        404,
+        { name: nameCheck.name },
+      );
+    }
+    return NextResponse.json({ revoked: true, name: nameCheck.name }, { status: 200 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "DELETE /api/agent-tokens/{name}",
+      installationId: auth.installationId,
+      name: nameCheck.name,
+    });
+  }
+}

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for POST /api/agent-tokens/{name}/set-capabilities.
+ * Phase B.1.d-ii.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+  AGENT_AUTH_V1_ERROR: {
+    MISSING_BEARER: "agent_auth_v1_missing_bearer",
+    UNKNOWN_BEARER: "agent_auth_v1_unknown_bearer",
+    TOKEN_EXPIRED: "agent_auth_v1_token_expired",
+    MISSING_CAPABILITY: "agent_auth_v1_missing_capability",
+    SERVER_MISCONFIGURATION: "agent_auth_v1_server_misconfiguration",
+  },
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    setAgentTokenCapabilities: vi.fn(),
+    getAgentTokenSummary: vi.fn(),
+  };
+});
+
+vi.mock("@/server/agent-token-v1-audit", () => ({
+  auditAppend: vi.fn(async () => undefined),
+}));
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  setAgentTokenCapabilities,
+  getAgentTokenSummary,
+  TokenNotFoundError,
+} from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedSet = vi.mocked(setAgentTokenCapabilities);
+const mockedShow = vi.mocked(getAgentTokenSummary);
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+function makeRequest(body?: unknown): NextRequest {
+  return new NextRequest(
+    "https://www.hivemoot.dev/api/agent-tokens/worker/set-capabilities",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_admin",
+        "content-type": "application/json",
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    },
+  );
+}
+
+function makeAuthOk(overrides: { name?: string } = {}) {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: overrides.name ?? "admin",
+    agent_role: "admin",
+    capabilities: ["agent_tokens.manage"],
+    envelope: {
+      ciphertext: "ct",
+      iv: "iv",
+      tag: "tag",
+      keyVersion: "v1",
+      tokenHash: "deadbeef00000000",
+      fingerprint: "deadbeef",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "bootstrap",
+      expiresAt: null,
+      name: overrides.name ?? "admin",
+      agent_role: "admin",
+      capabilities: ["agent_tokens.manage"],
+    },
+    redis: {} as never,
+  };
+}
+
+function makeContext(name: string) {
+  return { params: Promise.resolve({ name }) };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedSet.mockReset();
+  mockedShow.mockReset();
+  mockedAuditAppend.mockReset();
+});
+
+describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
+  it("auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "denied" }, { status: 403 }),
+    });
+    const res = await POST(
+      makeRequest({ capabilities: ["tasks.claim"] }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(403);
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("self-modify → 409 SELF_OP_REFUSED", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk({ name: "self-admin" }));
+    const res = await POST(
+      makeRequest({ capabilities: ["tasks.claim"] }),
+      makeContext("self-admin"),
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("agent_tokens_v1_self_op_refused");
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("missing both preset + capabilities → 400", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    const res = await POST(makeRequest({}), makeContext("worker"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+  });
+
+  it("preset 'monitoring' → replaces caps with monitoring's bundle", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    mockedSet.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.read", "tasks.read", "rooms.read"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    const res = await POST(
+      makeRequest({ preset: "monitoring" }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token.capabilities).toEqual([
+      "agent_health.read",
+      "tasks.read",
+      "rooms.read",
+    ]);
+    // Storage call received the preset's full list
+    expect(mockedSet.mock.calls[0][0].capabilities).toEqual([
+      "agent_health.read",
+      "tasks.read",
+      "rooms.read",
+    ]);
+  });
+
+  it("explicit capabilities → 200 with same list back", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    mockedSet.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.report", "rooms.read"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    const res = await POST(
+      makeRequest({ capabilities: ["agent_health.report", "rooms.read"] }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("auditEntry includes from + to capability lists", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    mockedSet.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim", "rooms.read"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    await POST(
+      makeRequest({ capabilities: ["tasks.claim", "rooms.read"] }),
+      makeContext("worker"),
+    );
+    const callArgs = mockedSet.mock.calls[0][0];
+    expect(callArgs.auditEntry?.action).toBe("set_capabilities");
+    expect(callArgs.auditEntry?.detail).toEqual({
+      from: ["tasks.claim"],
+      to: ["tasks.claim", "rooms.read"],
+    });
+  });
+
+  it("token not found → 404 TOKEN_NOT_FOUND", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockRejectedValue(new TokenNotFoundError("12345", "missing"));
+    mockedSet.mockRejectedValue(new TokenNotFoundError("12345", "missing"));
+    const res = await POST(
+      makeRequest({ capabilities: ["tasks.claim"] }),
+      makeContext("missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("bare '*' without allowWildcards → 400 WILDCARD_NOT_ALLOWED", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    const res = await POST(
+      makeRequest({ capabilities: ["*"] }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_wildcard_not_allowed");
+  });
+
+  it("emits auth.success audit on success", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedShow.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    mockedSet.mockResolvedValue({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["tasks.claim", "rooms.read"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    await POST(
+      makeRequest({ capabilities: ["tasks.claim", "rooms.read"] }),
+      makeContext("worker"),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    if (entry.action === "auth.success" || entry.action === "auth.failure") {
+      expect(entry.endpoint).toBe(
+        "POST /api/agent-tokens/{name}/set-capabilities",
+      );
+    }
+  });
+});

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
@@ -25,7 +25,6 @@ vi.mock("@/server/agent-token-v1", async () => {
   return {
     ...real,
     setAgentTokenCapabilities: vi.fn(),
-    getAgentTokenSummary: vi.fn(),
   };
 });
 
@@ -36,15 +35,14 @@ vi.mock("@/server/agent-token-v1-audit", () => ({
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
 import {
   setAgentTokenCapabilities,
-  getAgentTokenSummary,
   TokenNotFoundError,
+  TokenExpiredForMutationError,
 } from "@/server/agent-token-v1";
 import { auditAppend } from "@/server/agent-token-v1-audit";
 import { POST } from "./route";
 
 const mockedAuth = vi.mocked(authenticateAgentRequestV1);
 const mockedSet = vi.mocked(setAgentTokenCapabilities);
-const mockedShow = vi.mocked(getAgentTokenSummary);
 const mockedAuditAppend = vi.mocked(auditAppend);
 
 function makeRequest(body?: unknown): NextRequest {
@@ -93,7 +91,6 @@ function makeContext(name: string) {
 beforeEach(() => {
   mockedAuth.mockReset();
   mockedSet.mockReset();
-  mockedShow.mockReset();
   mockedAuditAppend.mockReset();
 });
 
@@ -124,15 +121,6 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
 
   it("missing both preset + capabilities → 400", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockResolvedValue({
-      name: "worker",
-      agent_role: "drone",
-      capabilities: ["tasks.claim"],
-      fingerprint: "01234567",
-      createdAt: "2026-04-27T10:00:00.000Z",
-      createdBy: "admin",
-      expiresAt: null,
-    });
     const res = await POST(makeRequest({}), makeContext("worker"));
     expect(res.status).toBe(400);
     expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
@@ -140,15 +128,6 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
 
   it("preset 'monitoring' → replaces caps with monitoring's bundle", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockResolvedValue({
-      name: "worker",
-      agent_role: "drone",
-      capabilities: ["tasks.claim"],
-      fingerprint: "01234567",
-      createdAt: "2026-04-27T10:00:00.000Z",
-      createdBy: "admin",
-      expiresAt: null,
-    });
     mockedSet.mockResolvedValue({
       name: "worker",
       agent_role: "drone",
@@ -169,7 +148,6 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
       "tasks.read",
       "rooms.read",
     ]);
-    // Storage call received the preset's full list
     expect(mockedSet.mock.calls[0][0].capabilities).toEqual([
       "agent_health.read",
       "tasks.read",
@@ -179,15 +157,6 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
 
   it("explicit capabilities → 200 with same list back", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockResolvedValue({
-      name: "worker",
-      agent_role: "drone",
-      capabilities: ["tasks.claim"],
-      fingerprint: "01234567",
-      createdAt: "2026-04-27T10:00:00.000Z",
-      createdBy: "admin",
-      expiresAt: null,
-    });
     mockedSet.mockResolvedValue({
       name: "worker",
       agent_role: "drone",
@@ -204,17 +173,8 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
     expect(res.status).toBe(200);
   });
 
-  it("auditEntry includes from + to capability lists", async () => {
+  it("auditContext passed with operator identity (storage builds entry from locked state, B3)", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockResolvedValue({
-      name: "worker",
-      agent_role: "drone",
-      capabilities: ["tasks.claim"],
-      fingerprint: "01234567",
-      createdAt: "2026-04-27T10:00:00.000Z",
-      createdBy: "admin",
-      expiresAt: null,
-    });
     mockedSet.mockResolvedValue({
       name: "worker",
       agent_role: "drone",
@@ -229,16 +189,16 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
       makeContext("worker"),
     );
     const callArgs = mockedSet.mock.calls[0][0];
-    expect(callArgs.auditEntry?.action).toBe("set_capabilities");
-    expect(callArgs.auditEntry?.detail).toEqual({
-      from: ["tasks.claim"],
-      to: ["tasks.claim", "rooms.read"],
-    });
+    // Endpoint passes ONLY operator identity. The `from` list is
+    // built INSIDE the storage layer using the locked envelope state
+    // (closes #506 builder R1 #3 — pre-read race window eliminated).
+    expect(callArgs.auditContext).toBeDefined();
+    expect(callArgs.auditContext?.operator.fingerprint).toBe("deadbeef");
+    expect(callArgs.auditContext?.operator.name).toBe("admin");
   });
 
   it("token not found → 404 TOKEN_NOT_FOUND", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockRejectedValue(new TokenNotFoundError("12345", "missing"));
     mockedSet.mockRejectedValue(new TokenNotFoundError("12345", "missing"));
     const res = await POST(
       makeRequest({ capabilities: ["tasks.claim"] }),
@@ -247,17 +207,27 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
     expect(res.status).toBe(404);
   });
 
+  it("expired-target mutation → 410 TOKEN_EXPIRED_FOR_MUTATION (B1)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedSet.mockRejectedValue(
+      new TokenExpiredForMutationError(
+        "12345",
+        "old-worker",
+        "2026-04-26T00:00:00.000Z",
+      ),
+    );
+    const res = await POST(
+      makeRequest({ capabilities: ["tasks.claim"] }),
+      makeContext("old-worker"),
+    );
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_token_expired_for_mutation");
+    expect(body.expiredAt).toBe("2026-04-26T00:00:00.000Z");
+  });
+
   it("bare '*' without allowWildcards → 400 WILDCARD_NOT_ALLOWED", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockResolvedValue({
-      name: "worker",
-      agent_role: "drone",
-      capabilities: ["tasks.claim"],
-      fingerprint: "01234567",
-      createdAt: "2026-04-27T10:00:00.000Z",
-      createdBy: "admin",
-      expiresAt: null,
-    });
     const res = await POST(
       makeRequest({ capabilities: ["*"] }),
       makeContext("worker"),
@@ -268,15 +238,6 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
 
   it("emits auth.success audit on success", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
-    mockedShow.mockResolvedValue({
-      name: "worker",
-      agent_role: "drone",
-      capabilities: ["tasks.claim"],
-      fingerprint: "01234567",
-      createdAt: "2026-04-27T10:00:00.000Z",
-      createdBy: "admin",
-      expiresAt: null,
-    });
     mockedSet.mockResolvedValue({
       name: "worker",
       agent_role: "drone",

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
@@ -1,0 +1,218 @@
+/**
+ * POST /api/agent-tokens/{name}/set-capabilities — replace the
+ * capability list on an existing token.
+ *
+ * Auth: bearer token with `agent_tokens.manage`.
+ *
+ * Body modes (mutually exclusive):
+ *   1. `{ capabilities: [...] }` — full-replace with the given list.
+ *   2. `{ preset: "worker" }` — replace with the named preset's
+ *      bundled caps (looked up via `resolvePreset`).
+ *
+ * **Why API doesn't support add/remove**: the design doc shows
+ * `--add` / `--remove` CLI flags, but the API takes only the FULL
+ * new list. The CLI computes the new list locally (GET-then-POST)
+ * before calling the API. This avoids a TOCTOU window where a
+ * concurrent set-capabilities elsewhere would make the add/remove
+ * math operate on stale state. Closes design § "set-capabilities
+ * — `--add` / `--remove` supported" by clarifying that the
+ * incremental ergonomics live in the CLI, not the API.
+ *
+ * **Self-modify guard**: refuses to change capabilities on the
+ * bearer's own token — losing `agent_tokens.manage` mid-flight
+ * locks the operator out (the same trap as self-revoke).
+ *
+ * **Bare-`*` opt-in**: same as POST /api/agent-tokens — bare `*`
+ * needs `allowWildcards: true`. Operators rotating an admin
+ * token's caps must still pass the wildcard gate.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  setAgentTokenCapabilities,
+  getAgentTokenSummary,
+} from "@/server/agent-token-v1";
+import {
+  isKnownPreset,
+  resolvePreset,
+} from "@/server/agent-token-capabilities";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import {
+  buildMutationAuditEntry,
+  projectV1TokenSummary,
+  mapV1StorageErrorToResponse,
+  readJsonObject,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+  type V1TokenSummaryView,
+} from "@/server/agent-token-v1-routes";
+
+const REQUIRED_CAPABILITY = "agent_tokens.manage";
+
+interface SetCapabilitiesResponse {
+  /** Updated summary view of the token. Caller can compare
+   * `capabilities` here against what they sent to confirm the
+   * canonical post-mutation state. */
+  token: V1TokenSummaryView;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ name: string }> },
+): Promise<NextResponse> {
+  const { name: rawName } = await context.params;
+
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: REQUIRED_CAPABILITY,
+  });
+  if (!auth.ok) return auth.response;
+
+  // Path-name validation runs as part of `setAgentTokenCapabilities`
+  // (it calls `validateName` internally), so we skip duplicating it
+  // here — but the self-op guard NEEDS the raw name to compare against
+  // `auth.name` before storage validation.
+  const name = rawName;
+
+  if (auth.name === name) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.SELF_OP_REFUSED,
+      "Refusing to modify capabilities on the bearer's own token — could lock you out mid-flight (e.g. by removing 'agent_tokens.manage'). Issue a successor with the new caps, switch to it, then revoke this one.",
+      409,
+      { name },
+    );
+  }
+
+  const parsedBody = await readJsonObject(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+
+  // ----- capabilities (preset OR explicit list) -----
+  let capabilities: readonly string[];
+  if (body.preset !== undefined) {
+    if (body.capabilities !== undefined) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "preset and capabilities are mutually exclusive — pass one or the other.",
+        400,
+      );
+    }
+    if (typeof body.preset !== "string" || !isKnownPreset(body.preset)) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_PRESET,
+        `preset must be one of the known names (got ${JSON.stringify(body.preset)}).`,
+        400,
+      );
+    }
+    capabilities = resolvePreset(body.preset);
+  } else if (Array.isArray(body.capabilities)) {
+    if (body.capabilities.length === 0) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "capabilities must contain ≥1 entry — refusing to set empty caps (would be permanently 401).",
+        400,
+      );
+    }
+    for (const c of body.capabilities) {
+      if (typeof c !== "string") {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+          "capabilities entries must be strings.",
+          400,
+        );
+      }
+    }
+    capabilities = body.capabilities as string[];
+  } else {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+      "Pass either preset (named bundle) or capabilities (string[]).",
+      400,
+    );
+  }
+
+  // Bare-`*` opt-in (same shape as POST /api/agent-tokens).
+  const allowWildcards = body.allowWildcards === true;
+  if (!allowWildcards) {
+    for (const c of capabilities) {
+      if (c === "*") {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.WILDCARD_NOT_ALLOWED,
+          "Bare '*' capability requires allowWildcards: true.",
+          400,
+        );
+      }
+    }
+  }
+
+  // For richer audit detail (`from` / `to` capability lists), read
+  // the current summary BEFORE mutating. Best-effort — if it fails
+  // we still proceed with the mutation but emit audit without
+  // `from` data. Closes the audit-narrative gap that the previous
+  // empty-detail set_capabilities entries left.
+  let previousCapabilities: string[] | undefined;
+  try {
+    const before = await getAgentTokenSummary({
+      installationId: auth.installationId,
+      name,
+      redis: auth.redis,
+    });
+    previousCapabilities = before.capabilities;
+  } catch (err) {
+    // If the token doesn't exist, the set-capabilities call will
+    // 404 us with the canonical error. Don't pre-empt it here.
+    if (
+      !(err instanceof Error && err.name === "TokenNotFoundError")
+    ) {
+      console.warn(
+        "[agent-tokens/set-capabilities] pre-read for audit detail failed",
+        { installationId: auth.installationId, name, error: err },
+      );
+    }
+  }
+
+  const auditEntry = buildMutationAuditEntry({
+    action: "set_capabilities",
+    operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
+    subjectName: name,
+    detail: {
+      to: [...capabilities],
+      ...(previousCapabilities !== undefined ? { from: previousCapabilities } : {}),
+    },
+  });
+
+  try {
+    const updated = await setAgentTokenCapabilities({
+      installationId: auth.installationId,
+      name,
+      capabilities,
+      redis: auth.redis,
+      auditEntry,
+    });
+
+    void auditAppend({
+      redis: auth.redis,
+      installationId: auth.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: auth.envelope.fingerprint,
+        name: auth.name,
+        action: "auth.success",
+        endpoint: "POST /api/agent-tokens/{name}/set-capabilities",
+        required_capability: REQUIRED_CAPABILITY,
+        outcome: "ok",
+      },
+    });
+
+    const responseBody: SetCapabilitiesResponse = {
+      token: projectV1TokenSummary(updated),
+    };
+    return NextResponse.json(responseBody, { status: 200 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "POST /api/agent-tokens/{name}/set-capabilities",
+      installationId: auth.installationId,
+      name,
+    });
+  }
+}

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
@@ -29,17 +29,13 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
-import {
-  setAgentTokenCapabilities,
-  getAgentTokenSummary,
-} from "@/server/agent-token-v1";
+import { setAgentTokenCapabilities } from "@/server/agent-token-v1";
 import {
   isKnownPreset,
   resolvePreset,
 } from "@/server/agent-token-capabilities";
 import { auditAppend } from "@/server/agent-token-v1-audit";
 import {
-  buildMutationAuditEntry,
   projectV1TokenSummary,
   mapV1StorageErrorToResponse,
   readJsonObject,
@@ -145,49 +141,20 @@ export async function POST(
     }
   }
 
-  // For richer audit detail (`from` / `to` capability lists), read
-  // the current summary BEFORE mutating. Best-effort — if it fails
-  // we still proceed with the mutation but emit audit without
-  // `from` data. Closes the audit-narrative gap that the previous
-  // empty-detail set_capabilities entries left.
-  let previousCapabilities: string[] | undefined;
-  try {
-    const before = await getAgentTokenSummary({
-      installationId: auth.installationId,
-      name,
-      redis: auth.redis,
-    });
-    previousCapabilities = before.capabilities;
-  } catch (err) {
-    // If the token doesn't exist, the set-capabilities call will
-    // 404 us with the canonical error. Don't pre-empt it here.
-    if (
-      !(err instanceof Error && err.name === "TokenNotFoundError")
-    ) {
-      console.warn(
-        "[agent-tokens/set-capabilities] pre-read for audit detail failed",
-        { installationId: auth.installationId, name, error: err },
-      );
-    }
-  }
-
-  const auditEntry = buildMutationAuditEntry({
-    action: "set_capabilities",
-    operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
-    subjectName: name,
-    detail: {
-      to: [...capabilities],
-      ...(previousCapabilities !== undefined ? { from: previousCapabilities } : {}),
-    },
-  });
-
+  // Storage builds the audit entry internally with `from` taken
+  // from the LOCKED envelope state. Closes #506 builder R1 #3:
+  // a previous pattern that pre-read `from` at the route layer
+  // could race a concurrent set-capabilities and produce a
+  // misleading `from: A, to: C` row when actual change was B → C.
   try {
     const updated = await setAgentTokenCapabilities({
       installationId: auth.installationId,
       name,
       capabilities,
       redis: auth.redis,
-      auditEntry,
+      auditContext: {
+        operator: { fingerprint: auth.envelope.fingerprint, name: auth.name },
+      },
     });
 
     void auditAppend({

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -382,7 +382,7 @@ describe("POST /api/agent-tokens — happy paths", () => {
     expect(res.status).toBe(201);
   });
 
-  it("auditEntry passed to storage with action=issue + operator's fingerprint", async () => {
+  it("auditContext passed to storage with operator's identity (storage builds entry internally)", async () => {
     mockedIssue.mockResolvedValue(makeIssued());
     await POST(
       makeRequest("POST", {
@@ -392,14 +392,41 @@ describe("POST /api/agent-tokens — happy paths", () => {
       }),
     );
     const callArgs = mockedIssue.mock.calls[0][0];
-    expect(callArgs.auditEntry).toBeDefined();
-    expect(callArgs.auditEntry?.action).toBe("issue");
+    expect(callArgs.auditContext).toBeDefined();
     // operator's fingerprint (from auth.envelope.fingerprint)
-    expect(callArgs.auditEntry?.fingerprint).toBe("deadbeef");
-    // subject = new token's name
-    expect(callArgs.auditEntry?.name).toBe("worker");
-    // actor = operator's name
-    expect(callArgs.auditEntry?.actor).toBe("admin");
+    expect(callArgs.auditContext?.operator.fingerprint).toBe("deadbeef");
+    // operator's name (from auth.name)
+    expect(callArgs.auditContext?.operator.name).toBe("admin");
+    // Storage will fill in action="issue", subject=name, and the
+    // detail object including the new token's fingerprint — none
+    // of which the route layer should pre-compute.
+  });
+
+  it("issue response surfaces policy back to caller (no extra GET needed)", async () => {
+    mockedIssue.mockResolvedValue({
+      ...makeIssued(),
+      policy: {
+        allowed_repos: ["hivemoot/foxstoria"],
+        allowed_permissions: { contents: "read" },
+      },
+    });
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        policy: {
+          allowedRepos: ["hivemoot/foxstoria"],
+          allowedPermissions: { contents: "read" },
+        },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria"],
+      allowedPermissions: { contents: "read" },
+    });
   });
 
   it("emits auth.success to :auth stream via auditAppend", async () => {

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Tests for POST /api/agent-tokens (issue) and GET /api/agent-tokens
+ * (list). Phase B.1.d-ii.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+  loadV1MintKeyring: vi.fn(),
+  AGENT_AUTH_V1_ERROR: {
+    MISSING_BEARER: "agent_auth_v1_missing_bearer",
+    UNKNOWN_BEARER: "agent_auth_v1_unknown_bearer",
+    TOKEN_EXPIRED: "agent_auth_v1_token_expired",
+    MISSING_CAPABILITY: "agent_auth_v1_missing_capability",
+    SERVER_MISCONFIGURATION: "agent_auth_v1_server_misconfiguration",
+  },
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    issueAgentToken: vi.fn(),
+    listAgentTokens: vi.fn(),
+  };
+});
+
+vi.mock("@/server/agent-token-v1-audit", () => ({
+  auditAppend: vi.fn(async () => undefined),
+}));
+
+import {
+  authenticateAgentRequestV1,
+  loadV1MintKeyring,
+} from "@/server/agent-token-v1-auth";
+import {
+  issueAgentToken,
+  listAgentTokens,
+  TokenNameTakenError,
+  TokenLimitReachedError,
+  type IssuedAgentTokenV1,
+  type AgentTokenSummaryV1,
+} from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import { POST, GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedKeyring = vi.mocked(loadV1MintKeyring);
+const mockedIssue = vi.mocked(issueAgentToken);
+const mockedList = vi.mocked(listAgentTokens);
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(method: "POST" | "GET", body?: unknown): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/agent-tokens", {
+    method,
+    headers: { authorization: "Bearer hmt_admin", "content-type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function makeAuthOk(overrides: { name?: string } = {}) {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: overrides.name ?? "admin",
+    agent_role: "admin",
+    capabilities: ["*", "agent_tokens.manage"],
+    envelope: {
+      ciphertext: "ct",
+      iv: "iv",
+      tag: "tag",
+      keyVersion: "v1",
+      tokenHash: "deadbeef00000000",
+      fingerprint: "deadbeef",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "bootstrap",
+      expiresAt: null,
+      name: overrides.name ?? "admin",
+      agent_role: "admin",
+      capabilities: ["*", "agent_tokens.manage"],
+    },
+    redis: {} as never,
+  };
+}
+
+function makeKeyringOk() {
+  return {
+    ok: true as const,
+    keyring: new Map<string, Buffer>([["v1", Buffer.alloc(32)]]),
+    keyVersion: "v1",
+  };
+}
+
+function makeIssued(overrides: Partial<IssuedAgentTokenV1> = {}): IssuedAgentTokenV1 {
+  return {
+    token: "hmt_brand_new_bearer",
+    name: overrides.name ?? "worker",
+    agent_role: overrides.agent_role ?? "drone",
+    capabilities: overrides.capabilities ?? ["agent_health.report", "tasks.claim"],
+    fingerprint: overrides.fingerprint ?? "abcd1234",
+    expiresAt: overrides.expiresAt ?? null,
+  };
+}
+
+function makeAuthFailure(status = 401) {
+  return {
+    ok: false as const,
+    response: NextResponse.json({ code: "denied" }, { status }),
+  };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedKeyring.mockReset();
+  mockedIssue.mockReset();
+  mockedList.mockReset();
+  mockedAuditAppend.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/agent-tokens — auth + keyring failures
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens — auth + keyring failures", () => {
+  it("auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue(makeAuthFailure(403));
+    const res = await POST(makeRequest("POST", { name: "x", agent_role: "y" }));
+    expect(res.status).toBe(403);
+    expect(mockedKeyring).not.toHaveBeenCalled();
+  });
+
+  it("keyring misconfiguration → 503 surfaces, issue not called", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue({
+      ok: false,
+      response: NextResponse.json(
+        { code: "agent_auth_v1_server_misconfiguration" },
+        { status: 503 },
+      ),
+    });
+    const res = await POST(makeRequest("POST", { name: "x", agent_role: "y" }));
+    expect(res.status).toBe(503);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/agent-tokens — body validation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens — body validation", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+  });
+
+  it("missing name → 400 INVALID_NAME", async () => {
+    const res = await POST(makeRequest("POST", { agent_role: "drone", preset: "worker" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+  });
+
+  it("missing agent_role → 400 INVALID_AGENT_ROLE (no implicit default)", async () => {
+    const res = await POST(makeRequest("POST", { name: "worker", preset: "worker" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_agent_role");
+  });
+
+  it("invalid name format → 400 INVALID_NAME", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "Worker!", agent_role: "drone", preset: "worker" }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+  });
+
+  it("preset + capabilities both provided → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        capabilities: ["tasks.claim"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+  });
+
+  it("unknown preset → 400 INVALID_PRESET", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "worker", agent_role: "drone", preset: "unicorn" }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_preset");
+  });
+
+  it("neither preset nor capabilities → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "worker", agent_role: "drone" }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+  });
+
+  it("empty capabilities array → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        capabilities: [],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+  });
+
+  it("bare '*' without allowWildcards → 400 WILDCARD_NOT_ALLOWED", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "super",
+        agent_role: "admin",
+        capabilities: ["*", "agent_tokens.manage"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_wildcard_not_allowed");
+  });
+
+  it("invalid expiresIn → 400 INVALID_EXPIRES_IN", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        expiresIn: "forever",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_expires_in");
+  });
+
+  it("V1.6-only policy (no allowedRepos) → 400 INVALID_POLICY", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        policy: { allowedPermissions: { contents: "read" } },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_policy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/agent-tokens — happy paths
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens — happy paths", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+  });
+
+  it("preset 'worker' → 201 with bearer + canonical caps", async () => {
+    mockedIssue.mockResolvedValue(
+      makeIssued({
+        capabilities: [
+          "agent_health.report",
+          "tasks.claim",
+          "tasks.progress",
+          "tasks.complete",
+          "rooms.watch",
+          "rooms.read",
+          "rooms.contribute",
+        ],
+      }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        expiresIn: "30d",
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.token).toBe("hmt_brand_new_bearer");
+    expect(body.fingerprint).toBe("abcd1234");
+    expect(body.capabilities).toContain("agent_health.report");
+    expect(body.message).toMatch(/ONCE/);
+    expect(body.policy).toBeNull();
+  });
+
+  it("explicit capabilities → 201 with the same list back", async () => {
+    mockedIssue.mockResolvedValue(
+      makeIssued({ capabilities: ["agent_health.report", "tasks.claim"] }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        capabilities: ["agent_health.report", "tasks.claim"],
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.capabilities).toEqual(["agent_health.report", "tasks.claim"]);
+  });
+
+  it("V1.5 policy round-trips as camelCase on response", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        policy: { allowedRepos: ["hivemoot/foxstoria"] },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.policy).toEqual({ allowedRepos: ["hivemoot/foxstoria"] });
+    // Storage call received snake_case
+    expect(mockedIssue.mock.calls[0][0].policy).toEqual({
+      allowed_repos: ["hivemoot/foxstoria"],
+    });
+  });
+
+  it("V1.6 policy (allowedRepos + allowedPermissions) round-trips", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+        policy: {
+          allowedRepos: ["hivemoot/foxstoria"],
+          allowedPermissions: { contents: "read" },
+        },
+      }),
+    );
+    const body = await res.json();
+    expect(body.policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria"],
+      allowedPermissions: { contents: "read" },
+    });
+    expect(mockedIssue.mock.calls[0][0].policy).toEqual({
+      allowed_repos: ["hivemoot/foxstoria"],
+      allowed_permissions: { contents: "read" },
+    });
+  });
+
+  it("bare '*' WITH allowWildcards: true → 201 (deliberate opt-in)", async () => {
+    mockedIssue.mockResolvedValue(
+      makeIssued({ capabilities: ["*", "agent_tokens.manage"] }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "super",
+        agent_role: "admin",
+        capabilities: ["*", "agent_tokens.manage"],
+        allowWildcards: true,
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("auditEntry passed to storage with action=issue + operator's fingerprint", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+      }),
+    );
+    const callArgs = mockedIssue.mock.calls[0][0];
+    expect(callArgs.auditEntry).toBeDefined();
+    expect(callArgs.auditEntry?.action).toBe("issue");
+    // operator's fingerprint (from auth.envelope.fingerprint)
+    expect(callArgs.auditEntry?.fingerprint).toBe("deadbeef");
+    // subject = new token's name
+    expect(callArgs.auditEntry?.name).toBe("worker");
+    // actor = operator's name
+    expect(callArgs.auditEntry?.actor).toBe("admin");
+  });
+
+  it("emits auth.success to :auth stream via auditAppend", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+      }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockedAuditAppend).toHaveBeenCalled();
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    expect(entry.action).toBe("auth.success");
+    if (entry.action === "auth.success" || entry.action === "auth.failure") {
+      expect(entry.endpoint).toBe("POST /api/agent-tokens");
+      expect(entry.required_capability).toBe("agent_tokens.manage");
+    }
+  });
+
+  it("SECURITY: response never contains envelope ciphertext / tokenHash", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+      }),
+    );
+    const raw = await res.text();
+    expect(raw).not.toContain("ciphertext");
+    expect(raw).not.toContain("deadbeef00000000"); // operator's tokenHash
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/agent-tokens — storage error mapping
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens — storage errors", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+  });
+
+  it("TokenNameTakenError → 409 NAME_TAKEN", async () => {
+    mockedIssue.mockRejectedValue(new TokenNameTakenError("12345", "worker"));
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("agent_tokens_v1_name_taken");
+  });
+
+  it("TokenLimitReachedError → 422 TOKEN_LIMIT_REACHED", async () => {
+    mockedIssue.mockRejectedValue(new TokenLimitReachedError("12345", 20));
+    const res = await POST(
+      makeRequest("POST", {
+        name: "worker",
+        agent_role: "drone",
+        preset: "worker",
+      }),
+    );
+    expect(res.status).toBe(422);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/agent-tokens — list
+// ---------------------------------------------------------------------------
+
+describe("GET /api/agent-tokens — list", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+  });
+
+  it("auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue(makeAuthFailure(403));
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(403);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it("empty installation → tokens: []", async () => {
+    mockedList.mockResolvedValue([]);
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tokens: [] });
+  });
+
+  it("populated installation → projects each summary to camelCase wire shape", async () => {
+    const summaries: AgentTokenSummaryV1[] = [
+      {
+        name: "worker",
+        agent_role: "drone",
+        capabilities: ["agent_health.report", "tasks.claim"],
+        fingerprint: "01234567",
+        createdAt: "2026-04-27T10:00:00.000Z",
+        createdBy: "admin",
+        expiresAt: null,
+        policy: {
+          allowed_repos: ["hivemoot/foxstoria"],
+          allowed_permissions: { contents: "read" },
+        },
+      },
+    ];
+    mockedList.mockResolvedValue(summaries);
+    const res = await GET(makeRequest("GET"));
+    const body = await res.json();
+    expect(body.tokens[0].policy).toEqual({
+      allowedRepos: ["hivemoot/foxstoria"],
+      allowedPermissions: { contents: "read" },
+    });
+  });
+
+  it("emits auth.success audit", async () => {
+    mockedList.mockResolvedValue([]);
+    await GET(makeRequest("GET"));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockedAuditAppend).toHaveBeenCalled();
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    if (entry.action === "auth.success" || entry.action === "auth.failure") {
+      expect(entry.endpoint).toBe("GET /api/agent-tokens");
+    }
+  });
+
+  it("SECURITY: response never contains envelope ciphertext / tokenHash for any token", async () => {
+    mockedList.mockResolvedValue([
+      {
+        name: "worker",
+        agent_role: "drone",
+        capabilities: ["agent_health.report"],
+        fingerprint: "01234567",
+        createdAt: "2026-04-27T10:00:00.000Z",
+        createdBy: "admin",
+        expiresAt: null,
+      },
+    ]);
+    const res = await GET(makeRequest("GET"));
+    const raw = await res.text();
+    expect(raw).not.toContain("ciphertext");
+    expect(raw).not.toContain("tokenHash");
+  });
+});

--- a/web/src/app/api/agent-tokens/route.ts
+++ b/web/src/app/api/agent-tokens/route.ts
@@ -37,7 +37,6 @@ import { auditAppend } from "@/server/agent-token-v1-audit";
 import {
   parseExpiresIn,
   parseV1RequestPolicy,
-  buildMutationAuditEntry,
   projectV1ResponsePolicy,
   projectV1TokenSummary,
   mapV1StorageErrorToResponse,
@@ -207,22 +206,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // ----- audit entry (fingerprint = OPERATOR's; subjectName = NEW token's) -----
-  const auditEntry = buildMutationAuditEntry({
-    action: "issue",
-    operator: {
-      fingerprint: auth.envelope.fingerprint,
-      name: auth.name,
-    },
-    subjectName: name,
-    detail: {
-      agent_role,
-      capabilities: [...capabilities],
-      expiresAt: expiresParse.expiresAt,
-      has_policy: policyParse.policy !== undefined,
-    },
-  });
-
+  // Storage builds the audit entry internally now (closes #506
+  // builder R1 #3 — entry construction inside the lock window so
+  // the new token's fingerprint can be included in detail and the
+  // entry lands atomically with the envelope write).
   try {
     const issued = await issueAgentToken({
       installationId: auth.installationId,
@@ -235,7 +222,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       keyring: keyringResult.keyring,
       keyVersion: keyringResult.keyVersion,
       redis: auth.redis,
-      auditEntry,
+      auditContext: {
+        operator: {
+          fingerprint: auth.envelope.fingerprint,
+          name: auth.name,
+        },
+      },
     });
 
     // Auth-success audit (fire-and-forget; same pattern as /whoami).

--- a/web/src/app/api/agent-tokens/route.ts
+++ b/web/src/app/api/agent-tokens/route.ts
@@ -1,0 +1,317 @@
+/**
+ * POST /api/agent-tokens — issue a new agent token (V1 envelope)
+ * GET  /api/agent-tokens — list this installation's tokens
+ *
+ * Auth: bearer token with `agent_tokens.manage` capability (admin
+ * preset, or explicit `--capabilities` including that string). The
+ * bootstrap admin token (B.1.d-iv) is the chain root; subsequent
+ * admin tokens are issued from that one.
+ *
+ * **Wire shape**: camelCase on request + response (`allowedRepos`,
+ * `allowedPermissions`); storage stays snake_case. Translation
+ * happens in `agent-token-v1-routes.ts` helpers.
+ *
+ * **Audit**: issue mutations land atomically in the `:audit` stream
+ * via the storage script's `auditEntry` slot — no fire-and-forget
+ * gap. Auth events (success/failure) emit fire-and-forget via
+ * `auditAppend` to the `:auth` stream, mirroring the /whoami pattern.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  authenticateAgentRequestV1,
+  loadV1MintKeyring,
+} from "@/server/agent-token-v1-auth";
+import {
+  issueAgentToken,
+  listAgentTokens,
+} from "@/server/agent-token-v1";
+import {
+  isKnownPreset,
+  resolvePreset,
+  validateName,
+  validateAgentRole,
+  CapabilityValidationError,
+} from "@/server/agent-token-capabilities";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import {
+  parseExpiresIn,
+  parseV1RequestPolicy,
+  buildMutationAuditEntry,
+  projectV1ResponsePolicy,
+  projectV1TokenSummary,
+  mapV1StorageErrorToResponse,
+  readJsonObject,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+  type V1ResponsePolicyView,
+  type V1TokenSummaryView,
+} from "@/server/agent-token-v1-routes";
+
+const REQUIRED_CAPABILITY = "agent_tokens.manage";
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+interface IssueResponse {
+  /** Raw bearer (`hmt_xxx...`). Shown ONCE — operators MUST persist
+   * it now; storage holds only the encrypted ciphertext + a SHA-256
+   * hash for reverse lookup. There's no GET-after-issue path. */
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+  policy: V1ResponsePolicyView | null;
+  /** Operator reminder. Static string; not parsed by clients. */
+  message: string;
+}
+
+interface ListResponse {
+  tokens: V1TokenSummaryView[];
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/agent-tokens — issue
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: REQUIRED_CAPABILITY,
+  });
+  if (!auth.ok) return auth.response;
+
+  const keyringResult = loadV1MintKeyring();
+  if (!keyringResult.ok) return keyringResult.response;
+
+  const parsedBody = await readJsonObject(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+
+  // ----- name + agent_role -----
+  if (typeof body.name !== "string") {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+      "name (string) is required.",
+      400,
+    );
+  }
+  if (typeof body.agent_role !== "string") {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_AGENT_ROLE,
+      "agent_role (string) is required. Per CAPABILITIES_DESIGN.md, agent_role is REQUIRED on issue — no implicit default.",
+      400,
+    );
+  }
+  try {
+    validateName(body.name);
+    validateAgentRole(body.agent_role);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      const code =
+        err.field === "name"
+          ? AGENT_TOKENS_V1_ERROR.INVALID_NAME
+          : AGENT_TOKENS_V1_ERROR.INVALID_AGENT_ROLE;
+      return v1Error(code, err.message, 400, {
+        field: err.field,
+        value: err.value,
+      });
+    }
+    throw err;
+  }
+  const name = body.name;
+  const agent_role = body.agent_role;
+
+  // ----- capabilities (preset OR explicit list) -----
+  let capabilities: readonly string[];
+  if (body.preset !== undefined) {
+    if (body.capabilities !== undefined) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "preset and capabilities are mutually exclusive — pass one or the other.",
+        400,
+      );
+    }
+    if (typeof body.preset !== "string" || !isKnownPreset(body.preset)) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_PRESET,
+        `preset must be one of the known names (got ${JSON.stringify(body.preset)}).`,
+        400,
+      );
+    }
+    capabilities = resolvePreset(body.preset);
+  } else if (Array.isArray(body.capabilities)) {
+    if (body.capabilities.length === 0) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "capabilities must contain ≥1 entry — refusing to issue an empty-capability token (would be permanently 401).",
+        400,
+      );
+    }
+    for (const c of body.capabilities) {
+      if (typeof c !== "string") {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+          "capabilities entries must be strings.",
+          400,
+        );
+      }
+    }
+    capabilities = body.capabilities as string[];
+  } else {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+      "Pass either preset (named bundle) or capabilities (string[]).",
+      400,
+    );
+  }
+
+  // ----- bare-`*` opt-in (closes design § Wildcard) -----
+  // Bare `*` granted by accident is the most dangerous shape; the
+  // CLI defaults to rejecting it and the API mirrors that here.
+  // Operators who want a true admin token must set
+  // `allowWildcards: true` AND list `*` explicitly. `agent_tokens.manage`
+  // is NOT included by `*` — they're separate caps for a reason.
+  const allowWildcards = body.allowWildcards === true;
+  if (!allowWildcards) {
+    for (const c of capabilities) {
+      if (c === "*") {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.WILDCARD_NOT_ALLOWED,
+          "Bare '*' capability requires allowWildcards: true (deliberate opt-in per design — bare wildcards are the most dangerous shape).",
+          400,
+        );
+      }
+    }
+  }
+
+  // ----- expiresIn → expiresAt -----
+  const expiresParse = parseExpiresIn(body.expiresIn);
+  if (!expiresParse.ok) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN,
+      expiresParse.message,
+      400,
+    );
+  }
+
+  // ----- policy (camelCase wire → snake_case storage) -----
+  const policyParse = parseV1RequestPolicy(body.policy);
+  if (!policyParse.ok) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_POLICY,
+      policyParse.message,
+      400,
+    );
+  }
+
+  // ----- audit entry (fingerprint = OPERATOR's; subjectName = NEW token's) -----
+  const auditEntry = buildMutationAuditEntry({
+    action: "issue",
+    operator: {
+      fingerprint: auth.envelope.fingerprint,
+      name: auth.name,
+    },
+    subjectName: name,
+    detail: {
+      agent_role,
+      capabilities: [...capabilities],
+      expiresAt: expiresParse.expiresAt,
+      has_policy: policyParse.policy !== undefined,
+    },
+  });
+
+  try {
+    const issued = await issueAgentToken({
+      installationId: auth.installationId,
+      name,
+      agent_role,
+      capabilities,
+      createdBy: auth.name, // operator's token name as createdBy
+      expiresAt: expiresParse.expiresAt,
+      ...(policyParse.policy ? { policy: policyParse.policy } : {}),
+      keyring: keyringResult.keyring,
+      keyVersion: keyringResult.keyVersion,
+      redis: auth.redis,
+      auditEntry,
+    });
+
+    // Auth-success audit (fire-and-forget; same pattern as /whoami).
+    void auditAppend({
+      redis: auth.redis,
+      installationId: auth.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: auth.envelope.fingerprint,
+        name: auth.name,
+        action: "auth.success",
+        endpoint: "POST /api/agent-tokens",
+        required_capability: REQUIRED_CAPABILITY,
+        outcome: "ok",
+      },
+    });
+
+    const responseBody: IssueResponse = {
+      token: issued.token,
+      name: issued.name,
+      agent_role: issued.agent_role,
+      capabilities: issued.capabilities,
+      fingerprint: issued.fingerprint,
+      expiresAt: issued.expiresAt,
+      policy: projectV1ResponsePolicy(policyParse.policy ?? null),
+      message:
+        "Bearer is shown ONCE — store it securely now. There is no GET-after-issue path.",
+    };
+    return NextResponse.json(responseBody, { status: 201 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "POST /api/agent-tokens",
+      installationId: auth.installationId,
+      name,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/agent-tokens — list
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: REQUIRED_CAPABILITY,
+  });
+  if (!auth.ok) return auth.response;
+
+  try {
+    const summaries = await listAgentTokens({
+      installationId: auth.installationId,
+      redis: auth.redis,
+    });
+
+    void auditAppend({
+      redis: auth.redis,
+      installationId: auth.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: auth.envelope.fingerprint,
+        name: auth.name,
+        action: "auth.success",
+        endpoint: "GET /api/agent-tokens",
+        required_capability: REQUIRED_CAPABILITY,
+        outcome: "ok",
+      },
+    });
+
+    const responseBody: ListResponse = {
+      tokens: summaries.map(projectV1TokenSummary),
+    };
+    return NextResponse.json(responseBody, { status: 200 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "GET /api/agent-tokens",
+      installationId: auth.installationId,
+    });
+  }
+}

--- a/web/src/app/api/whoami/route.test.ts
+++ b/web/src/app/api/whoami/route.test.ts
@@ -329,6 +329,13 @@ describe("GET /api/whoami — policy projection", () => {
     expect(raw).not.toContain("0123456789abcdef"); // tokenHash from envelope
     expect(raw).not.toContain("createdBy");
     expect(raw).not.toContain("operator");
+    // Carry-forward from #505 guard R2 N2: complete the envelope-fields
+    // blacklist. keyVersion + createdAt aren't in the projection by
+    // construction, but pinning their absence catches a future refactor
+    // that accidentally widens the projection.
+    expect(raw).not.toContain('"keyVersion"');
+    expect(raw).not.toContain('"createdAt"');
+    expect(raw).not.toContain("2026-04-27T10:00:00.000Z"); // mock createdAt
     // Sanity — the legitimate (camelCase) fields ARE there
     expect(raw).toContain("allowedRepos");
     expect(raw).toContain("allowedPermissions");

--- a/web/src/app/api/whoami/route.ts
+++ b/web/src/app/api/whoami/route.ts
@@ -53,9 +53,27 @@ import { auditAppend } from "@/server/agent-token-v1-audit";
  * shape entirely when absent — operators see "no narrowing" rather
  * than "narrowing: undefined".
  */
+/**
+ * GitHub permission level union. Inlined (not imported from
+ * agent-token.ts) to keep the wire type self-contained and decoupled
+ * from the storage type — same defense-in-depth rationale as
+ * `WhoamiPolicyView` itself. The values are a stable, well-known
+ * GitHub-permission set; if the storage union ever expands at
+ * `agent-token.ts:GitHubPermissionLevel`, the projection here
+ * intentionally still narrows what the wire promises until this
+ * file is updated explicitly.
+ *
+ * Carry-forward from #505 guard R2 N1: was `Record<string, string>`,
+ * but if storage drifts (CLI bug, manual envelope edit), the
+ * introspection signal would mislead operators reading /whoami.
+ * Narrowing the wire type catches drift at the type boundary even
+ * though GitHub rejects malformed values at mint time.
+ */
+type WhoamiPermissionLevel = "read" | "write" | "admin";
+
 interface WhoamiPolicyView {
   allowedRepos: string[];
-  allowedPermissions?: Record<string, string>;
+  allowedPermissions?: Record<string, WhoamiPermissionLevel>;
 }
 
 interface WhoamiResponse {

--- a/web/src/server/agent-token-v1-auth.ts
+++ b/web/src/server/agent-token-v1-auth.ts
@@ -33,6 +33,7 @@ import { type Redis } from "@upstash/redis";
 import { NextRequest, NextResponse } from "next/server";
 import { validateEnv } from "@/server/env";
 import { getRedisClient } from "@/server/redis";
+import { parseKeyring } from "@/server/crypto";
 import {
   bearerHasCapability,
 } from "@/server/agent-token-capabilities";
@@ -423,4 +424,98 @@ export async function authenticateAgentRequestV1(
     envelope,
     redis,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Keyring loader (for issue / rotate endpoints — anything that mints
+// new envelopes needs the active master key)
+// ---------------------------------------------------------------------------
+
+export type LoadV1MintKeyringResult =
+  | { ok: true; keyring: Map<string, Buffer>; keyVersion: string }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Load the active keyring + its version for V1 mutation endpoints
+ * that mint envelopes (issue + rotate). Read endpoints don't need
+ * this — they only `get` from Redis. Bootstrap (B.1.d-iv) reuses
+ * this same loader.
+ *
+ * Returns a 503 NextResponse when env config is missing or the
+ * active key version isn't in the keyring. Mirrors the BYOK auth
+ * pattern (`byok-auth.ts:loadRuntimeConfig`) but is scoped to the
+ * V1 endpoints' needs — we don't need the cookie-session storage
+ * here, only the keyring.
+ *
+ * Per CLAUDE.md fail-closed principle: when the keyring is
+ * misconfigured we return 503 rather than letting the endpoint
+ * try to encrypt with an undefined key.
+ */
+export function loadV1MintKeyring(): LoadV1MintKeyringResult {
+  const env = validateEnv();
+  if (!env.ok) {
+    console.error(
+      "[agent-token-v1-auth] mint keyring load failed: env validation failed",
+      { missing: env.missing },
+    );
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Server misconfiguration",
+        503,
+      ),
+    };
+  }
+
+  const { byokActiveKeyVersion, byokMasterKeysJson } = env.config;
+
+  if (!byokActiveKeyVersion || !byokMasterKeysJson) {
+    console.error(
+      "[agent-token-v1-auth] mint keyring load failed: BYOK_ACTIVE_KEY_VERSION or BYOK_MASTER_KEYS missing",
+    );
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Encryption is not configured",
+        503,
+      ),
+    };
+  }
+
+  let keyring: Map<string, Buffer>;
+  try {
+    keyring = parseKeyring(byokMasterKeysJson);
+  } catch (err) {
+    console.error(
+      "[agent-token-v1-auth] mint keyring load failed: parseKeyring threw",
+      { error: err },
+    );
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Invalid encryption configuration",
+        503,
+      ),
+    };
+  }
+
+  if (!keyring.has(byokActiveKeyVersion)) {
+    console.error(
+      "[agent-token-v1-auth] mint keyring load failed: active key version not in keyring",
+      { activeKeyVersion: byokActiveKeyVersion },
+    );
+    return {
+      ok: false,
+      response: authV1Error(
+        AGENT_AUTH_V1_ERROR.SERVER_MISCONFIGURATION,
+        "Active key version not in keyring",
+        503,
+      ),
+    };
+  }
+
+  return { ok: true, keyring, keyVersion: byokActiveKeyVersion };
 }

--- a/web/src/server/agent-token-v1-routes.test.ts
+++ b/web/src/server/agent-token-v1-routes.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Unit tests for the agent-tokens V1 route helpers.
+ *
+ * Helpers under test:
+ *   - parseExpiresIn (request-side duration → ISO timestamp)
+ *   - parseV1RequestPolicy (camelCase wire → snake_case storage)
+ *   - projectV1ResponsePolicy (snake_case storage → camelCase wire)
+ *   - projectV1TokenSummary (full summary projection)
+ *   - buildMutationAuditEntry (audit entry shape)
+ *   - mapV1StorageErrorToResponse (error → HTTP status)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseExpiresIn,
+  parseV1RequestPolicy,
+  projectV1ResponsePolicy,
+  projectV1TokenSummary,
+  buildMutationAuditEntry,
+  mapV1StorageErrorToResponse,
+  AGENT_TOKENS_V1_ERROR,
+} from "./agent-token-v1-routes";
+import {
+  TokenNameTakenError,
+  TokenNotFoundError,
+  TokenLimitReachedError,
+  InvalidExpiresAtError,
+  type AgentTokenSummaryV1,
+} from "./agent-token-v1";
+import { CapabilityValidationError } from "./agent-token-capabilities";
+import { LockTimeoutError } from "./redis-lock";
+
+// ---------------------------------------------------------------------------
+// parseExpiresIn
+// ---------------------------------------------------------------------------
+
+describe("parseExpiresIn", () => {
+  it("absent or null → expiresAt: null (no-expiry token)", () => {
+    expect(parseExpiresIn(undefined)).toEqual({ ok: true, expiresAt: null });
+    expect(parseExpiresIn(null)).toEqual({ ok: true, expiresAt: null });
+  });
+
+  it("'30d' → ISO timestamp ~30d in the future", () => {
+    const before = Date.now();
+    const result = parseExpiresIn("30d");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.expiresAt).not.toBeNull();
+      const ms = new Date(result.expiresAt!).getTime() - before;
+      // Allow small slack for the moment between Date.now() inside vs outside.
+      expect(ms).toBeGreaterThanOrEqual(30 * 24 * 60 * 60 * 1000 - 100);
+      expect(ms).toBeLessThanOrEqual(30 * 24 * 60 * 60 * 1000 + 100);
+    }
+  });
+
+  it("'12h' / '60m' both parse correctly", () => {
+    const r1 = parseExpiresIn("12h");
+    const r2 = parseExpiresIn("60m");
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+  });
+
+  it("trims + lowercases input ('  30D ' → 30d)", () => {
+    const result = parseExpiresIn("  30D  ");
+    expect(result.ok).toBe(true);
+  });
+
+  it("non-string → ok: false", () => {
+    expect(parseExpiresIn(30)).toMatchObject({ ok: false });
+    expect(parseExpiresIn({})).toMatchObject({ ok: false });
+    expect(parseExpiresIn(true)).toMatchObject({ ok: false });
+  });
+
+  it("malformed pattern ('30 d' / 'd30' / '0d' / '-1d') → ok: false", () => {
+    expect(parseExpiresIn("30 d")).toMatchObject({ ok: false });
+    expect(parseExpiresIn("d30")).toMatchObject({ ok: false });
+    expect(parseExpiresIn("0d")).toMatchObject({ ok: false });
+    expect(parseExpiresIn("-1d")).toMatchObject({ ok: false });
+  });
+
+  it("over-365d cap → ok: false (avoids accidental near-infinite tokens)", () => {
+    expect(parseExpiresIn("366d")).toMatchObject({ ok: false });
+    expect(parseExpiresIn("365d")).toMatchObject({ ok: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseV1RequestPolicy
+// ---------------------------------------------------------------------------
+
+describe("parseV1RequestPolicy", () => {
+  it("absent / null → policy: undefined (legacy permissive)", () => {
+    expect(parseV1RequestPolicy(undefined)).toEqual({
+      ok: true,
+      policy: undefined,
+    });
+    expect(parseV1RequestPolicy(null)).toEqual({
+      ok: true,
+      policy: undefined,
+    });
+  });
+
+  it("V1.5 (allowedRepos only) → snake_case allowed_repos, no allowed_permissions key", () => {
+    const result = parseV1RequestPolicy({
+      allowedRepos: ["hivemoot/foxstoria"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy).toEqual({
+        allowed_repos: ["hivemoot/foxstoria"],
+      });
+      expect("allowed_permissions" in (result.policy ?? {})).toBe(false);
+    }
+  });
+
+  it("V1.6 (allowedRepos + allowedPermissions) → both translated", () => {
+    const result = parseV1RequestPolicy({
+      allowedRepos: ["hivemoot/foxstoria"],
+      allowedPermissions: { contents: "read", issues: "write" },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy).toEqual({
+        allowed_repos: ["hivemoot/foxstoria"],
+        allowed_permissions: { contents: "read", issues: "write" },
+      });
+    }
+  });
+
+  it("intentional reject-all (allowedRepos: []) translates faithfully", () => {
+    const result = parseV1RequestPolicy({ allowedRepos: [] });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy).toEqual({ allowed_repos: [] });
+    }
+  });
+
+  it("V1.6-only (allowedPermissions without allowedRepos) → rejected", () => {
+    // Storage type requires allowed_repos when policy is set; the
+    // boundary rejects rather than silently materializing a bad
+    // envelope shape.
+    const result = parseV1RequestPolicy({
+      allowedPermissions: { contents: "read" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/allowedRepos is required/i);
+    }
+  });
+
+  it("empty object {} → rejected (ambiguous: legacy-permissive vs reject-all)", () => {
+    const result = parseV1RequestPolicy({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/empty|set allowedRepos/i);
+    }
+  });
+
+  it("non-object input → rejected", () => {
+    expect(parseV1RequestPolicy("hivemoot/foo")).toMatchObject({ ok: false });
+    expect(parseV1RequestPolicy([])).toMatchObject({ ok: false });
+    expect(parseV1RequestPolicy(42)).toMatchObject({ ok: false });
+  });
+
+  it("allowedRepos non-array → rejected", () => {
+    expect(
+      parseV1RequestPolicy({ allowedRepos: "hivemoot/foo" }),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("allowedRepos with non-string entry → rejected", () => {
+    expect(
+      parseV1RequestPolicy({ allowedRepos: ["hivemoot/foo", 42] }),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("allowedPermissions with invalid level → rejected", () => {
+    const result = parseV1RequestPolicy({
+      allowedRepos: ["hivemoot/foo"],
+      allowedPermissions: { contents: "owner" }, // not in {read, write, admin}
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/contents/);
+      expect(result.message).toMatch(/read.*write.*admin/i);
+    }
+  });
+
+  it("allowedPermissions non-object → rejected", () => {
+    expect(
+      parseV1RequestPolicy({
+        allowedRepos: [],
+        allowedPermissions: ["contents:read"],
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      parseV1RequestPolicy({
+        allowedRepos: [],
+        allowedPermissions: null,
+      }),
+    ).toMatchObject({ ok: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectV1ResponsePolicy
+// ---------------------------------------------------------------------------
+
+describe("projectV1ResponsePolicy", () => {
+  it("undefined / null → null (envelope had no policy)", () => {
+    expect(projectV1ResponsePolicy(undefined)).toBeNull();
+    expect(projectV1ResponsePolicy(null)).toBeNull();
+  });
+
+  it("V1.5 storage → camelCase wire", () => {
+    expect(
+      projectV1ResponsePolicy({ allowed_repos: ["hivemoot/foo"] }),
+    ).toEqual({ allowedRepos: ["hivemoot/foo"] });
+  });
+
+  it("V1.6 storage → camelCase wire (both fields)", () => {
+    expect(
+      projectV1ResponsePolicy({
+        allowed_repos: ["hivemoot/foo"],
+        allowed_permissions: { contents: "read" },
+      }),
+    ).toEqual({
+      allowedRepos: ["hivemoot/foo"],
+      allowedPermissions: { contents: "read" },
+    });
+  });
+
+  it("reject-all (allowed_repos: []) → allowedRepos: []", () => {
+    expect(projectV1ResponsePolicy({ allowed_repos: [] })).toEqual({
+      allowedRepos: [],
+    });
+  });
+
+  it("V1.5 (no allowed_permissions) omits the wire key entirely", () => {
+    const result = projectV1ResponsePolicy({
+      allowed_repos: ["hivemoot/foo"],
+    });
+    expect(result).not.toBeNull();
+    expect("allowedPermissions" in (result ?? {})).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectV1TokenSummary
+// ---------------------------------------------------------------------------
+
+describe("projectV1TokenSummary", () => {
+  const baseSummary: AgentTokenSummaryV1 = {
+    name: "worker",
+    agent_role: "drone",
+    capabilities: ["agent_health.report", "tasks.claim"],
+    fingerprint: "01234567",
+    createdAt: "2026-04-27T10:00:00.000Z",
+    createdBy: "operator",
+    expiresAt: null,
+  };
+
+  it("translates summary with no policy → policy: null on wire", () => {
+    expect(projectV1TokenSummary(baseSummary)).toEqual({
+      name: "worker",
+      agent_role: "drone",
+      capabilities: ["agent_health.report", "tasks.claim"],
+      fingerprint: "01234567",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "operator",
+      expiresAt: null,
+      policy: null,
+    });
+  });
+
+  it("translates summary with V1.6 policy → camelCase on wire", () => {
+    const result = projectV1TokenSummary({
+      ...baseSummary,
+      policy: {
+        allowed_repos: ["hivemoot/foo"],
+        allowed_permissions: { contents: "read" },
+      },
+    });
+    expect(result.policy).toEqual({
+      allowedRepos: ["hivemoot/foo"],
+      allowedPermissions: { contents: "read" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildMutationAuditEntry
+// ---------------------------------------------------------------------------
+
+describe("buildMutationAuditEntry", () => {
+  it("issue: fingerprint = operator's, name = subject's, actor = operator's name", () => {
+    const entry = buildMutationAuditEntry({
+      action: "issue",
+      operator: { fingerprint: "abcdef01", name: "admin" },
+      subjectName: "new-worker",
+      detail: { agent_role: "drone", capabilities: ["agent_health.report"] },
+    });
+    expect(entry.fingerprint).toBe("abcdef01");
+    expect(entry.name).toBe("new-worker");
+    expect(entry.action).toBe("issue");
+    expect(entry.actor).toBe("admin");
+    expect(entry.detail).toEqual({
+      agent_role: "drone",
+      capabilities: ["agent_health.report"],
+    });
+    expect(typeof entry.ts).toBe("string");
+    // ISO 8601 + UTC marker
+    expect(entry.ts).toMatch(/T.*Z$/);
+  });
+
+  it("revoke: minimal entry without detail", () => {
+    const entry = buildMutationAuditEntry({
+      action: "revoke",
+      operator: { fingerprint: "abcdef01", name: "admin" },
+      subjectName: "old-worker",
+    });
+    expect(entry.action).toBe("revoke");
+    expect(entry.name).toBe("old-worker");
+    expect(entry.actor).toBe("admin");
+    expect("detail" in entry).toBe(false);
+  });
+
+  it("set_capabilities: detail carries from + to lists", () => {
+    const entry = buildMutationAuditEntry({
+      action: "set_capabilities",
+      operator: { fingerprint: "abcdef01", name: "admin" },
+      subjectName: "worker",
+      detail: { from: ["tasks.claim"], to: ["tasks.claim", "rooms.read"] },
+    });
+    expect(entry.detail).toEqual({
+      from: ["tasks.claim"],
+      to: ["tasks.claim", "rooms.read"],
+    });
+  });
+
+  it("SECURITY: never includes raw token / bearer field", () => {
+    const entry = buildMutationAuditEntry({
+      action: "issue",
+      operator: { fingerprint: "abcdef01", name: "admin" },
+      subjectName: "worker",
+    });
+    const json = JSON.stringify(entry);
+    expect(json).not.toMatch(/"token"\s*:/);
+    expect(json).not.toMatch(/"bearer"\s*:/);
+    expect(json).not.toMatch(/hmt_/); // no raw bearer prefix
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapV1StorageErrorToResponse
+// ---------------------------------------------------------------------------
+
+describe("mapV1StorageErrorToResponse", () => {
+  const ctx = { route: "POST /api/agent-tokens", installationId: "12345" };
+
+  it("TokenNameTakenError → 409 NAME_TAKEN", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new TokenNameTakenError("12345", "worker"),
+      { ...ctx, name: "worker" },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.NAME_TAKEN);
+    expect(body.name).toBe("worker");
+  });
+
+  it("TokenNotFoundError → 404 TOKEN_NOT_FOUND", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new TokenNotFoundError("12345", "missing"),
+      { ...ctx, name: "missing" },
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.TOKEN_NOT_FOUND);
+  });
+
+  it("TokenLimitReachedError → 422 TOKEN_LIMIT_REACHED", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new TokenLimitReachedError("12345", 20),
+      ctx,
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.TOKEN_LIMIT_REACHED);
+  });
+
+  it("InvalidExpiresAtError → 400 INVALID_EXPIRES_IN", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new InvalidExpiresAtError("not-a-date", "not a valid ISO 8601 timestamp"),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN);
+  });
+
+  it("CapabilityValidationError → 400 INVALID_CAPABILITIES with field+value", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new CapabilityValidationError("name", "bad name", "lowercase ASCII"),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES);
+    expect(body.field).toBe("name");
+    expect(body.value).toBe("bad name");
+  });
+
+  it("LockTimeoutError → 503 LOCK_TIMEOUT", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new LockTimeoutError("hive:v1:lock:agent-token:12345:worker"),
+      ctx,
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.LOCK_TIMEOUT);
+  });
+
+  it("unknown error → 500 SERVER_ERROR (opaque, no leak)", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new Error("internal SQL state INVALID_DETAIL"),
+      ctx,
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.SERVER_ERROR);
+    // Critical: don't leak the raw error message to clients.
+    expect(body.message).not.toContain("INVALID_DETAIL");
+    expect(body.message).not.toContain("SQL");
+  });
+});

--- a/web/src/server/agent-token-v1-routes.test.ts
+++ b/web/src/server/agent-token-v1-routes.test.ts
@@ -6,8 +6,8 @@
  *   - parseV1RequestPolicy (camelCase wire → snake_case storage)
  *   - projectV1ResponsePolicy (snake_case storage → camelCase wire)
  *   - projectV1TokenSummary (full summary projection)
- *   - buildMutationAuditEntry (audit entry shape)
- *   - mapV1StorageErrorToResponse (error → HTTP status)
+ *   - mapV1StorageErrorToResponse (error → HTTP status,
+ *     including TokenExpiredForMutationError → 410 Gone)
  */
 
 import { describe, it, expect } from "vitest";
@@ -16,7 +16,6 @@ import {
   parseV1RequestPolicy,
   projectV1ResponsePolicy,
   projectV1TokenSummary,
-  buildMutationAuditEntry,
   mapV1StorageErrorToResponse,
   AGENT_TOKENS_V1_ERROR,
 } from "./agent-token-v1-routes";
@@ -24,6 +23,7 @@ import {
   TokenNameTakenError,
   TokenNotFoundError,
   TokenLimitReachedError,
+  TokenExpiredForMutationError,
   InvalidExpiresAtError,
   type AgentTokenSummaryV1,
 } from "./agent-token-v1";
@@ -289,69 +289,6 @@ describe("projectV1TokenSummary", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildMutationAuditEntry
-// ---------------------------------------------------------------------------
-
-describe("buildMutationAuditEntry", () => {
-  it("issue: fingerprint = operator's, name = subject's, actor = operator's name", () => {
-    const entry = buildMutationAuditEntry({
-      action: "issue",
-      operator: { fingerprint: "abcdef01", name: "admin" },
-      subjectName: "new-worker",
-      detail: { agent_role: "drone", capabilities: ["agent_health.report"] },
-    });
-    expect(entry.fingerprint).toBe("abcdef01");
-    expect(entry.name).toBe("new-worker");
-    expect(entry.action).toBe("issue");
-    expect(entry.actor).toBe("admin");
-    expect(entry.detail).toEqual({
-      agent_role: "drone",
-      capabilities: ["agent_health.report"],
-    });
-    expect(typeof entry.ts).toBe("string");
-    // ISO 8601 + UTC marker
-    expect(entry.ts).toMatch(/T.*Z$/);
-  });
-
-  it("revoke: minimal entry without detail", () => {
-    const entry = buildMutationAuditEntry({
-      action: "revoke",
-      operator: { fingerprint: "abcdef01", name: "admin" },
-      subjectName: "old-worker",
-    });
-    expect(entry.action).toBe("revoke");
-    expect(entry.name).toBe("old-worker");
-    expect(entry.actor).toBe("admin");
-    expect("detail" in entry).toBe(false);
-  });
-
-  it("set_capabilities: detail carries from + to lists", () => {
-    const entry = buildMutationAuditEntry({
-      action: "set_capabilities",
-      operator: { fingerprint: "abcdef01", name: "admin" },
-      subjectName: "worker",
-      detail: { from: ["tasks.claim"], to: ["tasks.claim", "rooms.read"] },
-    });
-    expect(entry.detail).toEqual({
-      from: ["tasks.claim"],
-      to: ["tasks.claim", "rooms.read"],
-    });
-  });
-
-  it("SECURITY: never includes raw token / bearer field", () => {
-    const entry = buildMutationAuditEntry({
-      action: "issue",
-      operator: { fingerprint: "abcdef01", name: "admin" },
-      subjectName: "worker",
-    });
-    const json = JSON.stringify(entry);
-    expect(json).not.toMatch(/"token"\s*:/);
-    expect(json).not.toMatch(/"bearer"\s*:/);
-    expect(json).not.toMatch(/hmt_/); // no raw bearer prefix
-  });
-});
-
-// ---------------------------------------------------------------------------
 // mapV1StorageErrorToResponse
 // ---------------------------------------------------------------------------
 
@@ -387,6 +324,24 @@ describe("mapV1StorageErrorToResponse", () => {
     expect(res.status).toBe(422);
     const body = await res.json();
     expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.TOKEN_LIMIT_REACHED);
+  });
+
+  it("TokenExpiredForMutationError → 410 Gone with name + expiredAt (B.1)", async () => {
+    const res = mapV1StorageErrorToResponse(
+      new TokenExpiredForMutationError(
+        "12345",
+        "old-worker",
+        "2026-04-26T00:00:00.000Z",
+      ),
+      { ...ctx, name: "old-worker" },
+    );
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe(AGENT_TOKENS_V1_ERROR.TOKEN_EXPIRED_FOR_MUTATION);
+    expect(body.name).toBe("old-worker");
+    expect(body.expiredAt).toBe("2026-04-26T00:00:00.000Z");
+    // Operator-facing message hints at the recovery path
+    expect(body.message).toMatch(/successor/i);
   });
 
   it("InvalidExpiresAtError → 400 INVALID_EXPIRES_IN", async () => {

--- a/web/src/server/agent-token-v1-routes.ts
+++ b/web/src/server/agent-token-v1-routes.ts
@@ -1,0 +1,494 @@
+/**
+ * Shared helpers for the V1 agent-token route handlers under
+ * `/api/agent-tokens/*` (Phase B.1.d-ii).
+ *
+ * The handlers themselves are thin shells: authenticate via
+ * `authenticateAgentRequestV1`, validate input, call the storage
+ * layer with an `auditEntry`, project the result onto the wire shape.
+ * Everything reusable across endpoints lives here.
+ *
+ * **Wire-shape convention** matches `/api/whoami` (B.1.d-i): camelCase
+ * on the public surface, snake_case in storage. The handler is the
+ * translation layer in BOTH directions:
+ *   - `parseV1RequestPolicy()` translates request `allowedRepos` →
+ *     storage `allowed_repos` so we can pass straight into
+ *     `issueAgentToken`/`setAgentTokenCapabilities`.
+ *   - `projectV1ResponsePolicy()` translates the stored snake_case
+ *     back to camelCase for the response — same projection /whoami uses.
+ *
+ * **Audit-entry construction** lives in `buildMutationAuditEntry` so
+ * every mutation endpoint emits a consistent shape: `fingerprint` =
+ * the operator's bearer fingerprint (i.e. who triggered the action),
+ * `name` = the SUBJECT (the token being acted on), `actor` = the
+ * operator's name. Per-action `detail` payloads are caller-specified.
+ *
+ * **Error mapping** centralizes the storage-error → HTTP-status
+ * translation. The route handler catches any error and lets
+ * `mapV1StorageErrorToResponse` decide the response — keeps each
+ * route's catch block down to one line.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  TokenNameTakenError,
+  TokenNotFoundError,
+  TokenLimitReachedError,
+  InvalidExpiresAtError,
+  type AgentTokenSummaryV1,
+} from "@/server/agent-token-v1";
+import { CapabilityValidationError } from "@/server/agent-token-capabilities";
+import { LockTimeoutError } from "@/server/redis-lock";
+import {
+  type AuditMutationEntry,
+  type AuditMutationAction,
+} from "@/server/agent-token-v1-audit";
+import type { AgentTokenPolicy } from "@/server/agent-token";
+
+// ---------------------------------------------------------------------------
+// Request-body helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * `expiresIn` request shape mirrors the legacy `/api/agent-token`
+ * endpoint (`90d` / `12h` / `30m`) so operators don't have to learn
+ * a new vocabulary. Capped at 365d to avoid accidental "infinite"
+ * tokens that bypass the deliberate-no-expiry path (`expiresIn:
+ * null`, which the V1 envelope explicitly supports).
+ */
+const EXPIRES_IN_PATTERN = /^([1-9]\d*)([mhd])$/;
+const EXPIRES_IN_UNITS_MS = {
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+} as const;
+const MAX_EXPIRES_IN_MS = 365 * EXPIRES_IN_UNITS_MS.d;
+
+export type ParsedExpiresIn =
+  | { ok: true; expiresAt: string | null }
+  | { ok: false; message: string };
+
+/**
+ * Translate an `expiresIn` request value (`"30d"`, `"12h"`, `"30m"`,
+ * `null`, or absent) into an absolute ISO 8601 timestamp.
+ *
+ * Returns `expiresAt: null` for absent/null inputs (no-expiry token,
+ * supported per the design). `null` means the operator deliberately
+ * chose no expiry — distinct from the legacy fallback. Storage
+ * layer (`issueAgentToken`) rejects past timestamps via
+ * `InvalidExpiresAtError`, so this helper only validates the
+ * request-side shape.
+ */
+export function parseExpiresIn(input: unknown): ParsedExpiresIn {
+  if (input == null) return { ok: true, expiresAt: null };
+  if (typeof input !== "string") {
+    return {
+      ok: false,
+      message: "expiresIn must be a duration string like '30d', '12h', '60m', or null for no expiry.",
+    };
+  }
+  const match = input.trim().toLowerCase().match(EXPIRES_IN_PATTERN);
+  if (!match) {
+    return {
+      ok: false,
+      message: "expiresIn must be a positive integer plus 'm', 'h', or 'd' (e.g. '30d').",
+    };
+  }
+  const amount = Number(match[1]);
+  const unit = match[2] as keyof typeof EXPIRES_IN_UNITS_MS;
+  const durationMs = amount * EXPIRES_IN_UNITS_MS[unit];
+  if (!Number.isSafeInteger(durationMs) || durationMs > MAX_EXPIRES_IN_MS) {
+    return {
+      ok: false,
+      message: "expiresIn must be no more than 365 days.",
+    };
+  }
+  return {
+    ok: true,
+    expiresAt: new Date(Date.now() + durationMs).toISOString(),
+  };
+}
+
+/**
+ * Wire-shape policy on the request body — `allowedRepos` (camelCase)
+ * to match the response shape used by `/api/whoami`. Both fields
+ * optional in the wire schema; absent = no narrowing applied to that
+ * dimension. Translated to snake_case `AgentTokenPolicy` for storage
+ * via `parseV1RequestPolicy`.
+ */
+interface RequestPolicyView {
+  allowedRepos?: unknown;
+  allowedPermissions?: unknown;
+}
+
+export type ParsedRequestPolicy =
+  | { ok: true; policy: AgentTokenPolicy | undefined }
+  | { ok: false; message: string };
+
+const ALLOWED_PERMISSION_LEVELS = new Set(["read", "write", "admin"]);
+
+/**
+ * Validate + translate a request-body `policy` from camelCase wire
+ * shape to the snake_case `AgentTokenPolicy` storage shape. Returns
+ * `policy: undefined` when the field is absent (no policy on the
+ * envelope = legacy permissive). Returns a structured policy when
+ * present.
+ *
+ * Validation:
+ *   - `allowedRepos` must be string[] when present (empty [] is OK
+ *     per the design — intentional reject-all marker)
+ *   - `allowedPermissions` must be Record<string, "read"|"write"|"admin">
+ *     when present
+ *
+ * If the operator sends `policy: null` or omits the key entirely,
+ * the storage envelope simply has no policy field. If they send
+ * `policy: {}` (empty object), we still need to materialize an
+ * `AgentTokenPolicy` — but `allowed_repos` is required there, so
+ * we reject empty-object policies as ambiguous.
+ */
+export function parseV1RequestPolicy(input: unknown): ParsedRequestPolicy {
+  if (input == null) return { ok: true, policy: undefined };
+  if (typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      message: "policy must be an object with allowedRepos and/or allowedPermissions.",
+    };
+  }
+  const view = input as RequestPolicyView;
+  const hasRepos = view.allowedRepos !== undefined;
+  const hasPermissions = view.allowedPermissions !== undefined;
+
+  if (!hasRepos && !hasPermissions) {
+    return {
+      ok: false,
+      message:
+        "policy is empty — set allowedRepos (string[], possibly empty for reject-all) and/or allowedPermissions, or omit the policy field entirely for legacy-permissive.",
+    };
+  }
+
+  if (!hasRepos) {
+    // Storage type requires allowed_repos when policy is set —
+    // intentionally rejecting V1.6-only-policy requests at the
+    // boundary, matching the design's stance (V1.6 is purely
+    // additive over V1.5; an `allowed_permissions`-only token still
+    // has to declare its repo scope).
+    return {
+      ok: false,
+      message:
+        "policy.allowedRepos is required when policy is set (use [] for intentional reject-all).",
+    };
+  }
+
+  if (!Array.isArray(view.allowedRepos)) {
+    return {
+      ok: false,
+      message: "policy.allowedRepos must be an array of 'owner/name' strings.",
+    };
+  }
+  for (const r of view.allowedRepos) {
+    if (typeof r !== "string") {
+      return {
+        ok: false,
+        message: "policy.allowedRepos entries must be strings.",
+      };
+    }
+  }
+
+  let allowedPermissions: Record<string, "read" | "write" | "admin"> | undefined;
+  if (hasPermissions) {
+    if (
+      typeof view.allowedPermissions !== "object" ||
+      view.allowedPermissions === null ||
+      Array.isArray(view.allowedPermissions)
+    ) {
+      return {
+        ok: false,
+        message:
+          "policy.allowedPermissions must be a map of permission name → 'read' | 'write' | 'admin'.",
+      };
+    }
+    allowedPermissions = {};
+    for (const [k, v] of Object.entries(
+      view.allowedPermissions as Record<string, unknown>,
+    )) {
+      if (typeof v !== "string" || !ALLOWED_PERMISSION_LEVELS.has(v)) {
+        return {
+          ok: false,
+          message: `policy.allowedPermissions.${k} must be 'read', 'write', or 'admin' (got ${JSON.stringify(v)}).`,
+        };
+      }
+      allowedPermissions[k] = v as "read" | "write" | "admin";
+    }
+  }
+
+  return {
+    ok: true,
+    policy: {
+      allowed_repos: view.allowedRepos as string[],
+      ...(allowedPermissions !== undefined ? { allowed_permissions: allowedPermissions } : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response-shape helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire-shape policy on responses — camelCase per design doc, matches
+ * `/api/whoami`. Local interface (not imported from AgentTokenPolicy)
+ * for the same auto-leak-defense reason as `WhoamiPolicyView`: future
+ * additions to the storage type can't silently appear on the wire.
+ */
+export interface V1ResponsePolicyView {
+  allowedRepos: string[];
+  allowedPermissions?: Record<string, "read" | "write" | "admin">;
+}
+
+/**
+ * Sanitized response-side policy projection. Returns `null` when the
+ * envelope has no policy (legacy / V1.5-pre); otherwise a camelCase
+ * projection that's identical in shape to /whoami's. Only copies
+ * known V1.5/V1.6 fields — never spreads the storage type wholesale.
+ */
+export function projectV1ResponsePolicy(
+  storage: AgentTokenPolicy | undefined | null,
+): V1ResponsePolicyView | null {
+  if (!storage) return null;
+  return {
+    allowedRepos: storage.allowed_repos,
+    ...(storage.allowed_permissions !== undefined
+      ? { allowedPermissions: storage.allowed_permissions }
+      : {}),
+  };
+}
+
+/** Wire-shape summary returned by GET list / GET show. Mirrors
+ * `AgentTokenSummaryV1` but with camelCase policy. */
+export interface V1TokenSummaryView {
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  createdAt: string;
+  createdBy: string;
+  expiresAt: string | null;
+  policy: V1ResponsePolicyView | null;
+}
+
+export function projectV1TokenSummary(
+  summary: AgentTokenSummaryV1,
+): V1TokenSummaryView {
+  return {
+    name: summary.name,
+    agent_role: summary.agent_role,
+    capabilities: summary.capabilities,
+    fingerprint: summary.fingerprint,
+    createdAt: summary.createdAt,
+    createdBy: summary.createdBy,
+    expiresAt: summary.expiresAt,
+    policy: projectV1ResponsePolicy(summary.policy ?? null),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Audit entry construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mutation-class audit entry for the storage script's
+ * atomic-XADD slot. All four mutation endpoints share this builder
+ * so the audit entries land in `:audit` with consistent shape.
+ *
+ * **Field semantics** (see also `BaseAuditEntry` jsdoc):
+ *   - `fingerprint` — the OPERATOR's bearer fingerprint (the bearer
+ *     that authenticated the call). Lets investigators trace
+ *     "which operator did this" back through the auth stream.
+ *   - `name` — the SUBJECT's name (the token being acted on). For
+ *     `issue` this is the new token's name. For revoke /
+ *     set_capabilities / rotate it's the existing token's name.
+ *   - `actor` — the operator's name (admin token name when API
+ *     bearer-driven; "dashboard" for cookie/bootstrap path —
+ *     B.1.d-iv will use that variant).
+ *   - `detail` — caller-specified action-specific payload. For issue:
+ *     the new token's metadata. For set_capabilities: from/to lists.
+ *     For rotate/revoke: typically minimal.
+ *
+ * Note: for `issue`, the new token's fingerprint is NOT in this
+ * entry's `fingerprint` field (unknown until inside the storage
+ * function). Callers SHOULD include it under `detail.created_fingerprint`.
+ */
+export function buildMutationAuditEntry(args: {
+  action: AuditMutationAction;
+  operator: { fingerprint: string; name: string };
+  subjectName: string;
+  detail?: Record<string, unknown>;
+}): AuditMutationEntry {
+  return {
+    ts: new Date().toISOString(),
+    fingerprint: args.operator.fingerprint,
+    name: args.subjectName,
+    action: args.action,
+    actor: args.operator.name,
+    ...(args.detail !== undefined ? { detail: args.detail } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable wire-error codes for the V1 endpoints' domain errors.
+ * Distinct from `AGENT_AUTH_V1_ERROR` (those are auth-layer codes).
+ */
+export const AGENT_TOKENS_V1_ERROR = {
+  INVALID_BODY: "agent_tokens_v1_invalid_body",
+  INVALID_NAME: "agent_tokens_v1_invalid_name",
+  INVALID_AGENT_ROLE: "agent_tokens_v1_invalid_agent_role",
+  INVALID_CAPABILITIES: "agent_tokens_v1_invalid_capabilities",
+  INVALID_PRESET: "agent_tokens_v1_invalid_preset",
+  INVALID_EXPIRES_IN: "agent_tokens_v1_invalid_expires_in",
+  INVALID_POLICY: "agent_tokens_v1_invalid_policy",
+  WILDCARD_NOT_ALLOWED: "agent_tokens_v1_wildcard_not_allowed",
+  NAME_TAKEN: "agent_tokens_v1_name_taken",
+  TOKEN_NOT_FOUND: "agent_tokens_v1_token_not_found",
+  TOKEN_LIMIT_REACHED: "agent_tokens_v1_token_limit_reached",
+  LOCK_TIMEOUT: "agent_tokens_v1_lock_timeout",
+  /** Caller tried to revoke / rotate / set-capabilities on the bearer
+   * they're authenticated with — would lock them out mid-flight. */
+  SELF_OP_REFUSED: "agent_tokens_v1_self_op_refused",
+  SERVER_ERROR: "agent_tokens_v1_server_error",
+} as const;
+
+export type AgentTokensV1ErrorCode =
+  (typeof AGENT_TOKENS_V1_ERROR)[keyof typeof AGENT_TOKENS_V1_ERROR];
+
+export function v1Error(
+  code: AgentTokensV1ErrorCode,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json({ code, message, ...(details ?? {}) }, { status });
+}
+
+/**
+ * Catch-all storage error → HTTP response mapper. Each route's catch
+ * block delegates here so the mapping is consistent across endpoints.
+ *
+ *   - `TokenNameTakenError` → 409 (issue with duplicate name)
+ *   - `TokenNotFoundError` → 404 (revoke/set/rotate of unknown name)
+ *   - `TokenLimitReachedError` → 422 (per-installation cap reached)
+ *   - `InvalidExpiresAtError` → 400 (caller-supplied bad timestamp)
+ *   - `CapabilityValidationError` → 400 (caller-supplied bad string)
+ *   - `LockTimeoutError` → 503 (concurrent op on same token)
+ *   - anything else → 500 (logged as unexpected; opaque to client)
+ *
+ * Safe-by-default: never echoes raw error message to clients (could
+ * leak internal state); just maps to a structured code + a stable
+ * operator-facing message. The actual error gets logged for ops.
+ */
+export function mapV1StorageErrorToResponse(
+  err: unknown,
+  context: { route: string; installationId: string; name?: string },
+): NextResponse {
+  if (err instanceof TokenNameTakenError) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.NAME_TAKEN,
+      err.message,
+      409,
+      context.name ? { name: context.name } : undefined,
+    );
+  }
+  if (err instanceof TokenNotFoundError) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.TOKEN_NOT_FOUND,
+      err.message,
+      404,
+      context.name ? { name: context.name } : undefined,
+    );
+  }
+  if (err instanceof TokenLimitReachedError) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.TOKEN_LIMIT_REACHED,
+      err.message,
+      422,
+    );
+  }
+  if (err instanceof InvalidExpiresAtError) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN,
+      err.message,
+      400,
+    );
+  }
+  if (err instanceof CapabilityValidationError) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+      err.message,
+      400,
+      { field: err.field, value: err.value },
+    );
+  }
+  if (err instanceof LockTimeoutError) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.LOCK_TIMEOUT,
+      "Another token operation is in progress for this name. Retry in a moment.",
+      503,
+    );
+  }
+  // Unexpected — log + opaque 500 (don't leak the error message).
+  console.error("[agent-tokens-v1] unexpected error", {
+    route: context.route,
+    installationId: context.installationId,
+    name: context.name,
+    error: err,
+  });
+  return v1Error(
+    AGENT_TOKENS_V1_ERROR.SERVER_ERROR,
+    "Internal server error.",
+    500,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Body parsing
+// ---------------------------------------------------------------------------
+
+export type ReadJsonObjectResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: NextResponse };
+
+/** Parse a JSON request body that MUST be a non-array object.
+ * Returns a structured error response on bad JSON / non-object so
+ * route handlers can early-return. Empty body → empty object. */
+export async function readJsonObject(
+  request: Request,
+): Promise<ReadJsonObjectResult> {
+  if (request.body === null) return { ok: true, body: {} };
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_BODY,
+        "Request body must be valid JSON.",
+        400,
+      ),
+    };
+  }
+  if (body == null) return { ok: true, body: {} };
+  if (typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      response: v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_BODY,
+        "Request body must be a JSON object.",
+        400,
+      ),
+    };
+  }
+  return { ok: true, body: body as Record<string, unknown> };
+}

--- a/web/src/server/agent-token-v1-routes.ts
+++ b/web/src/server/agent-token-v1-routes.ts
@@ -16,11 +16,12 @@
  *   - `projectV1ResponsePolicy()` translates the stored snake_case
  *     back to camelCase for the response — same projection /whoami uses.
  *
- * **Audit-entry construction** lives in `buildMutationAuditEntry` so
- * every mutation endpoint emits a consistent shape: `fingerprint` =
- * the operator's bearer fingerprint (i.e. who triggered the action),
- * `name` = the SUBJECT (the token being acted on), `actor` = the
- * operator's name. Per-action `detail` payloads are caller-specified.
+ * **Audit-entry construction** moved INTO the storage layer
+ * (`agent-token-v1.ts`) so entries are built using the LOCKED envelope
+ * state — `from` lists in `set_capabilities` audits, `fingerprint_revoked`
+ * in revoke audits, and `created_fingerprint` in issue audits are all
+ * accurate to the moment the mutation lands. Closes #506 builder R1 #3.
+ * Endpoints just pass an `auditContext` (operator fingerprint + name).
  *
  * **Error mapping** centralizes the storage-error → HTTP-status
  * translation. The route handler catches any error and lets
@@ -33,15 +34,14 @@ import {
   TokenNameTakenError,
   TokenNotFoundError,
   TokenLimitReachedError,
+  TokenExpiredForMutationError,
   InvalidExpiresAtError,
   type AgentTokenSummaryV1,
 } from "@/server/agent-token-v1";
 import { CapabilityValidationError } from "@/server/agent-token-capabilities";
 import { LockTimeoutError } from "@/server/redis-lock";
-import {
-  type AuditMutationEntry,
-  type AuditMutationAction,
-} from "@/server/agent-token-v1-audit";
+// Audit-entry construction lives in the storage layer now (see header).
+// Endpoints just pass an `AuditMutationContext` from `agent-token-v1.ts`.
 import type { AgentTokenPolicy } from "@/server/agent-token";
 
 // ---------------------------------------------------------------------------
@@ -291,49 +291,6 @@ export function projectV1TokenSummary(
 }
 
 // ---------------------------------------------------------------------------
-// Audit entry construction
-// ---------------------------------------------------------------------------
-
-/**
- * Build a mutation-class audit entry for the storage script's
- * atomic-XADD slot. All four mutation endpoints share this builder
- * so the audit entries land in `:audit` with consistent shape.
- *
- * **Field semantics** (see also `BaseAuditEntry` jsdoc):
- *   - `fingerprint` — the OPERATOR's bearer fingerprint (the bearer
- *     that authenticated the call). Lets investigators trace
- *     "which operator did this" back through the auth stream.
- *   - `name` — the SUBJECT's name (the token being acted on). For
- *     `issue` this is the new token's name. For revoke /
- *     set_capabilities / rotate it's the existing token's name.
- *   - `actor` — the operator's name (admin token name when API
- *     bearer-driven; "dashboard" for cookie/bootstrap path —
- *     B.1.d-iv will use that variant).
- *   - `detail` — caller-specified action-specific payload. For issue:
- *     the new token's metadata. For set_capabilities: from/to lists.
- *     For rotate/revoke: typically minimal.
- *
- * Note: for `issue`, the new token's fingerprint is NOT in this
- * entry's `fingerprint` field (unknown until inside the storage
- * function). Callers SHOULD include it under `detail.created_fingerprint`.
- */
-export function buildMutationAuditEntry(args: {
-  action: AuditMutationAction;
-  operator: { fingerprint: string; name: string };
-  subjectName: string;
-  detail?: Record<string, unknown>;
-}): AuditMutationEntry {
-  return {
-    ts: new Date().toISOString(),
-    fingerprint: args.operator.fingerprint,
-    name: args.subjectName,
-    action: args.action,
-    actor: args.operator.name,
-    ...(args.detail !== undefined ? { detail: args.detail } : {}),
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Error mapping
 // ---------------------------------------------------------------------------
 
@@ -353,6 +310,11 @@ export const AGENT_TOKENS_V1_ERROR = {
   NAME_TAKEN: "agent_tokens_v1_name_taken",
   TOKEN_NOT_FOUND: "agent_tokens_v1_token_not_found",
   TOKEN_LIMIT_REACHED: "agent_tokens_v1_token_limit_reached",
+  /** Caller tried to mutate (set-capabilities or rotate) a token whose
+   * expiresAt has already passed — refused at the storage boundary so
+   * the mutation can't resurrect a dying envelope. Closes #506
+   * builder R1 #1 (TTL cleanup invariant). */
+  TOKEN_EXPIRED_FOR_MUTATION: "agent_tokens_v1_token_expired_for_mutation",
   LOCK_TIMEOUT: "agent_tokens_v1_lock_timeout",
   /** Caller tried to revoke / rotate / set-capabilities on the bearer
    * they're authenticated with — would lock them out mid-flight. */
@@ -413,6 +375,21 @@ export function mapV1StorageErrorToResponse(
       AGENT_TOKENS_V1_ERROR.TOKEN_LIMIT_REACHED,
       err.message,
       422,
+    );
+  }
+  if (err instanceof TokenExpiredForMutationError) {
+    // 410 Gone — the resource exists but has reached the end of
+    // its lifecycle and won't be accepting further mutations.
+    // Distinct from 404 (token doesn't exist) and 422 (request
+    // would violate domain rules). Operators reading the response
+    // see expiredAt + the canonical message ("issue a successor
+    // instead of mutating an expired one") so the recovery path
+    // is obvious.
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.TOKEN_EXPIRED_FOR_MUTATION,
+      err.message,
+      410,
+      { name: err.tokenName, expiredAt: err.expiredAt },
     );
   }
   if (err instanceof InvalidExpiresAtError) {

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -39,6 +39,7 @@ import {
   TokenNameTakenError,
   TokenLimitReachedError,
   TokenNotFoundError,
+  TokenExpiredForMutationError,
   InvalidExpiresAtError,
   type AgentTokenEnvelopeV1,
   type AgentTokenHashRecordV1,
@@ -589,6 +590,29 @@ describe("setAgentTokenCapabilities", () => {
       }),
     ).rejects.toThrow(TokenNotFoundError);
   });
+
+  it("refuses to mutate an expired envelope (B1 — TTL cleanup invariant)", async () => {
+    // Closes #506 builder R1 #1: pre-fix, a set-capabilities call
+    // against an expired-but-not-yet-swept envelope (within the
+    // +300s margin) would land an unconditional SET in the Lua
+    // script, CLEARING the existing TTL and resurrecting the dead
+    // envelope. Storage now fails closed at the boundary.
+    await issueAgentToken(defaultIssueArgs(redis));
+    const envKey = envelopeKey("12345", "worker");
+    const env = redis._store.get(envKey) as AgentTokenEnvelopeV1;
+    // Manually re-store with a past expiresAt to simulate the +300s
+    // cleanup-window state that triggered the original bug.
+    redis._store.set(envKey, { ...env, expiresAt: "2025-01-01T00:00:00.000Z" });
+
+    await expect(
+      setAgentTokenCapabilities({
+        installationId: "12345",
+        name: "worker",
+        capabilities: ["agent_health.report", "tasks.claim", "rooms.read"],
+        redis,
+      }),
+    ).rejects.toThrow(TokenExpiredForMutationError);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -644,6 +668,50 @@ describe("rotateAgentToken", () => {
         redis,
       }),
     ).rejects.toThrow(TokenNotFoundError);
+  });
+
+  it("refuses to rotate an expired envelope (B1 — TTL cleanup invariant)", async () => {
+    // Closes #506 builder R1 #1: rotate would otherwise CLEAR the
+    // existing TTL on an expired envelope AND issue a new bearer
+    // already past expiresAt. Storage now fails closed at the
+    // boundary — operators must issue a successor instead.
+    await issueAgentToken(defaultIssueArgs(redis));
+    const envKey = envelopeKey("12345", "worker");
+    const env = redis._store.get(envKey) as AgentTokenEnvelopeV1;
+    redis._store.set(envKey, { ...env, expiresAt: "2025-01-01T00:00:00.000Z" });
+
+    await expect(
+      rotateAgentToken({
+        installationId: "12345",
+        name: "worker",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(TokenExpiredForMutationError);
+  });
+
+  it("response surfaces preserved policy (B2 round-trip)", async () => {
+    // Closes #506 builder R1 #2: rotate previously surfaced
+    // policy: null even when the envelope had policy preserved.
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      policy: {
+        allowed_repos: ["hivemoot/foxstoria"],
+        allowed_permissions: { contents: "read" },
+      },
+    });
+    const rotated = await rotateAgentToken({
+      installationId: "12345",
+      name: "worker",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+    expect(rotated.policy).toEqual({
+      allowed_repos: ["hivemoot/foxstoria"],
+      allowed_permissions: { contents: "read" },
+    });
   });
 
   it("preserves expiresAt (rotate ≠ extend)", async () => {

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -69,6 +69,20 @@ import type {
   AgentTokenPolicy,
   GitHubPermissionLevel,
 } from "@/server/agent-token";
+// `auditStreamKey` is owned by the audit module (where its sibling
+// `authStreamKey` lives, and where stream MAXLEN constants are
+// declared). Storage scripts in this file pass the stream key as a
+// KEYS slot to the Lua audit-emit guard. Cycle is safe: the audit
+// module's `auditStreamKey` reads `ENVELOPE_PREFIX` only at function
+// CALL time (live ESM binding), and this module's reverse import
+// reads `auditStreamKey` only at function CALL time too — neither
+// touches the cycled symbol at module init. Closes #505 guard R1
+// carry-forward #1 (drift risk between two definitions).
+import {
+  auditStreamKey,
+  buildAuditEntryJson,
+  type AuditMutationEntry,
+} from "@/server/agent-token-v1-audit";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -94,7 +108,6 @@ export const ENVELOPE_PREFIX = "hive:v1:agent-token:";
 const HASH_INDEX_PREFIX = "hive:v1:idx:agent-token:hash:";
 const INSTALLATION_INDEX_PREFIX = "hive:v1:idx:agent-token:installation:";
 const META_SUFFIX = ":meta";
-const AUDIT_SUFFIX = ":audit";
 const LOCK_PREFIX = "hive:v1:lock:agent-token:";
 
 export function envelopeKey(installationId: string, name: string): string {
@@ -113,17 +126,9 @@ export function envelopeMetaKey(installationId: string, name: string): string {
   return `${envelopeKey(installationId, name)}${META_SUFFIX}`;
 }
 
-/**
- * Per-installation audit stream (mutations only — issue / revoke /
- * set_capabilities / rotate / bootstrap). The high-volume auth-event
- * stream lives at a different key (B.1.d wires that one alongside
- * `auditAppend`). Per CAPABILITIES_DESIGN.md §Audit log: split-stream
- * model with `MAXLEN ~10000` on this stream → effectively unbounded
- * at <10 mutations/day.
- */
-export function auditStreamKey(installationId: string): string {
-  return `${ENVELOPE_PREFIX}${installationId}${AUDIT_SUFFIX}`;
-}
+// `auditStreamKey` lives in `agent-token-v1-audit.ts` (owns both
+// stream key constructors + their MAXLEN constants). Imported above.
+// Closes #505 guard R1 carry-forward #1.
 
 export function lockKey(installationId: string, name: string): string {
   return `${LOCK_PREFIX}${installationId}:${name}`;
@@ -577,6 +582,20 @@ export async function issueAgentToken(args: {
   keyVersion: string;
   redis: Redis;
   tokenLimit?: number;
+  /**
+   * Optional structured audit entry. When provided, JSON is passed
+   * into the script's atomic-XADD slot — the audit row lands in the
+   * `:audit` stream in the same EVAL as the envelope write, so a
+   * partial-success state where the token exists but the audit
+   * entry doesn't (or vice versa) is unrepresentable. When omitted
+   * the script no-ops the XADD (preserves pre-B.1.d behavior so
+   * direct-from-tests callers don't have to construct an entry).
+   *
+   * The endpoint layer (B.1.d-ii) is the canonical caller — it
+   * builds entries from `auth.envelope.fingerprint` + `auth.name`.
+   * Direct callers (CLI scripts, migration jobs) typically omit it.
+   */
+  auditEntry?: AuditMutationEntry;
 }): Promise<IssuedAgentTokenV1> {
   validateName(args.name);
   validateAgentRole(args.agent_role);
@@ -671,12 +690,11 @@ export async function issueAgentToken(args: {
             String(createdAtMs),
             String(limit),
             String(ttlSecs),
-            // B.1.d will replace this empty sentinel with the
-            // structured audit-entry JSON. Script no-ops when empty,
-            // so the atomic-audit guarantee from the design is
-            // preserved without B.1.d needing to re-version the
-            // script (closes guard R1 G1).
-            "",
+            // Empty sentinel = script no-ops the audit XADD. When the
+            // endpoint passes an `auditEntry`, this slot carries the
+            // serialized JSON, and the script's atomic-audit guard
+            // emits the row in the same EVAL as the envelope write.
+            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
           ],
         ),
       );
@@ -716,6 +734,8 @@ export async function revokeAgentToken(args: {
   installationId: string;
   name: string;
   redis: Redis;
+  /** See `issueAgentToken.auditEntry` — same atomic-audit semantics. */
+  auditEntry?: AuditMutationEntry;
 }): Promise<boolean> {
   validateName(args.name);
 
@@ -748,7 +768,10 @@ export async function revokeAgentToken(args: {
             envelopeMetaKey(args.installationId, args.name),
             auditStreamKey(args.installationId),
           ],
-          [args.name, ""],
+          [
+            args.name,
+            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
+          ],
         ),
       );
       return result.ok === 1;
@@ -772,6 +795,8 @@ export async function setAgentTokenCapabilities(args: {
   capabilities: readonly string[];
   redis: Redis;
   nowMs?: number;
+  /** See `issueAgentToken.auditEntry` — same atomic-audit semantics. */
+  auditEntry?: AuditMutationEntry;
 }): Promise<AgentTokenSummaryV1> {
   validateName(args.name);
   if (args.capabilities.length === 0) {
@@ -806,7 +831,11 @@ export async function setAgentTokenCapabilities(args: {
             envelopeKey(args.installationId, args.name),
             auditStreamKey(args.installationId),
           ],
-          [JSON.stringify(updated), String(ttlSecs), ""],
+          [
+            JSON.stringify(updated),
+            String(ttlSecs),
+            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
+          ],
         ),
       );
       if (result.ok === -1 && result.reason === "no_envelope") {
@@ -842,6 +871,8 @@ export async function rotateAgentToken(args: {
   keyVersion: string;
   redis: Redis;
   nowMs?: number;
+  /** See `issueAgentToken.auditEntry` — same atomic-audit semantics. */
+  auditEntry?: AuditMutationEntry;
 }): Promise<IssuedAgentTokenV1> {
   validateName(args.name);
 
@@ -901,7 +932,7 @@ export async function rotateAgentToken(args: {
             JSON.stringify(updated),
             JSON.stringify(newHashRecord),
             String(ttlSecs),
-            "",
+            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
           ],
         ),
       );
@@ -1047,13 +1078,18 @@ export async function pruneOrphanedIndexEntries(args: {
  *     SHA-256 — the bearer-resurrection scenario (see the
  *     BEARER-RESURRECTION INVARIANT docblock at top of file).
  *
- * Caller (B.1.c middleware) maps each failure code to its
- * appropriate HTTP response:
- *   - unknown_bearer / envelope_missing → 401 Invalid bearer
- *   - stale_bearer → 401 TOKEN_EXPIRED (semantically: the bearer
- *     points at a name whose envelope has been replaced; from
- *     the caller's perspective the bearer no longer maps to its
- *     identity)
+ * Caller (B.1.c middleware in `agent-token-v1-auth.ts`) maps each
+ * failure code to its appropriate HTTP response. Mapping reflects
+ * what the SHIPPED middleware does (was misdocumented in the
+ * pre-#505 JSDoc — closes #505 guard R1 carry-forward #2):
+ *   - unknown_bearer → 401 UNKNOWN_BEARER (no record at all — bearer
+ *     never existed or was revoked, hash index gone)
+ *   - envelope_missing → 401 TOKEN_EXPIRED (hash record points at an
+ *     envelope that was TTL-swept or concurrently revoked — from
+ *     the bearer's POV the credential is past its lifecycle)
+ *   - stale_bearer → 401 TOKEN_EXPIRED (envelope exists but a same-
+ *     name reissue replaced its tokenHash — the bearer-resurrection
+ *     check; bearer's identity no longer maps to current envelope)
  *   - ok → caller checks `envelope.expiresAt` against the wall
  *     clock + checks the `requires` capability per
  *     `bearerHasCapability(envelope.capabilities, requires)`.

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -80,7 +80,6 @@ import type {
 // carry-forward #1 (drift risk between two definitions).
 import {
   auditStreamKey,
-  buildAuditEntryJson,
   type AuditMutationEntry,
 } from "@/server/agent-token-v1-audit";
 
@@ -191,7 +190,12 @@ export interface AgentTokenSummaryV1 {
   policy?: AgentTokenPolicy;
 }
 
-/** Bearer + minimal metadata returned ONCE at issue time. */
+/** Bearer + minimal metadata returned ONCE at issue time (also the
+ * shape returned by `rotateAgentToken`). The optional `policy` field
+ * round-trips so callers can populate response bodies without an
+ * extra GET — closes #506 builder R1 #2: rotate previously surfaced
+ * `policy: null` even when the token had policy preserved on the
+ * envelope, which falsely advertised the token as legacy-permissive. */
 export interface IssuedAgentTokenV1 {
   token: string;
   name: string;
@@ -199,6 +203,10 @@ export interface IssuedAgentTokenV1 {
   capabilities: string[];
   fingerprint: string;
   expiresAt: string | null;
+  /** Present when the issued/rotated token has a policy on its
+   * envelope. Omitted (`undefined`) for legacy / V1.5-pre tokens
+   * that have no policy field at all. */
+  policy?: AgentTokenPolicy;
 }
 
 // ---------------------------------------------------------------------------
@@ -243,6 +251,82 @@ export class InvalidExpiresAtError extends Error {
       `Invalid expiresAt ${JSON.stringify(value)} — ${reason}. Provide a future ISO 8601 timestamp or null for no expiry.`,
     );
     this.name = "InvalidExpiresAtError";
+  }
+}
+
+/**
+ * Thrown when set-capabilities or rotate is called against an
+ * envelope whose `expiresAt` has already passed. Closes #506
+ * builder R1 #1 (TTL cleanup invariant): `computeEnvelopeTtlSeconds`
+ * returns 0 for past expiresAt, which would make the Lua script
+ * fall into the unconditional-`SET` branch, CLEARING the existing
+ * Redis TTL — turning an expired envelope into a permanent one.
+ * The fix is to fail-closed at the storage boundary: an admin
+ * holding a still-valid bearer can mutate someone else's token,
+ * but cannot resurrect an envelope that the cleanup sweep is
+ * about to remove. Operators wanting to extend lifetime must
+ * issue a fresh successor.
+ */
+export class TokenExpiredForMutationError extends Error {
+  public readonly installationId: string;
+  public readonly tokenName: string;
+  public readonly expiredAt: string;
+  constructor(installationId: string, tokenName: string, expiredAt: string) {
+    super(
+      `Refusing to mutate token '${tokenName}' for installation ${installationId}: envelope expired at ${expiredAt} and is awaiting cleanup. Issue a successor token instead of mutating an expired one.`,
+    );
+    this.name = "TokenExpiredForMutationError";
+    this.installationId = installationId;
+    this.tokenName = tokenName;
+    this.expiredAt = expiredAt;
+  }
+}
+
+/**
+ * Operator-side context for an atomic mutation. Replaces the
+ * pre-built `auditEntry` parameter (which let callers race the
+ * lock — closes #506 builder R1 #3): the storage layer now builds
+ * the entry ITSELF using the locked envelope state, so the `from`
+ * lists in `set_capabilities` audits + the `fingerprint_revoked`
+ * fields in `revoke` audits + the `created_fingerprint` field in
+ * `issue` audits are guaranteed accurate to the moment the
+ * mutation lands.
+ *
+ * The caller (route handler) only knows the operator's identity
+ * and any optional extra detail not derivable from envelope state.
+ * Storage knows the action, subject, and pre/post envelope state.
+ */
+export interface AuditMutationContext {
+  operator: { fingerprint: string; name: string };
+  /** Optional fields merged into the action's standard detail.
+   * Use sparingly — the standard detail (from/to / fingerprints)
+   * covers the canonical cases. */
+  detailExtras?: Record<string, unknown>;
+}
+
+/**
+ * Throw if the envelope has already expired (`expiresAt` ≤ now) —
+ * mutations must not resurrect a token that the cleanup sweep is
+ * about to remove. Closes #506 builder R1 #1: the Lua scripts'
+ * `tonumber(ARGV[N]) > 0 → SET EX, else SET` branch would CLEAR
+ * the existing TTL when called with `ttlSecs = 0`, making the
+ * expired envelope permanent. Failing closed at the storage
+ * boundary is simpler than per-script TTL preservation logic.
+ */
+function assertEnvelopeNotExpiredForMutation(
+  envelope: AgentTokenEnvelopeV1,
+  installationId: string,
+  nowMs: number,
+): void {
+  if (envelope.expiresAt === null) return;
+  const expiresAtMs = new Date(envelope.expiresAt).getTime();
+  if (Number.isNaN(expiresAtMs)) return; // unparseable — let it through to be cleaned up by other paths
+  if (expiresAtMs <= nowMs) {
+    throw new TokenExpiredForMutationError(
+      installationId,
+      envelope.name,
+      envelope.expiresAt,
+    );
   }
 }
 
@@ -583,19 +667,15 @@ export async function issueAgentToken(args: {
   redis: Redis;
   tokenLimit?: number;
   /**
-   * Optional structured audit entry. When provided, JSON is passed
-   * into the script's atomic-XADD slot — the audit row lands in the
-   * `:audit` stream in the same EVAL as the envelope write, so a
-   * partial-success state where the token exists but the audit
-   * entry doesn't (or vice versa) is unrepresentable. When omitted
-   * the script no-ops the XADD (preserves pre-B.1.d behavior so
-   * direct-from-tests callers don't have to construct an entry).
-   *
-   * The endpoint layer (B.1.d-ii) is the canonical caller — it
-   * builds entries from `auth.envelope.fingerprint` + `auth.name`.
-   * Direct callers (CLI scripts, migration jobs) typically omit it.
+   * Optional operator-side audit context. When provided, the
+   * storage layer builds the `issue` audit entry INSIDE the script's
+   * atomic-XADD slot so the mutation + audit land together (closes
+   * #506 builder R1 #3). The new token's fingerprint is included
+   * automatically — callers don't need to (and can't) compute it.
+   * When omitted the script no-ops the XADD (preserves pre-B.1.d
+   * behavior so direct-from-tests callers don't have to construct one).
    */
-  auditEntry?: AuditMutationEntry;
+  auditContext?: AuditMutationContext;
 }): Promise<IssuedAgentTokenV1> {
   validateName(args.name);
   validateAgentRole(args.agent_role);
@@ -691,10 +771,27 @@ export async function issueAgentToken(args: {
             String(limit),
             String(ttlSecs),
             // Empty sentinel = script no-ops the audit XADD. When the
-            // endpoint passes an `auditEntry`, this slot carries the
-            // serialized JSON, and the script's atomic-audit guard
+            // endpoint passes an `auditContext`, the entry is built
+            // here using the new token's fingerprint (which the caller
+            // can't pre-compute), and the script's atomic-audit guard
             // emits the row in the same EVAL as the envelope write.
-            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
+            args.auditContext
+              ? JSON.stringify({
+                  ts: createdAtIso,
+                  fingerprint: args.auditContext.operator.fingerprint,
+                  name: args.name,
+                  action: "issue" as const,
+                  actor: args.auditContext.operator.name,
+                  detail: {
+                    agent_role: args.agent_role,
+                    capabilities: [...args.capabilities],
+                    expiresAt: args.expiresAt,
+                    has_policy: args.policy !== undefined,
+                    created_fingerprint: tokenFingerprint,
+                    ...(args.auditContext.detailExtras ?? {}),
+                  },
+                } satisfies AuditMutationEntry)
+              : "",
           ],
         ),
       );
@@ -716,6 +813,10 @@ export async function issueAgentToken(args: {
         capabilities: [...args.capabilities],
         fingerprint: tokenFingerprint,
         expiresAt: args.expiresAt,
+        // Surface policy back to caller so the response shape can
+        // round-trip it without an extra GET. Closes #506 builder R1
+        // #2 for the issue path (rotate gets the same field below).
+        ...(args.policy ? { policy: args.policy } : {}),
       };
     },
   );
@@ -734,8 +835,11 @@ export async function revokeAgentToken(args: {
   installationId: string;
   name: string;
   redis: Redis;
-  /** See `issueAgentToken.auditEntry` — same atomic-audit semantics. */
-  auditEntry?: AuditMutationEntry;
+  /** See `issueAgentToken.auditContext` — same atomic-audit
+   * semantics. The revoked envelope's fingerprint is included in
+   * detail automatically (taken from the locked envelope read
+   * before the script runs). */
+  auditContext?: AuditMutationContext;
 }): Promise<boolean> {
   validateName(args.name);
 
@@ -770,7 +874,19 @@ export async function revokeAgentToken(args: {
           ],
           [
             args.name,
-            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
+            args.auditContext
+              ? JSON.stringify({
+                  ts: new Date().toISOString(),
+                  fingerprint: args.auditContext.operator.fingerprint,
+                  name: args.name,
+                  action: "revoke" as const,
+                  actor: args.auditContext.operator.name,
+                  detail: {
+                    fingerprint_revoked: envelopeRaw.fingerprint,
+                    ...(args.auditContext.detailExtras ?? {}),
+                  },
+                } satisfies AuditMutationEntry)
+              : "",
           ],
         ),
       );
@@ -795,8 +911,14 @@ export async function setAgentTokenCapabilities(args: {
   capabilities: readonly string[];
   redis: Redis;
   nowMs?: number;
-  /** See `issueAgentToken.auditEntry` — same atomic-audit semantics. */
-  auditEntry?: AuditMutationEntry;
+  /** See `issueAgentToken.auditContext` — same atomic-audit
+   * semantics. The audit `detail.from` list is built from the LOCKED
+   * envelope state inside this function, NOT pre-read at the route
+   * layer (closes #506 builder R1 #3: pre-read could race a
+   * concurrent set-capabilities and produce a `from` that doesn't
+   * match the actual previous state).
+   */
+  auditContext?: AuditMutationContext;
 }): Promise<AgentTokenSummaryV1> {
   validateName(args.name);
   if (args.capabilities.length === 0) {
@@ -810,20 +932,25 @@ export async function setAgentTokenCapabilities(args: {
     lockKey(args.installationId, args.name),
     args.redis,
     async () => {
+      const nowMs = args.nowMs ?? Date.now();
       const envelopeRaw = await args.redis.get<AgentTokenEnvelopeV1>(
         envelopeKey(args.installationId, args.name),
       );
       if (!envelopeRaw) {
         throw new TokenNotFoundError(args.installationId, args.name);
       }
+      // Closes #506 builder R1 #1 (TTL cleanup invariant): refuse
+      // to mutate an envelope whose expiry has passed. The Lua
+      // SET-without-EX branch (when ttlSecs=0) would clear the
+      // existing TTL and resurrect the dying envelope. Failing
+      // closed at the storage boundary is simpler than per-script
+      // TTL preservation logic and gives operators a clear error.
+      assertEnvelopeNotExpiredForMutation(envelopeRaw, args.installationId, nowMs);
       const updated: AgentTokenEnvelopeV1 = {
         ...envelopeRaw,
         capabilities: [...args.capabilities],
       };
-      const ttlSecs = computeEnvelopeTtlSeconds(
-        updated.expiresAt,
-        args.nowMs ?? Date.now(),
-      );
+      const ttlSecs = computeEnvelopeTtlSeconds(updated.expiresAt, nowMs);
       const result = dispatchScriptResult(
         await args.redis.eval(
           SET_CAPABILITIES_SCRIPT,
@@ -834,7 +961,20 @@ export async function setAgentTokenCapabilities(args: {
           [
             JSON.stringify(updated),
             String(ttlSecs),
-            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
+            args.auditContext
+              ? JSON.stringify({
+                  ts: new Date().toISOString(),
+                  fingerprint: args.auditContext.operator.fingerprint,
+                  name: args.name,
+                  action: "set_capabilities" as const,
+                  actor: args.auditContext.operator.name,
+                  detail: {
+                    from: [...envelopeRaw.capabilities],
+                    to: [...args.capabilities],
+                    ...(args.auditContext.detailExtras ?? {}),
+                  },
+                } satisfies AuditMutationEntry)
+              : "",
           ],
         ),
       );
@@ -871,8 +1011,11 @@ export async function rotateAgentToken(args: {
   keyVersion: string;
   redis: Redis;
   nowMs?: number;
-  /** See `issueAgentToken.auditEntry` — same atomic-audit semantics. */
-  auditEntry?: AuditMutationEntry;
+  /** See `issueAgentToken.auditContext` — same atomic-audit
+   * semantics. The audit detail includes both the old and new
+   * fingerprints so investigators can correlate the rotation event
+   * with prior `auth.success` entries tied to the old fingerprint. */
+  auditContext?: AuditMutationContext;
 }): Promise<IssuedAgentTokenV1> {
   validateName(args.name);
 
@@ -880,12 +1023,19 @@ export async function rotateAgentToken(args: {
     lockKey(args.installationId, args.name),
     args.redis,
     async () => {
+      const nowMs = args.nowMs ?? Date.now();
       const envelopeRaw = await args.redis.get<AgentTokenEnvelopeV1>(
         envelopeKey(args.installationId, args.name),
       );
       if (!envelopeRaw) {
         throw new TokenNotFoundError(args.installationId, args.name);
       }
+      // Closes #506 builder R1 #1 (TTL cleanup invariant): refuse
+      // to rotate an expired envelope. Without this guard the new
+      // bearer would be issued with the past expiresAt copied
+      // forward AND the SET-without-EX branch would clear the
+      // existing TTL — a doubly-broken state.
+      assertEnvelopeNotExpiredForMutation(envelopeRaw, args.installationId, nowMs);
 
       const newRawToken = generateRawToken();
       const newTokenHash = hashToken(newRawToken);
@@ -913,10 +1063,7 @@ export async function rotateAgentToken(args: {
         name: args.name,
       };
 
-      const ttlSecs = computeEnvelopeTtlSeconds(
-        updated.expiresAt,
-        args.nowMs ?? Date.now(),
-      );
+      const ttlSecs = computeEnvelopeTtlSeconds(updated.expiresAt, nowMs);
 
       const result = dispatchScriptResult(
         await args.redis.eval(
@@ -932,7 +1079,20 @@ export async function rotateAgentToken(args: {
             JSON.stringify(updated),
             JSON.stringify(newHashRecord),
             String(ttlSecs),
-            args.auditEntry ? buildAuditEntryJson(args.auditEntry) : "",
+            args.auditContext
+              ? JSON.stringify({
+                  ts: new Date().toISOString(),
+                  fingerprint: args.auditContext.operator.fingerprint,
+                  name: args.name,
+                  action: "rotate" as const,
+                  actor: args.auditContext.operator.name,
+                  detail: {
+                    fingerprint_old: envelopeRaw.fingerprint,
+                    fingerprint_new: newFingerprint,
+                    ...(args.auditContext.detailExtras ?? {}),
+                  },
+                } satisfies AuditMutationEntry)
+              : "",
           ],
         ),
       );
@@ -952,6 +1112,12 @@ export async function rotateAgentToken(args: {
         capabilities: [...updated.capabilities],
         fingerprint: newFingerprint,
         expiresAt: updated.expiresAt,
+        // Closes #506 builder R1 #2: surface the preserved policy
+        // back to the caller so the response can round-trip it
+        // accurately. Previously the rotate response said
+        // `policy: null` regardless, falsely advertising
+        // policy-narrowed tokens as legacy-permissive.
+        ...(envelopeRaw.policy ? { policy: envelopeRaw.policy } : {}),
       };
     },
   );


### PR DESCRIPTION
## Summary
The 6 admin-class endpoints under \`/api/agent-tokens/*\` that complete the operator-driven token lifecycle on top of the V1 storage + middleware shipped in #503/#504/#505. All require the \`agent_tokens.manage\` capability; bootstrap (B.1.d-iv, separate PR) is the chain root that issues the first such bearer.

| Method | Path | Storage call |
|---|---|---|
| POST | /api/agent-tokens | \`issueAgentToken\` |
| GET | /api/agent-tokens | \`listAgentTokens\` |
| GET | /api/agent-tokens/{name} | \`getAgentTokenSummary\` |
| DELETE | /api/agent-tokens/{name} | \`revokeAgentToken\` |
| POST | /api/agent-tokens/{name}/set-capabilities | \`setAgentTokenCapabilities\` |
| POST | /api/agent-tokens/{name}/rotate | \`rotateAgentToken\` |

## What it looks like

### POST /api/agent-tokens (issue) — request → 201 response
\`\`\`json
// Request body
{
  \"name\": \"worker\",
  \"agent_role\": \"drone\",
  \"preset\": \"worker\",
  \"expiresIn\": \"30d\",
  \"policy\": {
    \"allowedRepos\": [\"hivemoot/foxstoria\"],
    \"allowedPermissions\": { \"contents\": \"read\" }
  }
}

// Response (bearer shown ONCE)
{
  \"token\": \"hmt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",
  \"name\": \"worker\",
  \"agent_role\": \"drone\",
  \"capabilities\": [\"agent_health.report\", \"tasks.claim\", ...],
  \"fingerprint\": \"abcd1234\",
  \"expiresAt\": \"2026-05-27T15:00:00.000Z\",
  \"policy\": {
    \"allowedRepos\": [\"hivemoot/foxstoria\"],
    \"allowedPermissions\": { \"contents\": \"read\" }
  },
  \"message\": \"Bearer is shown ONCE — store it securely now. There is no GET-after-issue path.\"
}
\`\`\`

### Self-op refused (revoke / set-caps / rotate on bearer's own token)
\`\`\`json
HTTP 409
{
  \"code\": \"agent_tokens_v1_self_op_refused\",
  \"message\": \"Refusing to revoke the bearer's own token — would lock you out mid-flight. Issue a successor admin token, switch to it, then revoke this one.\",
  \"name\": \"self-admin\"
}
\`\`\`

### Bare-\`*\` rejected by default
\`\`\`json
HTTP 400
{
  \"code\": \"agent_tokens_v1_wildcard_not_allowed\",
  \"message\": \"Bare '*' capability requires allowWildcards: true (deliberate opt-in per design — bare wildcards are the most dangerous shape).\"
}
\`\`\`

## Wire shape

camelCase on request + response (\`allowedRepos\`, \`allowedPermissions\`) matching /whoami; storage stays snake_case. Translation lives in \`agent-token-v1-routes.ts\` (parseV1RequestPolicy + projectV1ResponsePolicy / projectV1TokenSummary). Defined LOCALLY so future \`AgentTokenPolicy\` additions can't auto-leak through the wire — same defense-in-depth pattern as \`WhoamiPolicyView\`.

## Audit

Mutation endpoints pass an \`auditEntry\` to the storage script's atomic-XADD slot (the slot was reserved in #503 R1 G1 for exactly this). Atomic mutate+audit means partial-success state where the envelope changed but no audit landed (or vice versa) is now unrepresentable. Auth events emit fire-and-forget via \`auditAppend\` on happy paths, mirroring /whoami.

| Action | \`fingerprint\` (in entry) | \`name\` | \`actor\` | \`detail\` |
|---|---|---|---|---|
| issue | operator's | new token's | operator's name | { agent_role, capabilities, expiresAt, has_policy } |
| revoke | operator's | revoked token's | operator's name | (none) |
| set_capabilities | operator's | modified token's | operator's name | { from: [...], to: [...] } |
| rotate | operator's | rotated token's | operator's name | (none) |

For \`issue\`, the new token's fingerprint isn't known until inside \`issueAgentToken\`. Per the audit doc, \`fingerprint\` is \"the bearer that triggered the event\" → the operator's. The new token's fingerprint is in the response payload + observable via the next \`auth.success\` for that name.

## Self-op guard

Refuses \`revoke\` / \`set-capabilities\` / \`rotate\` when \`auth.name === path name\`, returning 409 \`SELF_OP_REFUSED\`. A self-op on the bearer's own token would 401 the operator's next call (lock-out trap). Operators must issue a successor first, switch to it, then act on this one. Bootstrap (B.1.d-iv) is the recovery for full lockout.

## Bare-\`*\` opt-in

POST issue + POST set-capabilities both reject bare \`*\` capability unless \`allowWildcards: true\` is explicitly set. Mirrors the CLI default per design (bare wildcards are the most dangerous shape — closes guard \"\`*\` includes token management\" trap).

## Carry-forwards from #505 R1/R2

1. **Deduped \`auditStreamKey\`** — audit module owns it now (was duplicated in agent-token-v1.ts). Cycle is safe: function bodies evaluate at call time, not module init. Closes guard R1 #1.
2. **Fixed \`resolveBearerToEnvelope\` JSDoc** bearer→error mapping to reflect what the shipped middleware actually does (\`unknown_bearer → UNKNOWN_BEARER\`, \`envelope_missing + stale_bearer → TOKEN_EXPIRED\`). Closes guard R1 #2.
3. **Tightened \`WhoamiPolicyView.allowedPermissions\`** to \`Record<string, \"read\"|\"write\"|\"admin\">\` at the wire boundary (was \`Record<string, string>\`). Defensive for storage-drift scenarios. Closes guard R2 N1.
4. **Added keyVersion / createdAt / mock-createdAt-value** to /whoami leak-detector test 5 — completes the envelope-fields blacklist. Closes guard R2 N2.

## Storage signature change

\`issueAgentToken\` / \`revokeAgentToken\` / \`setAgentTokenCapabilities\` / \`rotateAgentToken\` all gain an optional \`auditEntry?: AuditMutationEntry\` parameter. When provided, \`JSON.stringify(entry)\` lands in the script's ARGV audit slot — the script's existing \`if argv[N] ~= \"\" then xadd end\` guard means atomic emit. When absent, scripts no-op the XADD (preserves direct-from-tests caller behavior, no breaking change to existing 67 V1 storage tests).

## Keyring loader

New \`loadV1MintKeyring()\` in \`agent-token-v1-auth.ts\` — issue + rotate need the active keyring to encrypt new envelopes. Reuses \`parseKeyring\` from \`crypto.ts\`, mirrors \`byok-auth\`'s misconfiguration-fail-closed pattern (per CLAUDE.md fail-closed principle).

## Test plan
- [x] All 940 web tests pass + typecheck clean
- [x] 36 helper tests for agent-token-v1-routes.ts (parseExpiresIn, parseV1RequestPolicy, projectV1ResponsePolicy/Summary, buildMutationAuditEntry, mapV1StorageErrorToResponse — including \"unknown error never leaks raw message\" SECURITY pin)
- [x] 27 POST issue + GET list tests (auth, body validation, happy paths, audit emit, error mapping, SECURITY no-ciphertext)
- [x] 11 GET show + DELETE revoke tests (path validation, self-op guard, idempotent revoke surfaces 404)
- [x] 9 POST set-capabilities tests (preset, explicit caps, bare-\`*\` gate, from/to audit detail)
- [x] 8 POST rotate tests (no body, keyring fail surfaces, ONCE message, response sanitization)
- [x] Existing 14/14 /whoami tests still pass with carry-forward 4

## Carry-forwards still open for B.1.d-iii (bootstrap) / V1.1
- Vercel suspension footgun for fire-and-forget audit emit on bootstrap — must use \`request.waitUntil()\` or atomic Lua (#505 guard R1 #3)
- Auth-stream DoS via /whoami spam — per-bearer rate limiting at middleware tier (#505 guard R1 #4)
- Drone D3 \`auth.failure\` audit emit — currently no failure-class auth events; middleware returns the response on failure so route handlers can't easily add it. Architectural gap.

Depends on #505 (merged). No backwards-incompatible changes to merged code; storage-function signature additions are all optional.