### PR TITLE
Phase D.1.a-ii — event appending + RSVP / contribute primitives

### DIFF
--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -129,6 +129,96 @@ function makeMockRedis() {
         return [1, roomId];
       }
 
+      // ROOM_PARTICIPANT_TRANSITION_SCRIPT — 6 keys, 12 args (D.1.a-ii R3)
+      if (
+        keys.length === 6 &&
+        argv.length === 12 &&
+        script.includes("no_participant")
+      ) {
+        const [seqK, eventsK, idemK, roomK, participantsK, contributionsK] = keys;
+        const [
+          eventTemplate,
+          idempotencyKey,
+          _eventType,
+          role,
+          ownerRequired,
+          ownerExpected,
+          allowedRoomStatuses,
+          _roomId,
+          _idemTtlSecs,
+          transform,
+          nowIso,
+          contributionFieldJson,
+        ] = argv;
+
+        // 1. Idempotency
+        if (idempotencyKey !== "") {
+          const existing = store.get(idemK);
+          if (existing !== undefined) return [-1, Number(existing)];
+        }
+        // 2. Room exists + status check
+        const roomHash = hashes.get(roomK);
+        const currStatus = roomHash?.get("status") as string | undefined;
+        if (currStatus === undefined) return [-3, "room_not_found"];
+        if (allowedRoomStatuses !== "") {
+          const allowed = allowedRoomStatuses.split(",");
+          if (!allowed.includes(currStatus)) return [-2, currStatus];
+        }
+        // 3. Participant slot must exist
+        const existingP = hashes.get(participantsK)?.get(role) as
+          | string
+          | undefined;
+        if (existingP === undefined) return [-5, "no_participant"];
+        const p = JSON.parse(existingP) as {
+          agent_id: string;
+          status: string;
+          rsvp_at: string;
+          role: string;
+        };
+        // 4. Owner check (when required)
+        if (ownerRequired === "1" && p.agent_id !== ownerExpected) {
+          return [-4, "owner_conflict", p.agent_id];
+        }
+        // 5. INCR + ZADD + idem
+        const oldSeq = (store.get(seqK) as number | undefined) ?? 0;
+        const seq = oldSeq + 1;
+        store.set(seqK, seq);
+        const eventJson = eventTemplate.replace("__SEQ__", String(seq));
+        getSortedSet(eventsK).push({ member: eventJson, score: seq });
+        if (idempotencyKey !== "") {
+          store.set(idemK, String(seq));
+        }
+        // 6. Apply transformation
+        if (transform === "resolve") {
+          const updated = {
+            ...p,
+            status: "resolved",
+            resolved_at: nowIso,
+            withdrew_at_sequence: undefined,
+          };
+          delete (updated as { withdrew_at_sequence?: unknown })
+            .withdrew_at_sequence;
+          getHash(participantsK).set(role, JSON.stringify(updated));
+        } else if (transform === "withdraw") {
+          const updated = {
+            ...p,
+            status: "withdrew",
+            resolved_at: nowIso,
+            withdrew_at_sequence: seq,
+          };
+          getHash(participantsK).set(role, JSON.stringify(updated));
+        } else if (transform === "timeout") {
+          const updated = { ...p, status: "timed_out", resolved_at: nowIso };
+          getHash(participantsK).set(role, JSON.stringify(updated));
+        }
+        // "noop" leaves slot unchanged
+        // 7. Optional contribution write
+        if (contributionFieldJson !== "") {
+          getHash(contributionsK).set(role, contributionFieldJson);
+        }
+        return [seq];
+      }
+
       // ROOM_APPEND_EVENT_SCRIPT R2 — 9 keys, 15 args (D.1.a-ii R2)
       if (
         keys.length === 9 &&
@@ -1104,6 +1194,7 @@ import {
   RoomEventBodyTooLargeError,
   RoomContributionTooLargeError,
   RoomParticipantOwnerConflictError,
+  RoomParticipantNotFoundError,
   ContributionValidationError,
 } from "./war-room";
 
@@ -1714,17 +1805,24 @@ describe("timeoutParticipant", () => {
       redis,
     });
     // Manually transition to awaiting_contributions so the watchdog
-    // path is gated correctly. (Real lifecycle does this when all
-    // expected roles RSVP — here we shortcut for the test.)
+    // path is gated correctly.
     redis._sets.delete(statusIndexKey("12345", "awaiting_rsvp"));
     redis._sets.set(
       statusIndexKey("12345", "awaiting_contributions"),
       new Set([RID_A]),
     );
-    // Bypass the public type guard and write the status directly to
-    // the hash for test setup (no public seek-status mutator yet).
-    const roomKey_ = roomKey("12345", RID_A);
-    await redis.hset(roomKey_, { status: "awaiting_contributions" });
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    // Pre-populate the participant slot so the new transition script's
+    // existence check passes (per design L746, /present is required
+    // before any non-create action like /timeout).
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-original",
+        role: "drone",
+        status: "pending",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+      }),
+    });
   });
 
   it("times out a participant in awaiting_contributions → status 'timed_out'", async () => {
@@ -1773,6 +1871,173 @@ describe("timeoutParticipant", () => {
     expect(events[0].actor_role).toBe("manager");
     expect(events[0].actor_id).toBe("bot-queen");
     expect(events[0].body.subject_role).toBe("drone");
+  });
+
+  it("preserves the original agent_id + rsvp_at on the timed_out participant (R2 G N2)", async () => {
+    // The transition script reads the existing slot via cjson.decode
+    // and modifies just status + resolved_at — agent_id, role, rsvp_at
+    // are preserved. Operators reading participants.drone now see the
+    // original participant, not the watchdog's identity.
+    await timeoutParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      subjectRole: "drone",
+      watchdogRole: "manager",
+      watchdogAgentId: "bot-queen",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.agent_id).toBe("drone-original");
+    expect(participants.drone.rsvp_at).toBe("2026-04-28T00:00:00.000Z");
+    expect(participants.drone.status).toBe("timed_out");
+  });
+});
+
+// ===========================================================================
+// D.1.a-ii R3 — additional builder R2 closures (B5 + B6)
+// ===========================================================================
+
+describe("D.1.a-ii R3 / B5 — submitContribution allows awaiting_rsvp (early contribution path)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    // Pre-populate participant slot — caller must /present first
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "pending",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+      }),
+    });
+    // Room is in awaiting_rsvp (NOT awaiting_contributions) — early-
+    // contribution path per design L201.
+  });
+
+  it("contribute during awaiting_rsvp succeeds (no status precondition error)", async () => {
+    const seq = await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      body: { verdict: "APPROVE", summary: "early submission" },
+      rawMd: "ok",
+      redis,
+    });
+    expect(seq).toBeGreaterThan(0);
+    const contributions = await getRoomContributions({ roomId: RID_A, redis });
+    expect(contributions.drone.body.verdict).toBe("APPROVE");
+    // Participant is now resolved (atomic dual-update)
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("resolved");
+  });
+
+  it("preserves the original rsvp_at across the early contribute (R2 R2 #2)", async () => {
+    // Original rsvp_at was "2026-04-28T00:00:00.000Z" (set in beforeEach).
+    // The transition script reads the slot via cjson.decode, modifies
+    // only status + resolved_at, re-encodes — rsvp_at is preserved
+    // atomically inside the lock.
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      body: { verdict: "APPROVE", summary: "ok" },
+      rawMd: "ok",
+      redis,
+    });
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.rsvp_at).toBe("2026-04-28T00:00:00.000Z");
+    expect(participants.drone.status).toBe("resolved");
+    expect(participants.drone.resolved_at).toBeDefined();
+    // resolved_at is later than rsvp_at
+    expect(
+      new Date(participants.drone.resolved_at!).getTime(),
+    ).toBeGreaterThan(new Date(participants.drone.rsvp_at).getTime());
+  });
+});
+
+describe("D.1.a-ii R3 / B6 — non-create actions require existing participant slot", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    // Note: NO participant slot pre-populated — caller hasn't /present'd
+  });
+
+  it("submitContribution without prior /present → RoomParticipantNotFoundError", async () => {
+    await expect(
+      submitContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        body: { verdict: "APPROVE", summary: "ok" },
+        rawMd: "ok",
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantNotFoundError);
+    // No phantom contribution landed
+    expect(await getRoomContributions({ roomId: RID_A, redis })).toEqual({});
+  });
+
+  it("withdrawParticipant without prior /present → RoomParticipantNotFoundError", async () => {
+    await expect(
+      withdrawParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantNotFoundError);
+    expect(await getRoomParticipants({ roomId: RID_A, redis })).toEqual({});
+  });
+
+  it("withdrawContribution without prior /present → RoomParticipantNotFoundError", async () => {
+    await expect(
+      withdrawContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantNotFoundError);
+  });
+
+  it("timeoutParticipant without prior /present → RoomParticipantNotFoundError", async () => {
+    await expect(
+      timeoutParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        subjectRole: "drone",
+        watchdogRole: "manager",
+        watchdogAgentId: "bot-queen",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantNotFoundError);
   });
 });
 
@@ -2181,6 +2446,15 @@ describe("D.1.a-ii R2 / Guard B1 — __SEQ__ first-match gsub preserves user con
 
   it("contribution body summary containing '__SEQ__' is preserved verbatim", async () => {
     await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    // submitContribution requires existing participant slot
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "pending",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+      }),
+    });
     await submitContribution({
       installationId: "12345",
       roomId: RID_A,

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -128,6 +128,83 @@ function makeMockRedis() {
         getSet(repoK).add(roomId);
         return [1, roomId];
       }
+
+      // ROOM_APPEND_EVENT_SCRIPT — 7 keys, 9 args (D.1.a-ii)
+      if (
+        keys.length === 7 &&
+        argv.length === 9 &&
+        script.includes("__SEQ__")
+      ) {
+        const [
+          seqK,
+          eventsK,
+          idemK,
+          roomK,
+          materializedK,
+          statusFromK,
+          statusToK,
+        ] = keys;
+        const [
+          eventTemplate,
+          idempotencyKey,
+          _eventType,
+          materializedFieldName,
+          materializedFieldJson,
+          statusFrom,
+          statusTo,
+          roomId,
+          _idemTtlSecs,
+        ] = argv;
+
+        // 1. Idempotency check
+        if (idempotencyKey !== "") {
+          const existing = store.get(idemK);
+          if (existing !== undefined) {
+            return [-1, Number(existing)];
+          }
+        }
+
+        // 2. Status precondition
+        const roomHash = hashes.get(roomK);
+        const currStatus = roomHash?.get("status") as string | undefined;
+        if (statusFrom !== "" && currStatus !== statusFrom) {
+          return [-2, currStatus ?? "missing"];
+        }
+
+        // 3. INCR seq
+        const oldSeq = (store.get(seqK) as number | undefined) ?? 0;
+        const seq = oldSeq + 1;
+        store.set(seqK, seq);
+
+        // 4. ZADD event (gsub __SEQ__ to seq)
+        const eventJson = eventTemplate.replace(/__SEQ__/g, String(seq));
+        getSortedSet(eventsK).push({ member: eventJson, score: seq });
+
+        // 5. SET idempotency reverse index
+        if (idempotencyKey !== "") {
+          store.set(idemK, String(seq));
+        }
+
+        // 6. HSET materialized view
+        if (materializedFieldName !== "") {
+          getHash(materializedK).set(
+            materializedFieldName,
+            materializedFieldJson,
+          );
+        }
+
+        // 7. Status transition
+        if (statusTo !== "") {
+          getHash(roomK).set("status", statusTo);
+          if (statusFrom !== statusTo) {
+            getSet(statusFromK).delete(roomId);
+            getSet(statusToK).add(roomId);
+          }
+        }
+
+        return [seq];
+      }
+
       return null;
     },
   );
