### PR TITLE
Phase D.1.a-iii.c — TERMINATE + CLOSE + drift detection

### DIFF
--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -346,7 +346,7 @@ function makeMockRedis() {
         return [seq];
       }
 
-      // ROOM_DECIDE_CLAIM_SCRIPT — 5 keys, 3 args (D.1.a-iii.b)
+      // ROOM_DECIDE_CLAIM_SCRIPT — 5 keys, 3 args (D.1.a-iii.b/c)
       if (
         keys.length === 5 &&
         argv.length === 3 &&
@@ -364,21 +364,33 @@ function makeMockRedis() {
         }
         const existingClaim = store.get(claimK);
         if (existingClaim !== undefined) {
-          const parsed =
-            typeof existingClaim === "string"
-              ? (JSON.parse(existingClaim) as {
-                  runner: string;
-                  throughSequence: number;
-                })
-              : (existingClaim as {
-                  runner: string;
-                  throughSequence: number;
-                });
+          // Mirror the script's pcall(cjson.decode, ...) — corrupted
+          // payloads return decode_error rather than panicking.
+          let parsed: { runner: string; throughSequence: number };
+          try {
+            parsed =
+              typeof existingClaim === "string"
+                ? (JSON.parse(existingClaim) as {
+                    runner: string;
+                    throughSequence: number;
+                  })
+                : (existingClaim as {
+                    runner: string;
+                    throughSequence: number;
+                  });
+          } catch {
+            return [-3, "decode_error"];
+          }
+          // R3 (D.1.a-iii.c): JSON-pack holder info into single
+          // tag2 string instead of positional tag3+tag4 (closes
+          // #512 guard N1 — dispatchScriptResult was dropping tag3+).
           return [
             0,
             "already_claimed",
-            parsed.runner,
-            parsed.throughSequence,
+            JSON.stringify({
+              runner: parsed.runner,
+              throughSequence: parsed.throughSequence,
+            }),
           ];
         }
         const seq = store.get(seqK) as number | undefined;
@@ -428,6 +440,149 @@ function makeMockRedis() {
         getSet(statusFromK).delete(roomId);
         getSet(statusToK).add(roomId);
         return [1, seq];
+      }
+
+      // ROOM_TERMINATE_SCRIPT — 10 keys, 5 args (D.1.a-iii.c)
+      if (
+        keys.length === 10 &&
+        argv.length === 5 &&
+        script.includes("closed_reason")
+      ) {
+        const [
+          roomK,
+          subjectIdxK,
+          statusCurrK,
+          installK,
+          repoK,
+          seqK,
+          eventsK,
+          _participantsK,
+          _contributionsK,
+          claimK,
+        ] = keys;
+        const [roomId, eventTemplate, closedAt, retentionSecs, closedReason] =
+          argv;
+
+        const currStatus = hashes.get(roomK)?.get("status") as
+          | string
+          | undefined;
+        if (currStatus === undefined) return [-1, "room_not_found"];
+        if (currStatus === "closed") return [-1, currStatus];
+
+        // DEL claim if any (deciding-state cleanup; closes design R3 N8)
+        store.delete(claimK);
+
+        const oldSeq = (store.get(seqK) as number | undefined) ?? 0;
+        const seq = oldSeq + 1;
+        store.set(seqK, seq);
+        const eventJson = eventTemplate.replace("__SEQ__", String(seq));
+        getSortedSet(eventsK).push({ member: eventJson, score: seq });
+        getHash(roomK).set("status", "closed");
+        getHash(roomK).set("closed_at", closedAt);
+        getHash(roomK).set("closed_reason", closedReason);
+        store.delete(subjectIdxK);
+        getSet(statusCurrK).delete(roomId);
+        // installation index is a sorted set — emulate ZREM
+        const installSet = sortedSets.get(installK);
+        if (installSet) {
+          const idx = installSet.findIndex((e) => e.member === roomId);
+          if (idx !== -1) installSet.splice(idx, 1);
+        }
+        getSet(repoK).delete(roomId);
+        // EXPIRE intentionally ignored — TTL not simulated
+        void retentionSecs;
+        return [1, seq];
+      }
+
+      // ROOM_CLOSE_SCRIPT — 11 keys, 6 args (D.1.a-iii.c)
+      if (
+        keys.length === 11 &&
+        argv.length === 6 &&
+        script.includes("claim_lost")
+      ) {
+        const [
+          roomK,
+          claimK,
+          seqK,
+          statusFromK,
+          statusToK,
+          subjectIdxK,
+          eventsK,
+          _participantsK,
+          _contributionsK,
+          installK,
+          repoK,
+        ] = keys;
+        const [
+          roomId,
+          expectedThroughSeqStr,
+          decisionJson,
+          closedEventTemplate,
+          closedAt,
+          retentionSecs,
+        ] = argv;
+
+        const claim = store.get(claimK);
+        if (claim === undefined) return [-3, "claim_lost"];
+
+        // pcall(cjson.decode, claim) emulation
+        let parsedClaim: { runner: string; throughSequence: number };
+        try {
+          parsedClaim =
+            typeof claim === "string"
+              ? (JSON.parse(claim) as {
+                  runner: string;
+                  throughSequence: number;
+                })
+              : (claim as { runner: string; throughSequence: number });
+        } catch {
+          return [-3, "decode_error"];
+        }
+        const expectedThroughSeq = Number(expectedThroughSeqStr);
+        if (parsedClaim.throughSequence !== expectedThroughSeq) {
+          return [
+            -3,
+            "claim_throughSeq_mismatch",
+            parsedClaim.throughSequence,
+          ];
+        }
+
+        const lastSeq = (store.get(seqK) as number | undefined) ?? 0;
+        if (lastSeq !== expectedThroughSeq) {
+          // Drift — atomic revert
+          store.delete(claimK);
+          getHash(roomK).set("status", "awaiting_contributions");
+          getHash(roomK).set("deciding_through_sequence", "");
+          getSet(statusFromK).delete(roomId);
+          getSet(statusToK).add(roomId);
+          return [-2, lastSeq];
+        }
+
+        // Happy path
+        const closedSeq = lastSeq + 1;
+        const closedEventJson = closedEventTemplate.replace(
+          "__SEQ__",
+          String(closedSeq),
+        );
+        getHash(roomK).set("status", "closed");
+        getHash(roomK).set("decision", decisionJson);
+        getHash(roomK).set("closed_at", closedAt);
+        getSortedSet(eventsK).push({
+          member: closedEventJson,
+          score: closedSeq,
+        });
+        store.set(seqK, closedSeq);
+        store.delete(claimK);
+        store.delete(subjectIdxK);
+        getSet(statusFromK).delete(roomId);
+        const installSet = sortedSets.get(installK);
+        if (installSet) {
+          const idx = installSet.findIndex((e) => e.member === roomId);
+          if (idx !== -1) installSet.splice(idx, 1);
+        }
+        getSet(repoK).delete(roomId);
+        void retentionSecs;
+        return [1, closedSeq];
       }
 
       return null;
@@ -3440,5 +3595,660 @@ describe("recoverDeciding", () => {
     const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
     const recovery = events.find((e) => e.event_type === "room_recovered");
     expect(recovery?.seq).toBe(result.sequence);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D.1.a-iii.c — TERMINATE + CLOSE + drift detection + carry-forwards
+// ---------------------------------------------------------------------------
+
+import {
+  ROOM_TERMINATE_SCRIPT,
+  ROOM_CLOSE_SCRIPT,
+  validateRunnerFormat,
+  terminateRoom,
+  closeRoomWithDecision,
+  RoomAlreadyClosedError,
+  RoomCloseClaimLostError,
+  RoomCloseClaimThroughSeqMismatchError,
+  RoomCloseDriftError,
+  RoomClaimPayloadCorruptError,
+  RoomRunnerFormatError,
+  type RoomDecision,
+} from "./war-room";
+
+describe("D.1.a-iii.c ROOM_TERMINATE_SCRIPT source", () => {
+  it("references closed_reason ARGV + claim DEL + index cleanup + sibling EXPIRE", () => {
+    expect(ROOM_TERMINATE_SCRIPT).toContain("closed_reason");
+    expect(ROOM_TERMINATE_SCRIPT).toContain('"closed"');
+    // Claim DEL covers deciding-state cleanup (closes design R3 N8)
+    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("del", KEYS[10])');
+    // Subject lock release
+    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("del", KEYS[2])');
+    // ZREM from installation index (closes Queen R2 #2)
+    expect(ROOM_TERMINATE_SCRIPT).toContain("zrem");
+    // SREM from per-repo index (closes M3)
+    expect(ROOM_TERMINATE_SCRIPT).toContain("srem");
+    // Sibling TTL (closes Queen R2 #1)
+    expect(ROOM_TERMINATE_SCRIPT).toContain("expire");
+    // First-match gsub (closes #510 guard B1)
+    expect(ROOM_TERMINATE_SCRIPT).toContain(", 1)");
+  });
+});
+
+describe("D.1.a-iii.c ROOM_CLOSE_SCRIPT source", () => {
+  it("references claim_lost + claim_throughSeq_mismatch + drift revert + pcall decode + capped gsub", () => {
+    expect(ROOM_CLOSE_SCRIPT).toContain("claim_lost");
+    expect(ROOM_CLOSE_SCRIPT).toContain("claim_throughSeq_mismatch");
+    // pcall wrap on cjson.decode (closes #512 guard N2)
+    expect(ROOM_CLOSE_SCRIPT).toContain("pcall(cjson.decode");
+    expect(ROOM_CLOSE_SCRIPT).toContain("decode_error");
+    // Drift revert: reverts status AND restores status-set membership (closes design B2)
+    expect(ROOM_CLOSE_SCRIPT).toContain('"awaiting_contributions"');
+    expect(ROOM_CLOSE_SCRIPT).toContain('"deciding_through_sequence", ""');
+    // Capped gsub on closed event template (closes #510 guard B1)
+    expect(ROOM_CLOSE_SCRIPT).toContain(", 1)");
+    // Sibling TTL on close
+    expect(ROOM_CLOSE_SCRIPT).toContain("expire");
+  });
+});
+
+describe("validateRunnerFormat", () => {
+  it("accepts canonical formats", () => {
+    expect(() => validateRunnerFormat("queen-host-1.pid42.tick0")).not.toThrow();
+    expect(() => validateRunnerFormat("queen-abc123")).not.toThrow();
+    expect(() =>
+      validateRunnerFormat("hivemoot/hivemoot:42"),
+    ).not.toThrow();
+    expect(() => validateRunnerFormat("a")).not.toThrow();
+    expect(() => validateRunnerFormat("a".repeat(128))).not.toThrow();
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateRunnerFormat("")).toThrow(RoomRunnerFormatError);
+  });
+
+  it("rejects whitespace", () => {
+    expect(() => validateRunnerFormat("queen 1")).toThrow(
+      RoomRunnerFormatError,
+    );
+    expect(() => validateRunnerFormat("\tqueen")).toThrow(RoomRunnerFormatError);
+  });
+
+  it("rejects > 128 chars", () => {
+    expect(() => validateRunnerFormat("a".repeat(129))).toThrow(
+      RoomRunnerFormatError,
+    );
+  });
+
+  it("rejects __SEQ__ literal (sentinel collision guard)", () => {
+    expect(() => validateRunnerFormat("queen__SEQ__1")).toThrow(
+      RoomRunnerFormatError,
+    );
+    try {
+      validateRunnerFormat("queen__SEQ__1");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomRunnerFormatError);
+      expect((err as RoomRunnerFormatError).message).toContain("__SEQ__");
+    }
+  });
+
+  it("rejects unsafe chars (quotes, control, etc.)", () => {
+    expect(() => validateRunnerFormat("queen'1")).toThrow(RoomRunnerFormatError);
+    expect(() => validateRunnerFormat('queen"1')).toThrow(RoomRunnerFormatError);
+    expect(() => validateRunnerFormat("queen\x00")).toThrow(
+      RoomRunnerFormatError,
+    );
+  });
+});
+
+describe("claimSynthesis (R3 — JSON-packed tag2 closes #512 guard N1)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+  });
+
+  it("desync edge case: surfaces holder identity AND throughSequence WITHOUT post-EVAL re-read", async () => {
+    // Manually rig the desync state. The R3 reshape means no race —
+    // the script returns the holder JSON in tag2 directly.
+    await redis.set(
+      claimKey(RID_A),
+      JSON.stringify({ runner: "queen-A.pid42", throughSequence: 7 }),
+    );
+    try {
+      await claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen-B.pid99",
+        redis,
+      });
+      throw new Error("expected RoomClaimAlreadyHeldError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomClaimAlreadyHeldError);
+      const e = err as RoomClaimAlreadyHeldError;
+      expect(e.heldByRunner).toBe("queen-A.pid42");
+      // CRITICAL — pre-R3 this was 0 because the script's tag3 was
+      // dropped by dispatchScriptResult and the post-EVAL re-read
+      // could race the claim TTL. Now it's the actual sequence.
+      expect(e.throughSequence).toBe(7);
+    }
+  });
+
+  it("rejects malformed queenRunner with RoomRunnerFormatError BEFORE storage call (closes #512 guard N6)", async () => {
+    await expect(
+      claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen__SEQ__bad",
+        redis,
+      }),
+    ).rejects.toThrow(RoomRunnerFormatError);
+    // Verify NO storage write happened — claim key is still empty.
+    const claim = await redis.get(claimKey(RID_A));
+    expect(claim).toBeNull();
+  });
+
+  it("corrupted claim payload → RoomClaimPayloadCorruptError (closes #512 guard N2)", async () => {
+    // Write garbage to the claim key to simulate partial write or
+    // manual ops intervention.
+    await redis.set(claimKey(RID_A), "not-json-at-all{{{");
+    await expect(
+      claimSynthesis({
+        installationId: "12345",
+        roomId: RID_A,
+        queenRunner: "queen-A",
+        redis,
+      }),
+    ).rejects.toThrow(RoomClaimPayloadCorruptError);
+  });
+});
+
+describe("terminateRoom", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("terminates from awaiting_rsvp — emits event, flips status, releases subject lock", async () => {
+    const seq = await terminateRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      reason: "manual",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      actorRole: "system",
+      actorId: "operator-1",
+      currentStatus: "awaiting_rsvp",
+      redis,
+    });
+    expect(seq).toBe(2);
+
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("closed");
+    expect(room?.closed_at).toBeDefined();
+    expect(room?.closed_reason).toBe("manual");
+
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    expect(events[0].event_type).toBe("room_terminated");
+    expect((events[0].body as { reason: string }).reason).toBe("manual");
+
+    // Subject index released — opening a fresh room with the same
+    // subject should now succeed.
+    await expect(
+      createRoom({
+        installationId: "12345",
+        roomId: RID_B,
+        manager: "bot-queen",
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("terminates from deciding — DELs the queen's claim (closes design R3 N8 — stuck-deciding path)", async () => {
+    // Drive room into deciding via claimSynthesis
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+    await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-stuck",
+      redis,
+    });
+    expect(await redis.get(claimKey(RID_A))).toBeTruthy();
+
+    // Force-close via terminate
+    await terminateRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      reason: "force_close",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      actorRole: "system",
+      actorId: "operator-1",
+      currentStatus: "deciding",
+      redis,
+    });
+    // Claim DELed — the queen's mid-flight close will see claim_lost.
+    expect(await redis.get(claimKey(RID_A))).toBeNull();
+  });
+
+  it("idempotent on already-closed: returns RoomAlreadyClosedError on second call", async () => {
+    await terminateRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      reason: "expired",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      actorRole: "system",
+      actorId: "watchdog",
+      currentStatus: "awaiting_rsvp",
+      redis,
+    });
+    await expect(
+      terminateRoom({
+        installationId: "12345",
+        roomId: RID_A,
+        reason: "manual",
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        actorRole: "system",
+        actorId: "operator-2",
+        currentStatus: "closed",
+        redis,
+      }),
+    ).rejects.toThrow(RoomAlreadyClosedError);
+  });
+
+  it("rejects malformed subject_ref BEFORE storage call", async () => {
+    await expect(
+      terminateRoom({
+        installationId: "12345",
+        roomId: RID_A,
+        reason: "manual",
+        subject: { type: "pr_review", ref: "no-slash-no-hash" },
+        actorRole: "system",
+        actorId: "operator-1",
+        currentStatus: "awaiting_rsvp",
+        redis,
+      }),
+    ).rejects.toThrow(RoomSubjectRefError);
+  });
+
+  it("missing room → RoomNotFoundError", async () => {
+    await expect(
+      terminateRoom({
+        installationId: "12345",
+        roomId: RID_C,
+        reason: "manual",
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        actorRole: "system",
+        actorId: "operator-1",
+        currentStatus: "awaiting_rsvp",
+        redis,
+      }),
+    ).rejects.toThrow(RoomNotFoundError);
+  });
+
+  it("event actor_role uses sentinel `system` for cron/watchdog (N5 system-actor exception)", async () => {
+    await terminateRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      reason: "expired",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      actorRole: "system",
+      actorId: "vercel-cron",
+      currentStatus: "awaiting_rsvp",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    const term = events.find((e) => e.event_type === "room_terminated");
+    expect(term?.actor_role).toBe("system");
+    expect(term?.actor_id).toBe("vercel-cron");
+  });
+});
+
+describe("closeRoomWithDecision", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  let claimResult: { throughSequence: number; claimTtlSecs: number };
+
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    // Promote the room to awaiting_contributions, then claim.
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+    claimResult = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-A.pid42",
+      redis,
+    });
+  });
+
+  function makeDecision(overrides?: Partial<RoomDecision>): RoomDecision {
+    return {
+      synthesized_at: "2026-04-28T07:00:00.000Z",
+      synthesis_runner: "queen-A.pid42",
+      content: "## Synthesis\n\nApprove with notes.",
+      sequence_closed: claimResult.throughSequence,
+      ...overrides,
+    };
+  }
+
+  it("happy path: closes room, writes decision, emits room_decided event, releases subject + indexes", async () => {
+    const closedSeq = await closeRoomWithDecision({
+      installationId: "12345",
+      roomId: RID_A,
+      expectedThroughSequence: claimResult.throughSequence,
+      decision: makeDecision(),
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    expect(closedSeq).toBeGreaterThan(claimResult.throughSequence);
+
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("closed");
+    expect(room?.closed_at).toBeDefined();
+    expect(room?.decision).toBeDefined();
+    expect(room?.decision?.synthesis_runner).toBe("queen-A.pid42");
+
+    // Claim DELed
+    expect(await redis.get(claimKey(RID_A))).toBeNull();
+
+    // Subject index released — fresh room with same subject succeeds.
+    await expect(
+      createRoom({
+        installationId: "12345",
+        roomId: RID_B,
+        manager: "bot-queen",
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).resolves.toBeDefined();
+
+    // Event emitted with capped __SEQ__ substitution
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    const decided = events.find((e) => e.event_type === "room_decided");
+    expect(decided).toBeDefined();
+    expect(decided?.seq).toBe(closedSeq);
+  });
+
+  it("claim_lost (race with force-close TERMINATE) → RoomCloseClaimLostError", async () => {
+    // Simulate force-close racing the queen: TERMINATE DELs the
+    // claim. The queen's subsequent close attempt must abort.
+    await terminateRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      reason: "force_close",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      actorRole: "system",
+      actorId: "operator-1",
+      currentStatus: "deciding",
+      redis,
+    });
+    await expect(
+      closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence,
+        decision: makeDecision(),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).rejects.toThrow(RoomCloseClaimLostError);
+  });
+
+  it("claim_throughSeq_mismatch: another runner re-claimed → RoomCloseClaimThroughSeqMismatchError", async () => {
+    // Manually rewrite the claim so its throughSequence differs
+    // from what queen-A captured. (In real life this can't happen
+    // because claim acquisition is atomic — but the script defends
+    // against partial-write desync.)
+    await redis.set(
+      claimKey(RID_A),
+      JSON.stringify({ runner: "queen-A.pid42", throughSequence: 99 }),
+    );
+    try {
+      await closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence, // 1
+        decision: makeDecision(),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      });
+      throw new Error("expected RoomCloseClaimThroughSeqMismatchError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomCloseClaimThroughSeqMismatchError);
+      const e = err as RoomCloseClaimThroughSeqMismatchError;
+      expect(e.expectedThroughSequence).toBe(1);
+      expect(e.actualThroughSequence).toBe(99);
+    }
+  });
+
+  it("drift detection: new event arrived during synthesis → RoomCloseDriftError + atomic revert", async () => {
+    // Bump the seq counter directly to simulate a new event landing
+    // between claim and close (e.g., subject_updated webhook).
+    await redis.set(seqKey(RID_A), 5);
+    try {
+      await closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence, // 1
+        decision: makeDecision(),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      });
+      throw new Error("expected RoomCloseDriftError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RoomCloseDriftError);
+      const e = err as RoomCloseDriftError;
+      expect(e.expectedThroughSequence).toBe(1);
+      expect(e.lastSeq).toBe(5);
+    }
+
+    // Revert effects: status reverted, claim DELed, status-set
+    // membership restored — the manager loop can re-claim cleanly.
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("awaiting_contributions");
+    expect(room?.deciding_through_sequence).toBeUndefined();
+    expect(await redis.get(claimKey(RID_A))).toBeNull();
+  });
+
+  it("after drift revert → re-claim cycle works (manager loop retry path)", async () => {
+    // Simulate drift then re-claim
+    await redis.set(seqKey(RID_A), 3);
+    await expect(
+      closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence,
+        decision: makeDecision(),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).rejects.toThrow(RoomCloseDriftError);
+
+    // Now re-claim — should succeed at throughSequence=3
+    const c2 = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-B.pid99",
+      redis,
+    });
+    expect(c2.throughSequence).toBe(3);
+
+    // Close at the new throughSequence — happy path
+    const closed = await closeRoomWithDecision({
+      installationId: "12345",
+      roomId: RID_A,
+      expectedThroughSequence: c2.throughSequence,
+      decision: makeDecision({
+        synthesis_runner: "queen-B.pid99",
+        sequence_closed: c2.throughSequence,
+      }),
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    expect(closed).toBe(4);
+  });
+
+  it("rejects malformed synthesis_runner BEFORE storage call (N6 boundary check)", async () => {
+    await expect(
+      closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence,
+        decision: makeDecision({ synthesis_runner: "queen__SEQ__bad" }),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).rejects.toThrow(RoomRunnerFormatError);
+    // Claim still alive — no storage modification happened.
+    expect(await redis.get(claimKey(RID_A))).toBeTruthy();
+  });
+
+  it("rejects content > 64 KiB BEFORE storage call", async () => {
+    const huge = "x".repeat(65 * 1024);
+    await expect(
+      closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence,
+        decision: makeDecision({ content: huge }),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).rejects.toThrow(/exceeds 64 KiB/);
+  });
+
+  it("__SEQ__ in decision content is preserved (capped gsub closes #510 guard B1)", async () => {
+    const closedSeq = await closeRoomWithDecision({
+      installationId: "12345",
+      roomId: RID_A,
+      expectedThroughSequence: claimResult.throughSequence,
+      decision: makeDecision({
+        content: "Synthesis ref __SEQ__ as intended",
+      }),
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    // Decision content preserved verbatim
+    expect(room?.decision?.content).toBe("Synthesis ref __SEQ__ as intended");
+    // Event seq stamped via FIRST-match gsub on event template, not decision body
+    const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
+    const decided = events.find((e) => e.event_type === "room_decided");
+    expect(decided?.seq).toBe(closedSeq);
+  });
+});
+
+describe("D.1.a-iii.c end-to-end: claim → close happy path", () => {
+  it("RSVP → contribute → claim → close → terminal closed state with full event log", async () => {
+    const redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    // Bump status to awaiting_contributions for synth path
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",
+      sequenceObservedByClient: 2,
+      body: { verdict: "APPROVE", summary: "ship it" },
+      rawMd: "# OK",
+      redis,
+    });
+    const c = await claimSynthesis({
+      installationId: "12345",
+      roomId: RID_A,
+      queenRunner: "queen-prod.pid7",
+      redis,
+    });
+    const closedSeq = await closeRoomWithDecision({
+      installationId: "12345",
+      roomId: RID_A,
+      expectedThroughSequence: c.throughSequence,
+      decision: {
+        synthesized_at: "2026-04-28T08:00:00.000Z",
+        synthesis_runner: "queen-prod.pid7",
+        content: "Decision: ship.",
+        sequence_closed: c.throughSequence,
+      },
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+
+    const events = await listRoomEvents({ roomId: RID_A, since: 0, redis });
+    const types = events.map((e) => e.event_type);
+    expect(types).toContain("room_opened");
+    expect(types).toContain("participant_presented");
+    expect(types).toContain("contribution_submitted");
+    expect(types).toContain("room_decided");
+    expect(events.find((e) => e.event_type === "room_decided")?.seq).toBe(
+      closedSeq,
+    );
+
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("closed");
+    expect(room?.decision?.content).toBe("Decision: ship.");
   });
 });

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -442,16 +442,18 @@ function makeMockRedis() {
         return [1, seq];
       }
 
