### PR TITLE
Phase B.1.d-iii — bootstrap admin token via dashboard cookie auth

### DIFF
--- a/web/src/app/api/agent-tokens/bootstrap/route.test.ts
+++ b/web/src/app/api/agent-tokens/bootstrap/route.test.ts
@@ -129,6 +129,19 @@ describe("POST /api/agent-tokens/bootstrap — body validation", () => {
     expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
   });
 
+  it("malformed name → 400 INVALID_NAME (boundary validation, not the storage-error fallthrough — closes #508 builder R1 #2)", async () => {
+    // Capital 'B' violates NAME_REGEX. Without boundary validation,
+    // this would fall through to issueAgentToken → CapabilityValidationError
+    // → mapV1StorageErrorToResponse → INVALID_CAPABILITIES (wrong code).
+    const res = await POST(makeRequest({ name: "Bootstrap" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_name");
+    expect(body.field).toBe("name");
+    expect(body.value).toBe("Bootstrap");
+    expect(mockedIssue).not.toHaveBeenCalled(); // didn't waste a storage call
+  });
+
   it("expiresIn longer than 24h → 400 INVALID_EXPIRES_IN", async () => {
     const res = await POST(
       makeRequest({ name: "bootstrap-admin", expiresIn: "30d" }),
@@ -253,6 +266,23 @@ describe("POST /api/agent-tokens/bootstrap — happy paths", () => {
       expect(entry.fingerprint).toBe(""); // cookie auth, no bearer
       expect(entry.required_capability).toBeNull();
     }
+  });
+
+  it("auth.success row uses name: '' (cookie-auth marker, not the new token's name — closes #508 builder R1 #1)", async () => {
+    // The auth.success row represents the CREDENTIAL that authenticated
+    // the request. Bootstrap authenticated with the dashboard cookie,
+    // not the new token (which doesn't exist until issueAgentToken
+    // returned). Setting name to body.name would make the auth stream
+    // look like the new token had authenticated before it existed —
+    // a temporal-ordering lie. Empty string is the cookie-auth marker.
+    // The SUBJECT token's name is captured by the matching `bootstrap`
+    // row on the :audit (mutation) stream, so investigators don't lose
+    // the linkage.
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(makeRequest({ name: "bootstrap-admin" }));
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    expect(entry.name).toBe("");
+    expect(entry.name).not.toBe("bootstrap-admin");
   });
 
   it("createdBy = operator's GitHub login (not 'dashboard') so the envelope's attribution is human-readable", async () => {

--- a/web/src/app/api/agent-tokens/bootstrap/route.test.ts
+++ b/web/src/app/api/agent-tokens/bootstrap/route.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for POST /api/agent-tokens/bootstrap. Phase B.1.d-iii.
+ *
+ * Bootstrap is the chain-root admin token endpoint: cookie auth
+ * (not bearer), hardcoded admin preset, capped 24h expiry, atomic
+ * audit emit (`bootstrap` action class), AWAITED auth.success
+ * audit (Vercel-safe, not fire-and-forget).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/require-installation", () => ({
+  requireInstallation: vi.fn(),
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    issueAgentToken: vi.fn(),
+  };
+});
+
+vi.mock("@/server/agent-token-v1-audit", () => ({
+  auditAppend: vi.fn(async () => undefined),
+}));
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  issueAgentToken,
+  TokenNameTakenError,
+} from "@/server/agent-token-v1";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedRequireInstallation = vi.mocked(requireInstallation);
+const mockedIssue = vi.mocked(issueAgentToken);
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+function makeRequest(body?: unknown): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/agent-tokens/bootstrap", {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie: "session=mock" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function makeByokAuthOk(overrides: { userLogin?: string } = {}) {
+  return {
+    ok: true as const,
+    session: {
+      userLogin: overrides.userLogin ?? "operator-gh-login",
+      installationId: "12345",
+    } as never,
+    keyring: new Map<string, Buffer>([["v1", Buffer.alloc(32)]]),
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  };
+}
+
+function makeIssued(name = "bootstrap-admin") {
+  return {
+    token: "hmt_brand_new_admin_bearer",
+    name,
+    agent_role: "admin",
+    capabilities: ["*", "agent_tokens.manage"],
+    fingerprint: "bootfp01",
+    expiresAt: new Date(Date.now() + 23 * 60 * 60 * 1000).toISOString(),
+  };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedRequireInstallation.mockReset();
+  mockedIssue.mockReset();
+  mockedAuditAppend.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Auth + installation context
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens/bootstrap — auth + installation", () => {
+  it("byok auth failure → middleware response surfaces", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "byok_session_invalid" }, { status: 401 }),
+    } as never);
+    const res = await POST(makeRequest({ name: "bootstrap-admin" }));
+    expect(res.status).toBe(401);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("requireInstallation failure → response surfaces", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ code: "missing_installation" }, { status: 400 }),
+    } as never);
+    const res = await POST(makeRequest({ name: "bootstrap-admin" }));
+    expect(res.status).toBe(400);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Body validation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens/bootstrap — body validation", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({ ok: true, installationId: "12345" } as never);
+  });
+
+  it("missing name → 400 INVALID_NAME", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+  });
+
+  it("expiresIn longer than 24h → 400 INVALID_EXPIRES_IN", async () => {
+    const res = await POST(
+      makeRequest({ name: "bootstrap-admin", expiresIn: "30d" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_expires_in");
+    expect(body.message).toMatch(/24h/);
+  });
+
+  it("expiresIn: null is treated as 'use default 24h' (bootstrap remaps the no-expiry semantic)", async () => {
+    // Distinct from POST /api/agent-tokens (the regular issue endpoint)
+    // where `expiresIn: null` means "no expiry". Bootstrap REQUIRES a
+    // bounded expiry to limit the one-time-display exposure window —
+    // operators sending null get the 24h default rather than an
+    // unbounded admin token.
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(
+      makeRequest({ name: "bootstrap-admin", expiresIn: null }),
+    );
+    expect(res.status).toBe(201);
+    const expiresAt = mockedIssue.mock.calls[0][0].expiresAt;
+    expect(expiresAt).not.toBeNull();
+    const ms = new Date(expiresAt!).getTime() - Date.now();
+    expect(ms).toBeGreaterThanOrEqual(24 * 60 * 60 * 1000 - 1000);
+    expect(ms).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 1000);
+  });
+
+  it("expiresIn shorter than 24h is allowed (e.g., '1h' for quick recovery)", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(
+      makeRequest({ name: "bootstrap-admin", expiresIn: "1h" }),
+    );
+    expect(res.status).toBe(201);
+    // Verify storage call got the 1h-from-now expiresAt, not 24h
+    const expiresAt = mockedIssue.mock.calls[0][0].expiresAt;
+    expect(expiresAt).not.toBeNull();
+    const ms = new Date(expiresAt!).getTime() - Date.now();
+    expect(ms).toBeLessThanOrEqual(60 * 60 * 1000 + 1000);
+    expect(ms).toBeGreaterThanOrEqual(60 * 60 * 1000 - 1000);
+  });
+
+  it("default expiresIn is 24h when caller omits the field", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(makeRequest({ name: "bootstrap-admin" }));
+    const expiresAt = mockedIssue.mock.calls[0][0].expiresAt;
+    const ms = new Date(expiresAt!).getTime() - Date.now();
+    // ~24h ± slack
+    expect(ms).toBeGreaterThanOrEqual(24 * 60 * 60 * 1000 - 1000);
+    expect(ms).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens/bootstrap — happy paths", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({ ok: true, installationId: "12345" } as never);
+  });
+
+  it("issues admin-preset token, returns bearer ONCE + bootstrappedBy attribution", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(makeRequest({ name: "bootstrap-admin" }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.token).toBe("hmt_brand_new_admin_bearer");
+    expect(body.fingerprint).toBe("bootfp01");
+    expect(body.capabilities).toEqual(["*", "agent_tokens.manage"]);
+    expect(body.agent_role).toBe("admin");
+    expect(body.bootstrappedBy).toBe("operator-gh-login");
+    expect(body.message).toMatch(/ONCE/);
+    expect(body.message).toMatch(/24h/);
+  });
+
+  it("hardcodes admin preset capabilities (operator can't override)", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(
+      makeRequest({
+        name: "bootstrap-admin",
+        // These should be IGNORED — bootstrap doesn't accept caps overrides
+        capabilities: ["tasks.claim"],
+        preset: "worker",
+      }),
+    );
+    const callArgs = mockedIssue.mock.calls[0][0];
+    expect(callArgs.capabilities).toEqual(["*", "agent_tokens.manage"]);
+    expect(callArgs.agent_role).toBe("admin");
+  });
+
+  it("auditContext with actionOverride: 'bootstrap' (storage emits 'bootstrap' action class)", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(makeRequest({ name: "bootstrap-admin" }));
+    const callArgs = mockedIssue.mock.calls[0][0];
+    expect(callArgs.auditContext?.actionOverride).toBe("bootstrap");
+    // Cookie auth → no bearer fingerprint to record
+    expect(callArgs.auditContext?.operator.fingerprint).toBe("");
+    // actor = "dashboard" per design (cookie-auth path marker)
+    expect(callArgs.auditContext?.operator.name).toBe("dashboard");
+    // GitHub user identity goes in detailExtras for attribution
+    expect(callArgs.auditContext?.detailExtras).toEqual({
+      bootstrapped_by: "operator-gh-login",
+    });
+  });
+
+  it("emits AWAITED auth.success audit (Vercel suspension safety)", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(makeRequest({ name: "bootstrap-admin" }));
+    // Notice: no setImmediate flush needed — audit was awaited.
+    // If the implementation regresses to fire-and-forget,
+    // mockedAuditAppend might still report a call here, but the
+    // `await` semantic is verified by the route.ts source pattern;
+    // this test pins the OBSERVABLE behavior (audit was emitted)
+    // and lets the implementation comment carry the rationale.
+    expect(mockedAuditAppend).toHaveBeenCalledTimes(1);
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    expect(entry.action).toBe("auth.success");
+    if (entry.action === "auth.success" || entry.action === "auth.failure") {
+      expect(entry.endpoint).toBe("POST /api/agent-tokens/bootstrap");
+      expect(entry.fingerprint).toBe(""); // cookie auth, no bearer
+      expect(entry.required_capability).toBeNull();
+    }
+  });
+
+  it("createdBy = operator's GitHub login (not 'dashboard') so the envelope's attribution is human-readable", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    await POST(makeRequest({ name: "bootstrap-admin" }));
+    expect(mockedIssue.mock.calls[0][0].createdBy).toBe("operator-gh-login");
+  });
+
+  it("SECURITY: response never contains envelope crypto material", async () => {
+    mockedIssue.mockResolvedValue(makeIssued());
+    const res = await POST(makeRequest({ name: "bootstrap-admin" }));
+    const raw = await res.text();
+    expect(raw).not.toContain("ciphertext");
+    expect(raw).not.toContain("tokenHash");
+    // The bearer string IS in the response (one-time display) but
+    // its hash isn't.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Storage error mapping
+// ---------------------------------------------------------------------------
+
+describe("POST /api/agent-tokens/bootstrap — storage errors", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({ ok: true, installationId: "12345" } as never);
+  });
+
+  it("name conflict → 409 NAME_TAKEN (operator must pick a different name)", async () => {
+    mockedIssue.mockRejectedValue(
+      new TokenNameTakenError("12345", "bootstrap-admin"),
+    );
+    const res = await POST(makeRequest({ name: "bootstrap-admin" }));
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("agent_tokens_v1_name_taken");
+  });
+});

