### PR TITLE
Phase D.1.b-i — read endpoints over /api/rooms

### DIFF
--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
@@ -128,10 +128,18 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
 
   it("preset 'monitoring' → replaces caps with monitoring's bundle", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
+    // Monitoring preset includes rooms.read_all (added in #517 R2 for
+    // installation-wide room listing — workers stay on rooms.read).
+    const monitoringCaps = [
+      "agent_health.read",
+      "tasks.read",
+      "rooms.read",
+      "rooms.read_all",
+    ];
     mockedSet.mockResolvedValue({
       name: "worker",
       agent_role: "drone",
-      capabilities: ["agent_health.read", "tasks.read", "rooms.read"],
+      capabilities: monitoringCaps,
       fingerprint: "01234567",
       createdAt: "2026-04-27T10:00:00.000Z",
       createdBy: "admin",
@@ -143,16 +151,8 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.token.capabilities).toEqual([
-      "agent_health.read",
-      "tasks.read",
-      "rooms.read",
-    ]);
-    expect(mockedSet.mock.calls[0][0].capabilities).toEqual([
-      "agent_health.read",
-      "tasks.read",
-      "rooms.read",
-    ]);
+    expect(body.token.capabilities).toEqual(monitoringCaps);
+    expect(mockedSet.mock.calls[0][0].capabilities).toEqual(monitoringCaps);
   });
 
   it("explicit capabilities → 200 with same list back", async () => {

--- a/web/src/app/api/rooms/[roomId]/contributions/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.test.ts
@@ -48,7 +48,7 @@ function makeAuthOk() {
     installationId: "12345",
     name: "worker",
     agent_role: "drone",
-    capabilities: ["rooms.read"],
+    capabilities: ["rooms.read_all"],
     redis: {} as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
@@ -68,7 +68,7 @@ describe("GET /api/rooms/:roomId/contributions", () => {
     await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
     expect(mockedAuth).toHaveBeenCalledWith(
       expect.anything(),
-      { requires: "rooms.read" },
+      { requires: "rooms.read_all" },
     );
   });
 

--- a/web/src/app/api/rooms/[roomId]/contributions/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for GET /api/rooms/:roomId/contributions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    getRoomCore: vi.fn(),
+    getRoomContributions: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  getRoomContributions,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedGetRoomCore = vi.mocked(getRoomCore);
+const mockedGetRoomContributions = vi.mocked(getRoomContributions);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(): NextRequest {
+  return new NextRequest(`https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/contributions`, {
+    method: "GET",
+    headers: { authorization: "Bearer hmt_test" },
+  });
+}
+
+function makeAuthOk() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "worker",
+    agent_role: "drone",
+    capabilities: ["rooms.read"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("GET /api/rooms/:roomId/contributions", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedGetRoomCore.mockReset();
+    mockedGetRoomContributions.mockReset();
+  });
+
+  it("requires rooms.read", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedGetRoomContributions.mockResolvedValue({});
+    await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.read" },
+    );
+  });
+
+  it("returns contributions keyed by role", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    const contributions = {
+      drone: {
+        role: "drone",
+        body: { verdict: "APPROVE", summary: "ok" },
+        contributed_at: "2026-04-28T07:00:00.000Z",
+      },
+    } as never;
+    mockedGetRoomContributions.mockResolvedValue(contributions);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contributions).toEqual(contributions);
+    expect(body.roomId).toBe(VALID_ROOM_ID);
+  });
+
+  it("withdrawn tombstones are surfaced as-is (caller distinguishes via withdrawn:true)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    const contributions = {
+      drone: { withdrawn: true, contributed_at: "2026-04-28T07:00:00.000Z" },
+    } as never;
+    mockedGetRoomContributions.mockResolvedValue(contributions);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contributions.drone.withdrawn).toBe(true);
+  });
+
+  it("verifies room exists FIRST (cross-install isolation)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockedGetRoomContributions).not.toHaveBeenCalled();
+  });
+
+  it("malformed roomId → 404", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(new RoomIdFormatError("bad"));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: "bad" }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/contributions/route.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.ts
@@ -27,7 +27,7 @@ export async function GET(
   { params }: { params: Promise<{ roomId: string }> },
 ): Promise<NextResponse> {
   const auth = await authenticateAgentRequestV1(request, {
-    requires: "rooms.read",
+    requires: "rooms.read_all",
   });
   if (!auth.ok) return auth.response;
 

--- a/web/src/app/api/rooms/[roomId]/contributions/route.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/rooms/:roomId/contributions — read materialized
+ * contributions hash (latest contribution per role, plus tombstones
+ * for withdrawn).
+ *
+ * Capability: `rooms.read`. Cross-installation isolation: same
+ * room-existence pre-check as `/events` (the contributions hash is
+ * keyed by roomId only).
+ *
+ * Response: `{ contributions: Record<role, RoomContribution>, roomId: string }`.
+ *           Withdrawn contributions surface as tombstones with
+ *           `{ withdrawn: true, contributed_at }`.
+ * Errors: 401, 403, 404.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  getRoomContributions,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.read",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  try {
+    await getRoomCore({
+      installationId: auth.installationId,
+      roomId,
+      redis: auth.redis,
+    });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+
+  const contributions = await getRoomContributions({
+    roomId,
+    redis: auth.redis,
+  });
+  return NextResponse.json({ contributions, roomId }, { status: 200 });
+}

