### PR TITLE
Phase D.1.a-iii.b — synthesis claim + recovery primitives

### DIFF
--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -346,6 +346,90 @@ function makeMockRedis() {
         return [seq];
       }
 
+      // ROOM_DECIDE_CLAIM_SCRIPT — 5 keys, 3 args (D.1.a-iii.b)
+      if (
+        keys.length === 5 &&
+        argv.length === 3 &&
+        script.includes("already_claimed")
+      ) {
+        const [roomK, claimK, statusFromK, statusToK, seqK] = keys;
+        const [roomId, queenRunner, claimTtlSecs] = argv;
+
+        const currStatus = hashes.get(roomK)?.get("status") as
+          | string
+          | undefined;
+        if (currStatus === undefined) return [-1, "room_not_found"];
+        if (currStatus !== "awaiting_contributions") {
+          return [-1, currStatus];
+        }
+        const existingClaim = store.get(claimK);
+        if (existingClaim !== undefined) {
+          const parsed =
+            typeof existingClaim === "string"
+              ? (JSON.parse(existingClaim) as {
+                  runner: string;
+                  throughSequence: number;
+                })
+              : (existingClaim as {
+                  runner: string;
+                  throughSequence: number;
+                });
+          return [
+            0,
+            "already_claimed",
+            parsed.runner,
+            parsed.throughSequence,
+          ];
+        }
+        const seq = store.get(seqK) as number | undefined;
+        if (seq === undefined) return [-1, "no_seq"];
+        const claimJson = JSON.stringify({
+          runner: queenRunner,
+          throughSequence: seq,
+        });
+        // TTL ignored in mock (no time travel simulated); the
+        // caller-set `_opts.ex` would normally apply.
+        store.set(claimK, claimJson);
+        // claimTtlSecs intentionally ignored — mock doesn't simulate
+        // TTL. Tests cover the script semantics, not Redis TTL.
+        void claimTtlSecs;
+        getHash(roomK).set("status", "deciding");
+        getHash(roomK).set("deciding_through_sequence", String(seq));
+        getSet(statusFromK).delete(roomId);
+        getSet(statusToK).add(roomId);
+        return [1, seq];
+      }
+
+      // ROOM_RECOVER_DECIDING_SCRIPT — 6 keys, 2 args (D.1.a-iii.b)
+      if (
+        keys.length === 6 &&
+        argv.length === 2 &&
+        script.includes("claim_active")
+      ) {
+        const [roomK, claimK, statusFromK, statusToK, seqK, eventsK] = keys;
+        const [roomId, eventTemplate] = argv;
+
+        const currStatus = hashes.get(roomK)?.get("status") as
+          | string
+          | undefined;
+        if (currStatus === undefined) return [-1, "room_not_found"];
+        if (currStatus !== "deciding") return [-1, currStatus];
+        if (store.has(claimK)) return [0, "claim_active"];
+
+        const oldSeq = (store.get(seqK) as number | undefined) ?? 0;
+        const seq = oldSeq + 1;
+        store.set(seqK, seq);
+        const eventJson = eventTemplate.replace("__SEQ__", String(seq));
+        getSortedSet(eventsK).push({ member: eventJson, score: seq });
+        getHash(roomK).set("status", "awaiting_contributions");
+        // Empty-string sentinel per design L415 / L523 — must NOT
+        // be coerced via `Number("")===0` (closes #511 builder R1).
+        getHash(roomK).set("deciding_through_sequence", "");
+        getSet(statusFromK).delete(roomId);
+        getSet(statusToK).add(roomId);
+        return [1, seq];
+      }
+
       return null;
     },
   );
@@ -2953,5 +3037,408 @@ describe("D.1.a-ii R4 — participant-state precondition (manager-loop race prot
         redis,
       }),
     ).resolves.toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D.1.a-iii.b — claimSynthesis + recoverDeciding