--- a/web/src/app/api/agent-tokens/bootstrap/route.ts
+++ b/web/src/app/api/agent-tokens/bootstrap/route.ts
@@ -36,6 +36,7 @@ import { requireInstallation } from "@/server/require-installation";
 import { issueAgentToken } from "@/server/agent-token-v1";
 import {
   resolvePreset,
+  validateName,
   CapabilityValidationError,
 } from "@/server/agent-token-capabilities";
 import { auditAppend } from "@/server/agent-token-v1-audit";
@@ -88,7 +89,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!parsedBody.ok) return parsedBody.response;
   const body = parsedBody.body;
 
-  // ----- name (required) -----
+  // ----- name (required + format-validated at the boundary) -----
   if (typeof body.name !== "string") {
     return v1Error(
       AGENT_TOKENS_V1_ERROR.INVALID_NAME,
@@ -96,8 +97,27 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       400,
     );
   }
-  // Name format validation happens inside issueAgentToken via
-  // validateName — surfaces as CapabilityValidationError → 400 here.
+  // Pre-validate the name format at the route boundary (closes
+  // #508 builder R1 #2). Without this, malformed names (e.g.
+  // "Bootstrap" — capital B violates the regex) fall through to
+  // issueAgentToken which throws CapabilityValidationError, and
+  // mapV1StorageErrorToResponse maps that to INVALID_CAPABILITIES
+  // — semantically wrong (the bad input is name, not caps).
+  // Pre-validation surfaces the correct stable code AND avoids the
+  // wasteful audit-emit + lock-acquire path for a guaranteed-400.
+  try {
+    validateName(body.name);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+        err.message,
+        400,
+        { field: err.field, value: err.value },
+      );
+    }
+    throw err;
+  }
 
   // ----- expiresIn (default to and capped at 24h) -----
   // Operator can pass a SHORTER expiresIn if they want (e.g., "1h"