--- a/web/src/app/api/rooms/[roomId]/events/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/events/route.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for GET /api/rooms/:roomId/events.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    getRoomCore: vi.fn(),
+    listRoomEvents: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  listRoomEvents,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedGetRoomCore = vi.mocked(getRoomCore);
+const mockedListRoomEvents = vi.mocked(listRoomEvents);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(url: string = `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/events`): NextRequest {
+  return new NextRequest(url, {
+    method: "GET",
+    headers: { authorization: "Bearer hmt_test" },
+  });
+}
+
+function makeAuthOk() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "worker",
+    agent_role: "drone",
+    capabilities: ["rooms.read"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("GET /api/rooms/:roomId/events", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedGetRoomCore.mockReset();
+    mockedListRoomEvents.mockReset();
+  });
+
+  it("requires rooms.read capability", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedListRoomEvents.mockResolvedValue([]);
+    await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.read" },
+    );
+  });
+
+  it("verifies room exists in bearer's installation BEFORE listing events (cross-install isolation)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    // listRoomEvents must NOT have been called when the room
+    // doesn't exist in this installation.
+    expect(mockedListRoomEvents).not.toHaveBeenCalled();
+  });
+
+  it("RoomIdFormatError → 404 (no oracle)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(new RoomIdFormatError("bad-id"));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: "bad-id" }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("room_not_found");
+  });
+
+  it("returns events on success with default since=0 + limit=200", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    const events = [{ seq: 1, event_type: "room_opened" }] as never[];
+    mockedListRoomEvents.mockResolvedValue(events);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual(events);
+    expect(body.roomId).toBe(VALID_ROOM_ID);
+    expect(mockedListRoomEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ roomId: VALID_ROOM_ID, since: 0, limit: 200 }),
+    );
+  });
+
+  it("respects valid since cursor", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedListRoomEvents.mockResolvedValue([]);
+    await GET(
+      makeRequest(`https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/events?since=42`),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(mockedListRoomEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ since: 42 }),
+    );
+  });
+
+  it("rejects negative since (falls back to default 0)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedListRoomEvents.mockResolvedValue([]);
+    await GET(
+      makeRequest(`https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/events?since=-5`),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(mockedListRoomEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ since: 0 }),
+    );
+  });
+
+  it("clamps limit to MAX_LIMIT (500)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedListRoomEvents.mockResolvedValue([]);
+    await GET(
+      makeRequest(`https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/events?limit=10000`),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(mockedListRoomEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 500 }),
+    );
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/events/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/events/route.test.ts
@@ -48,7 +48,7 @@ function makeAuthOk() {
     installationId: "12345",
     name: "worker",
     agent_role: "drone",
-    capabilities: ["rooms.read"],
+    capabilities: ["rooms.read_all"],
     redis: {} as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
@@ -68,7 +68,7 @@ describe("GET /api/rooms/:roomId/events", () => {
     await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
     expect(mockedAuth).toHaveBeenCalledWith(
       expect.anything(),
-      { requires: "rooms.read" },
+      { requires: "rooms.read_all" },
     );
   });
 

--- a/web/src/app/api/rooms/[roomId]/events/route.ts
+++ b/web/src/app/api/rooms/[roomId]/events/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /api/rooms/:roomId/events — list events from the room's
+ * append-only log, ordered by sequence ascending.
+ *
+ * Capability: `rooms.read`. Cross-installation isolation: the
+ * underlying events sorted set is keyed only by `roomId`, BUT the
+ * caller proves they have access to the room by passing the auth
+ * gate AND the route handler verifies the room exists in the
+ * bearer's installation before returning events (closes the
+ * cross-installation discovery vector — without the existence
+ * check, a worker could enumerate roomIds and read events from
+ * rooms in other installations).
+ *
+ * Query params:
+ *   - `since` (optional, default 0): events with `seq > since` are
+ *     returned. Use the last-seen `seq` from the prior page as the
+ *     cursor.
+ *   - `limit` (optional, default 200, max 500, min 1).
+ *
+ * Response: `{ events: RoomEvent[], roomId: string }`.
+ * Errors: 401, 403, 404 (room not found or in another installation).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  listRoomEvents,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 500;
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.read",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+  const url = new URL(request.url);
+  const rawSince = url.searchParams.get("since");
+  const rawLimit = url.searchParams.get("limit");
+  let since = 0;
+  if (rawSince !== null) {
+    const parsed = Number.parseInt(rawSince, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) since = parsed;
+  }
+  let limit = DEFAULT_LIMIT;
+  if (rawLimit !== null) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (Number.isFinite(parsed)) {
+      limit = Math.min(MAX_LIMIT, Math.max(1, parsed));
+    }
+  }
+
+  // Verify the room exists in THIS installation before reading
+  // events. Without this, a roomId from another installation would
+  // return that installation's events (events sorted set is keyed
+  // by roomId only). Closes the cross-installation discovery vector.
+  try {
+    await getRoomCore({
+      installationId: auth.installationId,
+      roomId,
+      redis: auth.redis,
+    });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+
+  const events = await listRoomEvents({
+    roomId,
+    since,
+    limit,
+    redis: auth.redis,
+  });
+
+  return NextResponse.json({ events, roomId }, { status: 200 });
+}

