### PR TITLE
Phase D.1.a-iii.a — RoomCoreData split (mutable fields → separate hash fields)

### DIFF
--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -925,6 +925,110 @@ describe("getRoomCore", () => {
       getRoomCore({ installationId: "12345", roomId: RID_A, redis }),
     ).rejects.toThrow(RoomNotFoundError);
   });
+
+  it("reads mutable transition fields from separate hash fields (D.1.a-iii.a split)", async () => {
+    // Per the RoomCoreData split: closed_at, closed_reason,
+    // deciding_through_sequence, decision are SEPARATE hash fields,
+    // NOT inside the `data` JSON blob. getRoomCore reconstructs by
+    // reading each field individually via HGETALL. This test
+    // simulates a closed room with all happy-path-close fields set.
+    const data: RoomCoreData = {
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "hivemoot/hivemoot#508",
+      opened_at: "2026-04-28T00:00:00.000Z",
+      timing_config: {
+        max_age_secs: 3600,
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      },
+    };
+    const decision = {
+      synthesized_at: "2026-04-28T01:00:00.000Z",
+      synthesis_runner: "bot-queen-runner-1",
+      content: "## Verdict: APPROVE",
+      sequence_closed: 42,
+    };
+    await redis.hset(roomKey("12345", RID_A), {
+      data: JSON.stringify(data),
+      status: "closed",
+      closed_at: "2026-04-28T01:00:00.000Z",
+      // closed_reason intentionally absent — happy-path queen close
+      // uses `decision` field instead (per design — operators
+      // distinguish CLOSE vs TERMINATE by which is populated).
+      deciding_through_sequence: 42,
+      decision: JSON.stringify(decision),
+    });
+    const core = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(core.status).toBe("closed");
+    expect(core.closed_at).toBe("2026-04-28T01:00:00.000Z");
+    expect(core.closed_reason).toBeUndefined();
+    expect(core.deciding_through_sequence).toBe(42);
+    expect(core.decision).toEqual(decision);
+    // Immutable fields still from the `data` blob
+    expect(core.manager).toBe("bot-queen");
+    expect(core.subject_ref).toBe("hivemoot/hivemoot#508");
+  });
+
+  it("reads closed_reason without decision (terminate path)", async () => {
+    const data: RoomCoreData = {
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "hivemoot/hivemoot#508",
+      opened_at: "2026-04-28T00:00:00.000Z",
+      timing_config: {
+        max_age_secs: 3600,
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      },
+    };
+    await redis.hset(roomKey("12345", RID_A), {
+      data: JSON.stringify(data),
+      status: "expired",
+      closed_at: "2026-04-28T01:00:00.000Z",
+      closed_reason: "expired",
+    });
+    const core = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(core.status).toBe("expired");
+    expect(core.closed_reason).toBe("expired");
+    expect(core.decision).toBeUndefined();
+  });
+
+  it("deciding_through_sequence is coerced from string to number (HSET stores numbers as strings)", async () => {
+    const data: RoomCoreData = {
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "hivemoot/hivemoot#508",
+      opened_at: "2026-04-28T00:00:00.000Z",
+      timing_config: {
+        max_age_secs: 3600,
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      },
+    };
+    // Simulate the Lua script's HSET which writes numbers as
+    // strings (Redis storage type is always string).
+    await redis.hset(roomKey("12345", RID_A), {
+      data: JSON.stringify(data),
+      status: "deciding",
+      deciding_through_sequence: "42",
+    });
+    const core = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(core.deciding_through_sequence).toBe(42);
+    expect(typeof core.deciding_through_sequence).toBe("number");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -1029,6 +1029,57 @@ describe("getRoomCore", () => {
     expect(core.deciding_through_sequence).toBe(42);
     expect(typeof core.deciding_through_sequence).toBe("number");
   });
+
+  it("deciding_through_sequence empty-string sentinel reads as undefined, NOT 0 (closes #511 builder R1)", async () => {
+    // Per design L415 (RECOVER) + L523 (CLOSE-drift), the recovery
+    // and drift-revert paths CLEAR the field via HSET ... "" rather
+    // than DELing it. JS's Number("") === 0 — without the empty-
+    // string check, a recovered room would read back as "claim
+    // active through sequence 0", a silent invariant break.
+    const data: RoomCoreData = {
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "hivemoot/hivemoot#508",
+      opened_at: "2026-04-28T00:00:00.000Z",
+      timing_config: {
+        max_age_secs: 3600,
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      },
+    };
+    await redis.hset(roomKey("12345", RID_A), {
+      data: JSON.stringify(data),
+      status: "awaiting_contributions", // back to awaiting after RECOVER
+      deciding_through_sequence: "", // cleared sentinel
+    });
+    const core = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(core.deciding_through_sequence).toBeUndefined();
+    // Defensive: pin that we don't accidentally produce 0
+    expect(core.deciding_through_sequence).not.toBe(0);
+  });
+
+  it("listRooms also handles the empty-string sentinel correctly (parser is shared)", async () => {
+    // Both readers share parseRoomCoreFields — make sure the fix
+    // applies to listRooms's fan-out HGETALL too.
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    // Simulate post-RECOVER state on the existing room
+    await redis.hset(roomKey("12345", RID_A), {
+      deciding_through_sequence: "",
+    });
+    const rooms = await listRooms({ installationId: "12345", redis });
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0].deciding_through_sequence).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -774,9 +774,15 @@ function parseRoomCoreFields(
   }
   if (
     fields.deciding_through_sequence !== undefined &&
-    fields.deciding_through_sequence !== null
+    fields.deciding_through_sequence !== null &&
+    fields.deciding_through_sequence !== ""
   ) {
     // HSET stores numbers as strings; coerce on read.
+    // Empty string is the design's "cleared" sentinel — RECOVER and
+    // CLOSE-drift paths set this field to "" rather than DELing the
+    // field (per WAR_ROOM_DESIGN.md L415, L523). JS's `Number("")`
+    // is 0, NOT NaN, which would silently misread as "claim active
+    // through sequence 0" — closes #511 builder R1.
     const n = Number(fields.deciding_through_sequence);
     if (Number.isFinite(n)) core.deciding_through_sequence = n;
   }

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -192,18 +192,24 @@ export interface TimingConfig {
 }
 
 /**
- * Stable bulk fields of a room core (everything EXCEPT `status`).
- * Stored as a JSON string in the room hash's `"data"` field per the
- * design's HSET shape (WAR_ROOM_DESIGN.md L303-304). `status` lives
- * in a separate hash field so transitions can `HSET status` without
- * marshaling/unmarshaling the whole record on the hot path.
+ * Immutable bulk fields of a room core. Stored as a JSON string in
+ * the room hash's `"data"` field per the design's HSET shape
+ * (WAR_ROOM_DESIGN.md L303-304). These fields are written ONCE at
+ * `createRoom` time and never mutated — making the JSON-blob shape
+ * safe (no per-field race against transition scripts).
+ *
+ * Mutable fields (`status`, `closed_at`, `closed_reason`,
+ * `deciding_through_sequence`, `decision`) live as SEPARATE hash
+ * fields so transition scripts (DECIDE_CLAIM, RECOVER, TERMINATE,
+ * CLOSE) can update them via single-field HSET without
+ * marshaling/unmarshaling the whole record on the hot path. Closes
+ * #509 guard R1 carry-forward (the original implementation merged
+ * mutable + immutable into one blob, requiring the close path to
+ * read-modify-write the entire JSON).
  *
  * Field naming uses snake_case to match the storage shape across
  * other modules (agent-token-v1 envelope, audit entries) —
  * wire-shape translation to camelCase happens at the API boundary.
- *
- * `closed_*` and `decision` fields are absent until the room
- * terminates; their presence is the close marker.
  */
 export interface RoomCoreData {
   /** Actor-id of whoever opened the room — typically the bot's
@@ -214,27 +220,42 @@ export interface RoomCoreData {
   subject_ref: string;
   opened_at: string; // ISO 8601
   timing_config: TimingConfig;
-
-  // Post-close fields (absent while open)
-  closed_at?: string;
-  closed_reason?: TerminalReason;
-  /** Sequence the queen synthesized through (set by claim script,
-   * verified at close to detect mid-synthesis drift). */
-  deciding_through_sequence?: number;
-  /** Decision payload — set by `ROOM_CLOSE_SCRIPT` on the
-   * happy path. JSON-serialized at storage time; decoded in
-   * `getRoomCore` for caller convenience. */
-  decision?: RoomDecision;
 }
 
 /**
- * Room core view returned by `getRoomCore` — `RoomCoreData` plus
- * the live `status`. Reconstructed from two hash fields at read
- * time; the underlying storage uses the split layout so status
- * transitions are single-field HSETs (per design L346, L382).
+ * Room core view returned by `getRoomCore` — the immutable
+ * `RoomCoreData` blob plus the mutable transition fields. Each
+ * mutable field maps to its own hash field on the room key:
+ *
+ *   `data`                       → JSON-encoded RoomCoreData (immutable)
+ *   `status`                     → string (RoomStatus enum)
+ *   `closed_at`                  → ISO 8601 string (set on terminate/close)
+ *   `closed_reason`              → TerminalReason (set on TERMINATE only)
+ *   `deciding_through_sequence`  → integer (set on DECIDE_CLAIM, cleared
+ *                                  on RECOVER + on CLOSE drift path)
+ *   `decision`                   → JSON-encoded RoomDecision (set on
+ *                                  CLOSE happy path only)
+ *
+ * Each transition script HSETs only the fields it changes — never a
+ * read-modify-write of `data`.
  */
 export interface RoomCore extends RoomCoreData {
   status: RoomStatus;
+  /** Set when the room reaches a terminal state (closed | expired). */
+  closed_at?: string;
+  /** Set ONLY by `ROOM_TERMINATE_SCRIPT` (expired/failed_synthesis/
+   * force_close/manual). The queen happy-path close via
+   * `ROOM_CLOSE_SCRIPT` sets `decision` instead and leaves this
+   * undefined — operators distinguish the two paths by which
+   * field is populated. */
+  closed_reason?: TerminalReason;
+  /** Sequence the queen synthesized through (set by claim script,
+   * verified at close to detect mid-synthesis drift). Cleared on
+   * recovery (claim TTL'd before close) and on CLOSE-drift revert. */
+  deciding_through_sequence?: number;
+  /** Decision payload — set ONLY by `ROOM_CLOSE_SCRIPT` on the
+   * queen happy path. */
+  decision?: RoomDecision;
 }
 
 /**
@@ -719,41 +740,80 @@ export async function createRoom(args: {
   return { ...data, status: "awaiting_rsvp" };
 }
 
+/** Internal: parse all room-hash fields into a typed RoomCore. Used
+ * by both `getRoomCore` and `listRooms` so the multi-field
+ * reconstruction logic lives in one place. */
+function parseRoomCoreFields(
+  fields: Record<string, unknown> | null,
+): RoomCore | null {
+  if (
+    fields === null ||
+    fields.data === undefined ||
+    fields.status === undefined
+  ) {
+    return null;
+  }
+  // Upstash auto-parses JSON when the stored value is a JSON string
+  // and the type generic is non-string. Defensive: accept both
+  // shapes (raw string from HSET, object after auto-parse).
+  const data =
+    typeof fields.data === "string"
+      ? (JSON.parse(fields.data) as RoomCoreData)
+      : (fields.data as RoomCoreData);
+  const core: RoomCore = {
+    ...data,
+    status: fields.status as RoomStatus,
+  };
+  // Mutable transition fields — each comes back as its own hash
+  // field (string for primitives, JSON-string for `decision`).
+  if (typeof fields.closed_at === "string") {
+    core.closed_at = fields.closed_at;
+  }
+  if (typeof fields.closed_reason === "string") {
+    core.closed_reason = fields.closed_reason as TerminalReason;
+  }
+  if (
+    fields.deciding_through_sequence !== undefined &&
+    fields.deciding_through_sequence !== null
+  ) {
+    // HSET stores numbers as strings; coerce on read.
+    const n = Number(fields.deciding_through_sequence);
+    if (Number.isFinite(n)) core.deciding_through_sequence = n;
+  }
+  if (fields.decision !== undefined && fields.decision !== null) {
+    core.decision =
+      typeof fields.decision === "string"
+        ? (JSON.parse(fields.decision) as RoomDecision)
+        : (fields.decision as RoomDecision);
+  }
+  return core;
+}
+
 /**
  * Read the room core. Throws `RoomNotFoundError` when the room hash
  * is absent (closed-and-TTL'd, never existed, or installation mismatch).
  *
- * Reconstructs `RoomCore` from the two hash fields the storage shape
- * uses: `data` (JSON blob with everything except status) + `status`
- * (separate field for transition hot-path). See ROOM_OPEN_SCRIPT
- * docstring + WAR_ROOM_DESIGN.md L303-304 for the rationale.
+ * Reconstructs `RoomCore` from the room hash's individual fields:
+ * the `data` field (immutable JSON blob) + `status` (mutable string)
+ * + optional `closed_at` / `closed_reason` /
+ * `deciding_through_sequence` / `decision` set by the transition
+ * scripts. See WAR_ROOM_DESIGN.md L303+L346+L457 for the rationale —
+ * each transition script HSETs only the fields it changes, never
+ * the whole record.
  */
 export async function getRoomCore(args: {
   installationId: string;
   roomId: string;
   redis: Redis;
 }): Promise<RoomCore> {
-  const fields = await args.redis.hgetall<{
-    data?: string | RoomCoreData;
-    status?: string;
-  }>(roomKey(args.installationId, args.roomId));
-  // Upstash returns null for missing-key OR an empty object hash;
-  // both cases are "room not found" from the caller's perspective.
-  if (
-    fields === null ||
-    fields.data === undefined ||
-    fields.status === undefined
-  ) {
+  const fields = await args.redis.hgetall<Record<string, unknown>>(
+    roomKey(args.installationId, args.roomId),
+  );
+  const core = parseRoomCoreFields(fields);
+  if (core === null) {
     throw new RoomNotFoundError(args.installationId, args.roomId);
   }
-  // Upstash auto-parses JSON when the stored value is a JSON string
-  // and the type generic is non-string. Defensive: accept both shapes
-  // (string from raw HSET, object after auto-parse).
-  const data =
-    typeof fields.data === "string"
-      ? (JSON.parse(fields.data) as RoomCoreData)
-      : fields.data;
-  return { ...data, status: fields.status as RoomStatus };
+  return core;
 }
 
 /**
@@ -785,7 +845,7 @@ export async function listRooms(args: {
 
   const fanout = await Promise.all(
     roomIds.map((id) =>
-      args.redis.hgetall<{ data?: string | RoomCoreData; status?: string }>(
+      args.redis.hgetall<Record<string, unknown>>(
         roomKey(args.installationId, id),
       ),
     ),
@@ -794,16 +854,12 @@ export async function listRooms(args: {
   const out: RoomCore[] = [];
   const orphans: string[] = [];
   for (let i = 0; i < fanout.length; i++) {
-    const f = fanout[i];
-    if (f === null || f.data === undefined || f.status === undefined) {
+    const core = parseRoomCoreFields(fanout[i]);
+    if (core === null) {
       orphans.push(roomIds[i]);
       continue;
     }
-    const data =
-      typeof f.data === "string"
-        ? (JSON.parse(f.data) as RoomCoreData)
-        : f.data;
-    out.push({ ...data, status: f.status as RoomStatus });
+    out.push(core);
   }
 
   // Best-effort cleanup of orphaned installation-index entries.


### PR DESCRIPTION
## Summary
Focused refactor that closes #509 guard R1 carry-forward: split the room hash so mutable transition fields (\`closed_at\`, \`closed_reason\`, \`deciding_through_sequence\`, \`decision\`) live as SEPARATE hash fields rather than nested inside the immutable \`data\` JSON blob. Sets up D.1.a-iii.b/c to atomically HSET individual fields per design.

## Why this slice exists separately

The next two D-iii slices add four atomicity-heavy Lua scripts (DECIDE_CLAIM, RECOVER_DECIDING, TERMINATE, CLOSE) that the design (WAR_ROOM_DESIGN.md L303+L346+L457) writes via single-field HSET. If \`closed_at\` etc. lived inside the \`data\` JSON blob, every transition would need a read-modify-write of the whole record — defeating the hash storage shape and creating a needless RMW race surface. Doing the split as its own focused refactor unblocks the next two slices and is reviewable on its own merits.

## Field-by-field map (after this slice)

| Hash field | Set by | Read by |
|---|---|---|
| \`data\` (JSON) | \`ROOM_OPEN_SCRIPT\` (write-once, immutable) | parseRoomCoreFields |
| \`status\` | \`ROOM_OPEN\`, all transition scripts | parseRoomCoreFields |
| \`closed_at\` | \`ROOM_TERMINATE\`, \`ROOM_CLOSE\` | parseRoomCoreFields |
| \`closed_reason\` | \`ROOM_TERMINATE\` only | parseRoomCoreFields |
| \`deciding_through_sequence\` | \`ROOM_DECIDE_CLAIM\` (set), \`RECOVER\` (cleared), \`CLOSE\` drift path (cleared) | parseRoomCoreFields |
| \`decision\` (JSON) | \`ROOM_CLOSE\` happy path only | parseRoomCoreFields |

Operators distinguish CLOSE vs TERMINATE by which mutable field is populated: \`decision\` for queen happy-path close, \`closed_reason\` for terminate paths. Both set \`closed_at\`.

## What changed
- \`RoomCoreData\` interface stripped to immutable fields only.
- \`RoomCore\` extended with \`status\` + four optional mutable fields (\`closed_at\`, \`closed_reason\`, \`deciding_through_sequence\`, \`decision\`).
- New internal helper \`parseRoomCoreFields\` reconstructs \`RoomCore\` from an HGETALL result. Used by both \`getRoomCore\` and \`listRooms\` — DRY single point of behavior.
- \`deciding_through_sequence\` is coerced from string to number on read (Redis HSET stores numbers as strings; parser handles both).
- \`decision\` JSON-string is auto-parsed (mirrors the \`data\` field behavior; defensive against Upstash auto-parse variants).

## What's NOT changed
- \`ROOM_OPEN_SCRIPT\` is unchanged — it only writes \`data\` + \`status\` (never wrote close-related fields anyway).
- No new transition scripts added in this slice — those are D.1.a-iii.b/c.

## What it looks like

A closed room (queen happy path) reads back as:
\`\`\`typescript
{
  // From the `data` JSON blob
  manager: "bot-queen",
  subject_type: "pr_review",
  subject_ref: "hivemoot/hivemoot#508",
  opened_at: "...",
  timing_config: {...},
  // From separate hash fields
  status: "closed",
  closed_at: "2026-04-28T01:00:00.000Z",
  deciding_through_sequence: 42,
  decision: { synthesized_at, synthesis_runner, content, sequence_closed }
  // closed_reason intentionally absent — distinguishes from TERMINATE path
}
\`\`\`

A terminated room (expired/failed_synthesis/force_close/manual) reads back as:
\`\`\`typescript
{
  // ...immutable data fields
  status: "expired",
  closed_at: "...",
  closed_reason: "expired",
  // decision absent — distinguishes from CLOSE happy path
}
\`\`\`

## Test plan
- [x] 134 war-room tests pass (was 131; +3 new)
- [x] Full suite: 1097 / 1 skipped (was 1094)
- [x] \`npx tsc --noEmit\` clean

New regression tests:
- \"reads mutable transition fields from separate hash fields\" — closed room with all four mutable fields populated; verifies happy-path-close shape (decision present, closed_reason absent)
- \"reads closed_reason without decision (terminate path)\" — verifies terminate-path shape
- \"deciding_through_sequence is coerced from string to number\" — Redis HSET stores numbers as strings; parser handles both shapes

## Governance
Same Phase D-series carve-out pattern as #509 / #510.