### PR TITLE
Phase D.1.b-ii — room lifecycle write endpoints

### DIFF
--- a/web/src/app/api/rooms/[roomId]/close/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/close/route.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for POST /api/rooms/:roomId/close — queen happy-path close.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    closeRoomWithDecision: vi.fn(),
+    getRoomCore: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  closeRoomWithDecision,
+  getRoomCore,
+  RoomNotFoundError,
+  RoomCloseClaimLostError,
+  RoomCloseClaimThroughSeqMismatchError,
+  RoomCloseDriftError,
+  RoomClaimPayloadCorruptError,
+  RoomRunnerFormatError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedClose = vi.mocked(closeRoomWithDecision);
+const mockedGetCore = vi.mocked(getRoomCore);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+const VALID_DECISION = {
+  synthesized_at: "2026-04-28T08:00:00.000Z",
+  synthesis_runner: "queen-A.pid42",
+  content: "## Decision\nApprove.",
+  sequence_closed: 7,
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/close`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeQueenAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "bot-queen",
+    agent_role: "queen",
+    capabilities: ["rooms.close"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+function makeFakeRoom() {
+  return {
+    subject_type: "pr_review" as const,
+    subject_ref: "hivemoot/hivemoot#1",
+    status: "deciding" as const,
+  } as never;
+}
+
+describe("POST /api/rooms/:roomId/close", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedClose.mockReset();
+    mockedGetCore.mockReset();
+  });
+
+  it("requires rooms.close capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.close" },
+    );
+  });
+
+  it("happy path → returns closedSequence + fetches subject from room hash (no caller-supplied subject)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedClose.mockResolvedValue(8);
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.closedSequence).toBe(8);
+    // Subject came from getRoomCore — caller can't smuggle a wrong one
+    expect(mockedClose).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+  });
+
+  it("rejects missing expectedThroughSequence → 400", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makeRequest({ decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_through_sequence");
+  });
+
+  it("rejects malformed decision shape → 400", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makeRequest({
+        expectedThroughSequence: 7,
+        decision: { synthesis_runner: "queen-A" }, // missing content/timestamp/sequence_closed
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_decision_shape");
+  });
+
+  it("RoomNotFoundError on getRoomCore → 404 (no close attempt)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(404);
+    expect(mockedClose).not.toHaveBeenCalled();
+  });
+
+  it("RoomCloseDriftError → 409 sequence_drift with lastSeq", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedClose.mockRejectedValue(
+      new RoomCloseDriftError(VALID_ROOM_ID, 7, 9),
+    );
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("sequence_drift");
+    expect(body.expectedThroughSequence).toBe(7);
+    expect(body.lastSeq).toBe(9);
+  });
+
+  it("RoomCloseClaimLostError → 409 claim_lost", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedClose.mockRejectedValue(new RoomCloseClaimLostError(VALID_ROOM_ID));
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("claim_lost");
+  });
+
+  it("RoomCloseClaimThroughSeqMismatchError → 409 with both sequences", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedClose.mockRejectedValue(
+      new RoomCloseClaimThroughSeqMismatchError(VALID_ROOM_ID, 7, 99),
+    );
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("claim_through_seq_mismatch");
+    expect(body.expectedThroughSequence).toBe(7);
+    expect(body.actualThroughSequence).toBe(99);
+  });
+
+  it("RoomRunnerFormatError → 400 invalid_synthesis_runner (boundary check)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedClose.mockRejectedValue(
+      new RoomRunnerFormatError("queen__SEQ__bad", "sentinel collision"),
+    );
+    const res = await POST(
+      makeRequest({
+        expectedThroughSequence: 7,
+        decision: { ...VALID_DECISION, synthesis_runner: "queen__SEQ__bad" },
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_synthesis_runner");
+  });
+
+  it("decision >64 KiB → 400 decision_too_large", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedClose.mockRejectedValue(
+      new Error("RoomDecision.content exceeds 64 KiB (88000 bytes); reduce body before close."),
+    );
+    const res = await POST(
+      makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("decision_too_large");
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/close/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/close/route.test.ts
@@ -221,17 +221,41 @@ describe("POST /api/rooms/:roomId/close", () => {
     expect((await res.json()).code).toBe("invalid_synthesis_runner");
   });
 
-  it("decision >64 KiB → 400 decision_too_large", async () => {
+  it("decision >64 KiB → 400 decision_too_large via typed RoomDecisionTooLargeError (closes #519 guard N1)", async () => {
     mockedAuth.mockResolvedValue(makeQueenAuth());
     mockedGetCore.mockResolvedValue(makeFakeRoom());
-    mockedClose.mockRejectedValue(
-      new Error("RoomDecision.content exceeds 64 KiB (88000 bytes); reduce body before close."),
-    );
+    // Use the typed class — closes the regex-fragility carry-forward.
+    // If the storage primitive's message text changes, the route
+    // mapping still fires via instanceof.
+    const { RoomDecisionTooLargeError } = await import("@/server/war-room");
+    mockedClose.mockRejectedValue(new RoomDecisionTooLargeError(88000));
     const res = await POST(
       makeRequest({ expectedThroughSequence: 7, decision: VALID_DECISION }),
       { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
     );
     expect(res.status).toBe(400);
-    expect((await res.json()).code).toBe("decision_too_large");
+    const body = await res.json();
+    expect(body.code).toBe("decision_too_large");
+    expect(body.sizeBytes).toBe(88000);
+  });
+
+  it("body=null → 400 invalid_body_shape (closes #519 builder R1)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest(null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedClose).not.toHaveBeenCalled();
+  });
+
+  it("body=array → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest([VALID_DECISION]), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedClose).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/api/rooms/[roomId]/close/route.ts
+++ b/web/src/app/api/rooms/[roomId]/close/route.ts
@@ -1,0 +1,197 @@
+/**
+ * POST /api/rooms/:roomId/close — queen happy-path close with
+ * synthesized decision. Atomic with sequence-consistency check.
+ *
+ * Capability: `rooms.close`. Queen-only — requires a live claim
+ * acquired via `/decide`.
+ *
+ * Body:
+ *   {
+ *     expectedThroughSequence: number,   // captured at claim time
+ *     decision: {
+ *       synthesized_at: string,           // ISO 8601
+ *       synthesis_runner: string,
+ *       content: string,                  // ≤ 64 KiB UTF-8 bytes
+ *       sequence_closed: number
+ *     }
+ *   }
+ *
+ * Response: `{ closedSequence: number }`
+ *
+ * Errors:
+ *   - 400 — malformed body / decision shape
+ *   - 401 / 403 — auth / capability
+ *   - 404 — room not found
+ *   - 409 — drift / claim_lost / through_seq_mismatch / payload_corrupt
+ *
+ * Subject is fetched server-side from the room hash — caller does
+ * NOT need to pass it. This keeps the request body queen-focused
+ * (just decision payload) and avoids subject-mismatch attacks.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  closeRoomWithDecision,
+  getRoomCore,
+  type RoomDecision,
+  type SubjectRef,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomCloseClaimLostError,
+  RoomCloseClaimThroughSeqMismatchError,
+  RoomCloseDriftError,
+  RoomClaimPayloadCorruptError,
+  RoomRunnerFormatError,
+} from "@/server/war-room";
+
+interface CloseRequestBody {
+  expectedThroughSequence?: number;
+  decision?: Partial<RoomDecision>;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.close",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  let body: CloseRequestBody;
+  try {
+    body = (await request.json()) as CloseRequestBody;
+  } catch {
+    return NextResponse.json(
+      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof body.expectedThroughSequence !== "number" ||
+    !Number.isFinite(body.expectedThroughSequence) ||
+    body.expectedThroughSequence < 1
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_through_sequence",
+        message: "expectedThroughSequence must be a positive integer (from /decide).",
+      },
+      { status: 400 },
+    );
+  }
+  if (!body.decision || typeof body.decision !== "object") {
+    return NextResponse.json(
+      { code: "invalid_decision", message: "Body must include `decision` object." },
+      { status: 400 },
+    );
+  }
+  const d = body.decision;
+  if (
+    typeof d.synthesized_at !== "string" ||
+    typeof d.synthesis_runner !== "string" ||
+    typeof d.content !== "string" ||
+    typeof d.sequence_closed !== "number"
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_decision_shape",
+        message:
+          "decision must include synthesized_at (string), synthesis_runner (string), content (string), sequence_closed (number).",
+      },
+      { status: 400 },
+    );
+  }
+  const decision: RoomDecision = {
+    synthesized_at: d.synthesized_at,
+    synthesis_runner: d.synthesis_runner,
+    content: d.content,
+    sequence_closed: d.sequence_closed,
+  };
+
+  // Server-side fetch of subject from the room hash. The storage
+  // primitive uses subject to compute the per-installation
+  // subject-index key; pulling from the room hash means caller
+  // can't induce a subject-key mismatch.
+  let subject: SubjectRef;
+  try {
+    const room = await getRoomCore({
+      installationId: auth.installationId,
+      roomId,
+      redis: auth.redis,
+    });
+    subject = { type: room.subject_type, ref: room.subject_ref };
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+
+  try {
+    const closedSequence = await closeRoomWithDecision({
+      installationId: auth.installationId,
+      roomId,
+      expectedThroughSequence: body.expectedThroughSequence,
+      decision,
+      subject,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ closedSequence }, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomRunnerFormatError) {
+      return NextResponse.json(
+        { code: "invalid_synthesis_runner", message: err.message },
+        { status: 400 },
+      );
+    }
+    if (err instanceof RoomCloseDriftError) {
+      return NextResponse.json(
+        {
+          code: "sequence_drift",
+          message: err.message,
+          expectedThroughSequence: err.expectedThroughSequence,
+          lastSeq: err.lastSeq,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomCloseClaimLostError) {
+      return NextResponse.json(
+        { code: "claim_lost", message: err.message },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomCloseClaimThroughSeqMismatchError) {
+      return NextResponse.json(
+        {
+          code: "claim_through_seq_mismatch",
+          message: err.message,
+          expectedThroughSequence: err.expectedThroughSequence,
+          actualThroughSequence: err.actualThroughSequence,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomClaimPayloadCorruptError) {
+      return NextResponse.json(
+        { code: "claim_payload_corrupt", message: err.message },
+        { status: 409 },
+      );
+    }
+    if (err instanceof Error && /exceeds 64 KiB/.test(err.message)) {
+      return NextResponse.json(
+        { code: "decision_too_large", message: err.message },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/close/route.ts
+++ b/web/src/app/api/rooms/[roomId]/close/route.ts
@@ -31,6 +31,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
 import {
   closeRoomWithDecision,
   getRoomCore,
@@ -43,6 +44,7 @@ import {
   RoomCloseDriftError,
   RoomClaimPayloadCorruptError,
   RoomRunnerFormatError,
+  RoomDecisionTooLargeError,
 } from "@/server/war-room";
 
 interface CloseRequestBody {
@@ -61,15 +63,14 @@ export async function POST(
 
   const { roomId } = await params;
 
-  let body: CloseRequestBody;
-  try {
-    body = (await request.json()) as CloseRequestBody;
-  } catch {
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
     return NextResponse.json(
-      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { code: parsed.code, message: parsed.message },
       { status: 400 },
     );
   }
+  const body = parsed.body as CloseRequestBody;
 
   if (
     typeof body.expectedThroughSequence !== "number" ||
@@ -186,9 +187,13 @@ export async function POST(
         { status: 409 },
       );
     }
-    if (err instanceof Error && /exceeds 64 KiB/.test(err.message)) {
+    if (err instanceof RoomDecisionTooLargeError) {
       return NextResponse.json(
-        { code: "decision_too_large", message: err.message },
+        {
+          code: "decision_too_large",
+          message: err.message,
+          sizeBytes: err.sizeBytes,
+        },
         { status: 400 },
       );
     }

--- a/web/src/app/api/rooms/[roomId]/decide/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/decide/route.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for POST /api/rooms/:roomId/decide — claim synthesis.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    claimSynthesis: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  claimSynthesis,
+  RoomNotFoundError,
+  RoomClaimAlreadyHeldError,
+  RoomTransitionInvalidStatusError,
+  RoomClaimPayloadCorruptError,
+  RoomRunnerFormatError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedClaim = vi.mocked(claimSynthesis);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/decide`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeQueenAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "bot-queen",
+    agent_role: "queen",
+    capabilities: ["rooms.decide"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("POST /api/rooms/:roomId/decide", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedClaim.mockReset();
+  });
+
+  it("requires rooms.decide capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { code: "agent_auth_v1_missing_capability" },
+        { status: 403 },
+      ),
+    });
+    const res = await POST(makeRequest({ queenRunner: "queen-A" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.decide" },
+    );
+    expect(mockedClaim).not.toHaveBeenCalled();
+  });
+
+  it("happy path → returns throughSequence + claimTtlSecs", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockResolvedValue({ throughSequence: 7, claimTtlSecs: 360 });
+    const res = await POST(makeRequest({ queenRunner: "queen-A" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ throughSequence: 7, claimTtlSecs: 360 });
+    expect(mockedClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "12345",
+        roomId: VALID_ROOM_ID,
+        queenRunner: "queen-A",
+      }),
+    );
+  });
+
+  it("respects optional claimTtlSecs override", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockResolvedValue({ throughSequence: 1, claimTtlSecs: 120 });
+    await POST(makeRequest({ queenRunner: "queen-A", claimTtlSecs: 120 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(mockedClaim).toHaveBeenCalledWith(
+      expect.objectContaining({ claimTtlSecs: 120 }),
+    );
+  });
+
+  it("rejects missing queenRunner → 400", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_queen_runner");
+  });
+
+  it("rejects negative claimTtlSecs → 400", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makeRequest({ queenRunner: "queen-A", claimTtlSecs: -10 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_claim_ttl");
+  });
+
+  it("RoomRunnerFormatError → 400 invalid_queen_runner", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockRejectedValue(
+      new RoomRunnerFormatError("queen__SEQ__bad", "sentinel collision"),
+    );
+    const res = await POST(makeRequest({ queenRunner: "queen__SEQ__bad" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_queen_runner");
+  });
+
+  it("RoomNotFoundError → 404", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(makeRequest({ queenRunner: "queen-A" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("RoomClaimAlreadyHeldError → 409 with holder identity + throughSequence", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockRejectedValue(
+      new RoomClaimAlreadyHeldError(VALID_ROOM_ID, "queen-other", 5),
+    );
+    const res = await POST(makeRequest({ queenRunner: "queen-A" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("claim_already_held");
+    expect(body.heldByRunner).toBe("queen-other");
+    expect(body.throughSequence).toBe(5);
+  });
+
+  it("RoomTransitionInvalidStatusError → 409 with actualStatus", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockRejectedValue(
+      new RoomTransitionInvalidStatusError(
+        VALID_ROOM_ID,
+        "claim_synthesis",
+        ["awaiting_contributions"],
+        "deciding",
+      ),
+    );
+    const res = await POST(makeRequest({ queenRunner: "queen-A" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("invalid_status_for_claim");
+    expect(body.actualStatus).toBe("deciding");
+  });
+
+  it("RoomClaimPayloadCorruptError → 409 claim_payload_corrupt", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedClaim.mockRejectedValue(new RoomClaimPayloadCorruptError(VALID_ROOM_ID));
+    const res = await POST(makeRequest({ queenRunner: "queen-A" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("claim_payload_corrupt");
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/decide/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/decide/route.test.ts
@@ -191,6 +191,26 @@ describe("POST /api/rooms/:roomId/decide", () => {
     expect(body.actualStatus).toBe("deciding");
   });
 
+  it("body=null → 400 invalid_body_shape (closes #519 builder R1)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest(null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedClaim).not.toHaveBeenCalled();
+  });
+
+  it("body=array → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest([{ queenRunner: "q" }]), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedClaim).not.toHaveBeenCalled();
+  });
+
   it("RoomClaimPayloadCorruptError → 409 claim_payload_corrupt", async () => {
     mockedAuth.mockResolvedValue(makeQueenAuth());
     mockedClaim.mockRejectedValue(new RoomClaimPayloadCorruptError(VALID_ROOM_ID));

--- a/web/src/app/api/rooms/[roomId]/decide/route.ts
+++ b/web/src/app/api/rooms/[roomId]/decide/route.ts
@@ -1,0 +1,137 @@
+/**
+ * POST /api/rooms/:roomId/decide — atomically claim the synthesis
+ * lane for a room.
+ *
+ * Capability: `rooms.decide`. Queen-only operation; the queen
+ * runner identity is captured in the claim record so that observers
+ * (operators, watchdog) know who holds it.
+ *
+ * Body: `{ queenRunner: string, claimTtlSecs?: number }`
+ *
+ * Response: `{ throughSequence, claimTtlSecs }`. The caller passes
+ * `throughSequence` back on `/close` to detect drift (events that
+ * arrived during synthesis); the queen runtime reads `claimTtlSecs`
+ * to decide when to refresh.
+ *
+ * Errors:
+ *   - 401 / 403 — auth / capability
+ *   - 400 — malformed body, invalid queenRunner format
+ *   - 404 — room not found in this installation
+ *   - 409 — claim already held / wrong status / payload corrupt
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  claimSynthesis,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomClaimAlreadyHeldError,
+  RoomTransitionInvalidStatusError,
+  RoomClaimPayloadCorruptError,
+  RoomRunnerFormatError,
+} from "@/server/war-room";
+
+interface DecideRequestBody {
+  queenRunner?: string;
+  claimTtlSecs?: number;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.decide",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  let body: DecideRequestBody;
+  try {
+    body = (await request.json()) as DecideRequestBody;
+  } catch {
+    return NextResponse.json(
+      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  if (typeof body.queenRunner !== "string" || body.queenRunner.length === 0) {
+    return NextResponse.json(
+      {
+        code: "invalid_queen_runner",
+        message: "Body must include `queenRunner` as a non-empty string.",
+      },
+      { status: 400 },
+    );
+  }
+  if (
+    body.claimTtlSecs !== undefined &&
+    (typeof body.claimTtlSecs !== "number" ||
+      !Number.isFinite(body.claimTtlSecs) ||
+      body.claimTtlSecs <= 0)
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_claim_ttl",
+        message: "claimTtlSecs must be a positive finite number.",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await claimSynthesis({
+      installationId: auth.installationId,
+      roomId,
+      queenRunner: body.queenRunner,
+      claimTtlSecs: body.claimTtlSecs,
+      redis: auth.redis,
+    });
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomRunnerFormatError) {
+      return NextResponse.json(
+        { code: "invalid_queen_runner", message: err.message },
+        { status: 400 },
+      );
+    }
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    if (err instanceof RoomClaimAlreadyHeldError) {
+      return NextResponse.json(
+        {
+          code: "claim_already_held",
+          message: err.message,
+          heldByRunner: err.heldByRunner,
+          throughSequence: err.throughSequence,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomTransitionInvalidStatusError) {
+      return NextResponse.json(
+        {
+          code: "invalid_status_for_claim",
+          message: err.message,
+          actualStatus: err.actualStatus,
+          expectedStatuses: err.expectedStatuses,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomClaimPayloadCorruptError) {
+      return NextResponse.json(
+        { code: "claim_payload_corrupt", message: err.message },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/decide/route.ts
+++ b/web/src/app/api/rooms/[roomId]/decide/route.ts
@@ -22,6 +22,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
 import {
   claimSynthesis,
   RoomNotFoundError,
@@ -48,15 +49,14 @@ export async function POST(
 
   const { roomId } = await params;
 
-  let body: DecideRequestBody;
-  try {
-    body = (await request.json()) as DecideRequestBody;
-  } catch {
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
     return NextResponse.json(
-      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { code: parsed.code, message: parsed.message },
       { status: 400 },
     );
   }
+  const body = parsed.body as DecideRequestBody;
 
   if (typeof body.queenRunner !== "string" || body.queenRunner.length === 0) {
     return NextResponse.json(

--- a/web/src/app/api/rooms/[roomId]/event/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/event/route.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for POST /api/rooms/:roomId/event — bot/queen meta-events.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    appendRoomEvent: vi.fn(),
+    deriveIdempotencyKey: real.deriveIdempotencyKey,
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  appendRoomEvent,
+  RoomNotFoundError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedAppend = vi.mocked(appendRoomEvent);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/event`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeQueenAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "bot-queen",
+    agent_role: "queen",
+    capabilities: ["rooms.update"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("POST /api/rooms/:roomId/event", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedAppend.mockReset();
+  });
+
+  it("requires rooms.update capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: {},
+        sequenceObservedByClient: 1,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.update" },
+    );
+  });
+
+  it("happy path: subject_updated event → returns sequence", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockResolvedValue(5);
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "PR rebased", sha: "abc123" },
+        sequenceObservedByClient: 4,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).sequence).toBe(5);
+    // Server fills timestamp + actor_role/actor_id from envelope
+    expect(mockedAppend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: VALID_ROOM_ID,
+        installationId: "12345",
+        event: expect.objectContaining({
+          event_type: "subject_updated",
+          actor_role: "queen",
+          actor_id: "bot-queen",
+          body: { reason: "PR rebased", sha: "abc123" },
+        }),
+      }),
+    );
+  });
+
+  it("rejects unknown event_type → 400 invalid_event_type", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makeRequest({
+        event_type: "room_decided", // lifecycle event NOT allowed via /event
+        body: {},
+        sequenceObservedByClient: 1,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_event_type");
+    expect(mockedAppend).not.toHaveBeenCalled();
+  });
+
+  it("queen_question event is allowed (V1.1 readiness)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockResolvedValue(3);
+    const res = await POST(
+      makeRequest({
+        event_type: "queen_question",
+        body: { target_role: "drone", question: "elaborate on..." },
+        sequenceObservedByClient: 2,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects missing idempotency input → 400 missing_idempotency", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "rebased" },
+        // No idempotencyKey + no sequenceObservedByClient
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("missing_idempotency");
+  });
+
+  it("accepts caller-supplied idempotencyKey directly", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockResolvedValue(5);
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "rebased" },
+        idempotencyKey: "caller-derived-key-abc123",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect(mockedAppend).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: "caller-derived-key-abc123" }),
+    );
+  });
+
+  it("RoomEventIdempotencyReplayError → 200 with replay flag (treats as success)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockRejectedValue(
+      new RoomEventIdempotencyReplayError(VALID_ROOM_ID, 3),
+    );
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "rebased" },
+        sequenceObservedByClient: 2,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sequence).toBe(3);
+    expect(body.replay).toBe(true);
+  });
+
+  it("RoomNotFoundError → 404", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "rebased" },
+        sequenceObservedByClient: 1,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("RoomEventBodyTooLargeError → 400 event_body_too_large", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockRejectedValue(
+      new RoomEventBodyTooLargeError(9 * 1024),
+    );
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { huge: "payload" },
+        sequenceObservedByClient: 1,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("event_body_too_large");
+  });
+
+  it("RoomEventStatusPreconditionError → 409 status_precondition_failed", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockRejectedValue(
+      new RoomEventStatusPreconditionError(
+        VALID_ROOM_ID,
+        "awaiting_contributions",
+        "closed",
+      ),
+    );
+    const res = await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "rebased" },
+        sequenceObservedByClient: 1,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("status_precondition_failed");
+    expect(body.actualStatus).toBe("closed");
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/event/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/event/route.test.ts
@@ -227,6 +227,49 @@ describe("POST /api/rooms/:roomId/event", () => {
     expect((await res.json()).code).toBe("event_body_too_large");
   });
 
+  it("BLOCKING regression #519 guard B1: passes allowedStatuses to gate deciding/closed rooms", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedAppend.mockResolvedValue(5);
+    await POST(
+      makeRequest({
+        event_type: "subject_updated",
+        body: { reason: "rebased" },
+        sequenceObservedByClient: 4,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    // Without this check, the script's status gate would silently
+    // never fire — `subject_updated` would land on closed rooms,
+    // breaking the bot's webhook-on-deciding deferral mechanism
+    // (design L919-932) AND polluting the audit log of terminal
+    // rooms during the retention window.
+    expect(mockedAppend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+      }),
+    );
+  });
+
+  it("body=null → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest(null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedAppend).not.toHaveBeenCalled();
+  });
+
+  it("body=array → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makeRequest([{ event_type: "subject_updated" }]), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedAppend).not.toHaveBeenCalled();
+  });
+
   it("RoomEventStatusPreconditionError → 409 status_precondition_failed", async () => {
     mockedAuth.mockResolvedValue(makeQueenAuth());
     mockedAppend.mockRejectedValue(

--- a/web/src/app/api/rooms/[roomId]/event/route.ts
+++ b/web/src/app/api/rooms/[roomId]/event/route.ts
@@ -36,6 +36,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
 import {
   appendRoomEvent,
   deriveIdempotencyKey,
@@ -80,15 +81,14 @@ export async function POST(
 
   const { roomId } = await params;
 
-  let body: EventRequestBody;
-  try {
-    body = (await request.json()) as EventRequestBody;
-  } catch {
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
     return NextResponse.json(
-      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { code: parsed.code, message: parsed.message },
       { status: 400 },
     );
   }
+  const body = parsed.body as EventRequestBody;
 
   if (
     typeof body.event_type !== "string" ||
@@ -150,6 +150,19 @@ export async function POST(
         body: body.body,
       },
       idempotencyKey,
+      // Closes #519 guard B1 (BLOCKER): the script's status gate
+      // only fires when allowedStatuses is non-empty. Without it,
+      // `subject_updated` and `queen_question` events would land on:
+      //   - `deciding` rooms — breaking the bot's
+      //     webhook-on-deciding deferral mechanism (design L919-932)
+      //   - `closed` / terminated rooms — polluting the audit log
+      //     for the entire retention window AND resurfacing dead
+      //     rooms on `/api/rooms/watching`
+      // Both `awaiting_rsvp` and `awaiting_contributions` accept
+      // bot meta-events; status-precondition failure → 409
+      // `status_precondition_failed` so the bot enqueues into its
+      // webhook-buffer and re-tries after the queen releases.
+      allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
       redis: auth.redis,
     });
     return NextResponse.json({ sequence }, { status: 200 });

--- a/web/src/app/api/rooms/[roomId]/event/route.ts
+++ b/web/src/app/api/rooms/[roomId]/event/route.ts
@@ -1,0 +1,191 @@
+/**
+ * POST /api/rooms/:roomId/event — append a queen meta-event to the
+ * room's append-only event log.
+ *
+ * Capability: `rooms.update`. Bot/queen-only. The event surface this
+ * endpoint exposes is intentionally narrow — only queen meta-events
+ * (`subject_updated`, `queen_question`) are accepted. Other event
+ * types (lifecycle: `room_opened`, `participant_*`, `contribution_*`,
+ * `room_decided`, `room_terminated`, `room_recovered`) are emitted
+ * by their own dedicated endpoints atomically with state changes,
+ * NEVER through this generic surface.
+ *
+ * Why the whitelist: the lifecycle events have invariants the
+ * dedicated endpoints enforce (status transition + materialized
+ * hash writes + sibling cleanup). Letting this endpoint emit them
+ * would let a misbehaving caller drive status transitions without
+ * the atomic sibling effects, breaking the state machine.
+ *
+ * Body:
+ *   {
+ *     event_type: "subject_updated" | "queen_question",
+ *     body: Record<string, unknown>,    // ≤ 8 KiB serialized
+ *     idempotencyKey?: string           // caller-derived; if omitted,
+ *                                       // server derives from sequenceObservedByClient
+ *     sequenceObservedByClient?: number // for server-side idem derivation
+ *   }
+ *
+ * Response: `{ sequence: number }`
+ *
+ * Errors:
+ *   - 400 — invalid event_type / oversized body / missing idempotency input
+ *   - 401 / 403 — auth / capability
+ *   - 404 — room not found
+ *   - 409 — idempotency replay / status precondition / owner conflict
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  appendRoomEvent,
+  deriveIdempotencyKey,
+  type RoomEventAction,
+  type RoomEventType,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
+} from "@/server/war-room";
+
+// Whitelist for /event — keep narrow per the docstring.
+const ALLOWED_META_EVENT_TYPES: ReadonlySet<RoomEventType> = new Set<RoomEventType>([
+  "subject_updated",
+  "queen_question",
+]);
+
+// Maps allowed event types to their canonical action key for
+// `deriveIdempotencyKey`. Keep in sync with RoomEventAction in
+// war-room.ts.
+const EVENT_TYPE_TO_ACTION: Record<string, RoomEventAction> = {
+  subject_updated: "subject_updated",
+  queen_question: "queen_question",
+};
+
+interface EventRequestBody {
+  event_type?: string;
+  body?: Record<string, unknown>;
+  idempotencyKey?: string;
+  sequenceObservedByClient?: number;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.update",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  let body: EventRequestBody;
+  try {
+    body = (await request.json()) as EventRequestBody;
+  } catch {
+    return NextResponse.json(
+      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof body.event_type !== "string" ||
+    !ALLOWED_META_EVENT_TYPES.has(body.event_type as RoomEventType)
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_event_type",
+        message: `event_type must be one of: ${Array.from(ALLOWED_META_EVENT_TYPES).join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+  if (!body.body || typeof body.body !== "object") {
+    return NextResponse.json(
+      { code: "invalid_event_body", message: "Body must include `body` object." },
+      { status: 400 },
+    );
+  }
+
+  // Idempotency: prefer caller-supplied key; otherwise derive from
+  // observed sequence + role + action. Either path requires SOME
+  // input — server can't synthesize a stable key from request alone.
+  let idempotencyKey: string;
+  if (typeof body.idempotencyKey === "string" && body.idempotencyKey.length > 0) {
+    idempotencyKey = body.idempotencyKey;
+  } else if (
+    typeof body.sequenceObservedByClient === "number" &&
+    Number.isFinite(body.sequenceObservedByClient)
+  ) {
+    idempotencyKey = deriveIdempotencyKey({
+      roomId,
+      role: auth.agent_role,
+      action: EVENT_TYPE_TO_ACTION[body.event_type as RoomEventType],
+      sequenceObservedByClient: body.sequenceObservedByClient,
+    });
+  } else {
+    return NextResponse.json(
+      {
+        code: "missing_idempotency",
+        message:
+          "Provide either `idempotencyKey` (string) or `sequenceObservedByClient` (number) for replay protection.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+
+  try {
+    const sequence = await appendRoomEvent({
+      installationId: auth.installationId,
+      roomId,
+      event: {
+        timestamp: nowIso,
+        event_type: body.event_type as RoomEventType,
+        actor_role: auth.agent_role,
+        actor_id: auth.name,
+        body: body.body,
+      },
+      idempotencyKey,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence }, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    if (err instanceof RoomEventBodyTooLargeError) {
+      return NextResponse.json(
+        { code: "event_body_too_large", message: err.message },
+        { status: 400 },
+      );
+    }
+    if (err instanceof RoomEventIdempotencyReplayError) {
+      // Replay is benign — the prior write already landed. Return 200
+      // with the prior sequence so the caller treats it as success
+      // (matches the design's "treat as success" instruction in the
+      // error message itself).
+      return NextResponse.json(
+        { sequence: err.existingSequence, replay: true },
+        { status: 200 },
+      );
+    }
+    if (err instanceof RoomEventStatusPreconditionError) {
+      return NextResponse.json(
+        {
+          code: "status_precondition_failed",
+          message: err.message,
+          actualStatus: err.actualStatus,
+        },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/force-close/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/force-close/route.test.ts
@@ -198,4 +198,49 @@ describe("POST /api/rooms/:roomId/force-close", () => {
       expect.objectContaining({ reason: "force_close" }),
     );
   });
+
+  it("BLOCKING regression #519 R1: malformed JSON → 400, terminateRoom NEVER called", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    // Operator request with truncated/garbage body must NOT silently
+    // fall back to defaults and trigger a real terminal state change.
+    const req = new NextRequest(
+      `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/force-close`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer hmt_test",
+          "content-type": "application/json",
+        },
+        body: "not json at all{{{",
+      },
+    );
+    const res = await POST(req, {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_json");
+    // CRITICAL: room is NOT actually terminated.
+    expect(mockedTerm).not.toHaveBeenCalled();
+    expect(mockedGetCore).not.toHaveBeenCalled();
+  });
+
+  it("body=null → 400 invalid_body_shape (closes #519 R1 cast-bypass)", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    const res = await POST(makeRequest(null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedTerm).not.toHaveBeenCalled();
+  });
+
+  it("body=array → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    const res = await POST(makeRequest([{ reason: "manual" }]), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedTerm).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/app/api/rooms/[roomId]/force-close/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/force-close/route.test.ts
@@ -243,4 +243,32 @@ describe("POST /api/rooms/:roomId/force-close", () => {
     expect((await res.json()).code).toBe("invalid_body_shape");
     expect(mockedTerm).not.toHaveBeenCalled();
   });
+
+  it("BLOCKING regression #519 R3: no body / no Content-Length header → 200 with default force_close reason", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedTerm.mockResolvedValue(8);
+    // operator one-liner: `curl -X POST .../force-close` with no -d
+    // sends NO Content-Length header at all. The prior R2 heuristic
+    // (`content-length === "0"` skip) returned `null` from get(),
+    // entered the parse branch, and `request.json()` threw on
+    // empty body → 400. This regression pins the operator-friendly
+    // path: empty body → defaults reason → 200.
+    const req = new NextRequest(
+      `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/force-close`,
+      {
+        method: "POST",
+        headers: { authorization: "Bearer hmt_test" }, // NO content-length, NO content-type
+      },
+    );
+    const res = await POST(req, {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reason).toBe("force_close");
+    expect(mockedTerm).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "force_close" }),
+    );
+  });
 });

--- a/web/src/app/api/rooms/[roomId]/force-close/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/force-close/route.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for POST /api/rooms/:roomId/force-close — operator terminate.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    terminateRoom: vi.fn(),
+    getRoomCore: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  terminateRoom,
+  getRoomCore,
+  RoomNotFoundError,
+  RoomAlreadyClosedError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedTerm = vi.mocked(terminateRoom);
+const mockedGetCore = vi.mocked(getRoomCore);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(body?: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/force-close`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: body !== undefined ? JSON.stringify(body) : "",
+    },
+  );
+}
+
+function makeAdminAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "operator-1",
+    agent_role: "admin",
+    capabilities: ["rooms.force_close"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+function makeFakeRoom() {
+  return {
+    subject_type: "pr_review" as const,
+    subject_ref: "hivemoot/hivemoot#1",
+    status: "deciding" as const,
+  } as never;
+}
+
+describe("POST /api/rooms/:roomId/force-close", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedTerm.mockReset();
+    mockedGetCore.mockReset();
+  });
+
+  it("requires rooms.force_close capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.force_close" },
+    );
+  });
+
+  it("happy path with default reason `force_close`", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedTerm.mockResolvedValue(8);
+    const res = await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sequence).toBe(8);
+    expect(body.reason).toBe("force_close");
+    expect(mockedTerm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "force_close",
+        actorRole: "admin",
+        actorId: "operator-1",
+      }),
+    );
+  });
+
+  it("respects explicit reason from body", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedTerm.mockResolvedValue(8);
+    const res = await POST(makeRequest({ reason: "manual" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).reason).toBe("manual");
+    expect(mockedTerm).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "manual" }),
+    );
+  });
+
+  it("rejects invalid reason → 400", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    const res = await POST(makeRequest({ reason: "bogus" }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_reason");
+  });
+
+  it("RoomNotFoundError on getRoomCore → 404 (no terminate attempt)", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockedTerm).not.toHaveBeenCalled();
+  });
+
+  it("RoomAlreadyClosedError → 409 room_already_closed (idempotent operator double-tap)", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedTerm.mockRejectedValue(
+      new RoomAlreadyClosedError(VALID_ROOM_ID, "closed"),
+    );
+    const res = await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("room_already_closed");
+    expect(body.status).toBe("closed");
+  });
+
+  it("subject is fetched server-side from room hash (no caller-supplied subject)", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedTerm.mockResolvedValue(8);
+    await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(mockedTerm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+  });
+
+  it("empty body (no reason) defaults to force_close (operator panic-button compat)", async () => {
+    mockedAuth.mockResolvedValue(makeAdminAuth());
+    mockedGetCore.mockResolvedValue(makeFakeRoom());
+    mockedTerm.mockResolvedValue(8);
+    // POST with content-length: 0 — no body parsed
+    const req = new NextRequest(
+      `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/force-close`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer hmt_test",
+          "content-length": "0",
+        },
+      },
+    );
+    const res = await POST(req, {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockedTerm).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "force_close" }),
+    );
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/force-close/route.ts
+++ b/web/src/app/api/rooms/[roomId]/force-close/route.ts
@@ -26,6 +26,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
 import {
   terminateRoom,
   getRoomCore,
@@ -43,10 +44,6 @@ const VALID_REASONS: ReadonlySet<TerminalReason> = new Set<TerminalReason>([
   "manual",
 ]);
 
-interface ForceCloseRequestBody {
-  reason?: string;
-}
-
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ roomId: string }> },
@@ -59,23 +56,31 @@ export async function POST(
   const { roomId } = await params;
 
   // Body is optional — empty body defaults reason to "force_close".
-  let body: ForceCloseRequestBody = {};
+  // Closes #519 builder R1: malformed JSON MUST NOT silently fall
+  // back to defaults and continue to a real terminal state change
+  // (operator panic-button must fail-loud on bad payload, not
+  // accidentally terminate with `force_close` reason).
+  let body: Record<string, unknown> = {};
   if (request.headers.get("content-length") !== "0") {
-    try {
-      body = (await request.json()) as ForceCloseRequestBody;
-    } catch {
-      // Defensive: malformed JSON falls back to defaults.
-      body = {};
+    const parsed = await parseJsonBody(request);
+    if (!parsed.ok) {
+      return NextResponse.json(
+        { code: parsed.code, message: parsed.message },
+        { status: 400 },
+      );
     }
+    body = parsed.body;
   }
-  const reason: TerminalReason =
-    typeof body.reason === "string" && VALID_REASONS.has(body.reason as TerminalReason)
-      ? (body.reason as TerminalReason)
-      : "force_close";
-
+  const rawReason = body.reason;
+  if (rawReason !== undefined && typeof rawReason !== "string") {
+    return NextResponse.json(
+      { code: "invalid_reason", message: "reason must be a string." },
+      { status: 400 },
+    );
+  }
   if (
-    body.reason !== undefined &&
-    !VALID_REASONS.has(body.reason as TerminalReason)
+    rawReason !== undefined &&
+    !VALID_REASONS.has(rawReason as TerminalReason)
   ) {
     return NextResponse.json(
       {
@@ -85,6 +90,8 @@ export async function POST(
       { status: 400 },
     );
   }
+  const reason: TerminalReason =
+    rawReason !== undefined ? (rawReason as TerminalReason) : "force_close";
 
   let subject: SubjectRef;
   try {

--- a/web/src/app/api/rooms/[roomId]/force-close/route.ts
+++ b/web/src/app/api/rooms/[roomId]/force-close/route.ts
@@ -1,0 +1,139 @@
+/**
+ * POST /api/rooms/:roomId/force-close — operator-initiated terminal
+ * close. Atomic across all status sets + claim DEL + index cleanup.
+ *
+ * Capability: `rooms.force_close`. Admin-only — distinct from the
+ * queen's happy-path `/close` (which requires a live claim AND
+ * sequence consistency). Force-close races the queen by DELing the
+ * claim; queen's mid-flight `/close` then returns
+ * `RoomCloseClaimLostError` and aborts the GitHub post.
+ *
+ * Body: `{ reason?: TerminalReason }` — defaults to `"force_close"`
+ *       if omitted. Other valid reasons (operator-driven):
+ *       `"manual"`, `"expired"`, `"failed_synthesis"` (rare).
+ *
+ * Subject is fetched from the room hash server-side — same pattern
+ * as `/close`, no subject-mismatch attacks.
+ *
+ * Response: `{ sequence: number }` — the terminating event's seq.
+ *
+ * Errors:
+ *   - 401 / 403 — auth / capability
+ *   - 400 — invalid reason
+ *   - 404 — room not found
+ *   - 409 — already closed (operator double-tap)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  terminateRoom,
+  getRoomCore,
+  type SubjectRef,
+  type TerminalReason,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomAlreadyClosedError,
+} from "@/server/war-room";
+
+const VALID_REASONS: ReadonlySet<TerminalReason> = new Set<TerminalReason>([
+  "expired",
+  "failed_synthesis",
+  "force_close",
+  "manual",
+]);
+
+interface ForceCloseRequestBody {
+  reason?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.force_close",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  // Body is optional — empty body defaults reason to "force_close".
+  let body: ForceCloseRequestBody = {};
+  if (request.headers.get("content-length") !== "0") {
+    try {
+      body = (await request.json()) as ForceCloseRequestBody;
+    } catch {
+      // Defensive: malformed JSON falls back to defaults.
+      body = {};
+    }
+  }
+  const reason: TerminalReason =
+    typeof body.reason === "string" && VALID_REASONS.has(body.reason as TerminalReason)
+      ? (body.reason as TerminalReason)
+      : "force_close";
+
+  if (
+    body.reason !== undefined &&
+    !VALID_REASONS.has(body.reason as TerminalReason)
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_reason",
+        message: `reason must be one of: ${Array.from(VALID_REASONS).join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  let subject: SubjectRef;
+  try {
+    const room = await getRoomCore({
+      installationId: auth.installationId,
+      roomId,
+      redis: auth.redis,
+    });
+    subject = { type: room.subject_type, ref: room.subject_ref };
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    throw err;
+  }
+
+  try {
+    const sequence = await terminateRoom({
+      installationId: auth.installationId,
+      roomId,
+      reason,
+      subject,
+      // Operator-driven: actor is the bearer's role + name. The
+      // event log preserves WHO force-closed for forensic trail.
+      actorRole: auth.agent_role,
+      actorId: auth.name,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence, reason }, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    if (err instanceof RoomAlreadyClosedError) {
+      return NextResponse.json(
+        {
+          code: "room_already_closed",
+          message: err.message,
+          status: err.status,
+        },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/force-close/route.ts
+++ b/web/src/app/api/rooms/[roomId]/force-close/route.ts
@@ -26,7 +26,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
-import { parseJsonBody } from "@/server/request-utils";
+import { parseOptionalJsonObjectBody } from "@/server/request-utils";
 import {
   terminateRoom,
   getRoomCore,
@@ -56,21 +56,26 @@ export async function POST(
   const { roomId } = await params;
 
   // Body is optional — empty body defaults reason to "force_close".
-  // Closes #519 builder R1: malformed JSON MUST NOT silently fall
-  // back to defaults and continue to a real terminal state change
-  // (operator panic-button must fail-loud on bad payload, not
-  // accidentally terminate with `force_close` reason).
-  let body: Record<string, unknown> = {};
-  if (request.headers.get("content-length") !== "0") {
-    const parsed = await parseJsonBody(request);
-    if (!parsed.ok) {
-      return NextResponse.json(
-        { code: parsed.code, message: parsed.message },
-        { status: 400 },
-      );
-    }
-    body = parsed.body;
+  // Two requirements that conflict if you naively `request.json()`:
+  //   1. Closes #519 builder R1: malformed JSON MUST fail-loud
+  //      (returns 400, terminateRoom NEVER called) so a bad/truncated
+  //      operator payload doesn't silently force-close with the
+  //      default reason.
+  //   2. Closes #519 builder R3: a valid empty POST (`curl -X POST`
+  //      with no `-d`) sends NO `Content-Length` header at all —
+  //      `request.json()` throws on empty body, which the prior
+  //      heuristic (`content-length === "0"` skip) didn't cover.
+  // `parseOptionalJsonObjectBody` reads body as text first, treats
+  // empty as `{}` (defaults), and JSON-parses non-empty (fail loud
+  // on bad payload). Both requirements satisfied by one helper.
+  const parsed = await parseOptionalJsonObjectBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
   }
+  const body = parsed.body;
   const rawReason = body.reason;
   if (rawReason !== undefined && typeof rawReason !== "string") {
     return NextResponse.json(

--- a/web/src/app/api/rooms/route.test.ts
+++ b/web/src/app/api/rooms/route.test.ts
@@ -260,6 +260,24 @@ describe("POST /api/rooms (D.1.b-ii — create room)", () => {
     );
   });
 
+  it("body=null → 400 invalid_body_shape (closes #519 builder R1)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makePostRequest(null));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedCreateRoom).not.toHaveBeenCalled();
+  });
+
+  it("body=array → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makePostRequest([{ subject: { type: "pr_review", ref: "x/y#1" } }]),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedCreateRoom).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid JSON body → 400 invalid_json", async () => {
     mockedAuth.mockResolvedValue(makeQueenAuth());
     const req = new NextRequest("https://www.hivemoot.dev/api/rooms", {

--- a/web/src/app/api/rooms/route.test.ts
+++ b/web/src/app/api/rooms/route.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for GET /api/rooms — list war rooms for the bearer's installation.
+ * Tests for /api/rooms — list (GET) and create (POST) war rooms.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -9,16 +9,30 @@ vi.mock("@/server/agent-token-v1-auth", () => ({
   authenticateAgentRequestV1: vi.fn(),
 }));
 
-vi.mock("@/server/war-room", () => ({
-  listRooms: vi.fn(),
-}));
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    listRooms: vi.fn(),
+    createRoom: vi.fn(),
+  };
+});
 
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
-import { listRooms } from "@/server/war-room";
+import {
+  listRooms,
+  createRoom,
+  RoomSubjectAlreadyOpenError,
+  RoomSubjectRefError,
+  RoomIdTakenError,
+} from "@/server/war-room";
 import { GET, POST } from "./route";
 
 const mockedAuth = vi.mocked(authenticateAgentRequestV1);
 const mockedListRooms = vi.mocked(listRooms);
+const mockedCreateRoom = vi.mocked(createRoom);
 
 function makeRequest(url: string = "https://www.hivemoot.dev/api/rooms"): NextRequest {
   return new NextRequest(url, {
@@ -133,13 +147,203 @@ describe("GET /api/rooms", () => {
   });
 });
 
-describe("POST /api/rooms", () => {
-  it("returns 405 method_not_allowed (room creation lands in D.1.b-ii)", async () => {
-    const res = await POST();
-    expect(res.status).toBe(405);
-    expect(res.headers.get("Allow")).toBe("GET");
+describe("POST /api/rooms (D.1.b-ii — create room)", () => {
+  function makePostRequest(body: unknown): NextRequest {
+    return new NextRequest("https://www.hivemoot.dev/api/rooms", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function makeQueenAuth() {
+    return {
+      ok: true as const,
+      installationId: "12345",
+      name: "bot-queen",
+      agent_role: "queen",
+      capabilities: ["rooms.create", "rooms.read_all"],
+      redis: {} as never,
+      envelope: { fingerprint: "fp", expiresAt: null } as never,
+    };
+  }
+
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedListRooms.mockReset();
+    mockedCreateRoom.mockReset();
+  });
+
+  it("requires rooms.create capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { code: "agent_auth_v1_missing_capability", missing: "rooms.create" },
+        { status: 403 },
+      ),
+    });
+    const res = await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.create" },
+    );
+    expect(mockedCreateRoom).not.toHaveBeenCalled();
+  });
+
+  it("creates a room scoped to the bearer's installation (no client-supplied installation override)", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockResolvedValue({
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "hivemoot/hivemoot#1",
+      status: "awaiting_rsvp",
+    } as never);
+    const res = await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    expect(res.status).toBe(201);
+    expect(mockedCreateRoom).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+
+  it("auto-mints a UUIDv4 roomId when caller omits one", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockResolvedValue({} as never);
+    await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    const calledWith = mockedCreateRoom.mock.calls[0][0];
+    expect(calledWith.roomId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("respects caller-supplied roomId when present", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockResolvedValue({} as never);
+    await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+        roomId: "01234567-89ab-4cde-9012-3456789abcde",
+      }),
+    );
+    expect(mockedCreateRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: "01234567-89ab-4cde-9012-3456789abcde",
+      }),
+    );
+  });
+
+  it("manager defaults to bearer's name when omitted", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockResolvedValue({} as never);
+    await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    expect(mockedCreateRoom).toHaveBeenCalledWith(
+      expect.objectContaining({ manager: "bot-queen" }),
+    );
+  });
+
+  it("rejects invalid JSON body → 400 invalid_json", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const req = new NextRequest("https://www.hivemoot.dev/api/rooms", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: "not json{{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_json");
+  });
+
+  it("rejects missing subject → 400 invalid_subject", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_subject");
+  });
+
+  it("rejects unknown subject_type → 400 invalid_subject_type", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    const res = await POST(
+      makePostRequest({
+        subject: { type: "release_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_subject_type");
+  });
+
+  it("RoomSubjectAlreadyOpenError → 409 with existingRoomId", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockRejectedValue(
+      new RoomSubjectAlreadyOpenError(
+        "12345",
+        "pr_review",
+        "hivemoot/hivemoot#1",
+        "OLD_ROOM_ID",
+      ),
+    );
+    const res = await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    expect(res.status).toBe(409);
     const body = await res.json();
-    expect(body.code).toBe("method_not_allowed");
+    expect(body.code).toBe("subject_already_open");
+    expect(body.existingRoomId).toBe("OLD_ROOM_ID");
+  });
+
+  it("RoomSubjectRefError → 400 invalid_subject_ref", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockRejectedValue(
+      new RoomSubjectRefError(
+        "pr_review",
+        "malformed-ref",
+        "owner/repo#NNN",
+      ),
+    );
+    const res = await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "malformed-ref" },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_subject_ref");
+  });
+
+  it("RoomIdTakenError → 409 room_id_taken", async () => {
+    mockedAuth.mockResolvedValue(makeQueenAuth());
+    mockedCreateRoom.mockRejectedValue(
+      new RoomIdTakenError("12345", "01234567-89ab-4cde-9012-3456789abcde"),
+    );
+    const res = await POST(
+      makePostRequest({
+        subject: { type: "pr_review", ref: "hivemoot/hivemoot#1" },
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("room_id_taken");
   });
 });
 

--- a/web/src/app/api/rooms/route.ts
+++ b/web/src/app/api/rooms/route.ts
@@ -16,6 +16,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
 import {
   listRooms,
   createRoom,
@@ -77,15 +78,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   });
   if (!auth.ok) return auth.response;
 
-  let body: CreateRoomRequestBody;
-  try {
-    body = (await request.json()) as CreateRoomRequestBody;
-  } catch {
+  // parseJsonBody rejects null / arrays / primitives + invalid JSON
+  // up-front, so the body-shape branches below can read fields
+  // without TypeError on a null bypass (closes #519 builder R1).
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
     return NextResponse.json(
-      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { code: parsed.code, message: parsed.message },
       { status: 400 },
     );
   }
+  const body = parsed.body as CreateRoomRequestBody;
 
   // Subject is required and must conform to the SubjectRef shape.
   // Boundary validation happens here; the storage primitive does

--- a/web/src/app/api/rooms/route.ts
+++ b/web/src/app/api/rooms/route.ts
@@ -1,28 +1,50 @@
 /**
- * GET /api/rooms — list war rooms for the bearer's installation.
+ * /api/rooms — list (GET) and create (POST) war rooms.
  *
- * Capability: `rooms.read`. The bearer's installation is the
- * canonical scope — clients cannot list other installations' rooms
- * regardless of any query parameter (cross-installation isolation
- * is enforced server-side from the envelope).
+ * GET — list rooms for the bearer's installation. Capability:
+ *       `rooms.read_all`. See file-level docstring on each handler.
  *
- * Query params:
- *   - `limit` (optional): max rooms to return. Default 50, max 200,
- *     min 1. Out-of-range values clamp silently to the bounds.
+ * POST — create a new war room for the bearer's installation.
+ *        Capability: `rooms.create`. The bot's queen module is the
+ *        primary caller (driven by GitHub webhook events); operator
+ *        UI may also create rooms in the future.
  *
- * Response: `{ rooms: RoomCore[] }` ordered newest-first by `opened_at`.
- *
- * Auth model: `requires: "rooms.read_all"`. Sub-endpoints
- * (`/api/rooms/:id/...`) defer to the same capability since they're
- * all read-shaped data about the same scope.
+ * Cross-installation isolation: the bearer's `installationId` from
+ * the envelope is the canonical scope. A client cannot create or
+ * list rooms in another installation regardless of body / query.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
-import { listRooms } from "@/server/war-room";
+import {
+  listRooms,
+  createRoom,
+  type SubjectRef,
+  type SubjectType,
+  type TimingConfig,
+  RoomSubjectAlreadyOpenError,
+  RoomSubjectRefError,
+  RoomIdFormatError,
+  RoomIdTakenError,
+} from "@/server/war-room";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+
+const SUBJECT_TYPES: ReadonlySet<SubjectType> = new Set<SubjectType>([
+  "pr_review",
+  "mention_response",
+  "issue_triage",
+]);
+
+interface CreateRoomRequestBody {
+  subject?: { type?: string; ref?: string };
+  manager?: string;
+  timing?: Partial<TimingConfig>;
+  /** Optional caller-supplied roomId. UUIDv4 lowercase. If omitted,
+   * the server mints one via crypto.randomUUID(). */
+  roomId?: string;
+}
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = await authenticateAgentRequestV1(request, {
@@ -49,12 +71,106 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   return NextResponse.json({ rooms }, { status: 200 });
 }
 
-export async function POST(): Promise<NextResponse> {
-  return NextResponse.json(
-    {
-      code: "method_not_allowed",
-      message: "GET /api/rooms only — POST not yet implemented (lands in D.1.b-ii).",
-    },
-    { status: 405, headers: { Allow: "GET" } },
-  );
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.create",
+  });
+  if (!auth.ok) return auth.response;
+
+  let body: CreateRoomRequestBody;
+  try {
+    body = (await request.json()) as CreateRoomRequestBody;
+  } catch {
+    return NextResponse.json(
+      { code: "invalid_json", message: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  // Subject is required and must conform to the SubjectRef shape.
+  // Boundary validation happens here; the storage primitive does
+  // the format-regex check on `ref` itself.
+  if (
+    !body.subject ||
+    typeof body.subject.type !== "string" ||
+    typeof body.subject.ref !== "string"
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_subject",
+        message: "Body must include `subject: { type, ref }` with string values.",
+      },
+      { status: 400 },
+    );
+  }
+  if (!SUBJECT_TYPES.has(body.subject.type as SubjectType)) {
+    return NextResponse.json(
+      {
+        code: "invalid_subject_type",
+        message: `subject.type must be one of: ${Array.from(SUBJECT_TYPES).join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+  const subject: SubjectRef = {
+    type: body.subject.type as SubjectType,
+    ref: body.subject.ref,
+  };
+
+  // Manager defaults to the bearer's name (typically "bot-queen" for
+  // the queen module). Caller can override for system-driven rooms
+  // opened by other internal modules.
+  const manager = body.manager ?? auth.name;
+
+  // Mint roomId server-side if absent. UUIDv4 from crypto for both
+  // randomness and the lowercase format the storage layer enforces.
+  const roomId = body.roomId ?? crypto.randomUUID();
+
+  try {
+    const room = await createRoom({
+      installationId: auth.installationId,
+      roomId,
+      manager,
+      subject,
+      timing: body.timing,
+      redis: auth.redis,
+    });
+    return NextResponse.json(room, { status: 201 });
+  } catch (err) {
+    if (err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        {
+          code: "invalid_room_id",
+          message: "roomId must be RFC 4122 UUIDv4 lowercase.",
+        },
+        { status: 400 },
+      );
+    }
+    if (err instanceof RoomSubjectRefError) {
+      return NextResponse.json(
+        { code: "invalid_subject_ref", message: err.message },
+        { status: 400 },
+      );
+    }
+    if (err instanceof RoomSubjectAlreadyOpenError) {
+      return NextResponse.json(
+        {
+          code: "subject_already_open",
+          message: err.message,
+          existingRoomId: err.existingRoomId,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomIdTakenError) {
+      return NextResponse.json(
+        {
+          code: "room_id_taken",
+          message: err.message,
+        },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
 }

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -146,6 +146,15 @@ export const KNOWN_CAPABILITIES = [
   // with `/api/rooms/watching` in a follow-up slice.
   "rooms.read_all",
   // War rooms — bot (queen module).
+  // Note (#519 guard N5): `POST /api/rooms` 409 `subject_already_open`
+  // surfaces `existingRoomId` in the response body. Today the only
+  // preset granting `rooms.create` (queen) also includes
+  // `rooms.read_all`, so the disclosure is benign — the bearer can
+  // already enumerate every room in the installation. Any future
+  // preset with `rooms.create` but WITHOUT `rooms.read_all` would
+  // turn the 409 into a roomId-discovery oracle. Keep this pairing
+  // when adding a new preset, or strip `existingRoomId` from the
+  // 409 when the bearer lacks `rooms.read_all`.
   "rooms.create",
   "rooms.update",
   "rooms.decide",

--- a/web/src/server/request-utils.ts
+++ b/web/src/server/request-utils.ts
@@ -52,3 +52,54 @@ export async function parseJsonBody(
   }
   return { ok: true, body: raw as Record<string, unknown> };
 }
+
+/**
+ * Parse an OPTIONAL JSON object body. Distinct from `parseJsonBody`
+ * in that an entirely-absent body (empty text, no `Content-Length`)
+ * is treated as `ok` with `body: {}` rather than `invalid_json`.
+ *
+ * Closes #519 builder R3: the prior `/force-close` heuristic
+ * (`content-length === "0"` skip-parse) didn't cover the operator
+ * one-liner `curl -X POST .../force-close` — `Content-Length` is
+ * absent (not `"0"`), so the handler entered the parse branch,
+ * `request.json()` threw "Unexpected end of JSON input", and the
+ * route returned 400 instead of defaulting to `force_close`.
+ *
+ * Reads body as text first, then:
+ *   - empty / whitespace-only text → `ok` with `body: {}` (operator
+ *     panic-button compat)
+ *   - non-empty text that doesn't parse → `invalid_json` (genuine
+ *     truncation / malformed payload — fail loud, do NOT default)
+ *   - non-empty text that parses but isn't a plain object →
+ *     `invalid_body_shape`
+ *
+ * Use this for endpoints where an empty body is a valid "use defaults"
+ * signal (force-close, possibly future internal-trigger endpoints).
+ * For endpoints that REQUIRE a body, stick with `parseJsonBody`.
+ */
+export async function parseOptionalJsonObjectBody(
+  request: Request,
+): Promise<ParseJsonBodyResult> {
+  const text = await request.text();
+  if (text.trim() === "") {
+    return { ok: true, body: {} };
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return {
+      ok: false,
+      code: "invalid_json",
+      message: "Request body must be valid JSON or empty.",
+    };
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      code: "invalid_body_shape",
+      message: "Request body must be a JSON object (got null, array, or primitive).",
+    };
+  }
+  return { ok: true, body: raw as Record<string, unknown> };
+}

--- a/web/src/server/request-utils.ts
+++ b/web/src/server/request-utils.ts
@@ -4,3 +4,51 @@ export function parseContentLength(header: string | null): number | null {
   if (!Number.isFinite(parsed) || parsed < 0) return null;
   return Math.floor(parsed);
 }
+
+/**
+ * Parse a request body as a JSON object.
+ *
+ * Closes #519 builder R1: the naive pattern
+ *
+ *   const body = (await request.json()) as MyShape;
+ *
+ * fails closed on `null`, arrays, and primitives. `JSON.parse("null")`
+ * returns `null` (TS-cast bypasses runtime check), then `body.foo`
+ * crashes with TypeError instead of returning the intended 400.
+ * `JSON.parse("[]")` returns an array, which `typeof === "object"`
+ * but has no named fields the handler expects.
+ *
+ * This helper consolidates the validation:
+ *   - JSON parse failure → `{ ok: false, code: "invalid_json" }`
+ *   - Parsed value is `null` / array / primitive → `{ ok: false, code: "invalid_body_shape" }`
+ *   - Plain object → `{ ok: true, body: value as Record<string, unknown> }`
+ *
+ * Caller still does its own field-shape validation; this just
+ * guarantees a non-null, non-array object to property-access into.
+ */
+export type ParseJsonBodyResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; code: "invalid_json" | "invalid_body_shape"; message: string };
+
+export async function parseJsonBody(
+  request: Request,
+): Promise<ParseJsonBodyResult> {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return {
+      ok: false,
+      code: "invalid_json",
+      message: "Request body must be valid JSON.",
+    };
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      code: "invalid_body_shape",
+      message: "Request body must be a JSON object (got null, array, or primitive).",
+    };
+  }
+  return { ok: true, body: raw as Record<string, unknown> };
+}

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -313,7 +313,13 @@ export type RoomEventType =
   | "contribution_withdrawn"
   | "room_decided"
   | "room_recovered"
-  | "room_terminated";
+  | "room_terminated"
+  // Bot/queen meta-events emitted via POST /api/rooms/{id}/event
+  // (D.1.b-ii). They DON'T transition status — the bot uses them
+  // to record context for workers (subject changed) or pose
+  // targeted questions (V1.1 follow-up).
+  | "subject_updated"
+  | "queen_question";
 
 /** Materialized RSVP entry per role (latest-state-wins). Stored as
  * JSON in the `:participants` hash, keyed by role.
@@ -1616,7 +1622,12 @@ export type RoomEventAction =
   | "withdraw_contribution"
   | "timeout"
   | "decide"
-  | "close";
+  | "close"
+  // Bot meta-event idempotency lanes (D.1.b-ii). Caller derives
+  // a key per (room, role, action, observed-sequence); same shape
+  // as the worker actions above.
+  | "subject_updated"
+  | "queen_question";
 
 // ---------------------------------------------------------------------------
 // ROOM_APPEND_EVENT_SCRIPT — atomic event append

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -1134,6 +1134,28 @@ export class RoomContributionTooLargeError extends Error {
 }
 
 /**
+ * `RoomDecision.content` exceeded the 64 KiB UTF-8 byte budget.
+ *
+ * Closes #519 guard N1 — the prior `closeRoomWithDecision`
+ * implementation threw a plain `Error` with a free-text message
+ * that the route layer had to regex-match (`/exceeds 64 KiB/`),
+ * making the mapping silently break on any copy-edit of the
+ * message string. Sibling-typed pattern restored: `RoomEventBodyTooLargeError`,
+ * `RoomContributionTooLargeError`, and now this one all carry
+ * `sizeBytes` for caller logs.
+ */
+export class RoomDecisionTooLargeError extends Error {
+  public readonly sizeBytes: number;
+  constructor(sizeBytes: number) {
+    super(
+      `RoomDecision.content exceeds 64 KiB (got ${sizeBytes} bytes). Reduce body before close — large synthesis output should reference an external gist/issue.`,
+    );
+    this.name = "RoomDecisionTooLargeError";
+    this.sizeBytes = sizeBytes;
+  }
+}
+
+/**
  * Thrown when `ROOM_DECIDE_CLAIM_SCRIPT` finds the synthesis claim
  * already held by another queen runner (benign conflict — the
  * caller should skip this tick and re-attempt on the next manager
@@ -3338,9 +3360,9 @@ export async function closeRoomWithDecision(args: {
   // assertEventBodySize).
   const decisionContentBytes = Buffer.byteLength(args.decision.content, "utf8");
   if (decisionContentBytes > 64 * 1024) {
-    throw new Error(
-      `RoomDecision.content exceeds 64 KiB (${decisionContentBytes} bytes); reduce body before close.`,
-    );
+    // Typed class (closes #519 guard N1) so the route layer can
+    // map via `instanceof` instead of regex-matching the message.
+    throw new RoomDecisionTooLargeError(decisionContentBytes);
   }
 
   const nowMs = args.nowMs ?? Date.now();


### PR DESCRIPTION
Fixes #518

## Summary

Five POST endpoints completing the queen + operator write surface for the war-room state machine. Builds on D.1.b-i read endpoints (#517).

| Endpoint | Capability | Storage primitive |
|---|---|---|
| `POST /api/rooms` | `rooms.create` | `createRoom` |
| `POST /api/rooms/:id/decide` | `rooms.decide` | `claimSynthesis` |
| `POST /api/rooms/:id/close` | `rooms.close` | `closeRoomWithDecision` |
| `POST /api/rooms/:id/force-close` | `rooms.force_close` | `terminateRoom` |
| `POST /api/rooms/:id/event` | `rooms.update` | `appendRoomEvent` |

## What it looks like

**Cross-installation isolation pattern (consistent with D.1.b-i):**
- `installationId` always comes from the bearer envelope, never from request body / query
- `/close` and `/force-close` fetch `subject` from `getRoomCore(installationId, roomId)` server-side — caller cannot smuggle a mismatched subject to redirect the script's subject-index key
- `/event` whitelists `event_type ∈ {subject_updated, queen_question}` so callers cannot drive lifecycle transitions through the generic surface (lifecycle events have invariants the dedicated endpoints enforce atomically)

**Error → HTTP status mapping:**

| Error | HTTP | Code |
|---|---|---|
| Missing/bad bearer | 401 | (delegated) |
| Missing capability | 403 | (delegated) |
| Malformed JSON / shape | 400 | `invalid_json`, `invalid_subject`, `invalid_event_type`, `invalid_through_sequence`, `invalid_decision_shape`, `invalid_reason`, `missing_idempotency` |
| Runner format violation (`__SEQ__` etc.) | 400 | `invalid_queen_runner` / `invalid_synthesis_runner` |
| Decision >64 KiB / event body >8 KiB | 400 | `decision_too_large`, `event_body_too_large` |
| Room not found / malformed UUID | 404 | `room_not_found` (same shape — no oracle) |
| Subject already open | 409 | `subject_already_open` (carries `existingRoomId`) |
| RoomId already taken | 409 | `room_id_taken` |
| Claim already held | 409 | `claim_already_held` (carries `heldByRunner`, `throughSequence`) |
| Wrong status | 409 | `invalid_status_for_claim`, `status_precondition_failed` |
| Sequence drift on close | 409 | `sequence_drift` (carries `expectedThroughSequence`, `lastSeq`) |
| Claim DEL'd mid-flight | 409 | `claim_lost` |
| Claim throughSeq mismatch | 409 | `claim_through_seq_mismatch` (carries both seqs) |
| Claim payload corruption | 409 | `claim_payload_corrupt` |
| Already closed (operator double-tap) | 409 | `room_already_closed` |
| Idempotency replay on `/event` | **200** | `{sequence, replay: true}` (treat as success per design) |

**Storage layer extensions (small):**
- `RoomEventType` += `subject_updated`, `queen_question` — bot meta-events that do NOT transition status
- `RoomEventAction` += same two for `deriveIdempotencyKey`

**End-to-end flow now possible (queen happy path):**

```
POST /api/rooms → 201 {roomId, ...}
[workers RSVP via D.1.b-iii endpoints — coming next]
[workers contribute via D.1.b-iii endpoints — coming next]
POST /api/rooms/:id/decide → 200 {throughSequence: 7, claimTtlSecs: 360}
POST /api/rooms/:id/close → 200 {closedSequence: 8}
```

If something goes wrong mid-flight, operator can:
```
POST /api/rooms/:id/force-close → 200 {sequence, reason}
```

## Test plan

- [x] Typecheck (`tsc --noEmit`) clean
- [x] Full web suite passes: **1227 tests** (was 1177 → +50)
- [x] Per-endpoint coverage:
  - `/rooms` POST: 12 tests (capability gate, install scoping, UUID auto-mint, manager default, all 4 error mappings)
  - `/decide`: 10 tests (capability, happy path, TTL override, validation, 5 error mappings)
  - `/close`: 10 tests (capability, server-fetched subject, drift/claim_lost/through_seq_mismatch/size cap)
  - `/force-close`: 8 tests (default reason, explicit reason, invalid reason, server-fetched subject, idempotent already-closed, empty body)
  - `/event`: 10 tests (whitelist enforcement, idempotency-replay → 200, lifecycle-event rejection, all error mappings)
- [ ] Reviewer fleet sign-off

## What's next

D.1.b-iii adds the **worker** write surface: `POST /api/rooms/:id/{present, withdraw, contribute}`, `DELETE /api/rooms/:id/contributions`, `POST /api/rooms/:id/timeout`, plus the worker-visibility `GET /api/rooms/watching` endpoint with the role-bound `canReadRoomForBearer` helper builder requested in #517 R1.