--- a/web/src/app/api/rooms/[roomId]/events/route.ts
+++ b/web/src/app/api/rooms/[roomId]/events/route.ts
@@ -38,7 +38,7 @@ export async function GET(
   { params }: { params: Promise<{ roomId: string }> },
 ): Promise<NextResponse> {
   const auth = await authenticateAgentRequestV1(request, {
-    requires: "rooms.read",
+    requires: "rooms.read_all",
   });
   if (!auth.ok) return auth.response;
 

--- a/web/src/app/api/rooms/[roomId]/participants/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/participants/route.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for GET /api/rooms/:roomId/participants.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    getRoomCore: vi.fn(),
+    getRoomParticipants: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  getRoomParticipants,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedGetRoomCore = vi.mocked(getRoomCore);
+const mockedGetRoomParticipants = vi.mocked(getRoomParticipants);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(): NextRequest {
+  return new NextRequest(`https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/participants`, {
+    method: "GET",
+    headers: { authorization: "Bearer hmt_test" },
+  });
+}
+
+function makeAuthOk() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "worker",
+    agent_role: "drone",
+    capabilities: ["rooms.read"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("GET /api/rooms/:roomId/participants", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedGetRoomCore.mockReset();
+    mockedGetRoomParticipants.mockReset();
+  });
+
+  it("requires rooms.read", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedGetRoomParticipants.mockResolvedValue({});
+    await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.read" },
+    );
+  });
+
+  it("returns participants keyed by role", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    const participants = {
+      drone: { role: "drone", agent_id: "drone-1", status: "pending" },
+    } as never;
+    mockedGetRoomParticipants.mockResolvedValue(participants);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.participants).toEqual(participants);
+    expect(body.roomId).toBe(VALID_ROOM_ID);
+  });
+
+  it("verifies room exists in bearer's installation FIRST (cross-install isolation)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockedGetRoomParticipants).not.toHaveBeenCalled();
+  });
+
+  it("malformed roomId → 404 not 400", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(new RoomIdFormatError("bad"));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: "bad" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("empty participants returns {} not null", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    mockedGetRoomParticipants.mockResolvedValue({});
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.participants).toEqual({});
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/participants/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/participants/route.test.ts
@@ -48,7 +48,7 @@ function makeAuthOk() {
     installationId: "12345",
     name: "worker",
     agent_role: "drone",
-    capabilities: ["rooms.read"],
+    capabilities: ["rooms.read_all"],
     redis: {} as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
@@ -68,7 +68,7 @@ describe("GET /api/rooms/:roomId/participants", () => {
     await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
     expect(mockedAuth).toHaveBeenCalledWith(
       expect.anything(),
-      { requires: "rooms.read" },
+      { requires: "rooms.read_all" },
     );
   });
 

--- a/web/src/app/api/rooms/[roomId]/participants/route.ts
+++ b/web/src/app/api/rooms/[roomId]/participants/route.ts
@@ -25,7 +25,7 @@ export async function GET(
   { params }: { params: Promise<{ roomId: string }> },
 ): Promise<NextResponse> {
   const auth = await authenticateAgentRequestV1(request, {
-    requires: "rooms.read",
+    requires: "rooms.read_all",
   });
   if (!auth.ok) return auth.response;
 

--- a/web/src/app/api/rooms/[roomId]/participants/route.ts
+++ b/web/src/app/api/rooms/[roomId]/participants/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /api/rooms/:roomId/participants — read materialized
+ * participants hash (latest state per role).
+ *
+ * Capability: `rooms.read`. Cross-installation isolation: same
+ * room-existence pre-check as `/events` (the participants hash is
+ * keyed by roomId only).
+ *
+ * Response: `{ participants: Record<role, RoomParticipant>, roomId: string }`.
+ *           Empty object when the room has no participants yet.
+ * Errors: 401, 403, 404.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  getRoomParticipants,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.read",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  try {
+    await getRoomCore({
+      installationId: auth.installationId,
+      roomId,
+      redis: auth.redis,
+    });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+
+  const participants = await getRoomParticipants({
+    roomId,
+    redis: auth.redis,
+  });
+  return NextResponse.json({ participants, roomId }, { status: 200 });
+}

--- a/web/src/app/api/rooms/[roomId]/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for GET /api/rooms/:roomId — fetch a single room's core record.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    getRoomCore: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedGetRoomCore = vi.mocked(getRoomCore);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/rooms/x", {
+    method: "GET",
+    headers: { authorization: "Bearer hmt_test" },
+  });
+}
+
+function makeAuthOk(installationId = "12345") {
+  return {
+    ok: true as const,
+    installationId,
+    name: "worker",
+    agent_role: "drone",
+    capabilities: ["rooms.read"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("GET /api/rooms/:roomId", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedGetRoomCore.mockReset();
+  });
+
+  it("delegates 401 on missing bearer", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "agent_auth_v1_missing_bearer" }, { status: 401 }),
+    });
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("requires rooms.read capability", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.read" },
+    );
+  });
+
+  it("returns 200 with the room core on success", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const fakeRoom = { status: "awaiting_rsvp", manager: "bot-queen" } as never;
+    mockedGetRoomCore.mockResolvedValue(fakeRoom);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(fakeRoom);
+  });
+
+  it("scopes read to bearer's installation (cross-installation isolation)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk("BEARER_INSTALL"));
+    mockedGetRoomCore.mockResolvedValue({} as never);
+    await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(mockedGetRoomCore).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "BEARER_INSTALL" }),
+    );
+  });
+
+  it("RoomNotFoundError → 404 with stable code", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("room_not_found");
+  });
+
+  it("RoomIdFormatError → 404 (no oracle for malformed-vs-missing)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(new RoomIdFormatError("not-a-uuid"));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    // Same response shape as missing room — closes the unauthorized
+    // discovery vector (caller can't distinguish "you guessed an
+    // invalid id" from "you guessed a valid id that doesn't exist
+    // OR is in another installation").
+    expect(body.code).toBe("room_not_found");
+  });
+
+  it("propagates unexpected errors (5xx)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedGetRoomCore.mockRejectedValue(new Error("Redis down"));
+    await expect(
+      GET(makeRequest(), {
+        params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+      }),
+    ).rejects.toThrow("Redis down");
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/route.test.ts
@@ -45,7 +45,7 @@ function makeAuthOk(installationId = "12345") {
     installationId,
     name: "worker",
     agent_role: "drone",
-    capabilities: ["rooms.read"],
+    capabilities: ["rooms.read_all"],
     redis: {} as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
@@ -74,7 +74,7 @@ describe("GET /api/rooms/:roomId", () => {
     await GET(makeRequest(), { params: Promise.resolve({ roomId: VALID_ROOM_ID }) });
     expect(mockedAuth).toHaveBeenCalledWith(
       expect.anything(),
-      { requires: "rooms.read" },
+      { requires: "rooms.read_all" },
     );
   });
 

--- a/web/src/app/api/rooms/[roomId]/route.ts
+++ b/web/src/app/api/rooms/[roomId]/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /api/rooms/:roomId — fetch a single room's core record.
+ *
+ * Capability: `rooms.read`. Cross-installation isolation: the room
+ * is read from the bearer's installation only — a roomId belonging
+ * to another installation will return 404 (the storage primitive
+ * uses the installation-scoped key).
+ *
+ * Path params:
+ *   - `roomId`: RFC 4122 UUIDv4 lowercase. Validated by the storage
+ *     primitive; malformed roomId returns 404 (not 400 — no oracle
+ *     for "room not found vs malformed id" since both are
+ *     unauthorized-discovery vectors).
+ *
+ * Response: `RoomCore` JSON.
+ * Errors: 401 (auth), 403 (capability), 404 (room not found OR
+ * malformed roomId — same response shape).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.read",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  try {
+    const room = await getRoomCore({
+      installationId: auth.installationId,
+      roomId,
+      redis: auth.redis,
+    });
+    return NextResponse.json(room, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/route.ts
+++ b/web/src/app/api/rooms/[roomId]/route.ts
@@ -30,7 +30,7 @@ export async function GET(
   { params }: { params: Promise<{ roomId: string }> },
 ): Promise<NextResponse> {
   const auth = await authenticateAgentRequestV1(request, {
-    requires: "rooms.read",
+    requires: "rooms.read_all",
   });
   if (!auth.ok) return auth.response;
 

--- a/web/src/app/api/rooms/route.test.ts
+++ b/web/src/app/api/rooms/route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for GET /api/rooms — list war rooms for the bearer's installation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", () => ({
+  listRooms: vi.fn(),
+}));
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { listRooms } from "@/server/war-room";
+import { GET, POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedListRooms = vi.mocked(listRooms);
+
+function makeRequest(url: string = "https://www.hivemoot.dev/api/rooms"): NextRequest {
+  return new NextRequest(url, {
+    method: "GET",
+    headers: { authorization: "Bearer hmt_test" },
+  });
+}
+
+function makeAuthOk(overrides?: { installationId?: string }) {
+  return {
+    ok: true as const,
+    installationId: overrides?.installationId ?? "12345",
+    name: "queen",
+    agent_role: "queen",
+    capabilities: ["rooms.read"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("GET /api/rooms", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedListRooms.mockReset();
+  });
+
+  it("delegates 401 to auth middleware on missing/invalid bearer", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "agent_auth_v1_missing_bearer" }, { status: 401 }),
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockedListRooms).not.toHaveBeenCalled();
+  });
+
+  it("requires rooms.read capability (passed to authenticateAgentRequestV1)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest());
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.read" },
+    );
+  });
+
+  it("returns rooms scoped to the bearer's installation (no cross-installation read)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk({ installationId: "12345" }));
+    const fakeRooms = [{ status: "awaiting_rsvp" } as never];
+    mockedListRooms.mockResolvedValue(fakeRooms);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rooms).toEqual(fakeRooms);
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+
+  it("ignores client-supplied installationId — bearer's installation wins", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk({ installationId: "BEARER_INSTALL" }));
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest("https://www.hivemoot.dev/api/rooms?installationId=ATTACKER_INSTALL"));
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "BEARER_INSTALL" }),
+    );
+  });
+
+  it("default limit is 50 when query omitted", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest());
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+
+  it("respects valid limit query param", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest("https://www.hivemoot.dev/api/rooms?limit=20"));
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 20 }),
+    );
+  });
+
+  it("clamps limit to MAX_LIMIT (200) on huge values", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest("https://www.hivemoot.dev/api/rooms?limit=10000"));
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 200 }),
+    );
+  });
+
+  it("clamps limit to 1 on zero/negative", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest("https://www.hivemoot.dev/api/rooms?limit=-5"));
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 1 }),
+    );
+  });
+
+  it("falls back to default on non-numeric limit", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest("https://www.hivemoot.dev/api/rooms?limit=abc"));
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+});
+
+describe("POST /api/rooms", () => {
+  it("returns 405 method_not_allowed (room creation lands in D.1.b-ii)", async () => {
+    const res = await POST();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("GET");
+    const body = await res.json();
+    expect(body.code).toBe("method_not_allowed");
+  });
+});