+// ---------------------------------------------------------------------------
+
+import {
+  SYNTHESIS_CLAIM_TTL_SECS,
+  ROOM_DECIDE_CLAIM_SCRIPT,
+  ROOM_RECOVER_DECIDING_SCRIPT,
+  claimSynthesis,
+  recoverDeciding,
+  RoomClaimAlreadyHeldError,
+  RoomTransitionInvalidStatusError,
+} from "./war-room";
+
+describe("D.1.a-iii.b constants", () => {
+  it("SYNTHESIS_CLAIM_TTL_SECS is 360 (6 min — 1 min above Vercel maxDuration)", () => {
+    expect(SYNTHESIS_CLAIM_TTL_SECS).toBe(360);
+  });
+});
+
+describe("D.1.a-iii.b ROOM_DECIDE_CLAIM_SCRIPT source", () => {
+  it("references status precondition + atomic claim+status flip", () => {
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain("awaiting_contributions");
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain("deciding");
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain("already_claimed");
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain("deciding_through_sequence");
+    // Status-set membership migration
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain("srem");
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain("sadd");
+    // TTL applied to claim key
+    expect(ROOM_DECIDE_CLAIM_SCRIPT).toContain('"EX"');
+  });
+});
+
+describe("D.1.a-iii.b ROOM_RECOVER_DECIDING_SCRIPT source", () => {
+  it("references claim-active guard + status revert + recovery event", () => {
+    expect(ROOM_RECOVER_DECIDING_SCRIPT).toContain("deciding");
+    expect(ROOM_RECOVER_DECIDING_SCRIPT).toContain("awaiting_contributions");
+    expect(ROOM_RECOVER_DECIDING_SCRIPT).toContain("claim_active");
+    // Empty-string sentinel for cleared deciding_through_sequence
+    // (closes #511 builder R1 — Number("") === 0 misread)
+    expect(ROOM_RECOVER_DECIDING_SCRIPT).toContain('"deciding_through_sequence", ""');
+    // Capped gsub (1 substitution) per #510 guard B1
+    expect(ROOM_RECOVER_DECIDING_SCRIPT).toContain("gsub");
+    expect(ROOM_RECOVER_DECIDING_SCRIPT).toContain(", 1)");
+  });
+});
+
+describe("claimSynthesis", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    // Claim requires `awaiting_contributions` — bump for the suite.
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+  });
+
+  it("acquires the claim and returns throughSequence + claimTtlSecs", async () => {
+    const result = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-host-1.pid42.tick0",
+      redis,
+    });
+    expect(result.throughSequence).toBe(1);
+    expect(result.claimTtlSecs).toBe(SYNTHESIS_CLAIM_TTL_SECS);
+
+    // Side effects: status flipped, deciding_through_sequence set,
+    // claim key written, status-set membership migrated.
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("deciding");
+    expect(room?.deciding_through_sequence).toBe(1);
+    const storedClaim = await redis.get<string>(claimKey(RID_A));
+    expect(storedClaim).toBeTruthy();
+    if (!storedClaim) throw new Error("claim missing after acquisition");
+    const claim =
+      typeof storedClaim === "string"
+        ? (JSON.parse(storedClaim) as {
+            runner: string;
+            throughSequence: number;
+          })
+        : (storedClaim as unknown as {
+            runner: string;
+            throughSequence: number;
+          });
+    expect(claim.runner).toBe("queen-host-1.pid42.tick0");
+    expect(claim.throughSequence).toBe(1);
+  });
+
+  it("respects an explicit claimTtlSecs override", async () => {
+    const result = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-A",
+      claimTtlSecs: 120,
+      redis,
+    });
+    expect(result.claimTtlSecs).toBe(120);
+  });
+
+  it("second concurrent claim hits status precondition (first claim atomically flipped status → deciding)", async () => {
+    await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-A",
+      redis,
+    });
+    // Second claim — status is now `deciding`, so status precondition
+    // fires BEFORE the claim-existence check. This is by design:
+    // status is the canonical state, claim is a secondary signal.
+    // The `already_claimed` branch only fires in desync edge cases
+    // (status=awaiting_contributions but claim already present).
+    try {
+      await claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen-B",
+        redis,
+      });
+      throw new Error("expected RoomTransitionInvalidStatusError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomTransitionInvalidStatusError);
+      const tErr = err as RoomTransitionInvalidStatusError;
+      expect(tErr.actualStatus).toBe("deciding");
+      expect(tErr.action).toBe("claim_synthesis");
+    }
+  });
+
+  it("desync edge case: status=awaiting_contributions + claim already present → RoomClaimAlreadyHeldError with holder + throughSeq", async () => {
+    // Manually rig the desync state — this should never happen in
+    // normal flow (claim+status flip is atomic), but the script's
+    // `already_claimed` branch is a defensive safety net for
+    // partial-write recovery bugs or manual ops intervention.
+    await redis.set(
+      claimKey(RID_A),
+      JSON.stringify({ runner: "queen-A", throughSequence: 1 }),
+    );
+    // Status is already awaiting_contributions from beforeEach.
+    try {
+      await claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen-B",
+        redis,
+      });
+      throw new Error("expected RoomClaimAlreadyHeldError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomClaimAlreadyHeldError);
+      const claimErr = err as RoomClaimAlreadyHeldError;
+      expect(claimErr.heldByRunner).toBe("queen-A");
+      expect(claimErr.throughSequence).toBe(1);
+      expect(claimErr.roomId).toBe(RID_A);
+    }
+  });
+
+  it("status precondition: rejects awaiting_rsvp with RoomTransitionInvalidStatusError", async () => {
+    // Reset status back to awaiting_rsvp
+    await redis.hset(roomKey("12345", RID_A), { status: "awaiting_rsvp" });
+    try {
+      await claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen-A",
+        redis,
+      });
+      throw new Error("expected RoomTransitionInvalidStatusError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomTransitionInvalidStatusError);
+      const tErr = err as RoomTransitionInvalidStatusError;
+      expect(tErr.action).toBe("claim_synthesis");
+      expect(tErr.expectedStatuses).toEqual(["awaiting_contributions"]);
+      expect(tErr.actualStatus).toBe("awaiting_rsvp");
+    }
+  });
+
+  it("status precondition: rejects deciding (idempotent claim attempt) with RoomTransitionInvalidStatusError", async () => {
+    // First claim succeeds and flips status to deciding
+    await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-A",
+      redis,
+    });
+    // Manually clear the claim key to simulate the holder having
+    // released without status revert (shouldn't happen but the
+    // script must be defensive).
+    await redis.del(claimKey(RID_A));
+    try {
+      await claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen-B",
+        redis,
+      });
+      throw new Error("expected RoomTransitionInvalidStatusError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomTransitionInvalidStatusError);
+      const tErr = err as RoomTransitionInvalidStatusError;
+      expect(tErr.actualStatus).toBe("deciding");
+    }
+  });
+
+  it("missing room → RoomNotFoundError", async () => {
+    await expect(
+      claimSynthesis({
+        installationId: "12345",
+        roomId: RID_C, // never created
+        queenRunner: "queen-A",
+        redis,
+      }),
+    ).rejects.toThrow(RoomNotFoundError);
+  });
+});
+
+describe("recoverDeciding", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+  });
+
+  it("reverts deciding → awaiting_contributions when claim TTL has expired (claim missing)", async () => {
+    // Drive the room into `deciding` via claimSynthesis…
+    await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-crashed",
+      redis,
+    });
+    // …then expire the claim key (simulating Redis TTL expiry).
+    await redis.del(claimKey(RID_A));
+
+    const result = await recoverDeciding({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(result.recovered).toBe(true);
+    if (result.recovered) {
+      expect(result.sequence).toBeGreaterThan(1);
+    }
+
+    // Side effects: status reverted, deciding_through_sequence
+    // cleared (empty string sentinel — NOT 0), recovery event emitted.
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("awaiting_contributions");
+    expect(room?.deciding_through_sequence).toBeUndefined();
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    const recoveryEvt = events.find((e) => e.event_type === "room_recovered");
+    expect(recoveryEvt).toBeDefined();
+    expect(recoveryEvt?.actor_role).toBe("manager");
+    expect((recoveryEvt?.body as { reason: string }).reason).toBe(
+      "claim_ttl_expired",
+    );
+  });
+
+  it("skips recovery when claim is still active — returns { recovered: false, reason: 'claim_active' }", async () => {
+    await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-still-running",
+      redis,
+    });
+    // Claim KEY is still set — recovery must skip.
+    const result = await recoverDeciding({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(result.recovered).toBe(false);
+    if (!result.recovered) {
+      expect(result.reason).toBe("claim_active");
+    }
+
+    // Status MUST still be deciding (recovery did not fire).
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("deciding");
+    expect(room?.deciding_through_sequence).toBe(1);
+  });
+
+  it("rejects recovery when room is not in deciding (e.g. already awaiting_contributions)", async () => {
+    // Room is in awaiting_contributions from beforeEach setup.
+    try {
+      await recoverDeciding({
+        installationId: "12345",
+        roomId: RID_A,
+        redis,
+      });
+      throw new Error("expected RoomTransitionInvalidStatusError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomTransitionInvalidStatusError);
+      const tErr = err as RoomTransitionInvalidStatusError;
+      expect(tErr.action).toBe("recover_deciding");
+      expect(tErr.expectedStatuses).toEqual(["deciding"]);
+      expect(tErr.actualStatus).toBe("awaiting_contributions");
+    }
+  });
+
+  it("missing room → RoomNotFoundError", async () => {
+    await expect(
+      recoverDeciding({
+        installationId: "12345",
+        roomId: RID_C,
+        redis,
+      }),
+    ).rejects.toThrow(RoomNotFoundError);
+  });
+
+  it("end-to-end: claim → expire → recover → re-claim cycle works", async () => {
+    // Cycle 1: claim
+    const c1 = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-A",
+      redis,
+    });
+    expect(c1.throughSequence).toBe(1);
+
+    // Crash: claim key TTL'd out
+    await redis.del(claimKey(RID_A));
+
+    // Recovery
+    const r = await recoverDeciding({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(r.recovered).toBe(true);
+
+    // Cycle 2: another runner picks it back up
+    const c2 = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-B",
+      redis,
+    });
+    // The recovery event bumped the sequence, so cycle 2's
+    // throughSequence is strictly > cycle 1's. The new claim's
+    // through-sequence reflects the post-recovery state.
+    expect(c2.throughSequence).toBeGreaterThan(c1.throughSequence);
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("deciding");
+    expect(room?.deciding_through_sequence).toBe(c2.throughSequence);
+  });
+
+  it("recovery event sequence is captured atomically (drift detection foundation for D.1.a-iii.c)", async () => {
+    await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-A",
+      redis,
+    });
+    await redis.del(claimKey(RID_A));
+    const result = await recoverDeciding({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    if (!result.recovered) throw new Error("expected recovery");
+    // The returned sequence is the NEW current sequence (post-recovery).
+    // ROOM_CLOSE in D.1.a-iii.c will compare deciding_through_sequence
+    // against current seq to detect events arrived during synthesis;
+    // the recovery primitive's job is to leave the room in a state
+    // where that comparison is meaningful for the NEXT claim cycle.
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    const recovery = events.find((e) => e.event_type === "room_recovered");
+    expect(recovery?.seq).toBe(result.sequence);
   });
 });

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -916,6 +916,21 @@ export const ROOM_CONTRIBUTION_RAW_MD_MAX_BYTES = 32 * 1024;
  *   max_age_secs default 3600 → idem TTL default 7200 (2 h). */
 export const IDEM_TTL_MULTIPLIER = 2;
 