@@ -200,7 +220,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         // bootstrapped_by field on the mutation entry's detail is
         // the canonical attribution for the dashboard user.
         fingerprint: "",
-        name: body.name,
+        // The auth.success row represents the CREDENTIAL that
+        // authenticated this request. Bootstrap authenticated with
+        // the dashboard cookie session, NOT the new token (which
+        // doesn't exist until issueAgentToken returned). Closes
+        // #508 builder R1 #1: previously this was set to body.name,
+        // making the auth stream look like the new token had
+        // authenticated before it existed. Empty string is the
+        // cookie-auth marker — the SUBJECT token's name is already
+        // captured by the matching `bootstrap` row on the :audit
+        // (mutation) stream.
+        name: "",
         action: "auth.success",
         endpoint: "POST /api/agent-tokens/bootstrap",
         required_capability: null,

--- a/web/src/app/api/agent-tokens/bootstrap/route.ts
+++ b/web/src/app/api/agent-tokens/bootstrap/route.ts
@@ -1,0 +1,230 @@
+/**
+ * POST /api/agent-tokens/bootstrap — issue the chain-root admin
+ * token via dashboard cookie auth.
+ *
+ * **Why a separate endpoint, not POST /api/agent-tokens?** Bootstrap
+ * is the ONLY path that doesn't require a pre-existing
+ * `agent_tokens.manage` bearer — it's the recovery path AND the
+ * cold-start path. Per CAPABILITIES_DESIGN.md §"Bootstrap path
+ * (closes guard B — blocking)": a logged-in installation admin
+ * (`authenticateByokRequest`) can issue an admin-preset token; all
+ * subsequent admin operations chain off that one. If the operator
+ * loses their admin token, this endpoint is the recovery — cookie
+ * auth always works for the installation owner.
+ *
+ * **Hardcoded admin preset, capped 24h expiry**: per design, bootstrap
+ * tokens are NOT a parameterized issuance path. The admin preset is
+ * fixed (`*` + `agent_tokens.manage`) so an operator can't accidentally
+ * bootstrap a non-admin token; the 24h cap (closes guard R2 N4) limits
+ * exposure window after the one-time-display flow.
+ *
+ * **Vercel suspension safety** (closes #505 guard R1 carry-forward
+ * #3): the auth.success audit emit is AWAITED here, not fire-and-
+ * forget. Bootstrap is operator-driven, low-volume (~5x lifetime per
+ * installation), so the extra ~50ms latency from one Redis XADD is
+ * cheaper than a `request.waitUntil` shim and avoids the entire
+ * serverless-suspension race surface for the audit row.
+ *
+ * The mutation event (`bootstrap` action on the `:audit` stream)
+ * lands ATOMICALLY inside the storage script's EVAL — same atomicity
+ * guarantee as issue/revoke/etc. via the `auditContext` plumbing.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { issueAgentToken } from "@/server/agent-token-v1";
+import {
+  resolvePreset,
+  CapabilityValidationError,
+} from "@/server/agent-token-capabilities";
+import { auditAppend } from "@/server/agent-token-v1-audit";
+import {
+  parseExpiresIn,
+  mapV1StorageErrorToResponse,
+  readJsonObject,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+} from "@/server/agent-token-v1-routes";
+
+/** Hardcoded admin agent_role on bootstrap envelopes. Distinct from
+ * worker/queen so `/api/whoami` clearly identifies bootstrap-derived
+ * tokens for operators reviewing the fleet. */
+const BOOTSTRAP_AGENT_ROLE = "admin";
+/** Per CAPABILITIES_DESIGN.md §Bootstrap path: 24h max so the one-
+ * time-display flow's exposure window is bounded. Operator MUST
+ * issue a longer-lived successor admin token within the window. */
+const BOOTSTRAP_MAX_EXPIRES_IN = "24h";
+
+interface BootstrapResponse {
+  /** Raw bearer (`hmt_xxx...`). Shown ONCE — no GET-after-issue path. */
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+  /** GitHub login of the dashboard operator who triggered the
+   * bootstrap. Surfaced so the operator can confirm the audit
+   * entry attribution matches their identity. */
+  bootstrappedBy: string;
+  /** Static reminder string. Not parsed by clients. */
+  message: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Cookie auth — `requireFresh: true` mirrors the legacy /api/agent-token
+  // POST: bootstrap is mutating (creates bearer + writes envelope), so a
+  // valid-but-stale session must re-authenticate per the dashboard's
+  // step-up gate.
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const parsedBody = await readJsonObject(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+
+  // ----- name (required) -----
+  if (typeof body.name !== "string") {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+      "name (string) is required. Pick a unique name for this bootstrap admin token, e.g. 'bootstrap-admin' or 'bootstrap-2026-04-27'.",
+      400,
+    );
+  }
+  // Name format validation happens inside issueAgentToken via
+  // validateName — surfaces as CapabilityValidationError → 400 here.
+
+  // ----- expiresIn (default to and capped at 24h) -----
+  // Operator can pass a SHORTER expiresIn if they want (e.g., "1h"
+  // for a quick recovery use); reject anything longer than 24h.
+  // Both `undefined` AND `null` (key absent OR explicitly nulled)
+  // default to 24h — bootstrap REQUIRES a bounded expiry, so the
+  // null-is-no-expiry semantics from the regular issue path are
+  // intentionally remapped here.
+  const expiresIn = body.expiresIn ?? BOOTSTRAP_MAX_EXPIRES_IN;
+  const expiresParse = parseExpiresIn(expiresIn);
+  if (!expiresParse.ok) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN,
+      expiresParse.message,
+      400,
+    );
+  }
+  // Defensive: parseExpiresIn returns expiresAt:null only for null/undefined
+  // inputs, which are remapped to "24h" above — so this branch is
+  // unreachable today. Pin it as an invariant in case the default
+  // logic changes later.
+  if (expiresParse.expiresAt === null) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.SERVER_ERROR,
+      "Internal invariant violated: bootstrap default expiry not applied.",
+      500,
+    );
+  }
+  // Verify the parsed expiresAt is within 24h. parseExpiresIn caps
+  // at 365d — bootstrap caps tighter. Compare against now + 24h
+  // (with a small slack to account for the round-trip latency).
+  const expiresAtMs = new Date(expiresParse.expiresAt).getTime();
+  const maxExpiresAtMs = Date.now() + 24 * 60 * 60 * 1000 + 1000; // +1s slack
+  if (expiresAtMs > maxExpiresAtMs) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN,
+      "Bootstrap admin tokens are capped at 24h (closes design guard R2 N4 — bounds the one-time-display exposure window). Issue a longer-lived successor admin token AFTER bootstrap via POST /api/agent-tokens.",
+      400,
+    );
+  }
+
+  // ----- capabilities (hardcoded admin preset) -----
+  // No operator override. Bootstrap = full admin token = `*` + agent_tokens.manage.
+  // The wildcard guard at POST /api/agent-tokens doesn't apply here
+  // because bootstrap is the deliberate-opt-in path BY DEFINITION.
+  let capabilities: readonly string[];
+  try {
+    capabilities = resolvePreset("admin");
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      // Internal invariant — admin preset must always exist. This
+      // branch only fires if PRESETS is corrupted at runtime.
+      console.error("[agent-tokens/bootstrap] admin preset missing", { error: err });
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.SERVER_ERROR,
+        "Server misconfiguration",
+        500,
+      );
+    }
+    throw err;
+  }
+
+  try {
+    const issued = await issueAgentToken({
+      installationId,
+      name: body.name,
+      agent_role: BOOTSTRAP_AGENT_ROLE,
+      capabilities,
+      createdBy: auth.session.userLogin, // GitHub user who clicked bootstrap
+      expiresAt: expiresParse.expiresAt,
+      keyring: auth.keyring,
+      keyVersion: auth.activeKeyVersion,
+      redis: auth.redis,
+      auditContext: {
+        // No bearer for cookie-auth path — fingerprint stays empty
+        // (per the audit schema's "Empty for bootstrap" allowance).
+        // `actor: "dashboard"` distinguishes cookie-auth from bearer-
+        // auth in the forensic stream; the operator's GitHub login
+        // goes in detailExtras for attribution.
+        operator: { fingerprint: "", name: "dashboard" },
+        actionOverride: "bootstrap",
+        detailExtras: {
+          bootstrapped_by: auth.session.userLogin,
+        },
+      },
+    });
+
+    // AWAITED audit emit (not fire-and-forget) — closes #505 guard
+    // R1 carry-forward #3. Vercel may suspend the function after
+    // the response is sent; awaiting guarantees the auth.success
+    // audit row lands before we return. Bootstrap is operator-driven
+    // (~5x lifetime per installation) so the latency cost is
+    // immaterial relative to the reliability gain.
+    await auditAppend({
+      redis: auth.redis,
+      installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        // Cookie auth — no bearer fingerprint to record. The
+        // bootstrapped_by field on the mutation entry's detail is
+        // the canonical attribution for the dashboard user.
+        fingerprint: "",
+        name: body.name,
+        action: "auth.success",
+        endpoint: "POST /api/agent-tokens/bootstrap",
+        required_capability: null,
+        outcome: "ok",
+      },
+    });
+
+    const responseBody: BootstrapResponse = {
+      token: issued.token,
+      name: issued.name,
+      agent_role: issued.agent_role,
+      capabilities: issued.capabilities,
+      fingerprint: issued.fingerprint,
+      expiresAt: issued.expiresAt,
+      bootstrappedBy: auth.session.userLogin,
+      message:
+        "Bearer is shown ONCE — store it securely now. There is no GET-after-issue path. Within 24h, issue a longer-lived successor admin token via POST /api/agent-tokens (using THIS bearer) and revoke this bootstrap one — the 24h cap exists to bound the one-time-display exposure window.",
+    };
+    return NextResponse.json(responseBody, { status: 201 });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "POST /api/agent-tokens/bootstrap",
+      installationId,
+      name: body.name,
+    });
+  }
+}