--- a/web/src/app/api/rooms/route.test.ts
+++ b/web/src/app/api/rooms/route.test.ts
@@ -33,7 +33,7 @@ function makeAuthOk(overrides?: { installationId?: string }) {
     installationId: overrides?.installationId ?? "12345",
     name: "queen",
     agent_role: "queen",
-    capabilities: ["rooms.read"],
+    capabilities: ["rooms.read_all"],
     redis: {} as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
@@ -61,7 +61,7 @@ describe("GET /api/rooms", () => {
     await GET(makeRequest());
     expect(mockedAuth).toHaveBeenCalledWith(
       expect.anything(),
-      { requires: "rooms.read" },
+      { requires: "rooms.read_all" },
     );
   });
 
@@ -140,5 +140,49 @@ describe("POST /api/rooms", () => {
     expect(res.headers.get("Allow")).toBe("GET");
     const body = await res.json();
     expect(body.code).toBe("method_not_allowed");
+  });
+});
+
+describe("R2 worker-vs-queen capability enforcement (closes #517 builder R1)", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedListRooms.mockReset();
+  });
+
+  it("rejects with 403 when bearer's only rooms-cap is `rooms.read` (worker preset)", async () => {
+    // Simulate the middleware's behavior when a worker bearer
+    // (capabilities=[rooms.read, rooms.watch, rooms.contribute]) hits
+    // the list endpoint requiring rooms.read_all. Middleware returns
+    // 403 with a missing-capability error code.
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        {
+          code: "agent_auth_v1_missing_capability",
+          missing: "rooms.read_all",
+        },
+        { status: 403 },
+      ),
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+    expect(mockedListRooms).not.toHaveBeenCalled();
+  });
+
+  it("queen / monitoring bearer (with rooms.read_all) succeeds", async () => {
+    // Both queen and monitoring presets include rooms.read_all per
+    // PRESETS in agent-token-capabilities.ts.
+    mockedAuth.mockResolvedValue({
+      ok: true as const,
+      installationId: "12345",
+      name: "monitor",
+      agent_role: "monitoring",
+      capabilities: ["rooms.read", "rooms.read_all", "agent_health.read", "tasks.read"],
+      redis: {} as never,
+      envelope: { fingerprint: "fp", expiresAt: null } as never,
+    });
+    mockedListRooms.mockResolvedValue([]);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
   });
 });