+/**
+ * Synthesis claim TTL in seconds. Per WAR_ROOM_DESIGN.md
+ * §"Storage layout" claim row: **6 minutes — intentionally 1 minute
+ * ABOVE Vercel Pro's `maxDuration` of 5 minutes** (closes guard R3
+ * N7 recovery-vs-synthesis double-post race).
+ *
+ * The +1m buffer means a queen runner that's still mid-synthesis
+ * when its serverless function's 5-minute maxDuration kills it
+ * will have already had its claim TTL refreshed (or be on a fresh
+ * tick). Recovery scripts only fire when the claim has GENUINELY
+ * expired, so a stale recovery can't race a still-active queen
+ * runner that hasn't quite finished posting `/close`.
+ */
+export const SYNTHESIS_CLAIM_TTL_SECS = 360;
+
 /** Contribution body bounds per WAR_ROOM_DESIGN.md L1166-1188. */
 export const CONTRIBUTION_SUMMARY_MAX_CHARS = 500;
 export const CONTRIBUTION_FINDING_AREA_MAX_CHARS = 80;
@@ -1061,6 +1076,68 @@ export class RoomContributionTooLargeError extends Error {
     );
     this.name = "RoomContributionTooLargeError";
     this.sizeBytes = sizeBytes;
+  }
+}
+
+/**
+ * Thrown when `ROOM_DECIDE_CLAIM_SCRIPT` finds the synthesis claim
+ * already held by another queen runner (benign conflict — the
+ * caller should skip this tick and re-attempt on the next manager
+ * loop cycle, OR observe the holder via `heldByRunner`).
+ *
+ * Per WAR_ROOM_DESIGN.md the claim TTL is 6 minutes (1 minute above
+ * Vercel Pro's 5-minute maxDuration cap), so a true crash recovery
+ * is bounded — `recoverDeciding` runs against rooms whose claims
+ * have actually expired.
+ */
+export class RoomClaimAlreadyHeldError extends Error {
+  public readonly roomId: string;
+  public readonly heldByRunner: string;
+  public readonly throughSequence: number;
+  constructor(
+    roomId: string,
+    heldByRunner: string,
+    throughSequence: number,
+  ) {
+    super(
+      `Synthesis claim for room ${roomId} is already held by ${JSON.stringify(heldByRunner)} through sequence ${throughSequence}. Skip this tick; the claim TTL will release on crash.`,
+    );
+    this.name = "RoomClaimAlreadyHeldError";
+    this.roomId = roomId;
+    this.heldByRunner = heldByRunner;
+    this.throughSequence = throughSequence;
+  }
+}
+
+/**
+ * Thrown when a status-changing transition (claim, recover) is
+ * called on a room whose current status doesn't match the action's
+ * allowed-from list.
+ *
+ * For `claimSynthesis`: room must be in `awaiting_contributions`.
+ * For `recoverDeciding`: room must be in `deciding`. (Other status
+ * transitions — TERMINATE, CLOSE — land in D.1.a-iii.c with their
+ * own allowed-from lists.)
+ */
+export class RoomTransitionInvalidStatusError extends Error {
+  public readonly roomId: string;
+  public readonly action: string;
+  public readonly expectedStatuses: RoomStatus[];
+  public readonly actualStatus: string;
+  constructor(
+    roomId: string,
+    action: string,
+    expectedStatuses: RoomStatus[],
+    actualStatus: string,
+  ) {
+    super(
+      `Room ${roomId} is in status ${JSON.stringify(actualStatus)}; ${action} requires one of [${expectedStatuses.map((s) => JSON.stringify(s)).join(", ")}].`,
+    );
+    this.name = "RoomTransitionInvalidStatusError";
+    this.roomId = roomId;
+    this.action = action;
+    this.expectedStatuses = expectedStatuses;
+    this.actualStatus = actualStatus;
   }
 }
 