@@ -179,15 +256,28 @@ function makeMockRedis() {
     zrange: vi.fn(
       async (
         key: string,
-        start: number,
-        stop: number,
-        opts?: { rev?: boolean },
+        start: number | string,
+        stop: number | string,
+        opts?: { rev?: boolean; byScore?: boolean; offset?: number; count?: number },
       ): Promise<string[]> => {
         const set = sortedSets.get(key) ?? [];
         const sorted = [...set].sort((a, b) => a.score - b.score);
+        if (opts?.byScore) {
+          // BYSCORE mode: start/stop are scores; "+inf" / "-inf" supported.
+          const minScore = start === "-inf" ? -Infinity : Number(start);
+          const maxScore = stop === "+inf" ? Infinity : Number(stop);
+          const filtered = sorted.filter(
+            (e) => e.score >= minScore && e.score <= maxScore,
+          );
+          const offset = opts.offset ?? 0;
+          const end = opts.count !== undefined ? offset + opts.count : filtered.length;
+          return filtered.slice(offset, end).map((e) => e.member);
+        }
         const ordered = opts?.rev ? sorted.reverse() : sorted;
-        const end = stop === -1 ? ordered.length : stop + 1;
-        return ordered.slice(start, end).map((e) => e.member);
+        const startN = Number(start);
+        const stopN = Number(stop);
+        const end = stopN === -1 ? ordered.length : stopN + 1;
+        return ordered.slice(startN, end).map((e) => e.member);
       },
     ),
     zrem: vi.fn(async (key: string, ...members: string[]) => {
@@ -941,5 +1031,708 @@ describe("storage shape", () => {
     // The plain GET shape is empty (room is a HASH, not a STRING)
     const rawGet = await redis.get(roomKey("12345", RID_A));
     expect(rawGet).toBeNull();
+  });
+});
+
+// ===========================================================================
+// D.1.a-ii — event appending + RSVP / contribute primitives
+// ===========================================================================
+
+import {
+  ROOM_APPEND_EVENT_SCRIPT,
+  ROOM_EVENT_BODY_MAX_BYTES,
+  ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES,
+  IDEM_TTL_MULTIPLIER,
+  deriveIdempotencyKey,
+  appendRoomEvent,
+  presentParticipant,
+  withdrawParticipant,
+  submitContribution,
+  withdrawContribution,
+  timeoutParticipant,
+  listRoomEvents,
+  getRoomParticipants,
+  getRoomContributions,
+  RoomEventStatusPreconditionError,
+  RoomEventIdempotencyReplayError,
+  RoomEventBodyTooLargeError,
+  RoomContributionTooLargeError,
+} from "./war-room";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("D.1.a-ii constants", () => {
+  it("ROOM_EVENT_BODY_MAX_BYTES = 8 KiB (design cap)", () => {
+    expect(ROOM_EVENT_BODY_MAX_BYTES).toBe(8 * 1024);
+  });
+
+  it("ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES = 32 KiB (design cap)", () => {
+    expect(ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES).toBe(32 * 1024);
+  });
+
+  it("IDEM_TTL_MULTIPLIER = 2 (idem TTL = 2 × max_age_secs per design)", () => {
+    expect(IDEM_TTL_MULTIPLIER).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveIdempotencyKey
+// ---------------------------------------------------------------------------
+
+describe("deriveIdempotencyKey", () => {
+  it("produces a 64-char SHA-256 hex string", () => {
+    const k = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    expect(k).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("identical inputs → identical key (replay-safe)", () => {
+    const a = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    const b = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    expect(a).toBe(b);
+  });
+
+  it("different role → different key (cross-role isolation)", () => {
+    const a = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    const b = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "builder",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("different action lane → different key (present vs withdraw don't dedupe)", () => {
+    const a = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    const b = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "withdraw_participant",
+      sequenceObservedByClient: 5,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("different observed sequence → different key (caller's progress key)", () => {
+    const a = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    const b = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 6,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("different roomId → different key (room isolation)", () => {
+    const a = deriveIdempotencyKey({
+      roomId: RID_A,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    const b = deriveIdempotencyKey({
+      roomId: RID_B,
+      role: "drone",
+      action: "present",
+      sequenceObservedByClient: 5,
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendRoomEvent — low-level
+// ---------------------------------------------------------------------------
+
+describe("appendRoomEvent", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    // Establish a room for events to land into
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("returns the new sequence (room_opened was 1, next event is 2)", async () => {
+    const seq = await appendRoomEvent({
+      installationId: "12345",
+      roomId: RID_A,
+      event: {
+        timestamp: "2026-04-28T00:00:00.000Z",
+        event_type: "participant_presented",
+        actor_role: "drone",
+        actor_id: "worker-drone",
+        body: {},
+      },
+      idempotencyKey: "",
+      redis,
+    });
+    expect(seq).toBe(2);
+  });
+
+  it("sequence numbers are monotonic across appends", async () => {
+    const s1 = await appendRoomEvent({
+      installationId: "12345",
+      roomId: RID_A,
+      event: {
+        timestamp: "2026-04-28T00:00:00.000Z",
+        event_type: "participant_presented",
+        actor_role: "drone",
+        actor_id: "worker-drone",
+        body: {},
+      },
+      idempotencyKey: "",
+      redis,
+    });
+    const s2 = await appendRoomEvent({
+      installationId: "12345",
+      roomId: RID_A,
+      event: {
+        timestamp: "2026-04-28T00:00:01.000Z",
+        event_type: "participant_presented",
+        actor_role: "builder",
+        actor_id: "worker-builder",
+        body: {},
+      },
+      idempotencyKey: "",
+      redis,
+    });
+    expect(s2).toBeGreaterThan(s1);
+  });
+
+  it("encodes the event JSON with the actual sequence (not __SEQ__)", async () => {
+    await appendRoomEvent({
+      installationId: "12345",
+      roomId: RID_A,
+      event: {
+        timestamp: "2026-04-28T00:00:00.000Z",
+        event_type: "participant_presented",
+        actor_role: "drone",
+        actor_id: "worker-drone",
+        body: {},
+      },
+      idempotencyKey: "",
+      redis,
+    });
+    const events = redis._sortedSets.get(eventsKey(RID_A));
+    expect(events).toHaveLength(2); // room_opened + participant_presented
+    const presentedJson = events![1].member;
+    expect(presentedJson).not.toContain("__SEQ__"); // gsub'd by Lua
+    const parsed = JSON.parse(presentedJson);
+    expect(parsed.seq).toBe(2);
+    expect(parsed.event_type).toBe("participant_presented");
+  });
+
+  it("idempotency replay returns the prior sequence via RoomEventIdempotencyReplayError", async () => {
+    const idemKey = "abcd1234";
+    await appendRoomEvent({
+      installationId: "12345",
+      roomId: RID_A,
+      event: {
+        timestamp: "2026-04-28T00:00:00.000Z",
+        event_type: "participant_presented",
+        actor_role: "drone",
+        actor_id: "worker-drone",
+        body: {},
+      },
+      idempotencyKey: idemKey,
+      redis,
+    });
+    // Same idempotency key → replay
+    try {
+      await appendRoomEvent({
+        installationId: "12345",
+        roomId: RID_A,
+        event: {
+          timestamp: "2026-04-28T00:00:00.000Z",
+          event_type: "participant_presented",
+          actor_role: "drone",
+          actor_id: "worker-drone",
+          body: {},
+        },
+        idempotencyKey: idemKey,
+        redis,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomEventIdempotencyReplayError);
+      if (err instanceof RoomEventIdempotencyReplayError) {
+        expect(err.existingSequence).toBe(2);
+      }
+    }
+    // Verify the second call didn't add a new event
+    expect(redis._sortedSets.get(eventsKey(RID_A))).toHaveLength(2);
+  });
+
+  it("status precondition mismatch → RoomEventStatusPreconditionError", async () => {
+    // Room is in awaiting_rsvp; try to append with from=awaiting_contributions
+    try {
+      await appendRoomEvent({
+        installationId: "12345",
+        roomId: RID_A,
+        event: {
+          timestamp: "2026-04-28T00:00:00.000Z",
+          event_type: "participant_timed_out",
+          actor_role: "manager",
+          actor_id: "bot-queen",
+          body: {},
+        },
+        idempotencyKey: "",
+        statusTransition: {
+          from: "awaiting_contributions",
+          to: "awaiting_contributions",
+        },
+        redis,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomEventStatusPreconditionError);
+      if (err instanceof RoomEventStatusPreconditionError) {
+        expect(err.expectedFrom).toBe("awaiting_contributions");
+        expect(err.actualStatus).toBe("awaiting_rsvp");
+      }
+    }
+  });
+
+  it("body > 8 KiB → RoomEventBodyTooLargeError BEFORE storage call", async () => {
+    const huge = { payload: "x".repeat(10 * 1024) };
+    try {
+      await appendRoomEvent({
+        installationId: "12345",
+        roomId: RID_A,
+        event: {
+          timestamp: "2026-04-28T00:00:00.000Z",
+          event_type: "participant_presented",
+          actor_role: "drone",
+          actor_id: "worker-drone",
+          body: huge,
+        },
+        idempotencyKey: "",
+        redis,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomEventBodyTooLargeError);
+      if (err instanceof RoomEventBodyTooLargeError) {
+        expect(err.sizeBytes).toBeGreaterThan(ROOM_EVENT_BODY_MAX_BYTES);
+      }
+    }
+    // Verify no storage write happened
+    expect(redis._sortedSets.get(eventsKey(RID_A))).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// presentParticipant
+// ---------------------------------------------------------------------------
+
+describe("presentParticipant", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("appends a participant_presented event + writes the participants hash", async () => {
+    const seq = await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    expect(seq).toBe(2);
+
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone).toBeDefined();
+    expect(participants.drone.role).toBe("drone");
+    expect(participants.drone.agent_id).toBe("drone-1");
+    expect(participants.drone.status).toBe("present");
+  });
+
+  it("idempotency: same observed sequence → replay error with prior seq", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomEventIdempotencyReplayError);
+  });
+
+  it("two roles can present concurrently — both get distinct sequences", async () => {
+    const [s1, s2] = await Promise.all([
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "builder",
+        agentId: "builder-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ]);
+    expect(s1).not.toBe(s2);
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone).toBeDefined();
+    expect(participants.builder).toBeDefined();
+  });
+
+  it("intentHint is included in the event body when provided", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      intentHint: "review for security regressions",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events[0].body.intent_hint).toBe("review for security regressions");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withdrawParticipant
+// ---------------------------------------------------------------------------
+
+describe("withdrawParticipant", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+  });
+
+  it("updates participant status to 'withdrawn' with resolved_at timestamp", async () => {
+    await withdrawParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 2,
+      reason: "out of capacity",
+      redis,
+    });
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("withdrawn");
+    expect(participants.drone.resolved_at).toBeDefined();
+  });
+
+  it("emits participant_withdrawn event with the reason in body", async () => {
+    await withdrawParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 2,
+      reason: "out of capacity",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 2, redis });
+    expect(events[0].event_type).toBe("participant_withdrawn");
+    expect(events[0].body.reason).toBe("out of capacity");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitContribution
+// ---------------------------------------------------------------------------
+
+describe("submitContribution", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("writes the contribution to the contributions hash + emits event", async () => {
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      body: { verdict: "approve", summary: "looks good" },
+      rawMd: "# Verdict\n\nApprove.",
+      redis,
+    });
+    const contributions = await getRoomContributions({ roomId: RID_A, redis });
+    expect(contributions.drone).toBeDefined();
+    expect(contributions.drone.body).toEqual({
+      verdict: "approve",
+      summary: "looks good",
+    });
+    expect(contributions.drone.raw_md).toBe("# Verdict\n\nApprove.");
+  });
+
+  it("re-submit overwrites prior contribution (latest-wins per role)", async () => {
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      body: { verdict: "approve" },
+      rawMd: "first",
+      redis,
+    });
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 2, // different observed seq → different idem key
+      body: { verdict: "request_changes" },
+      rawMd: "second",
+      redis,
+    });
+    const contributions = await getRoomContributions({ roomId: RID_A, redis });
+    expect(contributions.drone.body.verdict).toBe("request_changes");
+    expect(contributions.drone.raw_md).toBe("second");
+  });
+
+  it("rawMd > 32 KiB → RoomContributionTooLargeError BEFORE storage call", async () => {
+    const huge = "x".repeat(35 * 1024);
+    await expect(
+      submitContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        body: { verdict: "approve" },
+        rawMd: huge,
+        redis,
+      }),
+    ).rejects.toThrow(RoomContributionTooLargeError);
+    // No event landed
+    expect(await getRoomContributions({ roomId: RID_A, redis })).toEqual({});
+  });
+
+  it("rawMd is NOT in the event body (event body is bounded at 8 KiB; rawMd lives only in materialized hash)", async () => {
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      body: { verdict: "approve" },
+      rawMd: "x".repeat(20 * 1024), // 20 KiB — would blow event 8 KiB cap if included
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events[0].event_type).toBe("contribution_submitted");
+    expect(events[0].body.body).toEqual({ verdict: "approve" });
+    expect((events[0].body as Record<string, unknown>).raw_md).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timeoutParticipant — watchdog path with status precondition
+// ---------------------------------------------------------------------------
+
+describe("timeoutParticipant", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    // Manually transition to awaiting_contributions so the watchdog
+    // path is gated correctly. (Real lifecycle does this when all
+    // expected roles RSVP — here we shortcut for the test.)
+    redis._sets.delete(statusIndexKey("12345", "awaiting_rsvp"));
+    redis._sets.set(
+      statusIndexKey("12345", "awaiting_contributions"),
+      new Set([RID_A]),
+    );
+    // Bypass the public type guard and write the status directly to
+    // the hash for test setup (no public seek-status mutator yet).
+    const roomKey_ = roomKey("12345", RID_A);
+    await redis.hset(roomKey_, { status: "awaiting_contributions" });
+  });
+
+  it("times out a participant in awaiting_contributions → status 'timed_out'", async () => {
+    await timeoutParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      subjectRole: "drone",
+      watchdogRole: "manager",
+      watchdogAgentId: "bot-queen",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("timed_out");
+    expect(participants.drone.resolved_at).toBeDefined();
+  });
+
+  it("status precondition: room moved to deciding → RoomEventStatusPreconditionError (G7)", async () => {
+    // Simulate the queen claiming synthesis — status now 'deciding'
+    await redis.hset(roomKey("12345", RID_A), { status: "deciding" });
+    await expect(
+      timeoutParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        subjectRole: "drone",
+        watchdogRole: "manager",
+        watchdogAgentId: "bot-queen",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomEventStatusPreconditionError);
+  });
+
+  it("event actor is the watchdog, NOT the timed-out participant", async () => {
+    await timeoutParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      subjectRole: "drone",
+      watchdogRole: "manager",
+      watchdogAgentId: "bot-queen",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events[0].event_type).toBe("participant_timed_out");
+    expect(events[0].actor_role).toBe("manager");
+    expect(events[0].actor_id).toBe("bot-queen");
+    expect(events[0].body.subject_role).toBe("drone");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRoomEvents — read with since cursor
+// ---------------------------------------------------------------------------
+
+describe("listRoomEvents", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("returns all events when since is omitted (or 0)", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, redis });
+    expect(events).toHaveLength(2); // room_opened + participant_presented
+    expect(events[0].event_type).toBe("room_opened");
+    expect(events[1].event_type).toBe("participant_presented");
+  });
+
+  it("since=1 excludes seq=1 (room_opened); returns events strictly after", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe("participant_presented");
+    expect(events[0].seq).toBe(2);
   });
 });

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -129,10 +129,10 @@ function makeMockRedis() {
         return [1, roomId];
       }
 
-      // ROOM_APPEND_EVENT_SCRIPT — 7 keys, 9 args (D.1.a-ii)
+      // ROOM_APPEND_EVENT_SCRIPT R2 — 9 keys, 15 args (D.1.a-ii R2)
       if (
-        keys.length === 7 &&
-        argv.length === 9 &&
+        keys.length === 9 &&
+        argv.length === 15 &&
         script.includes("__SEQ__")
       ) {
         const [
@@ -140,20 +140,28 @@ function makeMockRedis() {
           eventsK,
           idemK,
           roomK,
-          materializedK,
+          ownerCheckK,
+          materializedK1,
           statusFromK,
           statusToK,
+          materializedK2,
         ] = keys;
         const [
           eventTemplate,
           idempotencyKey,
           _eventType,
-          materializedFieldName,
-          materializedFieldJson,
-          statusFrom,
+          ownerCheckRole,
+          ownerExpected,
+          materializedFieldName1,
+          materializedFieldJson1,
+          allowedStatuses,
           statusTo,
           roomId,
           _idemTtlSecs,
+          materializedFieldName2,
+          materializedFieldJson2,
+          substituteSeq1,
+          substituteSeq2,
         ] = argv;
 
         // 1. Idempotency check
@@ -164,39 +172,74 @@ function makeMockRedis() {
           }
         }
 
-        // 2. Status precondition
+        // 2. Room existence check (Lua's HGET status returns nil for missing room)
         const roomHash = hashes.get(roomK);
         const currStatus = roomHash?.get("status") as string | undefined;
-        if (statusFrom !== "" && currStatus !== statusFrom) {
-          return [-2, currStatus ?? "missing"];
+        if (currStatus === undefined) {
+          return [-3, "room_not_found"];
         }
 
-        // 3. INCR seq
+        // 3. Allowed-statuses gate
+        if (allowedStatuses !== "") {
+          const allowed = allowedStatuses.split(",");
+          if (!allowed.includes(currStatus)) {
+            return [-2, currStatus];
+          }
+        }
+
+        // 4. Owner check
+        if (ownerCheckRole !== "") {
+          const existingMatRaw = hashes.get(ownerCheckK)?.get(ownerCheckRole);
+          if (existingMatRaw !== undefined) {
+            const parsed = JSON.parse(existingMatRaw as string) as {
+              agent_id: string;
+              status: string;
+            };
+            if (
+              parsed.agent_id !== ownerExpected &&
+              parsed.status !== "withdrew"
+            ) {
+              return [-4, "owner_conflict", parsed.agent_id];
+            }
+          }
+        }
+
+        // 5. INCR seq
         const oldSeq = (store.get(seqK) as number | undefined) ?? 0;
         const seq = oldSeq + 1;
         store.set(seqK, seq);
 
-        // 4. ZADD event (gsub __SEQ__ to seq)
-        const eventJson = eventTemplate.replace(/__SEQ__/g, String(seq));
+        // 6. ZADD event (FIRST-MATCH gsub __SEQ__ to seq — closes guard B1)
+        const eventJson = eventTemplate.replace("__SEQ__", String(seq));
         getSortedSet(eventsK).push({ member: eventJson, score: seq });
 
-        // 5. SET idempotency reverse index
+        // 7. SET idempotency reverse index
         if (idempotencyKey !== "") {
           store.set(idemK, String(seq));
         }
 
-        // 6. HSET materialized view
-        if (materializedFieldName !== "") {
-          getHash(materializedK).set(
-            materializedFieldName,
-            materializedFieldJson,
-          );
+        // 8. HSET materialized 1 (opt-in __SEQ__ substitution)
+        if (materializedFieldName1 !== "") {
+          const mat1 =
+            substituteSeq1 === "1"
+              ? materializedFieldJson1.replace("__SEQ__", String(seq))
+              : materializedFieldJson1;
+          getHash(materializedK1).set(materializedFieldName1, mat1);
         }
 
-        // 7. Status transition
+        // 9. HSET materialized 2 (dual-update for submitContribution)
+        if (materializedFieldName2 !== "") {
+          const mat2 =
+            substituteSeq2 === "1"
+              ? materializedFieldJson2.replace("__SEQ__", String(seq))
+              : materializedFieldJson2;
+          getHash(materializedK2).set(materializedFieldName2, mat2);
+        }
+
+        // 10. Status transition
         if (statusTo !== "") {
           getHash(roomK).set("status", statusTo);
-          if (statusFrom !== statusTo) {
+          if (currStatus !== statusTo) {
             getSet(statusFromK).delete(roomId);
             getSet(statusToK).add(roomId);
           }
@@ -1043,7 +1086,10 @@ import {
   ROOM_EVENT_BODY_MAX_BYTES,
   ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES,
   IDEM_TTL_MULTIPLIER,
+  CONTRIBUTION_SUMMARY_MAX_CHARS,
+  CONTRIBUTION_FINDINGS_MAX_COUNT,
   deriveIdempotencyKey,
+  validateContributionBody,
   appendRoomEvent,
   presentParticipant,
   withdrawParticipant,
@@ -1057,6 +1103,8 @@ import {
   RoomEventIdempotencyReplayError,
   RoomEventBodyTooLargeError,
   RoomContributionTooLargeError,
+  RoomParticipantOwnerConflictError,
+  ContributionValidationError,
 } from "./war-room";
 
 // ---------------------------------------------------------------------------
@@ -1303,7 +1351,8 @@ describe("appendRoomEvent", () => {
   });
 
   it("status precondition mismatch → RoomEventStatusPreconditionError", async () => {
-    // Room is in awaiting_rsvp; try to append with from=awaiting_contributions
+    // Room is in awaiting_rsvp; try to append with allowedStatuses
+    // = [awaiting_contributions]
     try {
       await appendRoomEvent({
         installationId: "12345",
@@ -1316,10 +1365,7 @@ describe("appendRoomEvent", () => {
           body: {},
         },
         idempotencyKey: "",
-        statusTransition: {
-          from: "awaiting_contributions",
-          to: "awaiting_contributions",
-        },
+        allowedStatuses: ["awaiting_contributions"],
         redis,
       });
       throw new Error("expected throw");
@@ -1330,6 +1376,35 @@ describe("appendRoomEvent", () => {
         expect(err.actualStatus).toBe("awaiting_rsvp");
       }
     }
+  });
+
+  it("room missing → RoomNotFoundError (closes #510 builder B1 + guard N1)", async () => {
+    // Append to a roomId that was never created — script returns -3.
+    const fakeRoomId = "ffffffff-ffff-4fff-bfff-ffffffffffff";
+    try {
+      await appendRoomEvent({
+        installationId: "12345",
+        roomId: fakeRoomId,
+        event: {
+          timestamp: "2026-04-28T00:00:00.000Z",
+          event_type: "participant_presented",
+          actor_role: "drone",
+          actor_id: "drone-1",
+          body: {},
+        },
+        idempotencyKey: "",
+        // No allowedStatuses or statusTransition — this is the
+        // "soft event" path that was broken in R1.
+        redis,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomNotFoundError);
+    }
+    // Verify NO orphan keys were created against the fake room
+    expect(redis._sortedSets.get(eventsKey(fakeRoomId))).toBeUndefined();
+    expect(redis._store.get(seqKey(fakeRoomId))).toBeUndefined();
+    expect(redis._store.get(idemKey(fakeRoomId, ""))).toBeUndefined();
   });
 
   it("body > 8 KiB → RoomEventBodyTooLargeError BEFORE storage call", async () => {
@@ -1392,7 +1467,7 @@ describe("presentParticipant", () => {
     expect(participants.drone).toBeDefined();
     expect(participants.drone.role).toBe("drone");
     expect(participants.drone.agent_id).toBe("drone-1");
-    expect(participants.drone.status).toBe("present");
+    expect(participants.drone.status).toBe("pending");
   });
 
   it("idempotency: same observed sequence → replay error with prior seq", async () => {
@@ -1492,7 +1567,7 @@ describe("withdrawParticipant", () => {
       redis,
     });
     const participants = await getRoomParticipants({ roomId: RID_A, redis });
-    expect(participants.drone.status).toBe("withdrawn");
+    expect(participants.drone.status).toBe("withdrew");
     expect(participants.drone.resolved_at).toBeDefined();
   });
 
@@ -1527,6 +1602,18 @@ describe("submitContribution", () => {
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
       redis,
     });
+    // submitContribution requires awaiting_contributions; bump status
+    // for the suite (test setup, not a real lifecycle transition).
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    // Pre-populate participant slot so the owner check passes for "drone"
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "pending",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+      }),
+    });
   });
 
   it("writes the contribution to the contributions hash + emits event", async () => {
@@ -1536,14 +1623,14 @@ describe("submitContribution", () => {
       role: "drone",
       agentId: "drone-1",
       sequenceObservedByClient: 1,
-      body: { verdict: "approve", summary: "looks good" },
+      body: { verdict: "APPROVE", summary: "looks good" },
       rawMd: "# Verdict\n\nApprove.",
       redis,
     });
     const contributions = await getRoomContributions({ roomId: RID_A, redis });
     expect(contributions.drone).toBeDefined();
     expect(contributions.drone.body).toEqual({
-      verdict: "approve",
+      verdict: "APPROVE",
       summary: "looks good",
     });
     expect(contributions.drone.raw_md).toBe("# Verdict\n\nApprove.");
@@ -1556,7 +1643,7 @@ describe("submitContribution", () => {
       role: "drone",
       agentId: "drone-1",
       sequenceObservedByClient: 1,
-      body: { verdict: "approve" },
+      body: { verdict: "APPROVE", summary: "first cut" },
       rawMd: "first",
       redis,
     });
@@ -1566,12 +1653,12 @@ describe("submitContribution", () => {
       role: "drone",
       agentId: "drone-1",
       sequenceObservedByClient: 2, // different observed seq → different idem key
-      body: { verdict: "request_changes" },
+      body: { verdict: "REQUEST_CHANGES", summary: "needs work" },
       rawMd: "second",
       redis,
     });
     const contributions = await getRoomContributions({ roomId: RID_A, redis });
-    expect(contributions.drone.body.verdict).toBe("request_changes");
+    expect(contributions.drone.body.verdict).toBe("REQUEST_CHANGES");
     expect(contributions.drone.raw_md).toBe("second");
   });
 
@@ -1584,7 +1671,7 @@ describe("submitContribution", () => {
         role: "drone",
         agentId: "drone-1",
         sequenceObservedByClient: 1,
-        body: { verdict: "approve" },
+        body: { verdict: "APPROVE", summary: "ok" },
         rawMd: huge,
         redis,
       }),
@@ -1600,13 +1687,13 @@ describe("submitContribution", () => {
       role: "drone",
       agentId: "drone-1",
       sequenceObservedByClient: 1,
-      body: { verdict: "approve" },
+      body: { verdict: "APPROVE", summary: "ok" },
       rawMd: "x".repeat(20 * 1024), // 20 KiB — would blow event 8 KiB cap if included
       redis,
     });
     const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
     expect(events[0].event_type).toBe("contribution_submitted");
-    expect(events[0].body.body).toEqual({ verdict: "approve" });
+    expect(events[0].body.body).toEqual({ verdict: "APPROVE", summary: "ok" });
     expect((events[0].body as Record<string, unknown>).raw_md).toBeUndefined();
   });
 });
@@ -1734,5 +1821,524 @@ describe("listRoomEvents", () => {
     expect(events).toHaveLength(1);
     expect(events[0].event_type).toBe("participant_presented");
     expect(events[0].seq).toBe(2);
+  });
+});
+
+// ===========================================================================
+// D.1.a-ii R2 — regression tests for builder/guard/drone R1 blockers
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// B2 — per-(room, role) first-wins gate
+// ---------------------------------------------------------------------------
+
+describe("D.1.a-ii R2 / B2 — per-(room, role) first-wins gate", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("second runner same role different agent → RoomParticipantOwnerConflictError", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    // Different agent_id, same role
+    try {
+      await presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-2",
+        sequenceObservedByClient: 2,
+        redis,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomParticipantOwnerConflictError);
+      if (err instanceof RoomParticipantOwnerConflictError) {
+        expect(err.existingAgentId).toBe("drone-runner-1");
+        expect(err.attemptedAgentId).toBe("drone-runner-2");
+        expect(err.role).toBe("drone");
+      }
+    }
+    // Verify the original RSVP wasn't overwritten
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.agent_id).toBe("drone-runner-1");
+  });
+
+  it("same agent re-RSVPing is allowed (idempotent ownership)", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    // Same agent_id, different observed seq → fresh idem key but
+    // owner check passes because agent_id matches
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-1",
+        sequenceObservedByClient: 2,
+        redis,
+      }),
+    ).resolves.toBeGreaterThan(0);
+  });
+
+  it("re-RSVP from withdrew is allowed even with a different agent_id", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await withdrawParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-1",
+      sequenceObservedByClient: 2,
+      redis,
+    });
+    // Different runner re-RSVPs the now-withdrew slot — allowed
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-2", // different agent
+        sequenceObservedByClient: 3,
+        redis,
+      }),
+    ).resolves.toBeGreaterThan(0);
+    // New agent now owns the slot, status flipped back to pending
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.agent_id).toBe("drone-runner-2");
+    expect(participants.drone.status).toBe("pending");
+    // withdrew_at_sequence cleared on re-RSVP
+    expect(participants.drone.withdrew_at_sequence).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B3 — participant state shape (pending → resolved/withdrew, withdrew_at_sequence)
+// ---------------------------------------------------------------------------
+
+describe("D.1.a-ii R2 / B3 — participant lifecycle (pending/resolved/withdrew)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    // Advance to awaiting_contributions for the contribute path
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+  });
+
+  it("withdrawParticipant sets withdrew_at_sequence to the event seq (via __SEQ__)", async () => {
+    // Reset to awaiting_rsvp for the RSVP+withdraw flow
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_rsvp" });
+    const presentSeq = await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const withdrawSeq = await withdrawParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: presentSeq,
+      redis,
+    });
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("withdrew");
+    // Lua substituted __SEQ__ with the actual sequence
+    expect(participants.drone.withdrew_at_sequence).toBe(withdrawSeq);
+    // It's a number, not the literal "__SEQ__" placeholder
+    expect(typeof participants.drone.withdrew_at_sequence).toBe("number");
+  });
+
+  it("submitContribution flips participant status pending → resolved (atomic dual-update)", async () => {
+    // Set up: RSVP first (awaiting_rsvp → pending)
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_rsvp" });
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    // Move to awaiting_contributions for contribute
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    // Verify pending
+    let participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("pending");
+
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 2,
+      body: { verdict: "APPROVE", summary: "looks good" },
+      rawMd: "approved",
+      redis,
+    });
+    // Verify resolved
+    participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("resolved");
+    expect(participants.drone.resolved_at).toBeDefined();
+    // AND the contribution landed
+    const contributions = await getRoomContributions({ roomId: RID_A, redis });
+    expect(contributions.drone.body.verdict).toBe("APPROVE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B4 — ContributionBody schema validation
+// ---------------------------------------------------------------------------
+
+describe("D.1.a-ii R2 / B4 — validateContributionBody", () => {
+  it("accepts a minimal valid body (verdict + summary)", () => {
+    expect(() =>
+      validateContributionBody({ verdict: "APPROVE", summary: "ok" }),
+    ).not.toThrow();
+  });
+
+  it("accepts all four UPPERCASE verdict values", () => {
+    for (const v of ["APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"] as const) {
+      expect(() =>
+        validateContributionBody({ verdict: v, summary: "ok" }),
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects lowercase verdict (silent-downgrade trap)", () => {
+    try {
+      // Intentionally bypass TS for the runtime test
+      validateContributionBody({
+        verdict: "approve" as unknown as "APPROVE",
+        summary: "ok",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContributionValidationError);
+      if (err instanceof ContributionValidationError) {
+        expect(err.field).toBe("verdict");
+      }
+    }
+  });
+
+  it("rejects invalid verdict typo", () => {
+    expect(() =>
+      validateContributionBody({
+        verdict: "APPROVES" as unknown as "APPROVE",
+        summary: "ok",
+      }),
+    ).toThrow(ContributionValidationError);
+  });
+
+  it("rejects empty summary", () => {
+    expect(() =>
+      validateContributionBody({ verdict: "APPROVE", summary: "" }),
+    ).toThrow(ContributionValidationError);
+  });
+
+  it("rejects summary > 500 chars", () => {
+    expect(() =>
+      validateContributionBody({
+        verdict: "APPROVE",
+        summary: "x".repeat(CONTRIBUTION_SUMMARY_MAX_CHARS + 1),
+      }),
+    ).toThrow(ContributionValidationError);
+  });
+
+  it("rejects too many findings (>20)", () => {
+    const findings = Array.from(
+      { length: CONTRIBUTION_FINDINGS_MAX_COUNT + 1 },
+      () => ({ area: "a", severity: "info" as const, detail: "d" }),
+    );
+    expect(() =>
+      validateContributionBody({
+        verdict: "APPROVE",
+        summary: "ok",
+        findings,
+      }),
+    ).toThrow(ContributionValidationError);
+  });
+
+  it("rejects finding with invalid severity", () => {
+    expect(() =>
+      validateContributionBody({
+        verdict: "APPROVE",
+        summary: "ok",
+        findings: [
+          { area: "a", severity: "critical" as unknown as "blocker", detail: "d" },
+        ],
+      }),
+    ).toThrow(ContributionValidationError);
+  });
+
+  it("rejects severity_counts with negative number", () => {
+    expect(() =>
+      validateContributionBody({
+        verdict: "APPROVE",
+        summary: "ok",
+        severity_counts: { blocker: -1 },
+      }),
+    ).toThrow(ContributionValidationError);
+  });
+
+  it("submitContribution rejects malformed body BEFORE storage write", async () => {
+    const redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    await expect(
+      submitContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        body: { verdict: "approve" as unknown as "APPROVE", summary: "ok" },
+        rawMd: "test",
+        redis,
+      }),
+    ).rejects.toThrow(ContributionValidationError);
+    // No event landed
+    expect(await getRoomContributions({ roomId: RID_A, redis })).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard B1 — __SEQ__ substitution preserves user content
+// ---------------------------------------------------------------------------
+
+describe("D.1.a-ii R2 / Guard B1 — __SEQ__ first-match gsub preserves user content", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("intentHint containing literal '__SEQ__' is preserved verbatim in the event", async () => {
+    // This was guard's reproducer: feeding "__SEQ__" through user
+    // content would have been silently substituted by the unbounded
+    // gsub. Now it's preserved.
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      intentHint: "review for __SEQ__ regression",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events[0].body.intent_hint).toBe("review for __SEQ__ regression");
+    // The seq field on the event was substituted correctly though
+    expect(events[0].seq).toBe(2);
+  });
+
+  it("contribution body summary containing '__SEQ__' is preserved verbatim", async () => {
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      body: { verdict: "APPROVE", summary: "approved __SEQ__" },
+      rawMd: "ok",
+      redis,
+    });
+    const contributions = await getRoomContributions({ roomId: RID_A, redis });
+    expect(contributions.drone.body.summary).toBe("approved __SEQ__");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// N4 — withdrawContribution dedicated tests
+// ---------------------------------------------------------------------------
+
+describe("withdrawContribution (R2 N4)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+    // Set up a participant slot so the owner check passes
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "pending",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+      }),
+    });
+  });
+
+  it("writes a tombstone to the contributions hash with withdrawn=true", async () => {
+    await withdrawContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      reason: "data was incomplete",
+      redis,
+    });
+    const contributions = await getRoomContributions({ roomId: RID_A, redis });
+    expect(contributions.drone.withdrawn).toBe(true);
+    expect(contributions.drone.contributed_at).toBeDefined();
+  });
+
+  it("emits contribution_withdrawn event with reason in body", async () => {
+    await withdrawContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      reason: "data was incomplete",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events[0].event_type).toBe("contribution_withdrawn");
+    expect(events[0].body.reason).toBe("data was incomplete");
+  });
+
+  it("idempotent — same observed seq → replay error", async () => {
+    await withdrawContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await expect(
+      withdrawContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomEventIdempotencyReplayError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// N5 — ROOM_APPEND_EVENT_SCRIPT source pins
+// ---------------------------------------------------------------------------
+
+describe("ROOM_APPEND_EVENT_SCRIPT source (R2 N5)", () => {
+  it("idempotency check is FIRST (before any state read)", () => {
+    const idemIdx = ROOM_APPEND_EVENT_SCRIPT.indexOf('redis.call("get", KEYS[3])');
+    const statusIdx = ROOM_APPEND_EVENT_SCRIPT.indexOf(
+      'redis.call("hget", KEYS[4]',
+    );
+    expect(idemIdx).toBeGreaterThan(0);
+    expect(statusIdx).toBeGreaterThan(idemIdx);
+  });
+
+  it("room-existence check returns -3 when status is nil (B1 closure)", () => {
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /if not currStatus then return \{-3, "room_not_found"\} end/,
+    );
+  });
+
+  it("__SEQ__ gsub on event template is capped at FIRST match (Guard B1 closure)", () => {
+    // Lua's gsub takes an optional 4th arg = max replacements.
+    // The event template uses `1` to preserve user content
+    // containing the literal `__SEQ__` sentinel (e.g. intentHint
+    // or contribution body summary text containing the substring).
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /string\.gsub\(ARGV\[1\], "__SEQ__", tostring\(seq\), 1\)/,
+    );
+  });
+
+  it("materialized __SEQ__ substitution is OPT-IN (Guard B1 closure, ARGV[14]/[15] gates)", () => {
+    // Materialized writes only do gsub when caller explicitly opts in
+    // (ARGV[14]=="1" for slot 1, ARGV[15]=="1" for slot 2). Off-by-
+    // default so user-controlled materialized content (e.g. contribution
+    // body summary that legitimately contains "__SEQ__") is preserved
+    // verbatim. Only withdrawParticipant opts in (it needs the script
+    // to substitute the actual sequence into the withdrew_at_sequence
+    // field of the participant JSON).
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(/if ARGV\[14\] == "1" then/);
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(/if ARGV\[15\] == "1" then/);
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /string\.gsub\(mat1, "__SEQ__", tostring\(seq\), 1\)/,
+    );
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /string\.gsub\(mat2, "__SEQ__", tostring\(seq\), 1\)/,
+    );
+  });
+
+  it("owner check uses cjson.decode + agent_id comparison + withdrew exception (B2)", () => {
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(/cjson\.decode\(existingMat\)/);
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /parsed\.agent_id ~= ARGV\[5\] and parsed\.status ~= "withdrew"/,
+    );
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /return \{-4, "owner_conflict", parsed\.agent_id\}/,
+    );
+  });
+
+  it("dual-materialized writes (KEYS[6] + KEYS[9]) for submitContribution atomic resolved-flip", () => {
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /redis\.call\("hset", KEYS\[6\]/,
+    );
+    expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
+      /redis\.call\("hset", KEYS\[9\]/,
+    );
   });
 });

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -129,10 +129,10 @@ function makeMockRedis() {
         return [1, roomId];
       }
 