--- a/web/src/app/api/rooms/route.ts
+++ b/web/src/app/api/rooms/route.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /api/rooms — list war rooms for the bearer's installation.
+ *
+ * Capability: `rooms.read`. The bearer's installation is the
+ * canonical scope — clients cannot list other installations' rooms
+ * regardless of any query parameter (cross-installation isolation
+ * is enforced server-side from the envelope).
+ *
+ * Query params:
+ *   - `limit` (optional): max rooms to return. Default 50, max 200,
+ *     min 1. Out-of-range values clamp silently to the bounds.
+ *
+ * Response: `{ rooms: RoomCore[] }` ordered newest-first by `opened_at`.
+ *
+ * Auth model: `requires: "rooms.read"`. Sub-endpoints
+ * (`/api/rooms/:id/...`) defer to the same capability since they're
+ * all read-shaped data about the same scope.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { listRooms } from "@/server/war-room";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.read",
+  });
+  if (!auth.ok) return auth.response;
+
+  const url = new URL(request.url);
+  const rawLimit = url.searchParams.get("limit");
+  let limit = DEFAULT_LIMIT;
+  if (rawLimit !== null) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (Number.isFinite(parsed)) {
+      limit = Math.min(MAX_LIMIT, Math.max(1, parsed));
+    }
+  }
+
+  const rooms = await listRooms({
+    installationId: auth.installationId,
+    redis: auth.redis,
+    limit,
+  });
+
+  return NextResponse.json({ rooms }, { status: 200 });
+}
+
+export async function POST(): Promise<NextResponse> {
+  return NextResponse.json(
+    {
+      code: "method_not_allowed",
+      message: "GET /api/rooms only — POST not yet implemented (lands in D.1.b-ii).",
+    },
+    { status: 405, headers: { Allow: "GET" } },
+  );
+}