-      // ROOM_TERMINATE_SCRIPT — 10 keys, 5 args (D.1.a-iii.c)
+      // ROOM_TERMINATE_SCRIPT — 12 keys, 5 args (D.1.a-iii.c R2)
       if (
-        keys.length === 10 &&
+        keys.length === 12 &&
         argv.length === 5 &&
         script.includes("closed_reason")
       ) {
         const [
           roomK,
           subjectIdxK,
-          statusCurrK,
+          statusAwaitingRsvpK,
+          statusAwaitingContribK,
+          statusDecidingK,
           installK,
           repoK,
           seqK,
@@ -481,7 +483,12 @@ function makeMockRedis() {
         getHash(roomK).set("closed_at", closedAt);
         getHash(roomK).set("closed_reason", closedReason);
         store.delete(subjectIdxK);
-        getSet(statusCurrK).delete(roomId);
+        // SREM all three non-terminal status sets idempotently
+        // (closes #515 builder R1 — defensive against stale
+        // caller-observed status).
+        getSet(statusAwaitingRsvpK).delete(roomId);
+        getSet(statusAwaitingContribK).delete(roomId);
+        getSet(statusDecidingK).delete(roomId);
         // installation index is a sorted set — emulate ZREM
         const installSet = sortedSets.get(installK);
         if (installSet) {
@@ -3621,14 +3628,18 @@ describe("D.1.a-iii.c ROOM_TERMINATE_SCRIPT source", () => {
   it("references closed_reason ARGV + claim DEL + index cleanup + sibling EXPIRE", () => {
     expect(ROOM_TERMINATE_SCRIPT).toContain("closed_reason");
     expect(ROOM_TERMINATE_SCRIPT).toContain('"closed"');
-    // Claim DEL covers deciding-state cleanup (closes design R3 N8)
-    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("del", KEYS[10])');
+    // Claim DEL covers deciding-state cleanup (closes design R3 N8 +
+    // #515 builder R1 — KEYS[12] after the 3-status-set expansion)
+    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("del", KEYS[12])');
     // Subject lock release
     expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("del", KEYS[2])');
+    // Idempotent SREM from ALL non-terminal status sets (#515 R1):
+    // KEYS[3]=awaiting_rsvp, KEYS[4]=awaiting_contributions, KEYS[5]=deciding
+    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("srem", KEYS[3], ARGV[1])');
+    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("srem", KEYS[4], ARGV[1])');
+    expect(ROOM_TERMINATE_SCRIPT).toContain('redis.call("srem", KEYS[5], ARGV[1])');
     // ZREM from installation index (closes Queen R2 #2)
     expect(ROOM_TERMINATE_SCRIPT).toContain("zrem");
-    // SREM from per-repo index (closes M3)
-    expect(ROOM_TERMINATE_SCRIPT).toContain("srem");
     // Sibling TTL (closes Queen R2 #1)
     expect(ROOM_TERMINATE_SCRIPT).toContain("expire");
     // First-match gsub (closes #510 guard B1)
@@ -3795,7 +3806,6 @@ describe("terminateRoom", () => {
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
       actorRole: "system",
       actorId: "operator-1",
-      currentStatus: "awaiting_rsvp",
       redis,
     });
     expect(seq).toBe(2);
@@ -3847,7 +3857,6 @@ describe("terminateRoom", () => {
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
       actorRole: "system",
       actorId: "operator-1",
-      currentStatus: "deciding",
       redis,
     });
     // Claim DELed — the queen's mid-flight close will see claim_lost.
@@ -3862,7 +3871,6 @@ describe("terminateRoom", () => {
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
       actorRole: "system",
       actorId: "watchdog",
-      currentStatus: "awaiting_rsvp",
       redis,
     });
     await expect(
@@ -3873,7 +3881,6 @@ describe("terminateRoom", () => {
         subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
         actorRole: "system",
         actorId: "operator-2",
-        currentStatus: "closed",
         redis,
       }),
     ).rejects.toThrow(RoomAlreadyClosedError);
@@ -3888,7 +3895,6 @@ describe("terminateRoom", () => {
         subject: { type: "pr_review", ref: "no-slash-no-hash" },
         actorRole: "system",
         actorId: "operator-1",
-        currentStatus: "awaiting_rsvp",
         redis,
       }),
     ).rejects.toThrow(RoomSubjectRefError);
@@ -3903,7 +3909,6 @@ describe("terminateRoom", () => {
         subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
         actorRole: "system",
         actorId: "operator-1",
-        currentStatus: "awaiting_rsvp",
         redis,
       }),
     ).rejects.toThrow(RoomNotFoundError);
@@ -3917,13 +3922,73 @@ describe("terminateRoom", () => {
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
       actorRole: "system",
       actorId: "vercel-cron",
-      currentStatus: "awaiting_rsvp",
       redis,
     });
     const events = await listRoomEvents({ roomId: RID_A, since: 1, redis });
     const term = events.find((e) => e.event_type === "room_terminated");
     expect(term?.actor_role).toBe("system");
     expect(term?.actor_id).toBe("vercel-cron");
+  });
+
+  it("stale-currentStatus race: room moves awaiting_contributions → deciding via concurrent claim, terminate STILL cleans all open status sets (closes #515 builder R1)", async () => {
+    // Promote and put room into the contention window: caller's
+    // observation says "awaiting_contributions" but a concurrent
+    // claimSynthesis flips status to "deciding" + adds it to the
+    // deciding status set.
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+    // Replicate the claim's status-set membership migration that
+    // happens during normal claim flow — the room is now in the
+    // deciding status set. (createRoom put it in awaiting_rsvp; we
+    // simulate the awaiting_rsvp → awaiting_contributions and then
+    // → deciding moves explicitly here.)
+    const awaitingRsvpSetKey = statusIndexKey("12345", "awaiting_rsvp");
+    const decidingSetKey = statusIndexKey("12345", "deciding");
+    // Ensure the room id is in the deciding set (concurrent claim's
+    // post-state) and NOT in the awaiting_contributions set.
+    redis._sets.get(awaitingRsvpSetKey)?.delete(RID_A);
+    let decidingSet = redis._sets.get(decidingSetKey);
+    if (!decidingSet) {
+      decidingSet = new Set<string>();
+      redis._sets.set(decidingSetKey, decidingSet);
+    }
+    decidingSet.add(RID_A);
+    // Force the room hash status to deciding to mirror the claim's
+    // atomic flip (without going through claimSynthesis to keep the
+    // test focused on the index-cleanup property).
+    await redis.hset(roomKey("12345", RID_A), { status: "deciding" });
+
+    // Operator force-closes — but had OBSERVED awaiting_contributions
+    // on a stale read. (The new contract drops `currentStatus` —
+    // whatever the caller observed, the script handles all sets.)
+    await terminateRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      reason: "force_close",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      actorRole: "system",
+      actorId: "operator-1",
+      redis,
+    });
+
+    // CRITICAL — the room id is gone from EVERY non-terminal status set,
+    // not just the one the caller might have observed.
+    expect(redis._sets.get(awaitingRsvpSetKey)?.has(RID_A) ?? false).toBe(false);
+    expect(
+      redis._sets
+        .get(statusIndexKey("12345", "awaiting_contributions"))
+        ?.has(RID_A) ?? false,
+    ).toBe(false);
+    expect(redis._sets.get(decidingSetKey)?.has(RID_A) ?? false).toBe(false);
+
+    // Sanity: room hash is at status closed.
+    const room = await getRoomCore({
+      installationId: "12345",
+      roomId: RID_A,
+      redis,
+    });
+    expect(room?.status).toBe("closed");
   });
 });
 