@@ -1640,6 +1717,114 @@ if ARGV[12] ~= "" then
   redis.call("hset", KEYS[6], ARGV[4], ARGV[12])
 end
 return {seq}
+`;
+
+/**
+ * ROOM_DECIDE_CLAIM_SCRIPT — atomic synthesis claim acquisition.
+ *
+ * Per WAR_ROOM_DESIGN.md §"Storage layout" + §"Manager loop", a
+ * single queen runner claims the synthesis lane for a room atomically:
+ *   1. Room must be in `awaiting_contributions` (status precondition)
+ *   2. Claim key must be unset (TTL'd or never claimed)
+ *   3. Atomically: SET claim with TTL + HSET status="deciding" +
+ *      HSET deciding_through_sequence=currentSeq + status-set membership
+ *
+ * The claim record is `{runner, throughSequence}` JSON. The
+ * `throughSequence` is captured at claim time and verified at
+ * `ROOM_CLOSE` time to detect new-event drift during synthesis
+ * (D.1.a-iii.c). The TTL (6 min, see SYNTHESIS_CLAIM_TTL_SECS) is
+ * 1 min above Vercel Pro's maxDuration so a crash recovery is
+ * bounded but doesn't race the still-running queen.
+ *
+ * KEYS:
+ *   [1] roomKey                  — room hash (status + deciding_through_sequence)
+ *   [2] claimKey                 — synthesis claim with TTL
+ *   [3] statusSetAwaitingKey     — status:awaiting_contributions index
+ *   [4] statusSetDecidingKey     — status:deciding index
+ *   [5] seqKey                   — current sequence counter (read for throughSequence)
+ *
+ * ARGV:
+ *   [1] roomId                   — for set membership updates
+ *   [2] queenRunner              — opaque runner identity string
+ *   [3] claimTtlSecs             — TTL for the claim key
+ *
+ * Returns:
+ *   {1, throughSequence}                      claim acquired
+ *   {0, "already_claimed", runner, throughSeq} another runner holds it
+ *   {-1, currentStatus}                       not in awaiting_contributions
+ */
+export const ROOM_DECIDE_CLAIM_SCRIPT = `
+local currStatus = redis.call("hget", KEYS[1], "status")
+if not currStatus then return {-1, "room_not_found"} end
+if currStatus ~= "awaiting_contributions" then
+  return {-1, currStatus}
+end
+local existingClaim = redis.call("get", KEYS[2])
+if existingClaim then
+  local parsed = cjson.decode(existingClaim)
+  return {0, "already_claimed", parsed.runner, parsed.throughSequence}
+end
+local seq = redis.call("get", KEYS[5])
+if not seq then return {-1, "no_seq"} end
+local seqNum = tonumber(seq)
+local claimJson = cjson.encode({runner = ARGV[2], throughSequence = seqNum})
+redis.call("set", KEYS[2], claimJson, "EX", tonumber(ARGV[3]))
+redis.call("hset", KEYS[1], "status", "deciding", "deciding_through_sequence", tostring(seqNum))
+redis.call("srem", KEYS[3], ARGV[1])
+redis.call("sadd", KEYS[4], ARGV[1])
+return {1, seqNum}
+`;
+
+/**
+ * ROOM_RECOVER_DECIDING_SCRIPT — revert deciding → awaiting_contributions
+ * when the synthesis claim TTL has expired.
+ *
+ * Called by the manager loop's recovery branch. Critical: only
+ * fires when the claim KEY is genuinely gone (TTL'd by Redis), NOT
+ * when a queen runner is still actively claimed. The script
+ * verifies via `EXISTS claim` and returns benignly if the claim
+ * is still active (caller skips this tick).
+ *
+ * Atomicity:
+ *   1. Room status precondition (must be `deciding`)
+ *   2. Claim key existence check (must be MISSING for recovery to fire)
+ *   3. Atomically: INCR seq + ZADD recovery event + HSET status →
+ *      awaiting_contributions + clear deciding_through_sequence (via
+ *      empty-string sentinel per design L415) + status-set membership
+ *
+ * KEYS:
+ *   [1] roomKey                — room hash
+ *   [2] claimKey               — synthesis claim (must NOT exist)
+ *   [3] statusSetDecidingKey   — status:deciding index (SREM)
+ *   [4] statusSetAwaitingKey   — status:awaiting_contributions index (SADD)
+ *   [5] seqKey                 — sequence counter (for recovery event)
+ *   [6] eventsKey              — event log sorted set
+ *
+ * ARGV:
+ *   [1] roomId                 — for set membership updates
+ *   [2] recoveryEventTemplate  — JSON with `__SEQ__` placeholder
+ *
+ * Returns:
+ *   {1, sequence}              recovered (event emitted, status reverted)
+ *   {0, "claim_active"}        claim still alive — caller skips this tick
+ *   {-1, currentStatus}        room not in `deciding` (already moved on)
+ */
+export const ROOM_RECOVER_DECIDING_SCRIPT = `
+local currStatus = redis.call("hget", KEYS[1], "status")
+if not currStatus then return {-1, "room_not_found"} end
+if currStatus ~= "deciding" then
+  return {-1, currStatus}
+end
+if redis.call("exists", KEYS[2]) == 1 then
+  return {0, "claim_active"}
+end
+local seq = redis.call("incr", KEYS[5])
+local eventJson = string.gsub(ARGV[2], "__SEQ__", tostring(seq), 1)
+redis.call("zadd", KEYS[6], seq, eventJson)
+redis.call("hset", KEYS[1], "status", "awaiting_contributions", "deciding_through_sequence", "")
+redis.call("srem", KEYS[3], ARGV[1])
+redis.call("sadd", KEYS[4], ARGV[1])
+return {1, seq}
 `;
 
 // ---------------------------------------------------------------------------
@@ -2366,6 +2551,212 @@ export async function timeoutParticipant(args: {
     idemTtlSecs: idemTtlSecs(args.roomMaxAgeSecs ?? DEFAULT_MAX_AGE_SECS),
     redis: args.redis,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis claim / recovery primitives (D.1.a-iii.b)
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a successful synthesis claim acquisition. The
+ * `throughSequence` is captured atomically by the script and is
+ * the value that ROOM_CLOSE will compare against the current
+ * sequence at close-time to detect new-event drift during
+ * synthesis (D.1.a-iii.c).
+ */
+export interface ClaimSynthesisResult {
+  throughSequence: number;
+  claimTtlSecs: number;
+}
+
+/**
+ * Acquire the synthesis claim for a room — atomic transition from
+ * `awaiting_contributions` → `deciding` with claim TTL.
+ *
+ * Single-runner-wins: only one queen runner across the fleet can
+ * hold the claim at a time. The TTL (default 6 minutes — see
+ * `SYNTHESIS_CLAIM_TTL_SECS`) is intentionally 1 minute above
+ * Vercel Pro's 5-minute `maxDuration` so that a queen runner that
+ * crashes mid-synthesis releases its claim only after a buffer
+ * window. `recoverDeciding` then fires on the next manager tick.
+ *
+ * Sibling effects (all atomic):
+ *   - Status flips `awaiting_contributions` → `deciding`
+ *   - `deciding_through_sequence` is set to the current sequence
+ *     (frozen at claim time so close-time drift detection can fire)
+ *   - Status-set membership migrates from awaiting → deciding
+ *
+ * Throws:
+ *   - `RoomClaimAlreadyHeldError` when another runner holds it
+ *     (carries `heldByRunner` + `throughSequence` for caller log)
+ *   - `RoomTransitionInvalidStatusError` when the room is not in
+ *     `awaiting_contributions` (already deciding / closed / etc.)
+ *   - `RoomNotFoundError` when the room hash is gone (TTL'd or
+ *     never opened)
+ */
+export async function claimSynthesis(args: {
+  installationId: string;
+  roomId: string;
+  /** Opaque queen runner identity (hostname + pid + monotonic).
+   * Stored in the claim record so observers know who holds it. */
+  queenRunner: string;
+  claimTtlSecs?: number;
+  redis: Redis;
+}): Promise<ClaimSynthesisResult> {
+  const ttl = args.claimTtlSecs ?? SYNTHESIS_CLAIM_TTL_SECS;
+
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      ROOM_DECIDE_CLAIM_SCRIPT,
+      [
+        roomKey(args.installationId, args.roomId),
+        claimKey(args.roomId),
+        statusIndexKey(args.installationId, "awaiting_contributions"),
+        statusIndexKey(args.installationId, "deciding"),
+        seqKey(args.roomId),
+      ],
+      [args.roomId, args.queenRunner, String(ttl)],
+    ),
+  );
+
+  if (result.ok === 1 && typeof result.tag1 === "number") {
+    return { throughSequence: result.tag1, claimTtlSecs: ttl };
+  }
+  if (
+    result.ok === 0 &&
+    result.tag1 === "already_claimed" &&
+    typeof result.tag2 === "string"
+  ) {
+    // Script returns {0, "already_claimed", runner, throughSeq} — but
+    // ScriptResult only captures tag1+tag2. Re-decode the existing
+    // claim payload to surface the through-sequence, since the script
+    // already validated the status precondition before this branch.
+    const existing = await args.redis.get<string>(claimKey(args.roomId));
+    let heldByRunner = result.tag2;
+    let throughSequence = 0;
+    if (existing) {
+      try {
+        const parsed =
+          typeof existing === "string"
+            ? (JSON.parse(existing) as { runner?: string; throughSequence?: number })
+            : (existing as { runner?: string; throughSequence?: number });
+        if (typeof parsed.runner === "string") heldByRunner = parsed.runner;
+        if (typeof parsed.throughSequence === "number") {
+          throughSequence = parsed.throughSequence;
+        }
+      } catch {
+        // Fall through with tag2 as runner, 0 as throughSequence.
+      }
+    }
+    throw new RoomClaimAlreadyHeldError(
+      args.roomId,
+      heldByRunner,
+      throughSequence,
+    );
+  }
+  if (result.ok === -1 && typeof result.tag1 === "string") {
+    if (result.tag1 === "room_not_found" || result.tag1 === "no_seq") {
+      throw new RoomNotFoundError(args.installationId, args.roomId);
+    }
+    throw new RoomTransitionInvalidStatusError(
+      args.roomId,
+      "claim_synthesis",
+      ["awaiting_contributions"],
+      result.tag1,
+    );
+  }
+  throw new Error(
+    `ROOM_DECIDE_CLAIM_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
+}
+
+/**
+ * Recover a stuck `deciding` room when its synthesis claim TTL has
+ * expired. Reverts status to `awaiting_contributions` and emits a
+ * `room_recovered` event so observers can see why the manager
+ * loop re-opened it.
+ *
+ * Called from the bot's manager loop. Critical guard: the script
+ * verifies the claim key has GENUINELY expired (`EXISTS` returns 0)
+ * before reverting. If a still-active queen runner holds the claim,
+ * the script returns `{0, "claim_active"}` and this primitive
+ * returns `null` — the caller skips this tick and re-scans next.
+ *
+ * Atomicity:
+ *   - INCR seq + ZADD recovery event + HSET status + clear
+ *     `deciding_through_sequence` (empty-string sentinel) + status-set
+ *     membership update — all in one EVAL.
+ *
+ * Returns:
+ *   - `{ recovered: true, sequence }` — recovery event emitted
+ *   - `{ recovered: false, reason: "claim_active" }` — still active
+ *
+ * Throws:
+ *   - `RoomTransitionInvalidStatusError` if the room is not
+ *     `deciding` (already closed / terminated / awaiting via another
+ *     recovery path)
+ *   - `RoomNotFoundError` if the room hash is gone entirely
+ */
+export async function recoverDeciding(args: {
+  installationId: string;
+  roomId: string;
+  redis: Redis;
+  nowMs?: number;
+}): Promise<
+  | { recovered: true; sequence: number }
+  | { recovered: false; reason: "claim_active" }
+> {
+  const nowIso = new Date(args.nowMs ?? Date.now()).toISOString();
+
+  // Build the recovery event template with __SEQ__ placeholder; Lua
+  // gsub (capped at first match) substitutes the actual sequence
+  // atomically with the status revert. The template uses the same
+  // pattern as `appendRoomEvent` for consistency.
+  const eventTemplate = JSON.stringify({
+    seq: "__SEQ__",
+    timestamp: nowIso,
+    event_type: "room_recovered",
+    actor_role: "manager",
+    actor_id: "watchdog",
+    body: { reason: "claim_ttl_expired" },
+  });
+  const luaTemplate = eventTemplate.replace('"__SEQ__"', "__SEQ__");
+
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      ROOM_RECOVER_DECIDING_SCRIPT,
+      [
+        roomKey(args.installationId, args.roomId),
+        claimKey(args.roomId),
+        statusIndexKey(args.installationId, "deciding"),
+        statusIndexKey(args.installationId, "awaiting_contributions"),
+        seqKey(args.roomId),
+        eventsKey(args.roomId),
+      ],
+      [args.roomId, luaTemplate],
+    ),
+  );
+
+  if (result.ok === 1 && typeof result.tag1 === "number") {
+    return { recovered: true, sequence: result.tag1 };
+  }
+  if (result.ok === 0 && result.tag1 === "claim_active") {
+    return { recovered: false, reason: "claim_active" };
+  }
+  if (result.ok === -1 && typeof result.tag1 === "string") {
+    if (result.tag1 === "room_not_found") {
+      throw new RoomNotFoundError(args.installationId, args.roomId);
+    }
+    throw new RoomTransitionInvalidStatusError(
+      args.roomId,
+      "recover_deciding",
+      ["deciding"],
+      result.tag1,
+    );
+  }
+  throw new Error(
+    `ROOM_RECOVER_DECIDING_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #513

## Summary

Phase D.1.a-iii.b of the war-room storage layer — the atomic state machine driving the synthesis claim lane.

Two new Lua scripts and matching high-level primitives:

- **`ROOM_DECIDE_CLAIM_SCRIPT`** — atomically flips a room from `awaiting_contributions` → `deciding` while acquiring the synthesis claim. Captures `throughSequence` at claim time so `ROOM_CLOSE` (D.1.a-iii.c) can detect new-event drift during synthesis.
- **`ROOM_RECOVER_DECIDING_SCRIPT`** — reverts `deciding` → `awaiting_contributions` when the claim TTL has expired. Defensively checks claim-key absence before acting; a still-active queen runner never races recovery.

Claim TTL is 360s (6 min) — intentionally **1 minute above Vercel Pro's 5-minute `maxDuration`** so a crashed queen runner's claim is bounded but recovery cannot race a still-running synthesis function.

Status precondition is the canonical gate; the `already_claimed` branch is a defensive safety net for partial-write desync (e.g., a claim key that persists past a status revert from a buggy recovery path). Tests cover **both** the typical "second-claim-loses-on-status-precondition" path AND the manually-rigged desync edge case.

## What it looks like

**Behavior table — `claimSynthesis`:**

| Initial state | Result |
|---|---|
| status=`awaiting_contributions`, claim absent | acquires, returns `{throughSequence, claimTtlSecs}` |
| status=`deciding` (someone holds it) | `RoomTransitionInvalidStatusError(actualStatus="deciding")` |
| status=`awaiting_rsvp` | `RoomTransitionInvalidStatusError(actualStatus="awaiting_rsvp")` |
| status=`awaiting_contributions` BUT claim already set (desync) | `RoomClaimAlreadyHeldError(heldByRunner, throughSequence)` |
| room missing | `RoomNotFoundError` |

**Behavior table — `recoverDeciding`:**

| Initial state | Result |
|---|---|
| status=`deciding`, claim TTL'd (key absent) | `{recovered: true, sequence}` — emits `room_recovered` event, reverts status |
| status=`deciding`, claim still active | `{recovered: false, reason: "claim_active"}` — caller skips this tick |
| status=`awaiting_contributions` (already moved on) | `RoomTransitionInvalidStatusError` |
| room missing | `RoomNotFoundError` |

**Recovery event shape:**
```json
{
  "seq": 4,
  "timestamp": "2026-04-28T06:30:00.000Z",
  "event_type": "room_recovered",
  "actor_role": "manager",
  "actor_id": "watchdog",
  "body": { "reason": "claim_ttl_expired" }
}
```

**End-to-end cycle (test-verified):**
1. `claimSynthesis(queen-A)` → status=`deciding`, throughSeq=1
2. Queen-A's serverless function dies (claim key TTL'd)
3. `recoverDeciding()` → status=`awaiting_contributions`, emits `room_recovered` event (seq=2)
4. `claimSynthesis(queen-B)` → status=`deciding`, throughSeq=2 (post-recovery sequence)

## Test plan

- [x] Typecheck (`tsc --noEmit`) clean
- [x] Full web suite passes: 1115 tests passing (152 in `war-room.test.ts`)
- [x] 11 new tests covering: claim acquisition, claim-already-held desync, status precondition (both `awaiting_rsvp` and `deciding`), missing-room, recovery success, claim-active-skip, recovery wrong-status, missing-room-on-recover, end-to-end cycle, atomic sequence capture
- [x] Source-shape tests: both Lua scripts include the expected guard tokens (`already_claimed`, `claim_active`, `EX`, capped `gsub`, empty-string sentinel for cleared `deciding_through_sequence`)
- [ ] Reviewer fleet (guard / builder / drone) sign-off