--- a/web/src/app/api/rooms/route.ts
+++ b/web/src/app/api/rooms/route.ts
@@ -12,7 +12,7 @@
  *
  * Response: `{ rooms: RoomCore[] }` ordered newest-first by `opened_at`.
  *
- * Auth model: `requires: "rooms.read"`. Sub-endpoints
+ * Auth model: `requires: "rooms.read_all"`. Sub-endpoints
  * (`/api/rooms/:id/...`) defer to the same capability since they're
  * all read-shaped data about the same scope.
  */
@@ -26,7 +26,7 @@ const MAX_LIMIT = 200;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = await authenticateAgentRequestV1(request, {
-    requires: "rooms.read",
+    requires: "rooms.read_all",
   });
   if (!auth.ok) return auth.response;
 

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -360,10 +360,13 @@ describe("cross-invariants", () => {
     }
   });
 
-  it("KNOWN_CAPABILITIES count matches the design doc claim (19)", () => {
-    // R2.2 design recount: 19 capabilities. If this fails, the doc
-    // section "Total: 19 capabilities" needs to be updated alongside
-    // the addition.
-    expect(KNOWN_CAPABILITIES.length).toBe(19);
+  it("KNOWN_CAPABILITIES count matches the design doc claim (20)", () => {
+    // R2.2 baseline: 19 capabilities.
+    // R3 (D.1.b-i): added `rooms.read_all` to differentiate
+    // installation-wide listing (queen / monitoring) from worker
+    // self-rooms reads (`rooms.read`). +1 → 20.
+    // If this fails, the doc section "Total: N capabilities" needs
+    // to be updated alongside the addition.
+    expect(KNOWN_CAPABILITIES.length).toBe(20);
   });
 });

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -137,6 +137,14 @@ export const KNOWN_CAPABILITIES = [
   "rooms.watch",
   "rooms.read",
   "rooms.contribute",
+  // War rooms — installation-wide read (queen / monitoring / operator).
+  // Distinct from `rooms.read` (worker self-rooms only) — see #517
+  // builder R1: workers should not be able to enumerate every room
+  // in the installation via the list endpoint or read sibling keys
+  // for rooms outside their role-bound visibility set. The
+  // worker-side visibility helper (`canReadRoomForBearer`) lands
+  // with `/api/rooms/watching` in a follow-up slice.
+  "rooms.read_all",
   // War rooms — bot (queen module).
   "rooms.create",
   "rooms.update",
@@ -271,6 +279,7 @@ export const PRESETS: Readonly<Record<string, readonly string[]>> = {
     "tasks.cancel",
     "rooms.create",
     "rooms.read",
+    "rooms.read_all",
     "rooms.update",
     "rooms.decide",
     "rooms.close",
@@ -283,6 +292,7 @@ export const PRESETS: Readonly<Record<string, readonly string[]>> = {
     "agent_health.read",
     "tasks.read",
     "rooms.read",
+    "rooms.read_all",
   ],
   admin: [
     "*",


### PR DESCRIPTION
Fixes #516

## Summary

Phase D.1.b kicks off the war-room HTTP API layer, building on the now-complete storage layer (D.1.a-i through D.1.a-iii.c). This PR ships the five read endpoints — small, focused, sharing the same auth + cross-installation-isolation pattern.

Five GET endpoints, all gated by `rooms.read`:

| Endpoint | Returns |
|---|---|
| `GET /api/rooms` | `{ rooms: RoomCore[] }` newest-first, default 50 / max 200 |
| `GET /api/rooms/:roomId` | `RoomCore` |
| `GET /api/rooms/:roomId/events` | `{ events, roomId }` with `?since` cursor + `?limit` (default 200, max 500) |
| `GET /api/rooms/:roomId/participants` | `{ participants, roomId }` |
| `GET /api/rooms/:roomId/contributions` | `{ contributions, roomId }` |

## What it looks like

**Cross-installation isolation pattern** (key correctness invariant):

The room hash key is `hive:v1:room:{installationId}:{roomId}` — installation-scoped — but events / participants / contributions sibling keys are scoped only by `roomId`. Without a pre-check, a worker could enumerate UUIDs and read events from rooms in OTHER installations. Each sub-resource endpoint runs `getRoomCore` first against the bearer's installation:

```typescript
try {
  await getRoomCore({ installationId: auth.installationId, roomId, redis });
} catch (err) {
  if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
    return NextResponse.json({ code: "room_not_found", ... }, { status: 404 });
  }
  throw err;
}
const events = await listRoomEvents({ roomId, since, limit, redis });
```

**Error mapping:**

| Source | HTTP |
|---|---|
| Missing/invalid bearer | 401 (delegated to middleware) |
| Bearer lacks `rooms.read` | 403 (delegated to middleware) |
| `RoomNotFoundError` | 404 `{ code: "room_not_found" }` |
| `RoomIdFormatError` (malformed UUID) | 404 `{ code: "room_not_found" }` (same shape — no oracle) |
| Unexpected error | 5xx (rethrown to Next.js error boundary) |

**Sample response — `GET /api/rooms/:id/events`:**

```json
{
  "events": [
    {
      "seq": 1,
      "timestamp": "2026-04-28T07:00:00.000Z",
      "event_type": "room_opened",
      "actor_role": "manager",
      "actor_id": "bot-queen",
      "body": { ... }
    }
  ],
  "roomId": "01234567-89ab-4cde-9012-3456789abcde"
}
```

## Why split D.1.b into slices

D.1.b has ~14 endpoints (5 reads, 9 writes spread across room-lifecycle and participant-lifecycle). Shipping them as one PR would be 1500+ LOC and a single R-rev cycle would block the whole API layer. Slicing:

- **D.1.b-i** (this PR): 5 read endpoints — homogeneous, share auth + isolation pattern
- **D.1.b-ii** (next): room creation + lifecycle (`POST /api/rooms`, `/:id/terminate`, `/:id/claim`, `/:id/recover`, `/:id/close`)
- **D.1.b-iii**: participant lifecycle (`POST /:id/present`, `/withdraw`, `POST /:id/contributions`, `DELETE /:id/contributions`, `POST /:id/timeout`)

## Test plan

- [x] Typecheck (`tsc --noEmit`) clean
- [x] Full web suite passes: 1177 tests passing (34 new for the room API)
- [x] 34 new tests covering:
  - Auth gating (401 on missing bearer, capability check)
  - Cross-installation isolation (bearer's installation wins; pre-check ordering for sub-resources; sub-resource calls don't fire when room missing)
  - Query param parsing (`limit` clamping, default fallback, non-numeric fallback)
  - Error → status mapping (RoomNotFoundError / RoomIdFormatError both → 404)
  - Empty results return `{}` not `null`
  - Withdrawn contribution tombstones surface as-is
- [ ] Reviewer fleet sign-off