--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -422,6 +422,49 @@ describe("issueAgentToken", () => {
     expect(DEFAULT_TOKEN_LIMIT_PER_INSTALLATION).toBe(20);
   });
 
+  it("auditContext.actionOverride: 'bootstrap' makes the audit entry use action=bootstrap (B.1.d-iii)", async () => {
+    // The bootstrap endpoint reuses issueAgentToken but needs the
+    // audit row's action field to read "bootstrap" (distinguishes
+    // dashboard cookie-auth from bearer-auth in the :audit stream).
+    // Pin that the override flows through to the JSON the script
+    // receives.
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      auditContext: {
+        operator: { fingerprint: "", name: "dashboard" },
+        actionOverride: "bootstrap",
+        detailExtras: { bootstrapped_by: "operator-gh-login" },
+      },
+    });
+    const issueCall = redis._luaSim.mock.calls.find(
+      (c) => c[1].length === 4 && c[2].length === 7,
+    );
+    expect(issueCall).toBeDefined();
+    const auditEntryJson = issueCall![2][6] as string;
+    expect(auditEntryJson).not.toBe("");
+    const auditEntry = JSON.parse(auditEntryJson);
+    expect(auditEntry.action).toBe("bootstrap");
+    expect(auditEntry.actor).toBe("dashboard");
+    expect(auditEntry.fingerprint).toBe("");
+    expect(auditEntry.detail.bootstrapped_by).toBe("operator-gh-login");
+    expect(auditEntry.detail.created_fingerprint).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("auditContext without actionOverride defaults to action=issue", async () => {
+    await issueAgentToken({
+      ...defaultIssueArgs(redis),
+      auditContext: {
+        operator: { fingerprint: "feedface", name: "admin" },
+      },
+    });
+    const issueCall = redis._luaSim.mock.calls.find(
+      (c) => c[1].length === 4 && c[2].length === 7,
+    );
+    const auditEntry = JSON.parse(issueCall![2][6] as string);
+    expect(auditEntry.action).toBe("issue");
+    expect(auditEntry.actor).toBe("admin");
+  });
+
   it("with expiresAt set, ISSUE script call carries positive expirySecsOrZero", async () => {
     const future = new Date(Date.now() + 86400 * 1000).toISOString();
     await issueAgentToken({ ...defaultIssueArgs(redis), expiresAt: future });

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -302,6 +302,12 @@ export interface AuditMutationContext {
    * Use sparingly — the standard detail (from/to / fingerprints)
    * covers the canonical cases. */
   detailExtras?: Record<string, unknown>;
+  /** Override the action class. ONLY honored by `issueAgentToken`
+   * (the only function that can emit either `issue` or `bootstrap`
+   * — bootstrap is a special-case issue from the dashboard cookie-
+   * auth path). Other functions ignore this field — their action
+   * is determined by the function name. */
+  actionOverride?: "bootstrap";
 }
 
 /**
@@ -780,7 +786,13 @@ export async function issueAgentToken(args: {
                   ts: createdAtIso,
                   fingerprint: args.auditContext.operator.fingerprint,
                   name: args.name,
-                  action: "issue" as const,
+                  // Bootstrap path uses the same storage call but
+                  // emits a different action class so investigators
+                  // can distinguish operator-from-dashboard from
+                  // operator-from-bearer in the :audit stream.
+                  action: (args.auditContext.actionOverride ?? "issue") as
+                    | "issue"
+                    | "bootstrap",
                   actor: args.auditContext.operator.name,
                   detail: {
                     agent_role: args.agent_role,


### PR DESCRIPTION
## Summary
\`POST /api/agent-tokens/bootstrap\` — chain-root admin token issuance via dashboard cookie auth. Closes the design doc's \"Bootstrap path\" section: a logged-in installation admin can issue an admin-preset token without a pre-existing \`agent_tokens.manage\` bearer. Recovery path AND cold-start path.

## What it looks like

### Bootstrap request → 201 response
\`\`\`json
// Request body
{
  \"name\": \"bootstrap-admin\",
  \"expiresIn\": \"24h\"  // optional, defaults to 24h, max 24h
}

// Response (bearer shown ONCE)
{
  \"token\": \"hmt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",
  \"name\": \"bootstrap-admin\",
  \"agent_role\": \"admin\",
  \"capabilities\": [\"*\", \"agent_tokens.manage\"],
  \"fingerprint\": \"abcd1234\",
  \"expiresAt\": \"2026-04-28T15:00:00.000Z\",
  \"bootstrappedBy\": \"operator-gh-login\",
  \"message\": \"Bearer is shown ONCE — store it securely now. There is no GET-after-issue path. Within 24h, issue a longer-lived successor admin token via POST /api/agent-tokens (using THIS bearer) and revoke this bootstrap one — the 24h cap exists to bound the one-time-display exposure window.\"
}
\`\`\`

### Beyond-24h expiresIn rejected
\`\`\`json
HTTP 400
{
  \"code\": \"agent_tokens_v1_invalid_expires_in\",
  \"message\": \"Bootstrap admin tokens are capped at 24h (closes design guard R2 N4 — bounds the one-time-display exposure window). Issue a longer-lived successor admin token AFTER bootstrap via POST /api/agent-tokens.\"
}
\`\`\`

### Audit row landed atomically on the \`:audit\` stream
\`\`\`json
{
  \"ts\": \"2026-04-27T15:00:00.000Z\",
  \"fingerprint\": \"\",                             // cookie auth — no bearer
  \"name\": \"bootstrap-admin\",                     // subject
  \"action\": \"bootstrap\",                         // distinguishes cookie path
  \"actor\": \"dashboard\",                          // cookie-auth marker
  \"detail\": {
    \"agent_role\": \"admin\",
    \"capabilities\": [\"*\", \"agent_tokens.manage\"],
    \"expiresAt\": \"2026-04-28T15:00:00.000Z\",
    \"has_policy\": false,
    \"created_fingerprint\": \"abcd1234\",
    \"bootstrapped_by\": \"operator-gh-login\"       // detailExtras attribution
  }
}
\`\`\`

## Architecture

### Vercel suspension safety (closes #505 guard R1 carry-forward #3)
The auth.success audit emit is **AWAITED**, not fire-and-forget. Bootstrap is operator-driven (~5x lifetime per installation), so the latency cost of one Redis XADD is immaterial vs the reliability gain on a serverless runtime. The mutation event lands atomically inside the storage script's EVAL via \`auditContext\` — same atomicity guarantee as issue/revoke/etc.

### Hardcoded admin preset
Operator can NOT override the preset/caps via body — bootstrap is the deliberate-opt-in path by definition, no accidental misissuance possible. Capabilities = \`[*, agent_tokens.manage]\`, agent_role = \`\"admin\"\`. Body fields like \`capabilities\`, \`preset\` are silently ignored.

### 24h cap (closes design guard R2 N4)
\`expiresIn\` defaults to \`\"24h\"\` and rejects anything longer. Operator MUST issue a longer-lived successor admin via \`POST /api/agent-tokens\` within 24h. Bounds the one-time-display exposure window.

### Recovery path
Bootstrap is a recovery path too: if operator loses their admin bearer, calling bootstrap again issues a fresh one. Conflicts on the \`name\` field 409 — operator picks a different name.

## Storage extension

\`AuditMutationContext\` gains optional \`actionOverride?: \"bootstrap\"\`. \`issueAgentToken\` honors it when present (uses \`\"bootstrap\"\` instead of \`\"issue\"\` in the entry's action field). Other mutation functions ignore it (their action is determined by function identity).

This keeps the storage layer's audit-construction internals unchanged for the regular issue path while allowing the bootstrap path to flow through the SAME atomic-XADD slot that #506 plumbed.

## Test plan
- [x] All 962 web tests pass + 1 skipped, typecheck clean
- [x] 14 endpoint tests:
  - byok auth failure / requireInstallation failure
  - missing name → 400
  - expiresIn >24h → 400 with operator-actionable message
  - expiresIn null → defaults to 24h (bootstrap remaps the no-expiry semantic)
  - expiresIn shorter than 24h (e.g. \"1h\") → accepted
  - hardcoded admin preset (capabilities/preset overrides ignored)
  - auditContext.actionOverride: \"bootstrap\" wired
  - AWAITED audit (not fire-and-forget)
  - createdBy = operator's GitHub login (envelope attribution)
  - SECURITY: response never contains envelope ciphertext / tokenHash
  - name-conflict 409
- [x] 2 storage tests for actionOverride flow:
  - actionOverride: \"bootstrap\" → audit entry has action=\"bootstrap\", actor=\"dashboard\", detail carries created_fingerprint + bootstrapped_by
  - default (no actionOverride) → action=\"issue\" (regression)

## Out of scope (follow-up)
- Dashboard page \`/dashboard/installation/tokens\` — operators can hit the endpoint via curl + cookie session for now; UI ergonomics is a separate concern that doesn't block the Hive cutover backend path.
- Drone D2/D3 from #506 (path-validation asymmetry, V1.6-only error message clarity) — pure consistency/UX, deferred.

## Carry-forwards still open for V1.1
- Per-bearer rate limiting on /whoami spam (#505 guard R1 #4)
- Drone D3 \`auth.failure\` audit emit (architectural gap — middleware returns response on failure, route handlers can't easily add it)