@@ -4014,7 +4079,6 @@ describe("closeRoomWithDecision", () => {
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
       actorRole: "system",
       actorId: "operator-1",
-      currentStatus: "deciding",
       redis,
     });
     await expect(
@@ -4150,6 +4214,27 @@ describe("closeRoomWithDecision", () => {
         roomId: RID_A,
         expectedThroughSequence: claimResult.throughSequence,
         decision: makeDecision({ content: huge }),
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+        redis,
+      }),
+    ).rejects.toThrow(/exceeds 64 KiB/);
+  });
+
+  it("64 KiB cap counts BYTES not UTF-16 code units (multi-byte regression — closes #515 builder R1)", async () => {
+    // 22000 emoji × 4 bytes/emoji = 88000 bytes (> 64 KiB) but only
+    // 44000 UTF-16 code units (< 64 KiB cap if we used .length).
+    // The byte-aware check rejects; the code-unit check would have
+    // let it through, exceeding the storage budget.
+    const emoji = "🐝"; // 4 bytes UTF-8, 2 UTF-16 code units
+    const multiByteContent = emoji.repeat(22000);
+    expect(multiByteContent.length).toBeLessThan(64 * 1024); // .length check would pass
+    expect(Buffer.byteLength(multiByteContent, "utf8")).toBeGreaterThan(64 * 1024); // bytes exceed
+    await expect(
+      closeRoomWithDecision({
+        installationId: "12345",
+        roomId: RID_A,
+        expectedThroughSequence: claimResult.throughSequence,
+        decision: makeDecision({ content: multiByteContent }),
         subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
         redis,
       }),

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -284,10 +284,19 @@ export interface RoomEvent {
   event_type: RoomEventType;
   /** Server-derived from the bearer envelope's `agent_role` —
    * NEVER from request body. Lets investigators map an event to
-   * a role even if the actor's bearer is later rotated/revoked. */
+   * a role even if the actor's bearer is later rotated/revoked.
+   *
+   * **System-actor exception** (closes #512 guard N5): for
+   * cron/watchdog-driven transitions there is no bearer behind the
+   * action — the manager loop emits these events on its own tick.
+   * Such events use sentinel values (`actor_role="manager"`,
+   * `actor_id="watchdog"` for `room_recovered` and watchdog-triggered
+   * `participant_timed_out`; `actor_role="system"`, `actor_id="vercel-cron"`
+   * for cron-fired TERMINATE on expiry). The "never from body" rule
+   * still holds — system sentinels are server-issued, not client-supplied. */
   actor_role: string;
-  /** Server-derived: the bearer's `name` field. Same caveat as
-   * `actor_role` — never accepts a body-supplied identity. */
+  /** Server-derived: the bearer's `name` field. Same caveat AND same
+   * system-actor exception as `actor_role` (see above). */
   actor_id: string;
   /** Action-specific payload. Bounded ≤ 8 KiB serialized; events
    * exceeding the cap are rejected at append time. */
@@ -494,6 +503,45 @@ const ROOM_ID_REGEX =
 export function validateRoomId(roomId: string): void {
   if (!ROOM_ID_REGEX.test(roomId)) {
     throw new RoomIdFormatError(roomId);
+  }
+}
+
+/**
+ * Bounds on a queen runner identity (`queenRunner` for
+ * `claimSynthesis`, `synthesis_runner` in `RoomDecision`). Closes
+ * #512 guard N6 — defense-in-depth boundary check at the route
+ * layer so any string that flows through Lua `gsub` sentinel
+ * substitution is guaranteed not to collide with the sentinel.
+ *
+ * The shape covers the common queen identity formats:
+ *   `<host>.pid<N>.tick<N>`        — bot-as-queen
+ *   `queen-<short-hash>`            — standalone queen (post-V1)
+ *   `<owner>/<repo>:<runId>`        — GitHub Actions queen variant
+ *
+ * Constraints (any one violation rejects):
+ *   - 1-128 chars
+ *   - Only ASCII alphanumeric, `.`, `-`, `_`, `:`, `/`, `+`
+ *   - No literal `__SEQ__` substring (sentinel collision guard)
+ *   - No surrounding whitespace
+ */
+const RUNNER_FORMAT_REGEX = /^[A-Za-z0-9._:/+\-]{1,128}$/;
+const SEQ_SENTINEL = "__SEQ__";
+
+export function validateRunnerFormat(runner: string): void {
+  if (typeof runner !== "string" || runner.length === 0) {
+    throw new RoomRunnerFormatError(String(runner), "must be a non-empty string");
+  }
+  if (!RUNNER_FORMAT_REGEX.test(runner)) {
+    throw new RoomRunnerFormatError(
+      runner,
+      "must match /^[A-Za-z0-9._:/+\\-]{1,128}$/ (no whitespace, no special chars)",
+    );
+  }
+  if (runner.includes(SEQ_SENTINEL)) {
+    throw new RoomRunnerFormatError(
+      runner,
+      `must not contain the literal "${SEQ_SENTINEL}" sentinel — defense-in-depth against future gsub substitutions`,
+    );
   }
 }
 
@@ -1142,6 +1190,142 @@ export class RoomTransitionInvalidStatusError extends Error {
 }
 
 /**
+ * Thrown when a Lua script's `cjson.decode` fails on a stored claim
+ * payload (corrupted/partial-write/manual ops intervention). Closes
+ * #512 guard N2: even the defensive `already_claimed` branch shouldn't
+ * panic on payload corruption — the script returns `{-3, "decode_error"}`
+ * and the caller surfaces this typed error so an operator can DEL the
+ * claim key out-of-band.
+ */
+export class RoomClaimPayloadCorruptError extends Error {
+  public readonly roomId: string;
+  constructor(roomId: string) {
+    super(
+      `Claim payload for room ${roomId} could not be decoded — likely partial write or manual intervention. DEL the claim key out-of-band and re-attempt synthesis on the next manager tick.`,
+    );
+    this.name = "RoomClaimPayloadCorruptError";
+    this.roomId = roomId;
+  }
+}
+
+/**
+ * Thrown by `terminateRoom` when the room is already in `closed`
+ * status (operator double-tap or watchdog race after a queen close).
+ * Carries the actual status so the caller can distinguish "already
+ * terminal" (benign) from "wrong status" (programming error).
+ *
+ * Per design L443 — TERMINATE returns `{-1, currentStatus}` only on
+ * `closed`; any non-closed status proceeds with termination.
+ */
+export class RoomAlreadyClosedError extends Error {
+  public readonly roomId: string;
+  public readonly status: RoomStatus;
+  constructor(roomId: string, status: RoomStatus) {
+    super(
+      `Room ${roomId} is already in status ${JSON.stringify(status)}; terminate is a no-op.`,
+    );
+    this.name = "RoomAlreadyClosedError";
+    this.roomId = roomId;
+    this.status = status;
+  }
+}
+
+/**
+ * Thrown by `closeRoomWithDecision` when the synthesis claim has
+ * been DELed out from under the queen runner — typically by an
+ * `force_close` TERMINATE racing the queen's `/close`. The queen
+ * MUST abort the GitHub posting and let the operator's force-close
+ * stand (per design L508).
+ */
+export class RoomCloseClaimLostError extends Error {
+  public readonly roomId: string;
+  constructor(roomId: string) {
+    super(
+      `Synthesis claim for room ${roomId} was deleted before close completed (likely a force-close TERMINATE). Abort the GitHub post and surface the terminal state to the operator.`,
+    );
+    this.name = "RoomCloseClaimLostError";
+    this.roomId = roomId;
+  }
+}
+
+/**
+ * Thrown by `closeRoomWithDecision` when the claim record's stored
+ * `throughSequence` doesn't match the caller's `expectedThroughSequence`.
+ * Indicates a different runner re-claimed the room since this caller
+ * acquired the claim — should never happen in normal flow (claim TTL
+ * + atomic acquisition prevents it) but the script defends against
+ * partial-write desync.
+ */
+export class RoomCloseClaimThroughSeqMismatchError extends Error {
+  public readonly roomId: string;
+  public readonly expectedThroughSequence: number;
+  public readonly actualThroughSequence: number;
+  constructor(
+    roomId: string,
+    expectedThroughSequence: number,
+    actualThroughSequence: number,
+  ) {
+    super(
+      `Claim throughSequence mismatch for room ${roomId}: expected ${expectedThroughSequence}, got ${actualThroughSequence}. Another runner re-claimed mid-flight; abort and re-claim.`,
+    );
+    this.name = "RoomCloseClaimThroughSeqMismatchError";
+    this.roomId = roomId;
+    this.expectedThroughSequence = expectedThroughSequence;
+    this.actualThroughSequence = actualThroughSequence;
+  }
+}
+
+/**
+ * Thrown by `closeRoomWithDecision` when new events arrived between
+ * claim acquisition and close attempt — the script atomically reverts
+ * status to `awaiting_contributions` AND DELs the claim, so the queen
+ * runner aborts its GitHub post and the manager loop re-claims on the
+ * next tick (closes design L506-528: drift signal triggers
+ * synthesize-retry, not a hard error).
+ *
+ * The `lastSeq` field carries the live sequence at the close attempt
+ * — useful for caller logs ("synthesized through 7, but 9 events landed").
+ */
+export class RoomCloseDriftError extends Error {
+  public readonly roomId: string;
+  public readonly expectedThroughSequence: number;
+  public readonly lastSeq: number;
+  constructor(
+    roomId: string,
+    expectedThroughSequence: number,
+    lastSeq: number,
+  ) {
+    super(
+      `Sequence drift on room ${roomId}: synthesized through ${expectedThroughSequence}, but ${lastSeq - expectedThroughSequence} new event(s) landed during synthesis. Status reverted to awaiting_contributions; re-claim on next manager tick.`,
+    );
+    this.name = "RoomCloseDriftError";
+    this.roomId = roomId;
+    this.expectedThroughSequence = expectedThroughSequence;
+    this.lastSeq = lastSeq;
+  }
+}
+
+/**
+ * Thrown when a runner identity (`queenRunner` or
+ * `RoomDecision.synthesis_runner`) fails the boundary format check.
+ * Closes #512 guard N6: any string that flows through Lua `gsub`
+ * sentinel substitution must be guaranteed not to collide with the
+ * sentinel literal. Even though the claim script doesn't `gsub` the
+ * runner string today, validating at the boundary is the
+ * defense-in-depth pattern from #510 R2 N2.
+ */
+export class RoomRunnerFormatError extends Error {
+  public readonly invalidRunner: string;
+  constructor(invalidRunner: string, reason: string) {
+    super(
+      `Runner identity ${JSON.stringify(invalidRunner)} failed format validation: ${reason}.`,
+    );
+    this.name = "RoomRunnerFormatError";
+    this.invalidRunner = invalidRunner;
+  }
+}
+
+/**
  * Thrown when a participant transition's source state is illegal.
  *
  * Closes #510 builder R3: the manager loop's contract (per
@@ -1749,9 +1933,22 @@ return {seq}
  *   [3] claimTtlSecs             — TTL for the claim key
  *
  * Returns:
- *   {1, throughSequence}                      claim acquired
- *   {0, "already_claimed", runner, throughSeq} another runner holds it
- *   {-1, currentStatus}                       not in awaiting_contributions
+ *   {1, throughSequence}                       claim acquired
+ *   {0, "already_claimed", holderJson}         another runner holds it
+ *                                              (holderJson = JSON-encoded
+ *                                              {runner, throughSequence})
+ *   {-1, currentStatus}                        not in awaiting_contributions
+ *   {-3, "decode_error"}                       claim payload corruption
+ *                                              (cjson.decode failed —
+ *                                              defensive against partial
+ *                                              writes / manual ops; closes
+ *                                              #512 guard N2)
+ *
+ * R3 (D.1.a-iii.c): the conflict response now JSON-packs the holder
+ * info into a single tag2 string instead of using positional
+ * tag3+tag4. Closes #512 guard N1: previously `dispatchScriptResult`
+ * dropped the 4th element, forcing a post-EVAL `GET` to recover the
+ * throughSequence (racy if claim TTL'd between EVAL and re-read).
  */
 export const ROOM_DECIDE_CLAIM_SCRIPT = `
 local currStatus = redis.call("hget", KEYS[1], "status")
@@ -1761,8 +1958,9 @@ if currStatus ~= "awaiting_contributions" then
 end
 local existingClaim = redis.call("get", KEYS[2])
 if existingClaim then
-  local parsed = cjson.decode(existingClaim)
-  return {0, "already_claimed", parsed.runner, parsed.throughSequence}
+  local ok, parsed = pcall(cjson.decode, existingClaim)
+  if not ok then return {-3, "decode_error"} end
+  return {0, "already_claimed", cjson.encode({runner = parsed.runner, throughSequence = parsed.throughSequence})}
 end
 local seq = redis.call("get", KEYS[5])
 if not seq then return {-1, "no_seq"} end
@@ -1825,6 +2023,187 @@ redis.call("hset", KEYS[1], "status", "awaiting_contributions", "deciding_throug
 redis.call("srem", KEYS[3], ARGV[1])
 redis.call("sadd", KEYS[4], ARGV[1])
 return {1, seq}
+`;
+
+/**
+ * ROOM_TERMINATE_SCRIPT — atomic terminal close without claim.
+ *
+ * Per WAR_ROOM_DESIGN.md L428-470: covers the four non-decided
+ * terminal paths — `expired` (watchdog past max_age), `failed_synthesis`
+ * (queen consecutive failures), `force_close` (operator UI), `manual`
+ * (operator UI happy path). Distinct from `ROOM_CLOSE_SCRIPT` which
+ * requires a claim and represents the queen's clean synthesis path.
+ *
+ * Critical: if the room is in `deciding`, the queen had a claim — DEL
+ * it. The queen's mid-flight `/close` will then return
+ * `RoomCloseClaimLostError` and abort the GitHub post (closes design
+ * R3 N8: stuck-deciding past max_age was unreachable by the prior
+ * `ROOM_EXPIRE_SCRIPT`; same path covers force-close on a deciding
+ * room from S5).
+ *
+ * Atomicity:
+ *   1. Status precondition: must NOT be `closed` (already-terminal
+ *      check; benign no-op for operator double-tap)
+ *   2. DEL claim if any (covers deciding-state cleanup)
+ *   3. INCR seq + ZADD `room_terminated` event (`__SEQ__` substituted,
+ *      capped at first match per #510 guard B1)
+ *   4. HSET status="closed" + closed_at + closed_reason
+ *   5. DEL subject index (release the per-installation subject lock)
+ *   6. SREM/ZREM/SREM from status, installation, repo indexes (closes
+ *      Queen R2 #2 — index leaks; M3 — per-repo set leaks)
+ *   7. EXPIRE all sibling keys at retentionSecs (closes Queen R2 #1
+ *      — TTL leak)
+ *
+ * KEYS:
+ *   [1] roomKey
+ *   [2] subjectIndexKey
+ *   [3] statusSetCurrentKey   — current status's set (caller resolves)
+ *   [4] installationIndexKey  — all-rooms-for-installation sorted set
+ *   [5] repoIndexKey          — per-repo set
+ *   [6] seqKey
+ *   [7] eventsKey
+ *   [8] participantsKey       — for TTL only (read-once at terminate)
+ *   [9] contributionsKey      — for TTL only
+ *   [10] claimKey             — DELed if held (deciding-state cleanup)
+ *
+ * ARGV:
+ *   [1] roomId
+ *   [2] terminalEventJson     — JSON template with `__SEQ__` placeholder
+ *   [3] closedAt              — ISO 8601
+ *   [4] retentionSecs         — sibling-keys TTL after terminate
+ *   [5] closedReason          — TerminalReason
+ *
+ * Returns:
+ *   {1, sequence}             terminated cleanly
+ *   {-1, currentStatus}       already closed (no-op for operator double-tap)
+ */
+export const ROOM_TERMINATE_SCRIPT = `
+local currStatus = redis.call("hget", KEYS[1], "status")
+if not currStatus then return {-1, "room_not_found"} end
+if currStatus == "closed" then
+  return {-1, currStatus}
+end
+redis.call("del", KEYS[10])
+local seq = redis.call("incr", KEYS[6])
+local eventJson = string.gsub(ARGV[2], "__SEQ__", tostring(seq), 1)
+redis.call("zadd", KEYS[7], seq, eventJson)
+redis.call("hset", KEYS[1], "status", "closed",
+                          "closed_at", ARGV[3],
+                          "closed_reason", ARGV[5])
+redis.call("del", KEYS[2])
+redis.call("srem", KEYS[3], ARGV[1])
+redis.call("zrem", KEYS[4], ARGV[1])
+redis.call("srem", KEYS[5], ARGV[1])
+local retention = tonumber(ARGV[4])
+redis.call("expire", KEYS[1], retention)
+redis.call("expire", KEYS[6], retention)
+redis.call("expire", KEYS[7], retention)
+redis.call("expire", KEYS[8], retention)
+redis.call("expire", KEYS[9], retention)
+return {1, seq}
+`;
+
+/**
+ * ROOM_CLOSE_SCRIPT — queen happy-path close with sequence-consistency.
+ *
+ * Per WAR_ROOM_DESIGN.md L493-550: only the queen's `/close` path
+ * uses this script. Requires a live claim (DELed claim → abort
+ * GitHub post via `RoomCloseClaimLostError`) AND the claim's
+ * `throughSequence` to match the caller's `expectedThroughSequence`
+ * (mismatch → another runner re-claimed; abort).
+ *
+ * The drift detection (lastSeq != expectedThroughSequence) means
+ * NEW EVENTS arrived during synthesis — typically `subject_updated`
+ * from the bot's webhook layer when a worker re-pushed to the PR.
+ * The queen's synthesis is now stale; the script atomically:
+ *   - DELs the claim
+ *   - Reverts status to `awaiting_contributions`
+ *   - Restores the deciding → awaiting_contributions status-set
+ *     membership (closes design B2)
+ *   - Returns `{-2, lastSeq}` so the caller can log the drift and
+ *     not panic — manager loop will re-claim on the next tick.
+ *
+ * Happy path:
+ *   - Sequence-stamps the `room_decided` event JSON via `__SEQ__`
+ *     substitution (capped at first match)
+ *   - HSET status="closed", decision=<json>, closed_at
+ *   - ZADD the closed event at the new sequence
+ *   - SET seq counter to new sequence (so post-close reads are stable)
+ *   - DEL claim, subject index
+ *   - SREM/ZREM/SREM from deciding-status, installation, repo indexes
+ *   - EXPIRE all siblings at retentionSecs
+ *
+ * KEYS:
+ *   [1] roomKey
+ *   [2] claimKey
+ *   [3] seqKey
+ *   [4] statusSetDecidingKey
+ *   [5] statusSetAwaitingContribKey
+ *   [6] subjectIndexKey
+ *   [7] eventsKey
+ *   [8] participantsKey       — TTL only
+ *   [9] contributionsKey      — TTL only
+ *   [10] installationIndexKey
+ *   [11] repoIndexKey
+ *
+ * ARGV:
+ *   [1] roomId
+ *   [2] expectedThroughSequence  — caller's claim-time sequence (from claimSynthesis)
+ *   [3] decisionJson             — RoomDecision serialized
+ *   [4] closedEventJsonTemplate  — JSON with `__SEQ__` placeholder
+ *   [5] closedAt                 — ISO 8601
+ *   [6] retentionSecs            — sibling TTL
+ *
+ * Returns:
+ *   {1, sequence}                                    closed cleanly
+ *   {-2, lastSeq}                                    sequence drift (revert + retry)
+ *   {-3, "claim_lost"}                               claim DELed (force-close raced)
+ *   {-3, "claim_throughSeq_mismatch", actualThroughSeq}
+ *                                                    different runner re-claimed
+ *   {-3, "decode_error"}                             claim payload corruption
+ */
+export const ROOM_CLOSE_SCRIPT = `
+local claim = redis.call("get", KEYS[2])
+if not claim then return {-3, "claim_lost"} end
+local ok, parsed = pcall(cjson.decode, claim)
+if not ok then return {-3, "decode_error"} end
+local claimThroughSeq = tonumber(parsed.throughSequence)
+local expectedThroughSeq = tonumber(ARGV[2])
+if claimThroughSeq ~= expectedThroughSeq then
+  return {-3, "claim_throughSeq_mismatch", claimThroughSeq}
+end
+local lastSeq = tonumber(redis.call("get", KEYS[3])) or 0
+if lastSeq ~= expectedThroughSeq then
+  -- Drift: new events arrived during synthesis. Revert atomically
+  -- (closes design B2: prior implementation orphaned rooms from
+  -- both deciding and awaiting_contributions sets, making them
+  -- invisible to subsequent ticks).
+  redis.call("del", KEYS[2])
+  redis.call("hset", KEYS[1], "status", "awaiting_contributions",
+                            "deciding_through_sequence", "")
+  redis.call("srem", KEYS[4], ARGV[1])
+  redis.call("sadd", KEYS[5], ARGV[1])
+  return {-2, lastSeq}
+end
+local closedSeq = lastSeq + 1
+local closedEventJson = string.gsub(ARGV[4], "__SEQ__", tostring(closedSeq), 1)
+redis.call("hset", KEYS[1], "status", "closed",
+                          "decision", ARGV[3],
+                          "closed_at", ARGV[5])
+redis.call("zadd", KEYS[7], closedSeq, closedEventJson)
+redis.call("set", KEYS[3], tostring(closedSeq))
+redis.call("del", KEYS[2])
+redis.call("del", KEYS[6])
+redis.call("srem", KEYS[4], ARGV[1])
+redis.call("zrem", KEYS[10], ARGV[1])
+redis.call("srem", KEYS[11], ARGV[1])
+local retention = tonumber(ARGV[6])
+redis.call("expire", KEYS[1], retention)
+redis.call("expire", KEYS[3], retention)
+redis.call("expire", KEYS[7], retention)
+redis.call("expire", KEYS[8], retention)
+redis.call("expire", KEYS[9], retention)
+return {1, closedSeq}
 `;
 
 // ---------------------------------------------------------------------------
@@ -2598,11 +2977,14 @@ export async function claimSynthesis(args: {
   installationId: string;
   roomId: string;
   /** Opaque queen runner identity (hostname + pid + monotonic).
-   * Stored in the claim record so observers know who holds it. */
+   * Stored in the claim record so observers know who holds it.
+   * Boundary-validated via `validateRunnerFormat` (closes #512
+   * guard N6: defense-in-depth against gsub-sentinel collision). */
   queenRunner: string;
   claimTtlSecs?: number;
   redis: Redis;
 }): Promise<ClaimSynthesisResult> {
+  validateRunnerFormat(args.queenRunner);
   const ttl = args.claimTtlSecs ?? SYNTHESIS_CLAIM_TTL_SECS;
 
   const result = dispatchScriptResult(
@@ -2627,26 +3009,26 @@ export async function claimSynthesis(args: {
     result.tag1 === "already_claimed" &&
     typeof result.tag2 === "string"
   ) {
-    // Script returns {0, "already_claimed", runner, throughSeq} — but
-    // ScriptResult only captures tag1+tag2. Re-decode the existing
-    // claim payload to surface the through-sequence, since the script
-    // already validated the status precondition before this branch.
-    const existing = await args.redis.get<string>(claimKey(args.roomId));
-    let heldByRunner = result.tag2;
+    // Script JSON-packs the holder info into tag2 (closes #512 guard
+    // N1: previously the script returned 4 elements but
+    // `dispatchScriptResult` only captures tag1+tag2, forcing a
+    // post-EVAL `GET` to recover the throughSequence. The re-read
+    // was racy — the claim could TTL between EVAL and GET, leaving
+    // throughSequence as 0 in the surfaced error.
+    let heldByRunner = "(unparsed)";
     let throughSequence = 0;
-    if (existing) {
-      try {
-        const parsed =
-          typeof existing === "string"
-            ? (JSON.parse(existing) as { runner?: string; throughSequence?: number })
-            : (existing as { runner?: string; throughSequence?: number });
-        if (typeof parsed.runner === "string") heldByRunner = parsed.runner;
-        if (typeof parsed.throughSequence === "number") {
-          throughSequence = parsed.throughSequence;
-        }
-      } catch {
-        // Fall through with tag2 as runner, 0 as throughSequence.
+    try {
+      const parsed = JSON.parse(result.tag2) as {
+        runner?: string;
+        throughSequence?: number;
+      };
+      if (typeof parsed.runner === "string") heldByRunner = parsed.runner;
+      if (typeof parsed.throughSequence === "number") {
+        throughSequence = parsed.throughSequence;
       }
+    } catch {
+      // Defensive: script-emitted JSON should never fail to parse,
+      // but if it does we still raise the error rather than swallow it.
     }
     throw new RoomClaimAlreadyHeldError(
       args.roomId,
@@ -2664,6 +3046,13 @@ export async function claimSynthesis(args: {
       ["awaiting_contributions"],
       result.tag1,
     );
+  }
+  if (result.ok === -3 && result.tag1 === "decode_error") {
+    // Claim payload corrupted (cjson.decode failed in script).
+    // Surfaces #512 guard N2: defensive against partial writes /
+    // manual ops intervention. Operator should inspect the claim
+    // key directly and decide whether to DEL it.
+    throw new RoomClaimPayloadCorruptError(args.roomId);
   }
   throw new Error(
     `ROOM_DECIDE_CLAIM_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
@@ -2756,6 +3145,257 @@ export async function recoverDeciding(args: {
   }
   throw new Error(
     `ROOM_RECOVER_DECIDING_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Termination / close primitives (D.1.a-iii.c)
+// ---------------------------------------------------------------------------
+
+/**
+ * Terminate a room — atomic close without claim. Called from the
+ * watchdog (expired / failed_synthesis) AND from operator UI
+ * (force_close / manual). Distinct from `closeRoomWithDecision`
+ * which is the queen's clean synthesis-complete path.
+ *
+ * If the room is in `deciding`, the queen's claim is DELed so the
+ * queen's mid-flight `closeRoomWithDecision` returns
+ * `RoomCloseClaimLostError` and aborts the GitHub post.
+ *
+ * Idempotent on already-closed rooms: returns
+ * `RoomAlreadyClosedError` instead of double-emitting a terminate
+ * event. Caller chooses to swallow or surface.
+ *
+ * Status effects:
+ *   - status flips to `closed`
+ *   - closed_at = nowIso
+ *   - closed_reason = args.reason
+ *   - claim DELed if any
+ *   - subject index DELed (releases per-installation subject lock)
+ *   - removed from ALL secondary indexes (status / installation / repo)
+ *   - sibling keys EXPIRE at retentionSecs
+ *
+ * Throws:
+ *   - `RoomAlreadyClosedError` when status is already `closed`
+ *   - `RoomNotFoundError` when the room hash is gone
+ */
+export async function terminateRoom(args: {
+  installationId: string;
+  roomId: string;
+  reason: TerminalReason;
+  /** Subject ref needed to compute the subject index key (the
+   * subject lock to release). Caller-supplied because the room hash
+   * stores subject_ref inside the `data` JSON blob — passing it
+   * explicitly avoids a pre-EVAL HGETALL. */
+  subject: SubjectRef;
+  /** Source actor for the `room_terminated` event. System-driven
+   * paths (watchdog / cron) use sentinel actors; operator UI uses
+   * the bearer envelope's role+id. */
+  actorRole: string;
+  actorId: string;
+  /** Optional: surface the watchdog's observed-current-status so
+   * status-set membership migration uses the right "from" set. If
+   * omitted, caller must HGETALL first. */
+  currentStatus: RoomStatus;
+  retentionSecs?: number;
+  redis: Redis;
+  nowMs?: number;
+}): Promise<number> {
+  validateSubjectRef(args.subject);
+
+  const nowMs = args.nowMs ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const retention = args.retentionSecs ?? ROOM_RETENTION_AFTER_CLOSE_SECS;
+
+  const eventTemplate = JSON.stringify({
+    seq: "__SEQ__",
+    timestamp: nowIso,
+    event_type: "room_terminated",
+    actor_role: args.actorRole,
+    actor_id: args.actorId,
+    body: { reason: args.reason },
+  });
+  const luaTemplate = eventTemplate.replace('"__SEQ__"', "__SEQ__");
+
+  const repo = repoFromSubjectRef(args.subject.ref);
+
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      ROOM_TERMINATE_SCRIPT,
+      [
+        roomKey(args.installationId, args.roomId),
+        subjectIndexKey(
+          args.installationId,
+          args.subject.type,
+          args.subject.ref,
+        ),
+        statusIndexKey(args.installationId, args.currentStatus),
+        installationIndexKey(args.installationId),
+        repoIndexKey(args.installationId, repo),
+        seqKey(args.roomId),
+        eventsKey(args.roomId),
+        participantsKey(args.roomId),
+        contributionsKey(args.roomId),
+        claimKey(args.roomId),
+      ],
+      [
+        args.roomId,
+        luaTemplate,
+        nowIso,
+        String(retention),
+        args.reason,
+      ],
+    ),
+  );
+
+  if (result.ok === 1 && typeof result.tag1 === "number") {
+    return result.tag1;
+  }
+  if (result.ok === -1 && typeof result.tag1 === "string") {
+    if (result.tag1 === "room_not_found") {
+      throw new RoomNotFoundError(args.installationId, args.roomId);
+    }
+    if (result.tag1 === "closed") {
+      throw new RoomAlreadyClosedError(args.roomId, "closed");
+    }
+    // Defensive: any other status value would be a programming error
+    // (TERMINATE allows ALL non-closed statuses); surface it loudly.
+    throw new Error(
+      `ROOM_TERMINATE_SCRIPT returned unexpected status: ${result.tag1}`,
+    );
+  }
+  throw new Error(
+    `ROOM_TERMINATE_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+  );
+}
+
+/**
+ * Close a room with the queen's synthesized decision — happy-path
+ * close that requires a live claim AND sequence consistency.
+ *
+ * The queen calls this AFTER `claimSynthesis` returns
+ * `{throughSequence, claimTtlSecs}` and AFTER the queen's runtime
+ * has produced a `RoomDecision`. The script verifies:
+ *   1. Claim still exists (DEL'd → force-close raced; abort)
+ *   2. Claim's `throughSequence` matches caller's expectation
+ *      (mismatch → another runner re-claimed; abort)
+ *   3. Live `seq` matches `expectedThroughSequence` (drift → new
+ *      events arrived during synthesis; revert + retry)
+ *
+ * Drift handling: revert is atomic. The queen aborts its GitHub
+ * post on `RoomCloseDriftError`, and the manager loop re-claims on
+ * the next tick (the room's status is back at
+ * `awaiting_contributions` — synthesis re-enters cleanly).
+ *
+ * Throws (each typed for caller decision):
+ *   - `RoomCloseClaimLostError` — claim DELed (likely force-close);
+ *     ABORT the GitHub post and surface terminal state to operator
+ *   - `RoomCloseClaimThroughSeqMismatchError` — different runner
+ *     re-claimed; ABORT, do NOT post
+ *   - `RoomCloseDriftError` — sequence drift; revert is already
+ *     applied, queen logs and exits, manager re-claims
+ *   - `RoomClaimPayloadCorruptError` — claim payload corrupted;
+ *     ABORT, operator inspects
+ */
+export async function closeRoomWithDecision(args: {
+  installationId: string;
+  roomId: string;
+  /** Captured at claim time from `claimSynthesis(...).throughSequence`. */
+  expectedThroughSequence: number;
+  decision: RoomDecision;
+  subject: SubjectRef;
+  retentionSecs?: number;
+  redis: Redis;
+  nowMs?: number;
+}): Promise<number> {
+  validateSubjectRef(args.subject);
+  validateRunnerFormat(args.decision.synthesis_runner);
+  if (args.decision.content.length > 64 * 1024) {
+    throw new Error(
+      `RoomDecision.content exceeds 64 KiB (${args.decision.content.length} bytes); reduce body before close.`,
+    );
+  }
+
+  const nowMs = args.nowMs ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const retention = args.retentionSecs ?? ROOM_RETENTION_AFTER_CLOSE_SECS;
+
+  // Top-level `seq` carries the sequence; body intentionally does
+  // NOT duplicate it (would force an uncapped gsub and reintroduce
+  // #510 B1 — user-content collision risk on the synthesis_runner
+  // string). Consumers read seq from the event's top-level field.
+  const eventTemplate = JSON.stringify({
+    seq: "__SEQ__",
+    timestamp: nowIso,
+    event_type: "room_decided",
+    actor_role: "manager",
+    actor_id: args.decision.synthesis_runner,
+    body: { synthesis_runner: args.decision.synthesis_runner },
+  });
+  const luaTemplate = eventTemplate.replace('"__SEQ__"', "__SEQ__");
+
+  const repo = repoFromSubjectRef(args.subject.ref);
+
+  const result = dispatchScriptResult(
+    await args.redis.eval(
+      ROOM_CLOSE_SCRIPT,
+      [
+        roomKey(args.installationId, args.roomId),
+        claimKey(args.roomId),
+        seqKey(args.roomId),
+        statusIndexKey(args.installationId, "deciding"),
+        statusIndexKey(args.installationId, "awaiting_contributions"),
+        subjectIndexKey(
+          args.installationId,
+          args.subject.type,
+          args.subject.ref,
+        ),
+        eventsKey(args.roomId),
+        participantsKey(args.roomId),
+        contributionsKey(args.roomId),
+        installationIndexKey(args.installationId),
+        repoIndexKey(args.installationId, repo),
+      ],
+      [
+        args.roomId,
+        String(args.expectedThroughSequence),
+        JSON.stringify(args.decision),
+        luaTemplate,
+        nowIso,
+        String(retention),
+      ],
+    ),
+  );
+
+  if (result.ok === 1 && typeof result.tag1 === "number") {
+    return result.tag1;
+  }
+  if (result.ok === -2 && typeof result.tag1 === "number") {
+    throw new RoomCloseDriftError(
+      args.roomId,
+      args.expectedThroughSequence,
+      result.tag1,
+    );
+  }
+  if (result.ok === -3 && typeof result.tag1 === "string") {
+    if (result.tag1 === "claim_lost") {
+      throw new RoomCloseClaimLostError(args.roomId);
+    }
+    if (result.tag1 === "decode_error") {
+      throw new RoomClaimPayloadCorruptError(args.roomId);
+    }
+    if (result.tag1 === "claim_throughSeq_mismatch") {
+      const actual =
+        typeof result.tag2 === "number" ? result.tag2 : -1;
+      throw new RoomCloseClaimThroughSeqMismatchError(
+        args.roomId,
+        args.expectedThroughSequence,
+        actual,
+      );
+    }
+  }
+  throw new Error(
+    `ROOM_CLOSE_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
   );
 }
 

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -2049,22 +2049,27 @@ return {1, seq}
  *      capped at first match per #510 guard B1)
  *   4. HSET status="closed" + closed_at + closed_reason
  *   5. DEL subject index (release the per-installation subject lock)
- *   6. SREM/ZREM/SREM from status, installation, repo indexes (closes
- *      Queen R2 #2 — index leaks; M3 — per-repo set leaks)
+ *   6. SREM from ALL non-terminal status sets idempotently (closes
+ *      #515 builder R1: a stale caller-supplied `currentStatus` could
+ *      race a concurrent `claimSynthesis` and SREM the wrong set,
+ *      leaving phantom membership in the live status set). ZREM/SREM
+ *      from installation + per-repo indexes (closes Queen R2 #2 / M3).
  *   7. EXPIRE all sibling keys at retentionSecs (closes Queen R2 #1
  *      — TTL leak)
  *
  * KEYS:
  *   [1] roomKey
  *   [2] subjectIndexKey
- *   [3] statusSetCurrentKey   — current status's set (caller resolves)
- *   [4] installationIndexKey  — all-rooms-for-installation sorted set
- *   [5] repoIndexKey          — per-repo set
- *   [6] seqKey
- *   [7] eventsKey
- *   [8] participantsKey       — for TTL only (read-once at terminate)
- *   [9] contributionsKey      — for TTL only
- *   [10] claimKey             — DELed if held (deciding-state cleanup)
+ *   [3] statusSetAwaitingRsvpKey       — SREM idempotent
+ *   [4] statusSetAwaitingContribKey    — SREM idempotent
+ *   [5] statusSetDecidingKey           — SREM idempotent
+ *   [6] installationIndexKey           — all-rooms-for-installation sorted set
+ *   [7] repoIndexKey                   — per-repo set
+ *   [8] seqKey
+ *   [9] eventsKey
+ *   [10] participantsKey               — for TTL only
+ *   [11] contributionsKey              — for TTL only
+ *   [12] claimKey                      — DELed if held (deciding-state cleanup)
  *
  * ARGV:
  *   [1] roomId
@@ -2083,23 +2088,25 @@ if not currStatus then return {-1, "room_not_found"} end
 if currStatus == "closed" then
   return {-1, currStatus}
 end
-redis.call("del", KEYS[10])
-local seq = redis.call("incr", KEYS[6])
+redis.call("del", KEYS[12])
+local seq = redis.call("incr", KEYS[8])
 local eventJson = string.gsub(ARGV[2], "__SEQ__", tostring(seq), 1)
-redis.call("zadd", KEYS[7], seq, eventJson)
+redis.call("zadd", KEYS[9], seq, eventJson)
 redis.call("hset", KEYS[1], "status", "closed",
                           "closed_at", ARGV[3],
                           "closed_reason", ARGV[5])
 redis.call("del", KEYS[2])
 redis.call("srem", KEYS[3], ARGV[1])
-redis.call("zrem", KEYS[4], ARGV[1])
+redis.call("srem", KEYS[4], ARGV[1])
 redis.call("srem", KEYS[5], ARGV[1])
+redis.call("zrem", KEYS[6], ARGV[1])
+redis.call("srem", KEYS[7], ARGV[1])
 local retention = tonumber(ARGV[4])
 redis.call("expire", KEYS[1], retention)
-redis.call("expire", KEYS[6], retention)
-redis.call("expire", KEYS[7], retention)
 redis.call("expire", KEYS[8], retention)
 redis.call("expire", KEYS[9], retention)
+redis.call("expire", KEYS[10], retention)
+redis.call("expire", KEYS[11], retention)
 return {1, seq}
 `;
 
@@ -3193,10 +3200,6 @@ export async function terminateRoom(args: {
    * the bearer envelope's role+id. */
   actorRole: string;
   actorId: string;
-  /** Optional: surface the watchdog's observed-current-status so
-   * status-set membership migration uses the right "from" set. If
-   * omitted, caller must HGETALL first. */
-  currentStatus: RoomStatus;
   retentionSecs?: number;
   redis: Redis;
   nowMs?: number;
@@ -3229,7 +3232,13 @@ export async function terminateRoom(args: {
           args.subject.type,
           args.subject.ref,
         ),
-        statusIndexKey(args.installationId, args.currentStatus),
+        // All three non-terminal status sets — script SREMs each
+        // idempotently. Closes #515 builder R1: a stale
+        // caller-supplied currentStatus could SREM the wrong set
+        // and leave phantom membership in the live one.
+        statusIndexKey(args.installationId, "awaiting_rsvp"),
+        statusIndexKey(args.installationId, "awaiting_contributions"),
+        statusIndexKey(args.installationId, "deciding"),
         installationIndexKey(args.installationId),
         repoIndexKey(args.installationId, repo),
         seqKey(args.roomId),
@@ -3310,9 +3319,16 @@ export async function closeRoomWithDecision(args: {
 }): Promise<number> {
   validateSubjectRef(args.subject);
   validateRunnerFormat(args.decision.synthesis_runner);
-  if (args.decision.content.length > 64 * 1024) {
+  // BYTE length, not UTF-16 code-unit `.length`. A multi-byte
+  // synthesis (emoji, non-ASCII narrative) can have `.length` < byte
+  // budget while the actual storage payload exceeds 64 KiB. Closes
+  // #515 builder R1 — file uses Buffer.byteLength elsewhere for
+  // consistency (see ROOM_EVENT_BODY_MAX_BYTES enforcement at
+  // assertEventBodySize).
+  const decisionContentBytes = Buffer.byteLength(args.decision.content, "utf8");
+  if (decisionContentBytes > 64 * 1024) {
     throw new Error(
-      `RoomDecision.content exceeds 64 KiB (${args.decision.content.length} bytes); reduce body before close.`,
+      `RoomDecision.content exceeds 64 KiB (${decisionContentBytes} bytes); reduce body before close.`,
     );
   }
 


### PR DESCRIPTION
Fixes #514

## Summary

Phase D.1.a-iii.c closes the war-room storage layer — the room state machine now has all four transition scripts (DECIDE_CLAIM, RECOVER, **TERMINATE**, **CLOSE**) and is ready for the HTTP API layer (D.1.b).

Two new atomic Lua scripts + matching primitives:

1. **`ROOM_TERMINATE_SCRIPT`** (10 keys × 5 args) — atomic terminal close without claim. Covers `expired` / `failed_synthesis` / `force_close` / `manual` paths. DELs the queen's claim if held (deciding-state cleanup, closes design R3 N8) so a mid-flight `closeRoomWithDecision` returns `RoomCloseClaimLostError` and aborts.
2. **`ROOM_CLOSE_SCRIPT`** (11 keys × 6 args) — queen happy-path close with sequence-consistency check. Drift atomically reverts to `awaiting_contributions` + restores status-set membership + DELs claim → `RoomCloseDriftError` signals the manager loop to re-claim.

This PR also folds in the four non-blocking carry-forwards from #512 guard review (N1, N2, N5, N6).

## What it looks like

**State machine — completed:**

```
awaiting_rsvp ──[all roles RSVP'd]──> awaiting_contributions
                                            │
                       ┌────────────────────┼─────────────────────┐
                       │                    │                     │
                  [claim]              [terminate]           [contributions
                       │              (any reason)            still pending]
                       ▼                    │                     │
                  deciding ──[recover]──────┤                     │
                       │   (claim TTL'd)    │                     │
                       │                    ▼                     │
              ┌────────┼────────┐         closed                  │
              │        │        │                                 │
         [close]  [drift]  [terminate] ────────────────────────►◄─┘
              │        │     (force-close                      
              │        │      mid-deciding)                    
              ▼        ▼                                       
           closed  awaiting_contributions
                    (caller re-claims)                         
```

**Behavior table — `terminateRoom`:**

| Initial status | Effect |
|---|---|
| `awaiting_rsvp` / `awaiting_contributions` | flip → `closed` + emit `room_terminated` event |
| `deciding` | DEL claim + flip → `closed` + emit event (queen's mid-flight close will see `claim_lost`) |
| `closed` | `RoomAlreadyClosedError` (idempotent no-op) |
| missing | `RoomNotFoundError` |

**Behavior table — `closeRoomWithDecision`:**

| Pre-condition | Result |
|---|---|
| status=`deciding`, claim live, `lastSeq == expectedThroughSequence` | ✅ closes cleanly, emits `room_decided` |
| Claim DEL'd (force-closed mid-flight) | `RoomCloseClaimLostError` — abort GitHub post |
| Claim's `throughSequence` ≠ `expectedThroughSequence` | `RoomCloseClaimThroughSeqMismatchError(expected, actual)` — abort |
| `lastSeq > expectedThroughSequence` (drift) | `RoomCloseDriftError(expected, lastSeq)` — atomic revert applied; manager re-claims |
| Claim payload corruption | `RoomClaimPayloadCorruptError` — operator inspects |

**Carry-forwards from #512 guard review (all closed):**

- **N1** — `ROOM_DECIDE_CLAIM_SCRIPT` now JSON-packs holder info into `tag2` (single string) instead of positional `tag3+tag4`. Removes the racy post-EVAL `GET` in `claimSynthesis`. New script return: `{0, "already_claimed", JSON.stringify({runner, throughSequence})}`.
- **N2** — `pcall` wraps on `cjson.decode` in DECIDE_CLAIM and CLOSE. Corrupted payloads surface as `RoomClaimPayloadCorruptError` rather than panicking the script.
- **N5** — `RoomEvent.actor_role` / `actor_id` JSDoc now acknowledges the system-actor exception (sentinels: `manager`/`watchdog` for recovery + watchdog timeout, `system`/`vercel-cron` for cron-fired TERMINATE).
- **N6** — `validateRunnerFormat` boundary check applied at `claimSynthesis` and `closeRoomWithDecision` entry. Rejects `__SEQ__` literals, whitespace, control chars, > 128 chars BEFORE storage write.

## Test plan

- [x] Typecheck (`tsc --noEmit`) clean
- [x] Full web suite passes: 1141 tests passing (178 in `war-room.test.ts`)
- [x] 26 new tests covering:
  - Source-shape regression on both new Lua scripts (capped `gsub`, `pcall` decode, status-set migration, sibling EXPIRE)
  - `validateRunnerFormat` (canonical formats accepted, all rejection paths covered)
  - `claimSynthesis` R3 reshape (desync edge case surfaces real `throughSequence` without re-read; rejects malformed runner; surfaces `RoomClaimPayloadCorruptError` on garbage payload)
  - `terminateRoom` (each status path, claim cleanup on deciding, idempotent already-closed, malformed subject rejection, missing room, system-actor sentinels)
  - `closeRoomWithDecision` (happy path with full event log, claim_lost race, through-seq mismatch with rich error, drift + atomic revert, drift → re-claim cycle, runner validation, content size cap, `__SEQ__` preservation in decision content)
  - End-to-end: RSVP → contribute → claim → close → terminal closed state with full event log
- [ ] Reviewer fleet sign-off