-      // ROOM_PARTICIPANT_TRANSITION_SCRIPT — 6 keys, 12 args (D.1.a-ii R3)
+      // ROOM_PARTICIPANT_TRANSITION_SCRIPT — 6 keys, 13 args (D.1.a-ii R4)
       if (
         keys.length === 6 &&
-        argv.length === 12 &&
+        argv.length === 13 &&
         script.includes("no_participant")
       ) {
         const [seqK, eventsK, idemK, roomK, participantsK, contributionsK] = keys;
@@ -149,6 +149,7 @@ function makeMockRedis() {
           transform,
           nowIso,
           contributionFieldJson,
+          allowedParticipantStatuses,
         ] = argv;
 
         // 1. Idempotency
@@ -178,6 +179,13 @@ function makeMockRedis() {
         // 4. Owner check (when required)
         if (ownerRequired === "1" && p.agent_id !== ownerExpected) {
           return [-4, "owner_conflict", p.agent_id];
+        }
+        // 4b. Participant-state precondition (R4 closes builder R3)
+        if (allowedParticipantStatuses !== "") {
+          const allowed = allowedParticipantStatuses.split(",");
+          if (!allowed.includes(p.status)) {
+            return [-6, "participant_state_precondition", p.status];
+          }
         }
         // 5. INCR + ZADD + idem
         const oldSeq = (store.get(seqK) as number | undefined) ?? 0;
@@ -1195,6 +1203,7 @@ import {
   RoomContributionTooLargeError,
   RoomParticipantOwnerConflictError,
   RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
   ContributionValidationError,
 } from "./war-room";
 
@@ -2486,13 +2495,15 @@ describe("withdrawContribution (R2 N4)", () => {
       redis,
     });
     await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
-    // Set up a participant slot so the owner check passes
+    // withdrawContribution requires participant.status === "resolved"
+    // (per R4 — only resolved participants have a contribution to withdraw).
     await redis.hset(participantsKey(RID_A), {
       drone: JSON.stringify({
         agent_id: "drone-1",
         role: "drone",
-        status: "pending",
+        status: "resolved",
         rsvp_at: "2026-04-28T00:00:00.000Z",
+        resolved_at: "2026-04-28T00:01:00.000Z",
       }),
     });
   });
@@ -2614,5 +2625,178 @@ describe("ROOM_APPEND_EVENT_SCRIPT source (R2 N5)", () => {
     expect(ROOM_APPEND_EVENT_SCRIPT).toMatch(
       /redis\.call\("hset", KEYS\[9\]/,
     );
+  });
+});
+
+// ===========================================================================
+// D.1.a-ii R4 — participant-state precondition (closes builder R3)
+// ===========================================================================
+
+describe("D.1.a-ii R4 — participant-state precondition (manager-loop race protection)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_contributions" });
+  });
+
+  it("watchdog timeout loses race against worker resolve (resolved → timeout rejected)", async () => {
+    // Setup: worker presented + contributed → status = "resolved"
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "resolved",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+        resolved_at: "2026-04-28T00:01:00.000Z",
+      }),
+    });
+    // Stale watchdog scan tries to time out the now-resolved slot
+    try {
+      await timeoutParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        subjectRole: "drone",
+        watchdogRole: "manager",
+        watchdogAgentId: "bot-queen",
+        sequenceObservedByClient: 1,
+        redis,
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomParticipantStatePreconditionError);
+      if (err instanceof RoomParticipantStatePreconditionError) {
+        expect(err.actualState).toBe("resolved");
+        expect(err.allowedStates).toEqual(["pending"]);
+      }
+    }
+    // Verify the resolved slot wasn't overwritten
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("resolved");
+  });
+
+  it("submitContribution rejected on withdrew slot (must /present again first)", async () => {
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "withdrew",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+        resolved_at: "2026-04-28T00:01:00.000Z",
+        withdrew_at_sequence: 5,
+      }),
+    });
+    await expect(
+      submitContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        body: { verdict: "APPROVE", summary: "ok" },
+        rawMd: "ok",
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantStatePreconditionError);
+    expect(await getRoomContributions({ roomId: RID_A, redis })).toEqual({});
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("withdrew");
+  });
+
+  it("submitContribution rejected on timed_out slot", async () => {
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "timed_out",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+        resolved_at: "2026-04-28T00:01:00.000Z",
+      }),
+    });
+    await expect(
+      submitContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        body: { verdict: "APPROVE", summary: "ok" },
+        rawMd: "ok",
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantStatePreconditionError);
+  });
+
+  it("withdrawParticipant rejected on already-withdrew slot", async () => {
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "withdrew",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+        resolved_at: "2026-04-28T00:01:00.000Z",
+      }),
+    });
+    await expect(
+      withdrawParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantStatePreconditionError);
+  });
+
+  it("withdrawContribution rejected on pending slot (no contribution to withdraw)", async () => {
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "pending",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+      }),
+    });
+    await expect(
+      withdrawContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantStatePreconditionError);
+  });
+
+  it("submitContribution from resolved (re-submit) IS allowed", async () => {
+    await redis.hset(participantsKey(RID_A), {
+      drone: JSON.stringify({
+        agent_id: "drone-1",
+        role: "drone",
+        status: "resolved",
+        rsvp_at: "2026-04-28T00:00:00.000Z",
+        resolved_at: "2026-04-28T00:01:00.000Z",
+      }),
+    });
+    await expect(
+      submitContribution({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-1",
+        sequenceObservedByClient: 1,
+        body: { verdict: "REQUEST_CHANGES", summary: "found a regression" },
+        rawMd: "updated",
+        redis,
+      }),
+    ).resolves.toBeGreaterThan(0);
   });
 });

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -23,6 +23,7 @@
  */
 
 import { type Redis } from "@upstash/redis";
+import { createHash } from "crypto";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -809,5 +810,769 @@ export async function listRooms(args: {
     );
   }
 
+  return out;
+}
+
+// ===========================================================================
+// Phase D.1.a-ii — event appending + materialized RSVP/contribution views
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Constants (D.1.a-ii)
+// ---------------------------------------------------------------------------
+
+/** Per WAR_ROOM_DESIGN.md: event body bounded ≤ 8 KiB serialized.
+ * Larger payloads belong in the contribution `raw_md` (32 KiB) or
+ * external storage with a reference. Enforced at append time so a
+ * runaway event can't fill the per-room sorted set. */
+export const ROOM_EVENT_BODY_MAX_BYTES = 8 * 1024;
+
+/** Per WAR_ROOM_DESIGN.md: contribution `raw_md` bounded ≤ 32 KiB.
+ * Markdown that exceeds belongs in a gist or attached file with the
+ * URL in the contribution body. */
+export const ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES = 32 * 1024;
+
+/** Multiplier for idempotency-reverse-index TTL relative to the room's
+ * `max_age_secs`. The idem TTL must outlive any reasonable client
+ * retry window but expire well before the room's 30-day post-close
+ * retention so a stale replay can't resolve months later.
+ *   max_age_secs default 3600 → idem TTL default 7200 (2 h). */
+export const IDEM_TTL_MULTIPLIER = 2;
+
+// ---------------------------------------------------------------------------
+// Errors (D.1.a-ii)
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when `ROOM_APPEND_EVENT_SCRIPT` returns `{-2, currentStatus}` —
+ * the event's `status_from` precondition didn't match the room's
+ * actual status at the moment the script ran. Closes the
+ * watchdog-vs-/decide race: a `participant_timed_out` watchdog firing
+ * while the queen is in mid-claim will see status drift from
+ * `awaiting_contributions` to `deciding` and bail without writing.
+ *
+ * Caller handling depends on context: watchdog should re-scan on
+ * the next tick; an explicit `/present` from a worker should surface
+ * a 409 to the worker so they know the room moved on.
+ */
+export class RoomEventStatusPreconditionError extends Error {
+  public readonly roomId: string;
+  public readonly expectedFrom: string;
+  public readonly actualStatus: string;
+  constructor(roomId: string, expectedFrom: string, actualStatus: string) {
+    super(
+      `Event for room ${roomId} expected status_from=${JSON.stringify(expectedFrom)} but room is currently ${JSON.stringify(actualStatus)}. Re-read room state and retry if appropriate.`,
+    );
+    this.name = "RoomEventStatusPreconditionError";
+    this.roomId = roomId;
+    this.expectedFrom = expectedFrom;
+    this.actualStatus = actualStatus;
+  }
+}
+
+/**
+ * Thrown when `ROOM_APPEND_EVENT_SCRIPT` returns `{-1, existingSequence}` —
+ * the idempotency reverse index already has an entry for this key,
+ * meaning a prior call from the same client/action lane succeeded
+ * with the returned sequence. Caller treats this as a "your prior
+ * write took effect, the sequence is N" signal and proceeds.
+ *
+ * NOT a true error — it's the expected outcome of a client retry.
+ * Surfaced as a typed error so callers can distinguish replay from
+ * a genuine fresh write (the latter returns just `{seq}`).
+ */
+export class RoomEventIdempotencyReplayError extends Error {
+  public readonly roomId: string;
+  public readonly existingSequence: number;
+  constructor(roomId: string, existingSequence: number) {
+    super(
+      `Idempotency replay for room ${roomId}: prior write at sequence ${existingSequence}. Treat as success.`,
+    );
+    this.name = "RoomEventIdempotencyReplayError";
+    this.roomId = roomId;
+    this.existingSequence = existingSequence;
+  }
+}
+
+/** Event body exceeded `ROOM_EVENT_BODY_MAX_BYTES` (8 KiB serialized). */
+export class RoomEventBodyTooLargeError extends Error {
+  public readonly sizeBytes: number;
+  constructor(sizeBytes: number) {
+    super(
+      `Event body exceeds ${ROOM_EVENT_BODY_MAX_BYTES} bytes (got ${sizeBytes}). Move large payloads to a contribution body or external reference.`,
+    );
+    this.name = "RoomEventBodyTooLargeError";
+    this.sizeBytes = sizeBytes;
+  }
+}
+
+/** Contribution `raw_md` exceeded `ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES` (32 KiB). */
+export class RoomContributionTooLargeError extends Error {
+  public readonly sizeBytes: number;
+  constructor(sizeBytes: number) {
+    super(
+      `Contribution raw_md exceeds ${ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES} bytes (got ${sizeBytes}). Attach as a gist / external file and put the URL in the contribution body.`,
+    );
+    this.name = "RoomContributionTooLargeError";
+    this.sizeBytes = sizeBytes;
+  }
+}
+
+/**
+ * Role string is server-derived from the bearer envelope's `agent_role`
+ * field — never accepted from request body. This boundary regex
+ * catches the very unlikely "envelope had a corrupted role" case
+ * before it lands in the materialized hash key.
+ */
+const ROLE_REGEX = /^[a-z][a-z0-9_-]{0,31}$/;
+
+/**
+ * Server-canonical idempotency key derivation. Input is a stable
+ * tuple of (roomId, role, action, sequenceObservedByClient); SHA-256
+ * keeps the key opaque + bounded-length while making collisions
+ * cryptographically negligible.
+ *
+ * `sequenceObservedByClient` is the `If-Room-Sequence-At-Or-After`
+ * header value the client read when constructing the request. Two
+ * retries from the same client see the same observed sequence and
+ * thus derive the same key — that's the desired behavior for the
+ * replay-detection path.
+ */
+export function deriveIdempotencyKey(args: {
+  roomId: string;
+  role: string;
+  action: RoomEventAction;
+  sequenceObservedByClient: number;
+}): string {
+  return createHash("sha256")
+    .update(
+      `v1:${args.roomId}:${args.role}:${args.action}:${args.sequenceObservedByClient}`,
+    )
+    .digest("hex");
+}
+
+/** Action vocabulary for idempotency derivation. Distinct from
+ * `RoomEventType` because two event types can share the same
+ * action lane (e.g., `participant_presented` and a future
+ * `participant_re_presented` would both be `present`). */
+export type RoomEventAction =
+  | "present"
+  | "withdraw_participant"
+  | "contribute"
+  | "withdraw_contribution"
+  | "timeout"
+  | "decide"
+  | "close";
+
+// ---------------------------------------------------------------------------
+// ROOM_APPEND_EVENT_SCRIPT — atomic event append
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomic event append with idempotency, status precondition, and
+ * optional materialized-view update.
+ *
+ * Design references:
+ *   - WAR_ROOM_DESIGN.md L320-380 — script source
+ *   - WAR_ROOM_DESIGN.md L139-216 — RSVP-driven lifecycle
+ *
+ * Order of operations (single EVAL):
+ *   1. Idempotency check: if `idempotencyKey` is set and `:idem:{key}`
+ *      exists, return `{-1, existingSequence}` (replay-safe).
+ *   2. Status precondition: if `status_from` is set, compare against
+ *      the room's current `status` field. Mismatch → `{-2, currStatus}`.
+ *   3. INCR `:seq` for the new event's sequence number.
+ *   4. ZADD the event JSON to `:events` with score=seq. The TS caller
+ *      writes `__SEQ__` in the JSON template; the script `gsub`s it
+ *      to the actual sequence number before ZADD.
+ *   5. SET the idempotency reverse index (if key non-empty) with
+ *      caller-supplied TTL (parameterized — closes Queen R3 #5).
+ *   6. HSET the materialized view (participants / contributions) if
+ *      `materializedFieldName` is non-empty.
+ *   7. Status transition (if `status_to` is set): HSET status, SREM
+ *      from-set, SADD to-set.
+ *
+ * KEYS:
+ *   [1] seqKey                — sequence counter
+ *   [2] eventsKey             — event log sorted set
+ *   [3] idemKey               — idempotency reverse index for this key
+ *   [4] roomKey               — room hash (for status read/write)
+ *   [5] materializedKey       — participants OR contributions hash
+ *   [6] statusFromSetKey      — status:awaiting_X set (for transition SREM)
+ *   [7] statusToSetKey        — status:awaiting_Y set (for transition SADD)
+ *
+ * ARGV:
+ *   [1] eventJsonTemplate     — JSON with `__SEQ__` placeholder (Lua substitutes)
+ *   [2] idempotencyKey        — empty string disables idem check
+ *   [3] eventType             — diagnostic only (logged in audit)
+ *   [4] materializedFieldName — empty disables materialized update
+ *   [5] materializedFieldJson — value to HSET when fieldName set
+ *   [6] roomStatusFrom        — empty disables status precondition
+ *   [7] roomStatusTo          — empty disables status transition
+ *   [8] roomId                — for index updates
+ *   [9] idemTtlSecs           — TTL for the idempotency reverse index
+ *
+ * Returns:
+ *   {seq}                     success
+ *   {-1, existingSequence}    idempotency replay (caller treats as success)
+ *   {-2, currentRoomStatus}   status precondition mismatch
+ */
+export const ROOM_APPEND_EVENT_SCRIPT = `
+if ARGV[2] ~= "" then
+  local existing = redis.call("get", KEYS[3])
+  if existing then return {-1, tonumber(existing)} end
+end
+local currStatus = redis.call("hget", KEYS[4], "status")
+if ARGV[6] ~= "" and currStatus ~= ARGV[6] then
+  return {-2, currStatus}
+end
+local seq = redis.call("incr", KEYS[1])
+local eventJson = string.gsub(ARGV[1], "__SEQ__", tostring(seq))
+redis.call("zadd", KEYS[2], seq, eventJson)
+if ARGV[2] ~= "" then
+  redis.call("set", KEYS[3], tostring(seq), "EX", tonumber(ARGV[9]))
+end
+if ARGV[4] ~= "" then
+  redis.call("hset", KEYS[5], ARGV[4], ARGV[5])
+end
+if ARGV[7] ~= "" then
+  redis.call("hset", KEYS[4], "status", ARGV[7])
+  redis.call("srem", KEYS[6], ARGV[8])
+  redis.call("sadd", KEYS[7], ARGV[8])
+end
+return {seq}
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers (D.1.a-ii)
+// ---------------------------------------------------------------------------
+
+/** Validate role at the boundary. Server-supplied (from envelope) so
+ * mismatches are an internal-correctness signal, not a 400 to clients. */
+function assertRoleFormat(role: string): void {
+  if (!ROLE_REGEX.test(role)) {
+    throw new Error(
+      `Internal: role ${JSON.stringify(role)} from token envelope failed format validation (/^[a-z][a-z0-9_-]{0,31}$/).`,
+    );
+  }
+}
+
+/** Throw if event body exceeds the 8 KiB cap. Measured on the
+ * UTF-8 byte length of the serialized JSON (NOT the surrogate-pair
+ * character count). */
+function assertEventBodySize(body: Record<string, unknown>): void {
+  const serialized = JSON.stringify(body);
+  const bytes = Buffer.byteLength(serialized, "utf8");
+  if (bytes > ROOM_EVENT_BODY_MAX_BYTES) {
+    throw new RoomEventBodyTooLargeError(bytes);
+  }
+}
+
+/** Throw if contribution `raw_md` exceeds the 32 KiB cap. */
+function assertContributionMdSize(rawMd: string): void {
+  const bytes = Buffer.byteLength(rawMd, "utf8");
+  if (bytes > ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES) {
+    throw new RoomContributionTooLargeError(bytes);
+  }
+}
+
+/** Compute the IDEM TTL for a room, consistent across all event paths. */
+function idemTtlSecs(roomMaxAgeSecs: number): number {
+  return roomMaxAgeSecs * IDEM_TTL_MULTIPLIER;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level append primitive
+// ---------------------------------------------------------------------------
+
+interface AppendRoomEventArgs {
+  installationId: string;
+  roomId: string;
+  /** Event metadata. The serialized JSON gets `__SEQ__` substituted to the
+   * actual sequence inside the Lua script before the ZADD. */
+  event: {
+    timestamp: string;
+    event_type: RoomEventType;
+    actor_role: string;
+    actor_id: string;
+    body: Record<string, unknown>;
+  };
+  /** Empty disables idem check. Typically derived via `deriveIdempotencyKey`. */
+  idempotencyKey: string;
+  /** When set, append HSETs `materializedFieldName → materializedFieldJson` on
+   * `materializedKey` after the event lands. Use for participants /
+   * contributions materialized views. */
+  materialized?: {
+    key: string;
+    field: string;
+    json: string;
+  };
+  /** Optional status transition. When provided, both fields required:
+   * the script enforces `from` precondition + transitions status sets. */
+  statusTransition?: {
+    from: RoomStatus;
+    to: RoomStatus;
+  };
+  /** TTL for the idem reverse index. Defaults to
+   * `IDEM_TTL_MULTIPLIER × DEFAULT_MAX_AGE_SECS`. Caller passes the
+   * room's actual `timing_config.max_age_secs * IDEM_TTL_MULTIPLIER`
+   * for accuracy across rooms with custom timing. */
+  idemTtlSecs?: number;
+  redis: Redis;
+}
+
+/**
+ * Append an event to a war room atomically. Underlying primitive for
+ * the high-level RSVP / contribute / timeout / decide / close wrappers.
+ *
+ * Returns the assigned sequence number on success. On idempotency
+ * replay, throws `RoomEventIdempotencyReplayError` carrying the
+ * existing sequence so callers can treat it as success without
+ * losing the sequence-number signal.
+ *
+ * Throws:
+ *   - `RoomEventIdempotencyReplayError` (replay — caller treats as success)
+ *   - `RoomEventStatusPreconditionError` (room moved out of `from` state)
+ *   - `RoomEventBodyTooLargeError` (body > 8 KiB serialized)
+ */
+export async function appendRoomEvent(
+  args: AppendRoomEventArgs,
+): Promise<number> {
+  assertEventBodySize(args.event.body);
+
+  // Encode the event JSON template with __SEQ__ placeholder; Lua
+  // gsub replaces it with the actual sequence number atomically.
+  const eventTemplate = JSON.stringify({
+    seq: "__SEQ__",
+    timestamp: args.event.timestamp,
+    event_type: args.event.event_type,
+    actor_role: args.event.actor_role,
+    actor_id: args.event.actor_id,
+    body: args.event.body,
+  });
+
+  // The script gsub looks for the LITERAL string `"__SEQ__"` in the
+  // template (with quotes — JSON.stringify wrapped __SEQ__ as a
+  // string). Lua replaces with the unquoted number, producing valid
+  // JSON like `"seq":42`.
+  const luaTemplate = eventTemplate.replace('"__SEQ__"', "__SEQ__");
+
+  const ttl = args.idemTtlSecs ?? idemTtlSecs(DEFAULT_MAX_AGE_SECS);
+
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      ROOM_APPEND_EVENT_SCRIPT,
+      [
+        seqKey(args.roomId),
+        eventsKey(args.roomId),
+        idemKey(args.roomId, args.idempotencyKey),
+        roomKey(args.installationId, args.roomId),
+        args.materialized?.key ?? "__unused__",
+        args.statusTransition
+          ? statusIndexKey(args.installationId, args.statusTransition.from)
+          : "__unused__",
+        args.statusTransition
+          ? statusIndexKey(args.installationId, args.statusTransition.to)
+          : "__unused__",
+      ],
+      [
+        luaTemplate,
+        args.idempotencyKey,
+        args.event.event_type,
+        args.materialized?.field ?? "",
+        args.materialized?.json ?? "",
+        args.statusTransition?.from ?? "",
+        args.statusTransition?.to ?? "",
+        args.roomId,
+        String(ttl),
+      ],
+    ),
+  );
+
+  if (result.ok === -1 && typeof result.tag1 === "number") {
+    throw new RoomEventIdempotencyReplayError(args.roomId, result.tag1);
+  }
+  if (result.ok === -2 && typeof result.tag1 === "string") {
+    throw new RoomEventStatusPreconditionError(
+      args.roomId,
+      args.statusTransition?.from ?? "",
+      result.tag1,
+    );
+  }
+  // The script's success shape is `{seq}` — ScriptResult parses
+  // that as `{ok: seq, tag1: undefined}`. Sequence numbers from
+  // `INCR` are always positive integers, so `ok > 0` distinguishes
+  // success from the negative-tag error returns.
+  if (result.ok > 0) return result.ok;
+
+  throw new Error(
+    `ROOM_APPEND_EVENT_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// High-level RSVP / contribute / timeout primitives
+// ---------------------------------------------------------------------------
+
+interface RSVPCommonArgs {
+  installationId: string;
+  roomId: string;
+  /** Server-derived from token envelope's `agent_role`. NEVER accepted
+   * from request body — the materialized hash field key is the role,
+   * so client-supplied role would let one bearer overwrite another's
+   * RSVP. */
+  role: string;
+  /** Server-derived from token envelope's `name`. Used as the actor_id
+   * on the event log + materialized participant record. */
+  agentId: string;
+  /** Required header value (`If-Room-Sequence-At-Or-After`). Used to
+   * derive the idempotency key — two retries with the same observed
+   * sequence resolve to the same key, replay-safe. */
+  sequenceObservedByClient: number;
+  /** Optional — overrides the default IDEM TTL for rooms with custom
+   * `max_age_secs`. */
+  roomMaxAgeSecs?: number;
+  redis: Redis;
+  nowMs?: number;
+}
+
+/**
+ * Worker presents itself as a participant in a war room. Soft event —
+ * doesn't transition room status (transition to
+ * `awaiting_contributions` happens via a separate script when all
+ * expected roles are present).
+ *
+ * Idempotent: a retry with the same `sequenceObservedByClient` returns
+ * (via `RoomEventIdempotencyReplayError`) the original sequence.
+ */
+export async function presentParticipant(args: RSVPCommonArgs & {
+  intentHint?: string;
+}): Promise<number> {
+  assertRoleFormat(args.role);
+  const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+  const participant: RoomParticipant = {
+    agent_id: args.agentId,
+    role: args.role,
+    status: "present",
+    rsvp_at: nowIso,
+  };
+
+  return await appendRoomEvent({
+    installationId: args.installationId,
+    roomId: args.roomId,
+    event: {
+      timestamp: nowIso,
+      event_type: "participant_presented",
+      actor_role: args.role,
+      actor_id: args.agentId,
+      body: {
+        ...(args.intentHint !== undefined ? { intent_hint: args.intentHint } : {}),
+      },
+    },
+    idempotencyKey: deriveIdempotencyKey({
+      roomId: args.roomId,
+      role: args.role,
+      action: "present",
+      sequenceObservedByClient: args.sequenceObservedByClient,
+    }),
+    materialized: {
+      key: participantsKey(args.roomId),
+      field: args.role,
+      json: JSON.stringify(participant),
+    },
+    idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
+    redis: args.redis,
+  });
+}
+
+/**
+ * Worker withdraws their RSVP. Updates the participant record's
+ * `status` to `"withdrawn"` so leader election skips them. Soft —
+ * doesn't transition room status.
+ */
+export async function withdrawParticipant(
+  args: RSVPCommonArgs & { reason?: string },
+): Promise<number> {
+  assertRoleFormat(args.role);
+  const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+  const participant: RoomParticipant = {
+    agent_id: args.agentId,
+    role: args.role,
+    status: "withdrawn",
+    rsvp_at: nowIso,
+    resolved_at: nowIso,
+  };
+
+  return await appendRoomEvent({
+    installationId: args.installationId,
+    roomId: args.roomId,
+    event: {
+      timestamp: nowIso,
+      event_type: "participant_withdrawn",
+      actor_role: args.role,
+      actor_id: args.agentId,
+      body: {
+        ...(args.reason !== undefined ? { reason: args.reason } : {}),
+      },
+    },
+    idempotencyKey: deriveIdempotencyKey({
+      roomId: args.roomId,
+      role: args.role,
+      action: "withdraw_participant",
+      sequenceObservedByClient: args.sequenceObservedByClient,
+    }),
+    materialized: {
+      key: participantsKey(args.roomId),
+      field: args.role,
+      json: JSON.stringify(participant),
+    },
+    idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
+    redis: args.redis,
+  });
+}
+
+/**
+ * Worker submits a contribution (analysis / verdict). Latest-wins per
+ * role: re-submitting overwrites the prior contribution in the
+ * materialized hash. Soft — doesn't transition room status.
+ *
+ * Throws `RoomContributionTooLargeError` if `rawMd` exceeds 32 KiB.
+ */
+export async function submitContribution(args: RSVPCommonArgs & {
+  body: Record<string, unknown>;
+  rawMd: string;
+}): Promise<number> {
+  assertRoleFormat(args.role);
+  assertContributionMdSize(args.rawMd);
+  const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+  const contribution: RoomContribution = {
+    body: args.body,
+    raw_md: args.rawMd,
+    contributed_at: nowIso,
+  };
+
+  return await appendRoomEvent({
+    installationId: args.installationId,
+    roomId: args.roomId,
+    event: {
+      timestamp: nowIso,
+      event_type: "contribution_submitted",
+      actor_role: args.role,
+      actor_id: args.agentId,
+      body: {
+        body: args.body,
+        // Don't include raw_md in the event body (it's bounded
+        // separately at 32 KiB; the event body's 8 KiB cap would be
+        // blown by typical-sized contributions). The materialized
+        // hash carries the full raw_md for caller retrieval.
+      },
+    },
+    idempotencyKey: deriveIdempotencyKey({
+      roomId: args.roomId,
+      role: args.role,
+      action: "contribute",
+      sequenceObservedByClient: args.sequenceObservedByClient,
+    }),
+    materialized: {
+      key: contributionsKey(args.roomId),
+      field: args.role,
+      json: JSON.stringify(contribution),
+    },
+    idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
+    redis: args.redis,
+  });
+}
+
+/**
+ * Worker withdraws a previously-submitted contribution. Soft event —
+ * the contribution remains in the materialized hash with
+ * `withdrawn: true` flag. Queen synthesis skips withdrawn contributions.
+ */
+export async function withdrawContribution(
+  args: RSVPCommonArgs & { reason?: string },
+): Promise<number> {
+  assertRoleFormat(args.role);
+  const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+  // Mark the existing contribution as withdrawn. Caller is expected
+  // to have an existing contribution; if not, the event lands but
+  // the materialized hash has no prior entry to update — that's a
+  // diagnosable misuse, not a failure mode here.
+  const tombstone: Partial<RoomContribution> & { withdrawn: true } = {
+    withdrawn: true,
+    contributed_at: nowIso,
+  };
+
+  return await appendRoomEvent({
+    installationId: args.installationId,
+    roomId: args.roomId,
+    event: {
+      timestamp: nowIso,
+      event_type: "contribution_withdrawn",
+      actor_role: args.role,
+      actor_id: args.agentId,
+      body: {
+        ...(args.reason !== undefined ? { reason: args.reason } : {}),
+      },
+    },
+    idempotencyKey: deriveIdempotencyKey({
+      roomId: args.roomId,
+      role: args.role,
+      action: "withdraw_contribution",
+      sequenceObservedByClient: args.sequenceObservedByClient,
+    }),
+    materialized: {
+      key: contributionsKey(args.roomId),
+      field: args.role,
+      json: JSON.stringify(tombstone),
+    },
+    idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
+    redis: args.redis,
+  });
+}
+
+/**
+ * Watchdog-driven: mark a participant as timed out. Called by the
+ * bot's manager loop, NOT by clients. The `actorRole` is the
+ * watchdog's ("manager"); the `subjectRole` is the participant
+ * being timed out.
+ *
+ * Status precondition: only fires when the room is still in
+ * `awaiting_contributions` (closes G7 watchdog-vs-claim race —
+ * if the queen has already moved status to `deciding`, this
+ * returns `RoomEventStatusPreconditionError` and the watchdog
+ * re-scans on the next tick).
+ */
+export async function timeoutParticipant(args: {
+  installationId: string;
+  roomId: string;
+  /** The participant role being timed out (NOT the watchdog's role). */
+  subjectRole: string;
+  /** The watchdog's role + agent identity (server-derived). */
+  watchdogRole: string;
+  watchdogAgentId: string;
+  /** Watchdog observes the current sequence at scan time and passes
+   * it through for idempotency. */
+  sequenceObservedByClient: number;
+  roomMaxAgeSecs?: number;
+  redis: Redis;
+  nowMs?: number;
+}): Promise<number> {
+  assertRoleFormat(args.subjectRole);
+  assertRoleFormat(args.watchdogRole);
+  const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+  // Tombstone the participant. agent_id stays unchanged from the
+  // prior present (the timeout doesn't claim a new agent); since
+  // we're updating the existing record, we keep what was there
+  // semantically — but the watchdog doesn't have it on hand, so
+  // we record the agent_id as the watchdog's for traceability.
+  // Operators reading the participants hash see the timeout marker;
+  // forensic detail (who originally RSVP'd) lives in the event log.
+  const participant: RoomParticipant = {
+    agent_id: args.watchdogAgentId,
+    role: args.subjectRole,
+    status: "timed_out",
+    rsvp_at: nowIso,
+    resolved_at: nowIso,
+  };
+
+  return await appendRoomEvent({
+    installationId: args.installationId,
+    roomId: args.roomId,
+    event: {
+      timestamp: nowIso,
+      event_type: "participant_timed_out",
+      actor_role: args.watchdogRole,
+      actor_id: args.watchdogAgentId,
+      body: { subject_role: args.subjectRole },
+    },
+    idempotencyKey: deriveIdempotencyKey({
+      roomId: args.roomId,
+      role: args.subjectRole, // keyed on subject so concurrent watchdog ticks dedupe
+      action: "timeout",
+      sequenceObservedByClient: args.sequenceObservedByClient,
+    }),
+    materialized: {
+      key: participantsKey(args.roomId),
+      field: args.subjectRole,
+      json: JSON.stringify(participant),
+    },
+    // Status precondition: only time out while still awaiting contributions
+    // — closes the watchdog vs `/decide` race per design G7.
+    statusTransition: {
+      from: "awaiting_contributions",
+      to: "awaiting_contributions",
+    },
+    idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
+    redis: args.redis,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Read primitives — events / participants / contributions
+// ---------------------------------------------------------------------------
+
+/**
+ * Read events from a room's append-only log, ordered by sequence.
+ * `since` filters to events with `seq > since` (caller's last-seen
+ * cursor). `limit` defaults to 200 — large enough for the typical
+ * room (event count is bounded by the soft contribution deadline).
+ */
+export async function listRoomEvents(args: {
+  roomId: string;
+  since?: number;
+  limit?: number;
+  redis: Redis;
+}): Promise<RoomEvent[]> {
+  const limit = args.limit ?? 200;
+  const minScore = (args.since ?? 0) + 1; // exclusive of `since`
+  const raw = await args.redis.zrange<string[]>(
+    eventsKey(args.roomId),
+    minScore,
+    "+inf",
+    {
+      byScore: true,
+      offset: 0,
+      count: limit,
+    },
+  );
+  return raw.map((s) => JSON.parse(s) as RoomEvent);
+}
+
+/** Read all participants for a room, keyed by role. Returns `{}`
+ * for rooms with no participants yet (or rooms that don't exist —
+ * caller should `getRoomCore` separately if existence is meaningful). */
+export async function getRoomParticipants(args: {
+  roomId: string;
+  redis: Redis;
+}): Promise<Record<string, RoomParticipant>> {
+  const raw = await args.redis.hgetall<Record<string, string | RoomParticipant>>(
+    participantsKey(args.roomId),
+  );
+  if (raw === null) return {};
+  const out: Record<string, RoomParticipant> = {};
+  for (const [role, value] of Object.entries(raw)) {
+    out[role] =
+      typeof value === "string" ? (JSON.parse(value) as RoomParticipant) : value;
+  }
+  return out;
+}
+
+/** Read all contributions for a room, keyed by role. Same shape as
+ * `getRoomParticipants` — `{}` for empty / nonexistent. */
+export async function getRoomContributions(args: {
+  roomId: string;
+  redis: Redis;
+}): Promise<Record<string, RoomContribution>> {
+  const raw = await args.redis.hgetall<Record<string, string | RoomContribution>>(
+    contributionsKey(args.roomId),
+  );
+  if (raw === null) return {};
+  const out: Record<string, RoomContribution> = {};
+  for (const [role, value] of Object.entries(raw)) {
+    out[role] =
+      typeof value === "string"
+        ? (JSON.parse(value) as RoomContribution)
+        : value;
+  }
   return out;
 }

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -1003,6 +1003,32 @@ export class RoomContributionTooLargeError extends Error {
 }
 
 /**
+ * Thrown when withdraw / contribute / withdraw_contribution / timeout
+ * is called but the participant slot doesn't exist. Per
+ * WAR_ROOM_DESIGN.md L746, `/present` is required before
+ * `/contribute` (and similarly for the other transition paths).
+ *
+ * Closes #510 builder R2 #2: the prior implementation let
+ * withdraw / contribute / withdraw_contribution proceed even with
+ * a missing participant slot, creating phantom materialized state
+ * that the manager loop's RSVP-records logic couldn't reason over.
+ * The new `ROOM_PARTICIPANT_TRANSITION_SCRIPT` rejects at the
+ * boundary with -5 → this error.
+ */
+export class RoomParticipantNotFoundError extends Error {
+  public readonly roomId: string;
+  public readonly role: string;
+  constructor(roomId: string, role: string) {
+    super(
+      `Participant slot ${JSON.stringify(role)} not found in room ${roomId} — caller must /present before this action.`,
+    );
+    this.name = "RoomParticipantNotFoundError";
+    this.roomId = roomId;
+    this.role = role;
+  }
+}
+
+/**
  * Thrown when a write hits the per-(room, role) first-wins gate —
  * a different agent has already claimed this role in the room and
  * the slot is not in the `withdrew` state (which would allow re-RSVP).
@@ -1380,6 +1406,119 @@ end
 return {seq}
 `;
 
+/**
+ * Atomic participant-state transition. Used by withdraw / contribute /
+ * withdraw_contribution / timeout — actions that REQUIRE an existing
+ * participant slot and need to atomically transform its status while
+ * preserving fields like `agent_id` and `rsvp_at`.
+ *
+ * Closes #510 builder R2 #2: the prior generic `ROOM_APPEND_EVENT_SCRIPT`
+ * let these actions proceed with a missing slot, and `submitContribution`
+ * synthesized a fresh participant with `rsvp_at = now`, which would
+ * corrupt the manager-loop's quiet-period calculation. This script
+ * cjson-decodes the existing slot, applies an action-specific
+ * transformation in-place, and HSETs back. `agent_id` + `rsvp_at`
+ * are always preserved across `resolve` / `withdraw` / `timeout`.
+ *
+ * Closes #510 builder R2 #1 indirectly: `submitContribution` now
+ * uses this script with `allowedRoomStatuses = "awaiting_rsvp,
+ * awaiting_contributions"` per design L201 (RSVP'd workers may
+ * contribute during either room status).
+ *
+ * Order of operations:
+ *   1. Idempotency check (replay-safe)
+ *   2. Room exists + room status in allowed list
+ *   3. Read participant slot — MUST exist (-5 if missing)
+ *   4. Owner check (when ARGV[5]="1") — agent_id must match
+ *      ARGV[6], OR existing.status == "withdrew" (re-RSVP allowed)
+ *   5. INCR seq, ZADD event (first-match `__SEQ__` gsub), SET idem
+ *   6. Apply participant transformation in-place:
+ *        - "resolve":  status="resolved", resolved_at=now, clear withdrew_at_sequence
+ *        - "withdraw": status="withdrew", resolved_at=now, withdrew_at_sequence=seq
+ *        - "timeout":  status="timed_out", resolved_at=now
+ *        - "noop":     leave participant unchanged (used for withdraw_contribution)
+ *      `agent_id`, `role`, `rsvp_at` always preserved.
+ *   7. Optional contribution slot HSET (used by submitContribution
+ *      + withdrawContribution)
+ *
+ * KEYS:
+ *   [1] seqKey
+ *   [2] eventsKey
+ *   [3] idemKey
+ *   [4] roomKey
+ *   [5] participantsKey
+ *   [6] contributionsKey      (used when ARGV[12] != "")
+ *
+ * ARGV:
+ *   [1]  eventJsonTemplate    — JSON with first-match `__SEQ__` placeholder
+ *   [2]  idempotencyKey       — empty disables idem check
+ *   [3]  eventType            — diagnostic
+ *   [4]  role                 — participants hash field key
+ *   [5]  ownerRequired        — "1" enforces agent_id match; "" disables (watchdog)
+ *   [6]  ownerExpected        — agent_id (used only if ownerRequired)
+ *   [7]  allowedRoomStatuses  — comma-separated; empty = any
+ *   [8]  roomId               — for diagnostic / future status set ops
+ *   [9]  idemTtlSecs          — TTL for idem reverse-index
+ *   [10] participantTransform — "resolve" | "withdraw" | "timeout" | "noop"
+ *   [11] nowIso               — for resolved_at field
+ *   [12] contributionFieldJson — empty = don't write contribution slot
+ *
+ * Returns:
+ *   {seq}                                   success
+ *   {-1, existingSequence}                  idempotency replay
+ *   {-2, currentRoomStatus}                 allowed-status mismatch
+ *   {-3, "room_not_found"}                  room hash missing
+ *   {-4, "owner_conflict", existingAgentId} per-role owner mismatch
+ *   {-5, "no_participant"}                  participant slot missing
+ */
+export const ROOM_PARTICIPANT_TRANSITION_SCRIPT = `
+if ARGV[2] ~= "" then
+  local existing = redis.call("get", KEYS[3])
+  if existing then return {-1, tonumber(existing)} end
+end
+local currStatus = redis.call("hget", KEYS[4], "status")
+if not currStatus then return {-3, "room_not_found"} end
+if ARGV[7] ~= "" then
+  local found = false
+  for s in string.gmatch(ARGV[7], "[^,]+") do
+    if s == currStatus then found = true; break end
+  end
+  if not found then return {-2, currStatus} end
+end
+local existingP = redis.call("hget", KEYS[5], ARGV[4])
+if not existingP then return {-5, "no_participant"} end
+local p = cjson.decode(existingP)
+if ARGV[5] == "1" and p.agent_id ~= ARGV[6] then
+  return {-4, "owner_conflict", p.agent_id}
+end
+local seq = redis.call("incr", KEYS[1])
+local eventJson = string.gsub(ARGV[1], "__SEQ__", tostring(seq), 1)
+redis.call("zadd", KEYS[2], seq, eventJson)
+if ARGV[2] ~= "" then
+  redis.call("set", KEYS[3], tostring(seq), "EX", tonumber(ARGV[9]))
+end
+local transform = ARGV[10]
+if transform == "resolve" then
+  p.status = "resolved"
+  p.resolved_at = ARGV[11]
+  p.withdrew_at_sequence = nil
+  redis.call("hset", KEYS[5], ARGV[4], cjson.encode(p))
+elseif transform == "withdraw" then
+  p.status = "withdrew"
+  p.resolved_at = ARGV[11]
+  p.withdrew_at_sequence = seq
+  redis.call("hset", KEYS[5], ARGV[4], cjson.encode(p))
+elseif transform == "timeout" then
+  p.status = "timed_out"
+  p.resolved_at = ARGV[11]
+  redis.call("hset", KEYS[5], ARGV[4], cjson.encode(p))
+end
+if ARGV[12] ~= "" then
+  redis.call("hset", KEYS[6], ARGV[4], ARGV[12])
+end
+return {seq}
+`;
+
 // ---------------------------------------------------------------------------
 // Helpers (D.1.a-ii)
 // ---------------------------------------------------------------------------
@@ -1607,6 +1746,141 @@ export async function appendRoomEvent(
 }
 
 // ---------------------------------------------------------------------------
+// Low-level participant-transition primitive
+// ---------------------------------------------------------------------------
+
+interface TransitionRoomParticipantArgs {
+  installationId: string;
+  roomId: string;
+  /** Participants hash field key. */
+  role: string;
+  event: {
+    timestamp: string;
+    event_type: RoomEventType;
+    actor_role: string;
+    actor_id: string;
+    body: Record<string, unknown>;
+  };
+  idempotencyKey: string;
+  /** When true, the script enforces existing participant's `agent_id`
+   * matches `ownerExpected`. Watchdog-driven actions (timeout) skip
+   * the check (set `false`) so the watchdog can act on any role. */
+  ownerRequired: boolean;
+  /** Required when `ownerRequired === true`. */
+  ownerExpected?: string;
+  allowedRoomStatuses: RoomStatus[];
+  /** Atomic in-place transformation applied to the participant slot.
+   * `noop` leaves the slot unchanged (used by withdrawContribution). */
+  transform: "resolve" | "withdraw" | "timeout" | "noop";
+  /** Optional contribution-slot HSET. The contribution JSON is passed
+   * verbatim (no `__SEQ__` substitution — contributions don't carry
+   * sequence-derived fields). */
+  contributionJson?: string;
+  idemTtlSecs?: number;
+  redis: Redis;
+}
+
+/**
+ * Atomic participant-state transition. Underlying primitive for
+ * withdraw / contribute / withdraw_contribution / timeout — actions
+ * that REQUIRE an existing participant slot (per
+ * WAR_ROOM_DESIGN.md L746) and need rsvp_at preservation.
+ *
+ * Throws:
+ *   - `RoomEventIdempotencyReplayError` (replay)
+ *   - `RoomNotFoundError` (room hash missing)
+ *   - `RoomEventStatusPreconditionError` (room status not in allowed list)
+ *   - `RoomParticipantOwnerConflictError` (owner mismatch when ownerRequired)
+ *   - `RoomParticipantNotFoundError` (participant slot missing — must
+ *      `/present` first)
+ *   - `RoomEventBodyTooLargeError` (event body > 8 KiB)
+ */
+export async function transitionRoomParticipant(
+  args: TransitionRoomParticipantArgs,
+): Promise<number> {
+  assertEventBodySize(args.event.body);
+  if (args.ownerRequired && args.ownerExpected === undefined) {
+    throw new Error(
+      "Internal: transitionRoomParticipant requires ownerExpected when ownerRequired=true",
+    );
+  }
+
+  const eventTemplate = JSON.stringify({
+    seq: "__SEQ__",
+    timestamp: args.event.timestamp,
+    event_type: args.event.event_type,
+    actor_role: args.event.actor_role,
+    actor_id: args.event.actor_id,
+    body: args.event.body,
+  });
+  const luaTemplate = eventTemplate.replace('"__SEQ__"', "__SEQ__");
+
+  const ttl = args.idemTtlSecs ?? idemTtlSecs(DEFAULT_MAX_AGE_SECS);
+  const allowedCsv = args.allowedRoomStatuses.join(",");
+  const nowIso = args.event.timestamp;
+
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      ROOM_PARTICIPANT_TRANSITION_SCRIPT,
+      [
+        seqKey(args.roomId),
+        eventsKey(args.roomId),
+        idemKey(args.roomId, args.idempotencyKey),
+        roomKey(args.installationId, args.roomId),
+        participantsKey(args.roomId),
+        args.contributionJson !== undefined
+          ? contributionsKey(args.roomId)
+          : "__unused__",
+      ],
+      [
+        luaTemplate,
+        args.idempotencyKey,
+        args.event.event_type,
+        args.role,
+        args.ownerRequired ? "1" : "",
+        args.ownerExpected ?? "",
+        allowedCsv,
+        args.roomId,
+        String(ttl),
+        args.transform,
+        nowIso,
+        args.contributionJson ?? "",
+      ],
+    ),
+  );
+
+  if (result.ok === -1 && typeof result.tag1 === "number") {
+    throw new RoomEventIdempotencyReplayError(args.roomId, result.tag1);
+  }
+  if (result.ok === -2 && typeof result.tag1 === "string") {
+    throw new RoomEventStatusPreconditionError(
+      args.roomId,
+      allowedCsv,
+      result.tag1,
+    );
+  }
+  if (result.ok === -3) {
+    throw new RoomNotFoundError(args.installationId, args.roomId);
+  }
+  if (result.ok === -4 && typeof result.tag2 === "string") {
+    throw new RoomParticipantOwnerConflictError(
+      args.roomId,
+      args.role,
+      result.tag2,
+      args.ownerExpected ?? "",
+    );
+  }
+  if (result.ok === -5) {
+    throw new RoomParticipantNotFoundError(args.roomId, args.role);
+  }
+  if (result.ok > 0) return result.ok;
+
+  throw new Error(
+    `ROOM_PARTICIPANT_TRANSITION_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // High-level RSVP / contribute / timeout primitives
 // ---------------------------------------------------------------------------
 
@@ -1696,45 +1970,28 @@ export async function presentParticipant(args: RSVPCommonArgs & {
 }
 
 /**
- * Worker withdraws their RSVP. Updates the participant record's
- * `status` to `"withdrew"` (per design — past tense; not "withdrawn")
- * with `withdrew_at_sequence` set to the withdrawal event's sequence.
+ * Worker withdraws their RSVP. Uses `transitionRoomParticipant` so
+ * the existing slot's `agent_id` + `rsvp_at` are preserved and the
+ * `withdrew_at_sequence` field is set atomically to the withdrawal
+ * event's sequence. Status transforms from pending/resolved →
+ * withdrew.
  *
  * Allowed statuses: room must be in awaiting_rsvp or
- * awaiting_contributions (you can't withdraw from a closed/decided
- * room). Soft — doesn't transition room status.
+ * awaiting_contributions. Soft — doesn't transition room status.
  *
- * Owner check: only the agent that holds this role's slot may
- * withdraw (other agents get `RoomParticipantOwnerConflictError`).
+ * **Requires existing participant slot** (per design L746): if the
+ * caller never `/present`ed, this returns
+ * `RoomParticipantNotFoundError`. Closes #510 builder R2 #2.
  */
 export async function withdrawParticipant(
   args: RSVPCommonArgs & { reason?: string },
 ): Promise<number> {
   assertRoleFormat(args.role);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
-  // The participant record uses `__SEQ__` as a placeholder for the
-  // withdrew_at_sequence field; the Lua script substitutes it
-  // (first-match) so the record carries the actual sequence the
-  // withdrawal event landed at — used by the watcher's re-RSVP
-  // re-eligibility filter (`?since=N` past withdrew_at_sequence).
-  const participantTemplate = {
-    agent_id: args.agentId,
-    role: args.role,
-    status: "withdrew" as const,
-    rsvp_at: nowIso,
-    resolved_at: nowIso,
-    withdrew_at_sequence: "__SEQ__",
-  };
-  // Strip the quotes around __SEQ__ so the script substitutes a
-  // bare number (matches the same pattern as the event template).
-  const participantJson = JSON.stringify(participantTemplate).replace(
-    '"__SEQ__"',
-    "__SEQ__",
-  );
-
-  return await appendRoomEvent({
+  return await transitionRoomParticipant({
     installationId: args.installationId,
     roomId: args.roomId,
+    role: args.role,
     event: {
       timestamp: nowIso,
       event_type: "participant_withdrawn",
@@ -1750,45 +2007,42 @@ export async function withdrawParticipant(
       action: "withdraw_participant",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
-    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
-    materialized1: {
-      key: participantsKey(args.roomId),
-      field: args.role,
-      json: participantJson,
-      // Withdraw is the one path that NEEDS Lua to substitute __SEQ__
-      // in materialized JSON — withdrew_at_sequence must be the
-      // actual sequence the withdrawal event landed at.
-      substituteSeq: true,
-    },
+    ownerRequired: true,
+    ownerExpected: args.agentId,
+    allowedRoomStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+    transform: "withdraw",
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });
 }
 
 /**
- * Worker submits a contribution (analysis / verdict). Latest-wins per
- * role: re-submitting overwrites the prior contribution in the
- * materialized hash.
+ * Worker submits a contribution (analysis / verdict). Uses
+ * `transitionRoomParticipant` so the participant slot is updated
+ * atomically (status → "resolved", `resolved_at` = now,
+ * `agent_id` + `rsvp_at` preserved from the original RSVP) AND the
+ * contribution slot is HSET in the same EVAL.
  *
  * **Schema validation** (closes #510 builder R1 #4): the `body`
- * MUST conform to `ContributionBody` (UPPERCASE verdict enum,
- * 1-500 char summary, ≤20 findings with bounded sub-fields).
- * Validated at the boundary via `validateContributionBody` —
- * malformed bodies throw `ContributionValidationError` BEFORE
- * any storage write.
+ * MUST conform to `ContributionBody`. Validated at the boundary
+ * via `validateContributionBody` — malformed bodies throw
+ * `ContributionValidationError` BEFORE any storage write.
  *
- * **Allowed status**: `awaiting_contributions` only. The room must
- * have already advanced past RSVP collection.
+ * **Allowed statuses** (closes #510 builder R2 #1): both
+ * `awaiting_rsvp` AND `awaiting_contributions` per design L201 —
+ * RSVP'd workers may contribute during EITHER status. The
+ * canonical timeline depends on the early-contribution path during
+ * the RSVP window.
  *
- * **Owner check**: only the agent that holds the role's RSVP slot
- * may contribute (other agents get `RoomParticipantOwnerConflictError`).
+ * **Requires existing participant slot** (closes #510 builder R2 #2):
+ * caller must have called `presentParticipant` first. Otherwise
+ * `RoomParticipantNotFoundError`.
  *
- * **Dual materialized write** (closes #510 builder R1 #3): the
- * script atomically updates BOTH the contribution slot AND the
- * participant's `status` to `"resolved"` so the queen synthesis
- * watchdog observing "all participants resolved" sees consistent
- * state without a race window.
+ * **rsvp_at preservation**: the script reads the existing
+ * participant via `cjson.decode`, modifies status / resolved_at /
+ * clears withdrew_at_sequence, and re-encodes. The original
+ * `rsvp_at` is preserved across the call so the manager loop's
+ * quiet-period calculation reasons over true RSVP times.
  *
  * Throws `RoomContributionTooLargeError` if `rawMd` exceeds 32 KiB.
  */
@@ -1801,43 +2055,24 @@ export async function submitContribution(args: RSVPCommonArgs & {
   assertContributionMdSize(args.rawMd);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
   const contribution: RoomContribution = {
-    // RoomContribution.body is Record<string, unknown> for forward
-    // compat with future contribution types; ContributionBody is the
-    // V1-canonical schema and validates as a subtype.
     body: args.body as unknown as Record<string, unknown>,
     raw_md: args.rawMd,
     contributed_at: nowIso,
   };
-  // Updated participant: status flips to "resolved", resolved_at set.
-  // agent_id stays the same as the prior RSVP (verified by owner check).
-  const resolvedParticipant: RoomParticipant = {
-    agent_id: args.agentId,
-    role: args.role,
-    status: "resolved",
-    rsvp_at: nowIso, // best effort — original rsvp_at could be read
-                     // from existing slot; for V1 the resolved_at is
-                     // the more salient timestamp and the event log
-                     // preserves the original RSVP timestamp.
-    resolved_at: nowIso,
-  };
 
-  return await appendRoomEvent({
+  return await transitionRoomParticipant({
     installationId: args.installationId,
     roomId: args.roomId,
+    role: args.role,
     event: {
       timestamp: nowIso,
       event_type: "contribution_submitted",
       actor_role: args.role,
       actor_id: args.agentId,
       body: {
-        // Spread into a generic Record so the index-signature type
-        // check (event body must be Record<string, unknown>) is
-        // satisfied — args.body is the typed ContributionBody.
         body: args.body as unknown as Record<string, unknown>,
-        // Don't include raw_md in the event body (it's bounded
-        // separately at 32 KiB; the event body's 8 KiB cap would be
-        // blown by typical-sized contributions). The materialized
-        // hash carries the full raw_md for caller retrieval.
+        // raw_md NOT in event body — bounded separately at 32 KiB
+        // in the materialized contribution slot.
       },
     },
     idempotencyKey: deriveIdempotencyKey({
@@ -1846,20 +2081,11 @@ export async function submitContribution(args: RSVPCommonArgs & {
       action: "contribute",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    allowedStatuses: ["awaiting_contributions"],
-    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
-    // Materialized 1: update participants[role] → resolved
-    materialized1: {
-      key: participantsKey(args.roomId),
-      field: args.role,
-      json: JSON.stringify(resolvedParticipant),
-    },
-    // Materialized 2: write contribution
-    materialized2: {
-      key: contributionsKey(args.roomId),
-      field: args.role,
-      json: JSON.stringify(contribution),
-    },
+    ownerRequired: true,
+    ownerExpected: args.agentId,
+    allowedRoomStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+    transform: "resolve",
+    contributionJson: JSON.stringify(contribution),
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });
@@ -1869,13 +2095,16 @@ export async function submitContribution(args: RSVPCommonArgs & {
  * Worker withdraws a previously-submitted contribution. Soft event —
  * the contribution slot in the materialized hash gets a tombstone
  * (`withdrawn: true`); queen synthesis skips withdrawn contributions.
+ * The participant's status is **unchanged** — that's a separate
+ * signal from contribution withdrawal.
  *
- * **Allowed status**: `awaiting_contributions` only. **Owner check**:
- * agent must hold the role's RSVP slot. Doesn't write to participants
- * (only the contribution slot is tombstoned); the participant remains
- * "resolved" or whatever status they were prior to the withdrawal —
- * the contribution-level withdrawal is a separate signal from the
- * participant-level withdrawal.
+ * **Allowed statuses**: `awaiting_rsvp` or `awaiting_contributions`
+ * (matches submitContribution's allowed window).
+ *
+ * **Requires existing participant slot** (closes #510 builder R2 #2):
+ * caller must have called `presentParticipant` first.
+ *
+ * **Owner check**: agent must hold the role's RSVP slot.
  */
 export async function withdrawContribution(
   args: RSVPCommonArgs & { reason?: string },
@@ -1887,9 +2116,10 @@ export async function withdrawContribution(
     contributed_at: nowIso,
   };
 
-  return await appendRoomEvent({
+  return await transitionRoomParticipant({
     installationId: args.installationId,
     roomId: args.roomId,
+    role: args.role,
     event: {
       timestamp: nowIso,
       event_type: "contribution_withdrawn",
@@ -1905,18 +2135,11 @@ export async function withdrawContribution(
       action: "withdraw_contribution",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    allowedStatuses: ["awaiting_contributions"],
-    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
-    // Single materialized: tombstone the contribution slot.
-    // Participant record is left alone (still "resolved" if a
-    // contribution was submitted before this withdrawal, otherwise
-    // "pending" — either way, withdrawal of the contribution
-    // doesn't change the participant's status).
-    materialized1: {
-      key: contributionsKey(args.roomId),
-      field: args.role,
-      json: JSON.stringify(tombstone),
-    },
+    ownerRequired: true,
+    ownerExpected: args.agentId,
+    allowedRoomStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+    transform: "noop", // participant status unchanged
+    contributionJson: JSON.stringify(tombstone),
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });
@@ -1952,33 +2175,16 @@ export async function timeoutParticipant(args: {
   assertRoleFormat(args.subjectRole);
   assertRoleFormat(args.watchdogRole);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
-  // Read the existing participant first so we can preserve the
-  // original agent_id + rsvp_at on the timeout tombstone (closes
-  // #510 guard R1 N2: previously the watchdog overwrote agent_id
-  // with its own, making operators reading the participants hash
-  // think bot-queen was the participant).
-  //
-  // Best-effort: if the existing slot is missing, the timeout still
-  // proceeds with the watchdog's identity as a placeholder — this
-  // case shouldn't happen in normal flow (you can only time out
-  // someone who RSVP'd) but we don't want to fail the watchdog.
-  const existingParticipants = await getRoomParticipants({
-    roomId: args.roomId,
-    redis: args.redis,
-  });
-  const existing = existingParticipants[args.subjectRole];
-
-  const participant: RoomParticipant = {
-    agent_id: existing?.agent_id ?? args.watchdogAgentId,
-    role: args.subjectRole,
-    status: "timed_out",
-    rsvp_at: existing?.rsvp_at ?? nowIso,
-    resolved_at: nowIso,
-  };
-
-  return await appendRoomEvent({
+  // Use transitionRoomParticipant — the script atomically reads the
+  // existing slot, preserves agent_id + rsvp_at, and applies the
+  // timed_out transformation. Closes #510 guard R1 N2 properly
+  // (previously the wrapper read participant TS-side outside the
+  // lock, then overwrote with the watchdog's identity inside the
+  // script — race window).
+  return await transitionRoomParticipant({
     installationId: args.installationId,
     roomId: args.roomId,
+    role: args.subjectRole,
     event: {
       timestamp: nowIso,
       event_type: "participant_timed_out",
@@ -1993,21 +2199,9 @@ export async function timeoutParticipant(args: {
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
     // Watchdog can timeout any participant — no owner check.
-    allowedStatuses: ["awaiting_contributions"],
-    materialized1: {
-      key: participantsKey(args.roomId),
-      field: args.subjectRole,
-      json: JSON.stringify(participant),
-    },
-    // Status transition is a self-loop (awaiting_contributions →
-    // awaiting_contributions) so the SREM/SADD index updates fire
-    // but currStatus is preserved. Closes the watchdog vs `/decide`
-    // race per design G7 — script returns -2 if status drifted to
-    // deciding between the watchdog scan and the script run.
-    statusTransition: {
-      from: "awaiting_contributions",
-      to: "awaiting_contributions",
-    },
+    ownerRequired: false,
+    allowedRoomStatuses: ["awaiting_contributions"],
+    transform: "timeout",
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -1003,6 +1003,47 @@ export class RoomContributionTooLargeError extends Error {
 }
 
 /**
+ * Thrown when a participant transition's source state is illegal.
+ *
+ * Closes #510 builder R3: the manager loop's contract (per
+ * WAR_ROOM_DESIGN.md L1055) is that timeouts only fire on
+ * `pending` participants, and synthesis runs once no participants
+ * are pending. Without a state gate, a stale watchdog scan that
+ * read `pending` could race a worker's resolve and overwrite a
+ * `resolved` slot to `timed_out`, corrupting the synthesis trigger.
+ *
+ * Each transition wrapper passes its allowed source states:
+ *   - submitContribution:  pending | resolved   (re-submit allowed)
+ *   - withdrawParticipant: pending | resolved   (withdraw a stale RSVP)
+ *   - withdrawContribution: resolved             (only resolved has a contribution to withdraw)
+ *   - timeoutParticipant:  pending               (per design L1055)
+ *
+ * The script checks `existingP.status` BEFORE the INCR + ZADD and
+ * returns -6 → this error if the source state isn't allowed.
+ */
+export class RoomParticipantStatePreconditionError extends Error {
+  public readonly roomId: string;
+  public readonly role: string;
+  public readonly allowedStates: string[];
+  public readonly actualState: string;
+  constructor(
+    roomId: string,
+    role: string,
+    allowedStates: string[],
+    actualState: string,
+  ) {
+    super(
+      `Participant ${JSON.stringify(role)} in room ${roomId} is in state ${JSON.stringify(actualState)}; this transition requires one of [${allowedStates.map((s) => JSON.stringify(s)).join(", ")}]. Re-read state and retry if appropriate.`,
+    );
+    this.name = "RoomParticipantStatePreconditionError";
+    this.roomId = roomId;
+    this.role = role;
+    this.allowedStates = allowedStates;
+    this.actualState = actualState;
+  }
+}
+
+/**
  * Thrown when withdraw / contribute / withdraw_contribution / timeout
  * is called but the participant slot doesn't exist. Per
  * WAR_ROOM_DESIGN.md L746, `/present` is required before
@@ -1462,6 +1503,10 @@ return {seq}
  *   [10] participantTransform — "resolve" | "withdraw" | "timeout" | "noop"
  *   [11] nowIso               — for resolved_at field
  *   [12] contributionFieldJson — empty = don't write contribution slot
+ *   [13] allowedParticipantStatuses — comma-separated list of allowed
+ *                                     source states for the participant
+ *                                     slot; empty = any. Closes #510
+ *                                     builder R3.
  *
  * Returns:
  *   {seq}                                   success
@@ -1470,6 +1515,8 @@ return {seq}
  *   {-3, "room_not_found"}                  room hash missing
  *   {-4, "owner_conflict", existingAgentId} per-role owner mismatch
  *   {-5, "no_participant"}                  participant slot missing
+ *   {-6, "participant_state_precondition", currentParticipantStatus}
+ *                                           participant status not in allowed list
  */
 export const ROOM_PARTICIPANT_TRANSITION_SCRIPT = `
 if ARGV[2] ~= "" then
@@ -1490,6 +1537,20 @@ if not existingP then return {-5, "no_participant"} end
 local p = cjson.decode(existingP)
 if ARGV[5] == "1" and p.agent_id ~= ARGV[6] then
   return {-4, "owner_conflict", p.agent_id}
+end
+-- Participant-state precondition (closes #510 builder R3): each
+-- transition is gated on the participant's current status so a
+-- stale watchdog scan can't run timeout against an already-resolved
+-- slot, and submitContribution can't reach into withdrew/timed_out
+-- slots without a fresh /present.
+if ARGV[13] ~= "" then
+  local found = false
+  for s in string.gmatch(ARGV[13], "[^,]+") do
+    if s == p.status then found = true; break end
+  end
+  if not found then
+    return {-6, "participant_state_precondition", p.status}
+  end
 end
 local seq = redis.call("incr", KEYS[1])
 local eventJson = string.gsub(ARGV[1], "__SEQ__", tostring(seq), 1)
@@ -1772,6 +1833,16 @@ interface TransitionRoomParticipantArgs {
   /** Atomic in-place transformation applied to the participant slot.
    * `noop` leaves the slot unchanged (used by withdrawContribution). */
   transform: "resolve" | "withdraw" | "timeout" | "noop";
+  /** Allowed source states for the participant slot — gates the
+   * transformation atomically inside the script. Closes #510
+   * builder R3 (manager-loop race). E.g.:
+   *   - submitContribution → ["pending", "resolved"] (re-submit allowed)
+   *   - withdrawParticipant → ["pending", "resolved"]
+   *   - withdrawContribution → ["resolved"]
+   *   - timeoutParticipant → ["pending"] (per design L1055)
+   * Empty = any source state allowed (defensive default; callers
+   * should typically pass an explicit list). */
+  allowedParticipantStatuses?: RoomParticipant["status"][];
   /** Optional contribution-slot HSET. The contribution JSON is passed
    * verbatim (no `__SEQ__` substitution — contributions don't carry
    * sequence-derived fields). */
@@ -1845,6 +1916,7 @@ export async function transitionRoomParticipant(
         args.transform,
         nowIso,
         args.contributionJson ?? "",
+        args.allowedParticipantStatuses?.join(",") ?? "",
       ],
     ),
   );
@@ -1872,6 +1944,14 @@ export async function transitionRoomParticipant(
   }
   if (result.ok === -5) {
     throw new RoomParticipantNotFoundError(args.roomId, args.role);
+  }
+  if (result.ok === -6 && typeof result.tag2 === "string") {
+    throw new RoomParticipantStatePreconditionError(
+      args.roomId,
+      args.role,
+      args.allowedParticipantStatuses ?? [],
+      result.tag2,
+    );
   }
   if (result.ok > 0) return result.ok;
 
@@ -2011,6 +2091,10 @@ export async function withdrawParticipant(
     ownerExpected: args.agentId,
     allowedRoomStatuses: ["awaiting_rsvp", "awaiting_contributions"],
     transform: "withdraw",
+    // Withdraw a pending RSVP or a resolved (already-contributed)
+    // RSVP. Already-withdrew or timed_out are terminal — caller
+    // gets RoomParticipantStatePreconditionError.
+    allowedParticipantStatuses: ["pending", "resolved"],
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });
@@ -2085,6 +2169,10 @@ export async function submitContribution(args: RSVPCommonArgs & {
     ownerExpected: args.agentId,
     allowedRoomStatuses: ["awaiting_rsvp", "awaiting_contributions"],
     transform: "resolve",
+    // First contribution from "pending"; re-submit overwrites from
+    // "resolved". A worker who withdrew or got timed_out must
+    // /present again first (re-RSVP flips the slot back to pending).
+    allowedParticipantStatuses: ["pending", "resolved"],
     contributionJson: JSON.stringify(contribution),
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
@@ -2139,6 +2227,9 @@ export async function withdrawContribution(
     ownerExpected: args.agentId,
     allowedRoomStatuses: ["awaiting_rsvp", "awaiting_contributions"],
     transform: "noop", // participant status unchanged
+    // Only resolved participants have a contribution to withdraw.
+    // Pending hasn't contributed; withdrew/timed_out are terminal.
+    allowedParticipantStatuses: ["resolved"],
     contributionJson: JSON.stringify(tombstone),
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
@@ -2202,6 +2293,14 @@ export async function timeoutParticipant(args: {
     ownerRequired: false,
     allowedRoomStatuses: ["awaiting_contributions"],
     transform: "timeout",
+    // Per design L1055, the manager loop only times out PENDING
+    // participants — once a worker has resolved (contributed),
+    // they're synthesis-ready and the timeout is the wrong signal.
+    // Closes #510 builder R3: a stale watchdog scan that read
+    // "pending" can no longer overwrite a now-resolved slot to
+    // timed_out. Stale calls return RoomParticipantStatePreconditionError
+    // and the watchdog re-scans on the next tick.
+    allowedParticipantStatuses: ["pending"],
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -286,13 +286,28 @@ export type RoomEventType =
   | "room_terminated";
 
 /** Materialized RSVP entry per role (latest-state-wins). Stored as
- * JSON in the `:participants` hash, keyed by role. */
+ * JSON in the `:participants` hash, keyed by role.
+ *
+ * Status lifecycle (per WAR_ROOM_DESIGN.md):
+ *   pending  → resolved   (worker submits a contribution)
+ *   pending  → withdrew   (worker explicitly withdraws)
+ *   pending  → timed_out  (watchdog times out)
+ *   withdrew → pending    (re-RSVP after subject_updated event;
+ *                          clears withdrew_at_sequence)
+ */
 export interface RoomParticipant {
   agent_id: string;
   role: string;
-  status: "present" | "withdrawn" | "timed_out";
+  status: "pending" | "resolved" | "withdrew" | "timed_out";
   rsvp_at: string;
+  /** Set when status moved to resolved / withdrew / timed_out. */
   resolved_at?: string;
+  /** Sequence of the participant_withdrawn event. Set ONLY when
+   * status === "withdrew"; cleared on re-RSVP. Used by the
+   * server-side watcher filter (`GET /api/rooms/watching`) to
+   * re-include the room for that role IFF the room has new events
+   * past `withdrew_at_sequence`. */
+  withdrew_at_sequence?: number;
 }
 
 /** Materialized contribution per role (latest-wins). Stored as JSON
@@ -839,6 +854,75 @@ export const ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES = 32 * 1024;
  *   max_age_secs default 3600 → idem TTL default 7200 (2 h). */
 export const IDEM_TTL_MULTIPLIER = 2;
 
+/** Contribution body bounds per WAR_ROOM_DESIGN.md L1166-1188. */
+export const CONTRIBUTION_SUMMARY_MAX_CHARS = 500;
+export const CONTRIBUTION_FINDING_AREA_MAX_CHARS = 80;
+export const CONTRIBUTION_FINDING_DETAIL_MAX_CHARS = 2000;
+export const CONTRIBUTION_FINDINGS_MAX_COUNT = 20;
+
+// ---------------------------------------------------------------------------
+// ContributionBody schema (D.1.a-ii)
+// ---------------------------------------------------------------------------
+
+/**
+ * Verdict enum for contribution bodies. UPPERCASE per
+ * WAR_ROOM_DESIGN.md §"silent downgrade trap" — the synthesis path
+ * applies a structural DOWNGRADE-only invariant and must reject
+ * malformed/typo'd verdicts at the boundary rather than silently
+ * defaulting to COMMENT.
+ */
+export type ContributionVerdict =
+  | "APPROVE"
+  | "COMMENT"
+  | "CONCERNS"
+  | "REQUEST_CHANGES";
+
+const CONTRIBUTION_VERDICTS: ReadonlySet<string> = new Set([
+  "APPROVE",
+  "COMMENT",
+  "CONCERNS",
+  "REQUEST_CHANGES",
+]);
+
+export type ContributionFindingSeverity = "blocker" | "warning" | "info";
+
+const FINDING_SEVERITIES: ReadonlySet<string> = new Set([
+  "blocker",
+  "warning",
+  "info",
+]);
+
+export interface ContributionFinding {
+  /** 1-80 chars. Open-ended free text; the synthesis prompt treats
+   * this as untrusted user-supplied content. */
+  area: string;
+  severity: ContributionFindingSeverity;
+  /** 1-2000 chars (subject to G2 raw_text cap). */
+  detail: string;
+  /** Optional file:line reference for IDE / dashboard navigation. */
+  code_ref?: string;
+}
+
+/**
+ * Structured contribution body. Bounded fields, enforced enums, and
+ * a hard `verdict` requirement so the queen synthesis can rely on
+ * the body being well-formed. Validated at submit time via
+ * `validateContributionBody` — violations throw
+ * `ContributionValidationError` BEFORE any storage write.
+ */
+export interface ContributionBody {
+  verdict: ContributionVerdict;
+  /** 1-500 chars. */
+  summary: string;
+  /** ≤20 items. */
+  findings?: ContributionFinding[];
+  severity_counts?: {
+    blocker?: number;
+    warning?: number;
+    info?: number;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Errors (D.1.a-ii)
 // ---------------------------------------------------------------------------
@@ -919,6 +1003,186 @@ export class RoomContributionTooLargeError extends Error {
 }
 
 /**
+ * Thrown when a write hits the per-(room, role) first-wins gate —
+ * a different agent has already claimed this role in the room and
+ * the slot is not in the `withdrew` state (which would allow re-RSVP).
+ *
+ * Closes #510 builder R1 #2: previous unconditional HSET let a
+ * second runner overwrite the first runner's RSVP. The script now
+ * cjson.decodes the existing slot and rejects with -4 when the
+ * agent_id mismatches AND the slot isn't withdrew.
+ *
+ * Per WAR_ROOM_DESIGN.md §`agent_id semantics`: subscriber-mode
+ * fleets where multiple runners share one token still get distinct
+ * agent_ids; the per-(room, role) gate ensures only one of them
+ * wins the RSVP — others get this error and skip dispatch.
+ */
+export class RoomParticipantOwnerConflictError extends Error {
+  public readonly roomId: string;
+  public readonly role: string;
+  public readonly existingAgentId: string;
+  public readonly attemptedAgentId: string;
+  constructor(
+    roomId: string,
+    role: string,
+    existingAgentId: string,
+    attemptedAgentId: string,
+  ) {
+    super(
+      `Per-(room=${roomId}, role=${role}) first-wins gate: role is already claimed by agent ${existingAgentId}; attempted by ${attemptedAgentId}. Skip and re-poll on the next watcher tick.`,
+    );
+    this.name = "RoomParticipantOwnerConflictError";
+    this.roomId = roomId;
+    this.role = role;
+    this.existingAgentId = existingAgentId;
+    this.attemptedAgentId = attemptedAgentId;
+  }
+}
+
+/**
+ * Thrown when a contribution body fails schema validation at the
+ * boundary. Carries the offending field name + reason so the route
+ * layer can surface a structured 400 with per-field error codes
+ * (`MISSING_VERDICT`, `INVALID_VERDICT`, `SUMMARY_TOO_LONG`, etc.
+ * per WAR_ROOM_DESIGN.md L1187).
+ */
+export class ContributionValidationError extends Error {
+  public readonly field: string;
+  public readonly value: unknown;
+  constructor(field: string, value: unknown, expected: string) {
+    super(
+      `Invalid contribution body field ${JSON.stringify(field)} = ${JSON.stringify(value)}: expected ${expected}.`,
+    );
+    this.name = "ContributionValidationError";
+    this.field = field;
+    this.value = value;
+  }
+}
+
+/**
+ * Validate a `ContributionBody` against the design's bounded-field
+ * schema. Throws `ContributionValidationError` on any violation.
+ * Pure function — no storage side effects.
+ *
+ * Closes #510 builder R1 #4: previously `submitContribution`
+ * accepted arbitrary `Record<string, unknown>` and tests landed
+ * lowercase verdicts like `"approve"`. Validating at the boundary
+ * means malformed bodies cannot land in Redis before queen
+ * synthesis ever sees them.
+ */
+export function validateContributionBody(body: ContributionBody): void {
+  if (typeof body.verdict !== "string") {
+    throw new ContributionValidationError(
+      "verdict",
+      body.verdict,
+      "one of APPROVE | COMMENT | CONCERNS | REQUEST_CHANGES (UPPERCASE)",
+    );
+  }
+  if (!CONTRIBUTION_VERDICTS.has(body.verdict)) {
+    throw new ContributionValidationError(
+      "verdict",
+      body.verdict,
+      "one of APPROVE | COMMENT | CONCERNS | REQUEST_CHANGES (UPPERCASE)",
+    );
+  }
+  if (typeof body.summary !== "string") {
+    throw new ContributionValidationError(
+      "summary",
+      body.summary,
+      "string (1-500 chars)",
+    );
+  }
+  if (body.summary.length < 1 || body.summary.length > CONTRIBUTION_SUMMARY_MAX_CHARS) {
+    throw new ContributionValidationError(
+      "summary",
+      body.summary,
+      `string of 1-${CONTRIBUTION_SUMMARY_MAX_CHARS} chars (got ${body.summary.length})`,
+    );
+  }
+  if (body.findings !== undefined) {
+    if (!Array.isArray(body.findings)) {
+      throw new ContributionValidationError(
+        "findings",
+        body.findings,
+        `array of ≤${CONTRIBUTION_FINDINGS_MAX_COUNT} ContributionFinding objects`,
+      );
+    }
+    if (body.findings.length > CONTRIBUTION_FINDINGS_MAX_COUNT) {
+      throw new ContributionValidationError(
+        "findings",
+        body.findings,
+        `array of ≤${CONTRIBUTION_FINDINGS_MAX_COUNT} items (got ${body.findings.length})`,
+      );
+    }
+    for (let i = 0; i < body.findings.length; i++) {
+      const f = body.findings[i];
+      if (typeof f !== "object" || f === null) {
+        throw new ContributionValidationError(
+          `findings[${i}]`,
+          f,
+          "ContributionFinding object",
+        );
+      }
+      if (
+        typeof f.area !== "string" ||
+        f.area.length < 1 ||
+        f.area.length > CONTRIBUTION_FINDING_AREA_MAX_CHARS
+      ) {
+        throw new ContributionValidationError(
+          `findings[${i}].area`,
+          f.area,
+          `string of 1-${CONTRIBUTION_FINDING_AREA_MAX_CHARS} chars`,
+        );
+      }
+      if (typeof f.severity !== "string" || !FINDING_SEVERITIES.has(f.severity)) {
+        throw new ContributionValidationError(
+          `findings[${i}].severity`,
+          f.severity,
+          "one of blocker | warning | info",
+        );
+      }
+      if (
+        typeof f.detail !== "string" ||
+        f.detail.length < 1 ||
+        f.detail.length > CONTRIBUTION_FINDING_DETAIL_MAX_CHARS
+      ) {
+        throw new ContributionValidationError(
+          `findings[${i}].detail`,
+          f.detail,
+          `string of 1-${CONTRIBUTION_FINDING_DETAIL_MAX_CHARS} chars`,
+        );
+      }
+      if (f.code_ref !== undefined && typeof f.code_ref !== "string") {
+        throw new ContributionValidationError(
+          `findings[${i}].code_ref`,
+          f.code_ref,
+          "optional string",
+        );
+      }
+    }
+  }
+  if (body.severity_counts !== undefined) {
+    if (typeof body.severity_counts !== "object" || body.severity_counts === null) {
+      throw new ContributionValidationError(
+        "severity_counts",
+        body.severity_counts,
+        "optional object with blocker/warning/info numeric fields",
+      );
+    }
+    for (const k of ["blocker", "warning", "info"] as const) {
+      const v = body.severity_counts[k];
+      if (v !== undefined && (typeof v !== "number" || v < 0 || !Number.isFinite(v))) {
+        throw new ContributionValidationError(
+          `severity_counts.${k}`,
+          v,
+          "non-negative finite number",
+        );
+      }
+    }
+  }
+}
+
+/**
  * Role string is server-derived from the bearer envelope's `agent_role`
  * field — never accepted from request body. This boundary regex
  * catches the very unlikely "envelope had a corrupted role" case
@@ -969,53 +1233,96 @@ export type RoomEventAction =
 // ---------------------------------------------------------------------------
 
 /**
- * Atomic event append with idempotency, status precondition, and
- * optional materialized-view update.
+ * Atomic event append. Single EVAL handles idempotency, room-
+ * existence + status preconditions, per-(role) owner check, the
+ * event log ZADD, two optional materialized-view writes, and an
+ * optional status transition.
  *
  * Design references:
- *   - WAR_ROOM_DESIGN.md L320-380 — script source
+ *   - WAR_ROOM_DESIGN.md L320-380 — original script (extended here
+ *     for the closures below)
  *   - WAR_ROOM_DESIGN.md L139-216 — RSVP-driven lifecycle
  *
+ * Closures (R2 fixes for #510 R1 review):
+ *   - **Builder B1 / Guard N1**: `room must exist` is now an
+ *     unconditional check. HGET status returns nil for a missing
+ *     room hash → `{-3, "room_not_found"}`. Soft events (RSVPs,
+ *     contributions) can no longer create orphan `:seq`/`:events`
+ *     keys against a typo'd roomId.
+ *   - **Builder B2**: `per-(room, role) first-wins gate` via
+ *     cjson.decode of the participants slot. If existing.agent_id
+ *     differs from ARGV[5] AND existing.status != "withdrew", the
+ *     script returns `{-4, "owner_conflict", existingAgentId}`.
+ *     Re-RSVP from `withdrew` is allowed (status flips back to
+ *     pending; new agent_id may differ from prior).
+ *   - **Builder B3**: dual-materialized writes via KEYS[8]/9 +
+ *     ARGV[12]/13 so `submitContribution` can update BOTH the
+ *     contribution slot AND the participant's status to "resolved"
+ *     atomically (prevents race where queen sees contribution
+ *     before participant resolution).
+ *   - **Guard B1**: `__SEQ__` gsub is capped at FIRST match so
+ *     user-controlled body content containing the literal sentinel
+ *     is preserved. The TS template has exactly one unquoted
+ *     `__SEQ__` (the seq field); user content is JSON-stringified
+ *     and surrounded by quotes — first-match gets the seq slot
+ *     deterministically. Materialized JSON gsub also capped.
+ *
  * Order of operations (single EVAL):
- *   1. Idempotency check: if `idempotencyKey` is set and `:idem:{key}`
- *      exists, return `{-1, existingSequence}` (replay-safe).
- *   2. Status precondition: if `status_from` is set, compare against
- *      the room's current `status` field. Mismatch → `{-2, currStatus}`.
- *   3. INCR `:seq` for the new event's sequence number.
- *   4. ZADD the event JSON to `:events` with score=seq. The TS caller
- *      writes `__SEQ__` in the JSON template; the script `gsub`s it
- *      to the actual sequence number before ZADD.
- *   5. SET the idempotency reverse index (if key non-empty) with
- *      caller-supplied TTL (parameterized — closes Queen R3 #5).
- *   6. HSET the materialized view (participants / contributions) if
- *      `materializedFieldName` is non-empty.
- *   7. Status transition (if `status_to` is set): HSET status, SREM
- *      from-set, SADD to-set.
+ *   1. Idempotency check: if `idempotencyKey` is set and
+ *      `:idem:{key}` exists → `{-1, existingSequence}`.
+ *   2. Room existence: HGET roomKey "status"; nil → `{-3,
+ *      "room_not_found"}`. Always runs (even for "soft" events).
+ *   3. Allowed-status gate: if `allowedStatuses` is non-empty,
+ *      currStatus must be in that comma-separated list →
+ *      `{-2, currStatus}` on mismatch.
+ *   4. Owner check (per-role first-wins): if `ownerCheckRole` is
+ *      set, HGET ownerCheckKey ownerCheckRole; if existing has a
+ *      different agent_id AND status != "withdrew", returns
+ *      `{-4, "owner_conflict", existingAgentId}`.
+ *   5. INCR `:seq`.
+ *   6. ZADD event JSON (gsub `__SEQ__` → seq, FIRST MATCH only).
+ *   7. SET idem reverse-index with parameterized TTL.
+ *   8. HSET materialized 1 (with `__SEQ__` substitution, first-match).
+ *   9. HSET materialized 2 (same, for dual-update on submit).
+ *   10. Status transition: HSET status, SREM/SADD set membership.
  *
  * KEYS:
- *   [1] seqKey                — sequence counter
- *   [2] eventsKey             — event log sorted set
- *   [3] idemKey               — idempotency reverse index for this key
- *   [4] roomKey               — room hash (for status read/write)
- *   [5] materializedKey       — participants OR contributions hash
- *   [6] statusFromSetKey      — status:awaiting_X set (for transition SREM)
- *   [7] statusToSetKey        — status:awaiting_Y set (for transition SADD)
+ *   [1] seqKey
+ *   [2] eventsKey
+ *   [3] idemKey
+ *   [4] roomKey
+ *   [5] ownerCheckKey         — typically participantsKey for
+ *                               first-wins enforcement; "__unused__"
+ *                               disables (paired with empty ARGV[4])
+ *   [6] materializedKey1
+ *   [7] statusFromSetKey
+ *   [8] statusToSetKey
+ *   [9] materializedKey2      — for dual-update on submitContribution;
+ *                               "__unused__" disables (paired with
+ *                               empty ARGV[12])
  *
  * ARGV:
- *   [1] eventJsonTemplate     — JSON with `__SEQ__` placeholder (Lua substitutes)
- *   [2] idempotencyKey        — empty string disables idem check
- *   [3] eventType             — diagnostic only (logged in audit)
- *   [4] materializedFieldName — empty disables materialized update
- *   [5] materializedFieldJson — value to HSET when fieldName set
- *   [6] roomStatusFrom        — empty disables status precondition
- *   [7] roomStatusTo          — empty disables status transition
- *   [8] roomId                — for index updates
- *   [9] idemTtlSecs           — TTL for the idempotency reverse index
+ *   [1]  eventJsonTemplate      — JSON with `"__SEQ__"` placeholder
+ *   [2]  idempotencyKey         — empty disables idem check
+ *   [3]  eventType              — diagnostic
+ *   [4]  ownerCheckRole         — hash field name to read on KEYS[5]
+ *                                  (typically the role); empty disables
+ *   [5]  ownerExpected          — agent_id that must own the slot
+ *   [6]  materializedFieldName1 — empty disables materialized 1
+ *   [7]  materializedFieldJson1 — value (with optional `__SEQ__`)
+ *   [8]  allowedStatuses        — comma-separated; empty = any
+ *   [9]  statusTo               — empty disables status transition
+ *   [10] roomId                 — for set membership updates
+ *   [11] idemTtlSecs            — TTL for idem reverse-index
+ *   [12] materializedFieldName2 — empty disables materialized 2
+ *   [13] materializedFieldJson2 — value (with optional `__SEQ__`)
  *
  * Returns:
- *   {seq}                     success
- *   {-1, existingSequence}    idempotency replay (caller treats as success)
- *   {-2, currentRoomStatus}   status precondition mismatch
+ *   {seq}                                   success
+ *   {-1, existingSequence}                  idempotency replay
+ *   {-2, currentRoomStatus}                 allowed-status mismatch
+ *   {-3, "room_not_found"}                  roomKey hash missing
+ *   {-4, "owner_conflict", existingAgentId} per-role first-wins gate
  */
 export const ROOM_APPEND_EVENT_SCRIPT = `
 if ARGV[2] ~= "" then
@@ -1023,22 +1330,52 @@ if ARGV[2] ~= "" then
   if existing then return {-1, tonumber(existing)} end
 end
 local currStatus = redis.call("hget", KEYS[4], "status")
-if ARGV[6] ~= "" and currStatus ~= ARGV[6] then
-  return {-2, currStatus}
-end
-local seq = redis.call("incr", KEYS[1])
-local eventJson = string.gsub(ARGV[1], "__SEQ__", tostring(seq))
-redis.call("zadd", KEYS[2], seq, eventJson)
-if ARGV[2] ~= "" then
-  redis.call("set", KEYS[3], tostring(seq), "EX", tonumber(ARGV[9]))
+if not currStatus then return {-3, "room_not_found"} end
+if ARGV[8] ~= "" then
+  local found = false
+  for s in string.gmatch(ARGV[8], "[^,]+") do
+    if s == currStatus then found = true; break end
+  end
+  if not found then return {-2, currStatus} end
 end
 if ARGV[4] ~= "" then
-  redis.call("hset", KEYS[5], ARGV[4], ARGV[5])
+  local existingMat = redis.call("hget", KEYS[5], ARGV[4])
+  if existingMat then
+    local parsed = cjson.decode(existingMat)
+    if parsed.agent_id ~= ARGV[5] and parsed.status ~= "withdrew" then
+      return {-4, "owner_conflict", parsed.agent_id}
+    end
+  end
 end
-if ARGV[7] ~= "" then
-  redis.call("hset", KEYS[4], "status", ARGV[7])
-  redis.call("srem", KEYS[6], ARGV[8])
-  redis.call("sadd", KEYS[7], ARGV[8])
+local seq = redis.call("incr", KEYS[1])
+local eventJson = string.gsub(ARGV[1], "__SEQ__", tostring(seq), 1)
+redis.call("zadd", KEYS[2], seq, eventJson)
+if ARGV[2] ~= "" then
+  redis.call("set", KEYS[3], tostring(seq), "EX", tonumber(ARGV[11]))
+end
+if ARGV[6] ~= "" then
+  local mat1 = ARGV[7]
+  -- Opt-in seq substitution. Off-by-default so user-controlled
+  -- materialized content (e.g. contribution bodies whose summary
+  -- contains the literal "__SEQ__") cannot be silently rewritten.
+  -- Caller sets ARGV[14]="1" for the withdraw-participant path
+  -- where withdrew_at_sequence MUST be the actual sequence number.
+  if ARGV[14] == "1" then
+    mat1 = string.gsub(mat1, "__SEQ__", tostring(seq), 1)
+  end
+  redis.call("hset", KEYS[6], ARGV[6], mat1)
+end
+if ARGV[12] ~= "" then
+  local mat2 = ARGV[13]
+  if ARGV[15] == "1" then
+    mat2 = string.gsub(mat2, "__SEQ__", tostring(seq), 1)
+  end
+  redis.call("hset", KEYS[9], ARGV[12], mat2)
+end
+if ARGV[9] ~= "" then
+  redis.call("hset", KEYS[4], "status", ARGV[9])
+  redis.call("srem", KEYS[7], ARGV[10])
+  redis.call("sadd", KEYS[8], ARGV[10])
 end
 return {seq}
 `;
@@ -1088,8 +1425,10 @@ function idemTtlSecs(roomMaxAgeSecs: number): number {
 interface AppendRoomEventArgs {
   installationId: string;
   roomId: string;
-  /** Event metadata. The serialized JSON gets `__SEQ__` substituted to the
-   * actual sequence inside the Lua script before the ZADD. */
+  /** Event metadata. The serialized JSON gets `__SEQ__` substituted
+   * to the actual sequence inside the Lua script (FIRST MATCH only —
+   * user-controlled body content containing the literal sentinel is
+   * preserved). */
   event: {
     timestamp: string;
     event_type: RoomEventType;
@@ -1099,16 +1438,42 @@ interface AppendRoomEventArgs {
   };
   /** Empty disables idem check. Typically derived via `deriveIdempotencyKey`. */
   idempotencyKey: string;
-  /** When set, append HSETs `materializedFieldName → materializedFieldJson` on
-   * `materializedKey` after the event lands. Use for participants /
-   * contributions materialized views. */
-  materialized?: {
+  /** Per-(room, role) first-wins gate. When set, the script HGETs the
+   * participants slot at `field`, cjson-decodes, and rejects if the
+   * existing `agent_id` differs from `expectedAgentId` AND status is
+   * not "withdrew" (re-RSVP from withdrew is allowed). */
+  ownerCheck?: {
+    field: string; // typically the role
+    expectedAgentId: string;
+  };
+  /** First materialized write (HSET). Set `substituteSeq: true` to
+   * have the script gsub `__SEQ__` (first match) with the actual
+   * sequence — used by withdrawParticipant for `withdrew_at_sequence`.
+   * Default is OFF so user-controlled materialized content (e.g.
+   * contribution body summaries) cannot be silently rewritten. */
+  materialized1?: {
     key: string;
     field: string;
     json: string;
+    substituteSeq?: boolean;
   };
+  /** Second materialized write — used by `submitContribution` to
+   * update BOTH the contribution slot AND the participant's status
+   * to "resolved" atomically (closes #510 builder R1 #3 dual-update
+   * concern). Same opt-in `substituteSeq` semantics as materialized1. */
+  materialized2?: {
+    key: string;
+    field: string;
+    json: string;
+    substituteSeq?: boolean;
+  };
+  /** Allowed-status gate. Comma-separated list of valid current
+   * statuses for this action. Empty = any non-empty status accepted
+   * (room must still exist; that's a separate -3 path). */
+  allowedStatuses?: RoomStatus[];
   /** Optional status transition. When provided, both fields required:
-   * the script enforces `from` precondition + transitions status sets. */
+   * caller asserts the from-set is correct (must match currStatus
+   * after the allowed-statuses gate). */
   statusTransition?: {
     from: RoomStatus;
     to: RoomStatus;
@@ -1132,7 +1497,10 @@ interface AppendRoomEventArgs {
  *
  * Throws:
  *   - `RoomEventIdempotencyReplayError` (replay — caller treats as success)
- *   - `RoomEventStatusPreconditionError` (room moved out of `from` state)
+ *   - `RoomNotFoundError` (room hash missing — typo'd roomId or
+ *      closed-and-TTL'd room)
+ *   - `RoomEventStatusPreconditionError` (currStatus not in `allowedStatuses`)
+ *   - `RoomParticipantOwnerConflictError` (per-role first-wins gate)
  *   - `RoomEventBodyTooLargeError` (body > 8 KiB serialized)
  */
 export async function appendRoomEvent(
@@ -1154,10 +1522,16 @@ export async function appendRoomEvent(
   // The script gsub looks for the LITERAL string `"__SEQ__"` in the
   // template (with quotes — JSON.stringify wrapped __SEQ__ as a
   // string). Lua replaces with the unquoted number, producing valid
-  // JSON like `"seq":42`.
+  // JSON like `"seq":42`. Cap at first match — preserves any user-
+  // supplied content that happens to contain the literal `__SEQ__`
+  // (closes #510 guard R1 B1).
   const luaTemplate = eventTemplate.replace('"__SEQ__"', "__SEQ__");
 
   const ttl = args.idemTtlSecs ?? idemTtlSecs(DEFAULT_MAX_AGE_SECS);
+  const allowedCsv =
+    args.allowedStatuses && args.allowedStatuses.length > 0
+      ? args.allowedStatuses.join(",")
+      : "";
 
   const result = dispatchScriptResult(
     await args.redis.eval(
@@ -1167,24 +1541,35 @@ export async function appendRoomEvent(
         eventsKey(args.roomId),
         idemKey(args.roomId, args.idempotencyKey),
         roomKey(args.installationId, args.roomId),
-        args.materialized?.key ?? "__unused__",
+        // Owner check key is the participants hash by convention;
+        // safe to compute even when ownerCheck is unset since the
+        // Lua script gates the read on ARGV[4] non-empty.
+        participantsKey(args.roomId),
+        args.materialized1?.key ?? "__unused__",
         args.statusTransition
           ? statusIndexKey(args.installationId, args.statusTransition.from)
           : "__unused__",
         args.statusTransition
           ? statusIndexKey(args.installationId, args.statusTransition.to)
           : "__unused__",
+        args.materialized2?.key ?? "__unused__",
       ],
       [
         luaTemplate,
         args.idempotencyKey,
         args.event.event_type,
-        args.materialized?.field ?? "",
-        args.materialized?.json ?? "",
-        args.statusTransition?.from ?? "",
+        args.ownerCheck?.field ?? "",
+        args.ownerCheck?.expectedAgentId ?? "",
+        args.materialized1?.field ?? "",
+        args.materialized1?.json ?? "",
+        allowedCsv,
         args.statusTransition?.to ?? "",
         args.roomId,
         String(ttl),
+        args.materialized2?.field ?? "",
+        args.materialized2?.json ?? "",
+        args.materialized1?.substituteSeq ? "1" : "",
+        args.materialized2?.substituteSeq ? "1" : "",
       ],
     ),
   );
@@ -1195,8 +1580,19 @@ export async function appendRoomEvent(
   if (result.ok === -2 && typeof result.tag1 === "string") {
     throw new RoomEventStatusPreconditionError(
       args.roomId,
-      args.statusTransition?.from ?? "",
+      allowedCsv,
       result.tag1,
+    );
+  }
+  if (result.ok === -3) {
+    throw new RoomNotFoundError(args.installationId, args.roomId);
+  }
+  if (result.ok === -4 && typeof result.tag2 === "string") {
+    throw new RoomParticipantOwnerConflictError(
+      args.roomId,
+      args.ownerCheck?.field ?? "",
+      result.tag2,
+      args.ownerCheck?.expectedAgentId ?? "",
     );
   }
   // The script's success shape is `{seq}` — ScriptResult parses
@@ -1242,18 +1638,30 @@ interface RSVPCommonArgs {
  * `awaiting_contributions` happens via a separate script when all
  * expected roles are present).
  *
- * Idempotent: a retry with the same `sequenceObservedByClient` returns
- * (via `RoomEventIdempotencyReplayError`) the original sequence.
+ * Allowed statuses: `awaiting_rsvp` (canonical) + `awaiting_contributions`
+ * (late RSVP after some other role has presented and the room moved
+ * forward via a separate transition path).
+ *
+ * Per-(room, role) first-wins gate: if a different agent already
+ * holds this role's slot AND the slot status isn't "withdrew", the
+ * second runner gets `RoomParticipantOwnerConflictError` and skips
+ * dispatch (per WAR_ROOM_DESIGN.md §subscriber-mode fleets).
+ *
+ * Re-RSVP from withdrew: status flips back to "pending"; agent_id
+ * may differ from the prior holder (a restarted runner gets a new
+ * agent_id and may legitimately re-claim).
  */
 export async function presentParticipant(args: RSVPCommonArgs & {
   intentHint?: string;
 }): Promise<number> {
   assertRoleFormat(args.role);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+  // Fresh participant record — status: "pending", no
+  // withdrew_at_sequence (cleared on re-RSVP per design).
   const participant: RoomParticipant = {
     agent_id: args.agentId,
     role: args.role,
-    status: "present",
+    status: "pending",
     rsvp_at: nowIso,
   };
 
@@ -1275,7 +1683,9 @@ export async function presentParticipant(args: RSVPCommonArgs & {
       action: "present",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    materialized: {
+    allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
+    materialized1: {
       key: participantsKey(args.roomId),
       field: args.role,
       json: JSON.stringify(participant),
@@ -1287,21 +1697,40 @@ export async function presentParticipant(args: RSVPCommonArgs & {
 
 /**
  * Worker withdraws their RSVP. Updates the participant record's
- * `status` to `"withdrawn"` so leader election skips them. Soft —
- * doesn't transition room status.
+ * `status` to `"withdrew"` (per design — past tense; not "withdrawn")
+ * with `withdrew_at_sequence` set to the withdrawal event's sequence.
+ *
+ * Allowed statuses: room must be in awaiting_rsvp or
+ * awaiting_contributions (you can't withdraw from a closed/decided
+ * room). Soft — doesn't transition room status.
+ *
+ * Owner check: only the agent that holds this role's slot may
+ * withdraw (other agents get `RoomParticipantOwnerConflictError`).
  */
 export async function withdrawParticipant(
   args: RSVPCommonArgs & { reason?: string },
 ): Promise<number> {
   assertRoleFormat(args.role);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
-  const participant: RoomParticipant = {
+  // The participant record uses `__SEQ__` as a placeholder for the
+  // withdrew_at_sequence field; the Lua script substitutes it
+  // (first-match) so the record carries the actual sequence the
+  // withdrawal event landed at — used by the watcher's re-RSVP
+  // re-eligibility filter (`?since=N` past withdrew_at_sequence).
+  const participantTemplate = {
     agent_id: args.agentId,
     role: args.role,
-    status: "withdrawn",
+    status: "withdrew" as const,
     rsvp_at: nowIso,
     resolved_at: nowIso,
+    withdrew_at_sequence: "__SEQ__",
   };
+  // Strip the quotes around __SEQ__ so the script substitutes a
+  // bare number (matches the same pattern as the event template).
+  const participantJson = JSON.stringify(participantTemplate).replace(
+    '"__SEQ__"',
+    "__SEQ__",
+  );
 
   return await appendRoomEvent({
     installationId: args.installationId,
@@ -1321,10 +1750,16 @@ export async function withdrawParticipant(
       action: "withdraw_participant",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    materialized: {
+    allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
+    materialized1: {
       key: participantsKey(args.roomId),
       field: args.role,
-      json: JSON.stringify(participant),
+      json: participantJson,
+      // Withdraw is the one path that NEEDS Lua to substitute __SEQ__
+      // in materialized JSON — withdrew_at_sequence must be the
+      // actual sequence the withdrawal event landed at.
+      substituteSeq: true,
     },
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
@@ -1334,21 +1769,56 @@ export async function withdrawParticipant(
 /**
  * Worker submits a contribution (analysis / verdict). Latest-wins per
  * role: re-submitting overwrites the prior contribution in the
- * materialized hash. Soft — doesn't transition room status.
+ * materialized hash.
+ *
+ * **Schema validation** (closes #510 builder R1 #4): the `body`
+ * MUST conform to `ContributionBody` (UPPERCASE verdict enum,
+ * 1-500 char summary, ≤20 findings with bounded sub-fields).
+ * Validated at the boundary via `validateContributionBody` —
+ * malformed bodies throw `ContributionValidationError` BEFORE
+ * any storage write.
+ *
+ * **Allowed status**: `awaiting_contributions` only. The room must
+ * have already advanced past RSVP collection.
+ *
+ * **Owner check**: only the agent that holds the role's RSVP slot
+ * may contribute (other agents get `RoomParticipantOwnerConflictError`).
+ *
+ * **Dual materialized write** (closes #510 builder R1 #3): the
+ * script atomically updates BOTH the contribution slot AND the
+ * participant's `status` to `"resolved"` so the queen synthesis
+ * watchdog observing "all participants resolved" sees consistent
+ * state without a race window.
  *
  * Throws `RoomContributionTooLargeError` if `rawMd` exceeds 32 KiB.
  */
 export async function submitContribution(args: RSVPCommonArgs & {
-  body: Record<string, unknown>;
+  body: ContributionBody;
   rawMd: string;
 }): Promise<number> {
   assertRoleFormat(args.role);
+  validateContributionBody(args.body);
   assertContributionMdSize(args.rawMd);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
   const contribution: RoomContribution = {
-    body: args.body,
+    // RoomContribution.body is Record<string, unknown> for forward
+    // compat with future contribution types; ContributionBody is the
+    // V1-canonical schema and validates as a subtype.
+    body: args.body as unknown as Record<string, unknown>,
     raw_md: args.rawMd,
     contributed_at: nowIso,
+  };
+  // Updated participant: status flips to "resolved", resolved_at set.
+  // agent_id stays the same as the prior RSVP (verified by owner check).
+  const resolvedParticipant: RoomParticipant = {
+    agent_id: args.agentId,
+    role: args.role,
+    status: "resolved",
+    rsvp_at: nowIso, // best effort — original rsvp_at could be read
+                     // from existing slot; for V1 the resolved_at is
+                     // the more salient timestamp and the event log
+                     // preserves the original RSVP timestamp.
+    resolved_at: nowIso,
   };
 
   return await appendRoomEvent({
@@ -1360,7 +1830,10 @@ export async function submitContribution(args: RSVPCommonArgs & {
       actor_role: args.role,
       actor_id: args.agentId,
       body: {
-        body: args.body,
+        // Spread into a generic Record so the index-signature type
+        // check (event body must be Record<string, unknown>) is
+        // satisfied — args.body is the typed ContributionBody.
+        body: args.body as unknown as Record<string, unknown>,
         // Don't include raw_md in the event body (it's bounded
         // separately at 32 KiB; the event body's 8 KiB cap would be
         // blown by typical-sized contributions). The materialized
@@ -1373,7 +1846,16 @@ export async function submitContribution(args: RSVPCommonArgs & {
       action: "contribute",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    materialized: {
+    allowedStatuses: ["awaiting_contributions"],
+    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
+    // Materialized 1: update participants[role] → resolved
+    materialized1: {
+      key: participantsKey(args.roomId),
+      field: args.role,
+      json: JSON.stringify(resolvedParticipant),
+    },
+    // Materialized 2: write contribution
+    materialized2: {
       key: contributionsKey(args.roomId),
       field: args.role,
       json: JSON.stringify(contribution),
@@ -1385,18 +1867,21 @@ export async function submitContribution(args: RSVPCommonArgs & {
 
 /**
  * Worker withdraws a previously-submitted contribution. Soft event —
- * the contribution remains in the materialized hash with
- * `withdrawn: true` flag. Queen synthesis skips withdrawn contributions.
+ * the contribution slot in the materialized hash gets a tombstone
+ * (`withdrawn: true`); queen synthesis skips withdrawn contributions.
+ *
+ * **Allowed status**: `awaiting_contributions` only. **Owner check**:
+ * agent must hold the role's RSVP slot. Doesn't write to participants
+ * (only the contribution slot is tombstoned); the participant remains
+ * "resolved" or whatever status they were prior to the withdrawal —
+ * the contribution-level withdrawal is a separate signal from the
+ * participant-level withdrawal.
  */
 export async function withdrawContribution(
   args: RSVPCommonArgs & { reason?: string },
 ): Promise<number> {
   assertRoleFormat(args.role);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
-  // Mark the existing contribution as withdrawn. Caller is expected
-  // to have an existing contribution; if not, the event lands but
-  // the materialized hash has no prior entry to update — that's a
-  // diagnosable misuse, not a failure mode here.
   const tombstone: Partial<RoomContribution> & { withdrawn: true } = {
     withdrawn: true,
     contributed_at: nowIso,
@@ -1420,7 +1905,14 @@ export async function withdrawContribution(
       action: "withdraw_contribution",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    materialized: {
+    allowedStatuses: ["awaiting_contributions"],
+    ownerCheck: { field: args.role, expectedAgentId: args.agentId },
+    // Single materialized: tombstone the contribution slot.
+    // Participant record is left alone (still "resolved" if a
+    // contribution was submitted before this withdrawal, otherwise
+    // "pending" — either way, withdrawal of the contribution
+    // doesn't change the participant's status).
+    materialized1: {
       key: contributionsKey(args.roomId),
       field: args.role,
       json: JSON.stringify(tombstone),
@@ -1460,18 +1952,27 @@ export async function timeoutParticipant(args: {
   assertRoleFormat(args.subjectRole);
   assertRoleFormat(args.watchdogRole);
   const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
-  // Tombstone the participant. agent_id stays unchanged from the
-  // prior present (the timeout doesn't claim a new agent); since
-  // we're updating the existing record, we keep what was there
-  // semantically — but the watchdog doesn't have it on hand, so
-  // we record the agent_id as the watchdog's for traceability.
-  // Operators reading the participants hash see the timeout marker;
-  // forensic detail (who originally RSVP'd) lives in the event log.
+  // Read the existing participant first so we can preserve the
+  // original agent_id + rsvp_at on the timeout tombstone (closes
+  // #510 guard R1 N2: previously the watchdog overwrote agent_id
+  // with its own, making operators reading the participants hash
+  // think bot-queen was the participant).
+  //
+  // Best-effort: if the existing slot is missing, the timeout still
+  // proceeds with the watchdog's identity as a placeholder — this
+  // case shouldn't happen in normal flow (you can only time out
+  // someone who RSVP'd) but we don't want to fail the watchdog.
+  const existingParticipants = await getRoomParticipants({
+    roomId: args.roomId,
+    redis: args.redis,
+  });
+  const existing = existingParticipants[args.subjectRole];
+
   const participant: RoomParticipant = {
-    agent_id: args.watchdogAgentId,
+    agent_id: existing?.agent_id ?? args.watchdogAgentId,
     role: args.subjectRole,
     status: "timed_out",
-    rsvp_at: nowIso,
+    rsvp_at: existing?.rsvp_at ?? nowIso,
     resolved_at: nowIso,
   };
 
@@ -1491,13 +1992,18 @@ export async function timeoutParticipant(args: {
       action: "timeout",
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
-    materialized: {
+    // Watchdog can timeout any participant — no owner check.
+    allowedStatuses: ["awaiting_contributions"],
+    materialized1: {
       key: participantsKey(args.roomId),
       field: args.subjectRole,
       json: JSON.stringify(participant),
     },
-    // Status precondition: only time out while still awaiting contributions
-    // — closes the watchdog vs `/decide` race per design G7.
+    // Status transition is a self-loop (awaiting_contributions →
+    // awaiting_contributions) so the SREM/SADD index updates fire
+    // but currStatus is preserved. Closes the watchdog vs `/decide`
+    // race per design G7 — script returns -2 if status drifted to
+    // deciding between the watchdog scan and the script run.
     statusTransition: {
       from: "awaiting_contributions",
       to: "awaiting_contributions",


### PR DESCRIPTION
## Summary
Second war-room storage slice (Phase D per \`docs/architecture/WAR_ROOM_DESIGN.md\`). Builds on the foundation in #509 (\`createRoom\` + types + key helpers) by adding the atomic event-append script, idempotency mechanism, and the RSVP / contribute / timeout primitives the worker runtime + bot watchdog will call.

## What's in this slice

### \`ROOM_APPEND_EVENT_SCRIPT\` — single-EVAL atomic event log
- 7 keys × 9 args. Handles: idempotency check → status precondition → INCR seq → ZADD event JSON (with \`__SEQ__\` → seq gsub) → optional idem reverse-index SET → optional materialized HSET (participants/contributions) → optional status transition (HSET status + SREM/SADD set membership).
- Returns: \`{seq}\` success, \`{-1, existingSeq}\` idem replay, \`{-2, currStatus}\` status mismatch.
- IDEM TTL parameterized via ARGV (Queen R3 #5).

### Idempotency derivation
\`\`\`
deriveIdempotencyKey({roomId, role, action, sequenceObservedByClient})
  = sha256(\"v1:\" + roomId + \":\" + role + \":\" + action + \":\" + seq)
\`\`\`
Server-canonical, derived from auth-derived role + the client's \`If-Room-Sequence-At-Or-After\` header. Two retries with the same observed sequence resolve to the same key.

### Errors
| Class | When | HTTP guidance |
|---|---|---|
| \`RoomEventStatusPreconditionError\` | script returned -2 (status drift) | 409 Conflict with currentStatus |
| \`RoomEventIdempotencyReplayError\` | script returned -1 (replay) | 200 with prior seq (treat as success) |
| \`RoomEventBodyTooLargeError\` | body > 8 KiB serialized | 413 Payload Too Large |
| \`RoomContributionTooLargeError\` | raw_md > 32 KiB | 413 Payload Too Large |

### High-level primitives
| Function | Soft? | Status transition |
|---|---|---|
| \`presentParticipant\` | yes | none |
| \`withdrawParticipant\` | yes | none |
| \`submitContribution\` | yes | none |
| \`withdrawContribution\` | yes | none |
| \`timeoutParticipant\` | gated | \`awaiting_contributions → awaiting_contributions\` (precondition only) |
| \`listRoomEvents\` (read) | — | — |
| \`getRoomParticipants\` (read) | — | — |
| \`getRoomContributions\` (read) | — | — |

### What's NOT in this slice
- **D.1.a-iii**: \`ROOM_DECIDE_CLAIM\` + \`ROOM_RECOVER_DECIDING\` + \`ROOM_TERMINATE\` + \`ROOM_CLOSE\` scripts (synthesis claim with TTL recovery, force-close, queen's happy-path close with sequence drift detection)
- **D.1.b**: HTTP API endpoints over \`/api/rooms/*\`
- **D.1.c**: watchdog driver

## What it looks like

### Worker presents in a war room
\`\`\`typescript
const seq = await presentParticipant({
  installationId: \"12345\",
  roomId: \"01234567-89ab-4cde-9012-3456789abcde\",
  role: \"drone\",                     // server-derived from envelope
  agentId: \"drone-1\",                // server-derived from envelope
  sequenceObservedByClient: 1,       // from If-Room-Sequence-At-Or-After header
  intentHint: \"review for security regressions\",
  redis,
});
// → seq = 2 (room_opened was 1)
\`\`\`

### Idempotent retry returns prior sequence
\`\`\`typescript
try {
  await presentParticipant({...samePayload});
} catch (err) {
  if (err instanceof RoomEventIdempotencyReplayError) {
    // err.existingSequence === 2 — treat as success
  }
}
\`\`\`

### Watchdog timing out a participant (G7 race protected)
\`\`\`typescript
try {
  await timeoutParticipant({
    installationId: \"12345\",
    roomId: \"01234567-89ab-4cde-9012-3456789abcde\",
    subjectRole: \"drone\",
    watchdogRole: \"manager\",
    watchdogAgentId: \"bot-queen\",
    sequenceObservedByClient: 5,
    redis,
  });
} catch (err) {
  if (err instanceof RoomEventStatusPreconditionError) {
    // Queen claimed synthesis between scan + write — re-scan next tick
  }
}
\`\`\`

## Concurrency invariants pinned by tests

1. **Idempotency replay** — same seq returned, no duplicate event appended.
2. **Watchdog vs /decide race** — \`timeoutParticipant\` against a room whose status moved to \`deciding\` returns \`RoomEventStatusPreconditionError\` (script returned -2).
3. **Concurrent presents from different roles** — both get distinct sequences via INCR atomicity.
4. **raw_md isolation** — submitting a 20 KiB contribution puts the markdown in the materialized hash but NOT the event body (which is bounded at 8 KiB).

## Test plan
- [x] 91 war-room tests pass (was 61; +30 new for this slice)
- [x] Full suite: 1054 / 1 skipped (was 1024)
- [x] \`npx tsc --noEmit\` clean
- [x] Constants pinned (8 KiB / 32 KiB caps, IDEM_TTL_MULTIPLIER=2)
- [x] \`deriveIdempotencyKey\` 6 cases (deterministic, role/action/sequence/room isolation)
- [x] \`appendRoomEvent\` low-level: monotonic seq, \`__SEQ__\` gsub'd, idem replay, status precondition, body-too-large pre-flight rejection
- [x] \`presentParticipant\`: writes participants hash, idem replay, concurrent-roles distinct seqs, intentHint flows to event body
- [x] \`withdrawParticipant\`: status=withdrawn + resolved_at, reason in event
- [x] \`submitContribution\`: writes contributions hash, latest-wins on re-submit, raw_md > 32 KiB rejected, raw_md NOT in event body
- [x] \`timeoutParticipant\`: watchdog write succeeds in \`awaiting_contributions\`, status-drift to \`deciding\` throws (G7), actor is the watchdog
- [x] \`listRoomEvents\`: returns all without \`since\`, \`since=N\` excludes seq=N

## Governance — Queen-bypass rationale
Same Phase D-series carve-out pattern as #509 (war room storage foundation). Phase D scope tracked in the ratified design doc (\`docs/architecture/WAR_ROOM_DESIGN.md\`); each implementation slice is self-contained and reviewed individually by the listen-only fleet.