### PR TITLE
Phase D.1.b-iii — worker write endpoints + /api/rooms/watching

### DIFF
--- a/web/src/app/api/rooms/[roomId]/contributions/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.test.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for GET /api/rooms/:roomId/contributions.
+ * Tests for /api/rooms/:roomId/contributions — GET (D.1.b-i),
+ * POST + DELETE (D.1.b-iii).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -17,6 +18,8 @@ vi.mock("@/server/war-room", async () => {
     ...real,
     getRoomCore: vi.fn(),
     getRoomContributions: vi.fn(),
+    submitContribution: vi.fn(),
+    withdrawContribution: vi.fn(),
   };
 });
 
@@ -24,10 +27,17 @@ import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
 import {
   getRoomCore,
   getRoomContributions,
+  submitContribution,
+  withdrawContribution,
   RoomNotFoundError,
   RoomIdFormatError,
+  RoomEventIdempotencyReplayError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+  RoomContributionTooLargeError,
+  ContributionValidationError,
 } from "@/server/war-room";
-import { GET } from "./route";
+import { GET, POST, DELETE } from "./route";
 
 const mockedAuth = vi.mocked(authenticateAgentRequestV1);
 const mockedGetRoomCore = vi.mocked(getRoomCore);
@@ -126,5 +136,243 @@ describe("GET /api/rooms/:roomId/contributions", () => {
       params: Promise.resolve({ roomId: "bad" }),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST + DELETE (D.1.b-iii — rooms.contribute)
+// ---------------------------------------------------------------------------
+
+const mockedSubmit = vi.mocked(submitContribution);
+const mockedWithdraw = vi.mocked(withdrawContribution);
+
+function makeWriteRequest(method: "POST" | "DELETE", body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/contributions`,
+    {
+      method,
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeWorkerAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "drone-1",
+    agent_role: "drone",
+    capabilities: ["rooms.contribute"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+const VALID_BODY = { verdict: "APPROVE", summary: "looks good" };
+
+describe("POST /api/rooms/:roomId/contributions", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedSubmit.mockReset();
+  });
+
+  it("requires rooms.contribute", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: VALID_BODY,
+        rawMd: "# ok",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.contribute" },
+    );
+  });
+
+  it("happy path → returns sequence; role/agentId server-derived", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedSubmit.mockResolvedValue(5);
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: VALID_BODY,
+        rawMd: "# Verdict\nApprove.",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).sequence).toBe(5);
+    expect(mockedSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "drone",
+        agentId: "drone-1",
+        body: VALID_BODY,
+      }),
+    );
+  });
+
+  it("rejects missing rawMd → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: VALID_BODY,
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_raw_md");
+  });
+
+  it("ContributionValidationError → 400 invalid_contribution_body", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedSubmit.mockRejectedValue(
+      new ContributionValidationError("verdict", "approve", "uppercase"),
+    );
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: { verdict: "approve", summary: "ok" }, // lowercase!
+        rawMd: "x",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_contribution_body");
+  });
+
+  it("RoomContributionTooLargeError → 400 raw_md_too_large with sizeBytes", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedSubmit.mockRejectedValue(new RoomContributionTooLargeError(40000));
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: VALID_BODY,
+        rawMd: "x".repeat(40000),
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    const respBody = await res.json();
+    expect(respBody.code).toBe("raw_md_too_large");
+    expect(respBody.sizeBytes).toBe(40000);
+  });
+
+  it("RoomParticipantNotFoundError → 409 participant_not_found", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedSubmit.mockRejectedValue(
+      new RoomParticipantNotFoundError(VALID_ROOM_ID, "drone"),
+    );
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: VALID_BODY,
+        rawMd: "x",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("participant_not_found");
+  });
+
+  it("idempotency replay → 200 with replay flag", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedSubmit.mockRejectedValue(
+      new RoomEventIdempotencyReplayError(VALID_ROOM_ID, 5),
+    );
+    const res = await POST(
+      makeWriteRequest("POST", {
+        sequenceObservedByClient: 1,
+        body: VALID_BODY,
+        rawMd: "x",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).replay).toBe(true);
+  });
+
+  it("body=null → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(makeWriteRequest("POST", null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+  });
+});
+
+describe("DELETE /api/rooms/:roomId/contributions", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedWithdraw.mockReset();
+  });
+
+  it("requires rooms.contribute", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await DELETE(makeWriteRequest("DELETE", { sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.contribute" },
+    );
+  });
+
+  it("happy path → returns sequence", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockResolvedValue(7);
+    const res = await DELETE(
+      makeWriteRequest("DELETE", {
+        sequenceObservedByClient: 2,
+        reason: "found regression",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).sequence).toBe(7);
+  });
+
+  it("RoomParticipantStatePreconditionError → 409 participant_state_precondition", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockRejectedValue(
+      new RoomParticipantStatePreconditionError(
+        VALID_ROOM_ID,
+        "drone",
+        ["resolved"],
+        "pending",
+      ),
+    );
+    const res = await DELETE(
+      makeWriteRequest("DELETE", { sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    const respBody = await res.json();
+    expect(respBody.code).toBe("participant_state_precondition");
+    expect(respBody.actualState).toBe("pending");
+  });
+
+  it("body=null → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await DELETE(makeWriteRequest("DELETE", null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/web/src/app/api/rooms/[roomId]/contributions/route.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.ts
@@ -39,6 +39,7 @@ import {
   RoomIdFormatError,
   RoomEventIdempotencyReplayError,
   RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
   RoomParticipantOwnerConflictError,
   RoomParticipantNotFoundError,
   RoomParticipantStatePreconditionError,
@@ -221,6 +222,14 @@ export async function DELETE(
 // ---------------------------------------------------------------------------
 
 function mapWriteError(err: unknown, roomId: string): NextResponse {
+  if (err instanceof RoomEventBodyTooLargeError) {
+    // Closes #521 builder R1 #2: oversized event body (verdict +
+    // findings serialized) bubbles up via assertEventBodySize.
+    return NextResponse.json(
+      { code: "event_body_too_large", message: err.message, sizeBytes: err.sizeBytes },
+      { status: 400 },
+    );
+  }
   if (err instanceof ContributionValidationError) {
     return NextResponse.json(
       { code: "invalid_contribution_body", message: err.message },

--- a/web/src/app/api/rooms/[roomId]/contributions/route.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.ts
@@ -1,26 +1,54 @@
 /**
- * GET /api/rooms/:roomId/contributions — read materialized
- * contributions hash (latest contribution per role, plus tombstones
- * for withdrawn).
+ * /api/rooms/:roomId/contributions — read (GET), submit (POST), and
+ * withdraw (DELETE) contributions.
  *
- * Capability: `rooms.read`. Cross-installation isolation: same
- * room-existence pre-check as `/events` (the contributions hash is
- * keyed by roomId only).
+ * GET — D.1.b-i. Capability `rooms.read_all`. Lists materialized
+ *       contribution hash for the room.
  *
- * Response: `{ contributions: Record<role, RoomContribution>, roomId: string }`.
- *           Withdrawn contributions surface as tombstones with
- *           `{ withdrawn: true, contributed_at }`.
- * Errors: 401, 403, 404.
+ * POST — D.1.b-iii. Capability `rooms.contribute`. Worker submits a
+ *        contribution. Body shape:
+ *          {
+ *            sequenceObservedByClient: number,
+ *            body: ContributionBody,    // typed (verdict, summary, findings, etc.)
+ *            rawMd: string              // ≤ 32 KiB UTF-8 bytes
+ *          }
+ *        Server-derived: role, agent_id from envelope.
+ *
+ * DELETE — D.1.b-iii. Capability `rooms.contribute`. Worker withdraws
+ *          a previously-submitted contribution. Body shape:
+ *          { sequenceObservedByClient: number, reason?: string }
+ *          Tombstone: writes `{ withdrawn: true, contributed_at }` to
+ *          the contributions hash; events sorted set preserves the
+ *          original audit trail.
+ *
+ * Errors: same shape as /present and /withdraw, plus 400 for body
+ * validation failures (invalid verdict, oversized rawMd, etc.) via
+ * the typed validation primitives.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
 import {
+  submitContribution,
+  withdrawContribution,
   getRoomCore,
   getRoomContributions,
+  type ContributionBody,
   RoomNotFoundError,
   RoomIdFormatError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomParticipantOwnerConflictError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+  RoomContributionTooLargeError,
+  ContributionValidationError,
 } from "@/server/war-room";
+
+// ---------------------------------------------------------------------------
+// GET — read contributions hash (D.1.b-i, scoped to rooms.read_all)
+// ---------------------------------------------------------------------------
 
 export async function GET(
   request: NextRequest,
@@ -54,4 +82,201 @@ export async function GET(
     redis: auth.redis,
   });
   return NextResponse.json({ contributions, roomId }, { status: 200 });
+}
+
+// ---------------------------------------------------------------------------
+// POST — submit contribution (D.1.b-iii, rooms.contribute)
+// ---------------------------------------------------------------------------
+
+interface SubmitRequestBody {
+  sequenceObservedByClient?: number;
+  body?: ContributionBody;
+  rawMd?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.contribute",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const reqBody = parsed.body as SubmitRequestBody;
+
+  if (
+    typeof reqBody.sequenceObservedByClient !== "number" ||
+    !Number.isFinite(reqBody.sequenceObservedByClient) ||
+    reqBody.sequenceObservedByClient < 0
+  ) {
+    return NextResponse.json(
+      { code: "invalid_sequence", message: "sequenceObservedByClient required (non-negative integer)." },
+      { status: 400 },
+    );
+  }
+  if (!reqBody.body || typeof reqBody.body !== "object") {
+    return NextResponse.json(
+      { code: "invalid_body", message: "body (ContributionBody) is required." },
+      { status: 400 },
+    );
+  }
+  if (typeof reqBody.rawMd !== "string") {
+    return NextResponse.json(
+      { code: "invalid_raw_md", message: "rawMd must be a string." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const sequence = await submitContribution({
+      installationId: auth.installationId,
+      roomId,
+      role: auth.agent_role,
+      agentId: auth.name,
+      sequenceObservedByClient: reqBody.sequenceObservedByClient,
+      body: reqBody.body,
+      rawMd: reqBody.rawMd,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence }, { status: 200 });
+  } catch (err) {
+    return mapWriteError(err, roomId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE — withdraw contribution tombstone (D.1.b-iii, rooms.contribute)
+// ---------------------------------------------------------------------------
+
+interface WithdrawContributionBody {
+  sequenceObservedByClient?: number;
+  reason?: string;
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.contribute",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const reqBody = parsed.body as WithdrawContributionBody;
+
+  if (
+    typeof reqBody.sequenceObservedByClient !== "number" ||
+    !Number.isFinite(reqBody.sequenceObservedByClient) ||
+    reqBody.sequenceObservedByClient < 0
+  ) {
+    return NextResponse.json(
+      { code: "invalid_sequence", message: "sequenceObservedByClient required (non-negative integer)." },
+      { status: 400 },
+    );
+  }
+  if (reqBody.reason !== undefined && typeof reqBody.reason !== "string") {
+    return NextResponse.json(
+      { code: "invalid_reason", message: "reason must be a string." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const sequence = await withdrawContribution({
+      installationId: auth.installationId,
+      roomId,
+      role: auth.agent_role,
+      agentId: auth.name,
+      sequenceObservedByClient: reqBody.sequenceObservedByClient,
+      reason: reqBody.reason,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence }, { status: 200 });
+  } catch (err) {
+    return mapWriteError(err, roomId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared write-error mapping (POST + DELETE)
+// ---------------------------------------------------------------------------
+
+function mapWriteError(err: unknown, roomId: string): NextResponse {
+  if (err instanceof ContributionValidationError) {
+    return NextResponse.json(
+      { code: "invalid_contribution_body", message: err.message },
+      { status: 400 },
+    );
+  }
+  if (err instanceof RoomContributionTooLargeError) {
+    return NextResponse.json(
+      {
+        code: "raw_md_too_large",
+        message: err.message,
+        sizeBytes: err.sizeBytes,
+      },
+      { status: 400 },
+    );
+  }
+  if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+    return NextResponse.json(
+      { code: "room_not_found", message: `Room ${roomId} not found.` },
+      { status: 404 },
+    );
+  }
+  if (err instanceof RoomEventIdempotencyReplayError) {
+    return NextResponse.json(
+      { sequence: err.existingSequence, replay: true },
+      { status: 200 },
+    );
+  }
+  if (err instanceof RoomParticipantNotFoundError) {
+    return NextResponse.json(
+      { code: "participant_not_found", message: err.message },
+      { status: 409 },
+    );
+  }
+  if (err instanceof RoomParticipantStatePreconditionError) {
+    return NextResponse.json(
+      {
+        code: "participant_state_precondition",
+        message: err.message,
+        actualState: err.actualState,
+        allowedStates: err.allowedStates,
+      },
+      { status: 409 },
+    );
+  }
+  if (err instanceof RoomEventStatusPreconditionError) {
+    return NextResponse.json(
+      { code: "status_precondition_failed", message: err.message, actualStatus: err.actualStatus },
+      { status: 409 },
+    );
+  }
+  if (err instanceof RoomParticipantOwnerConflictError) {
+    return NextResponse.json(
+      { code: "owner_conflict", message: err.message, existingAgentId: err.existingAgentId },
+      { status: 409 },
+    );
+  }
+  throw err;
 }

--- a/web/src/app/api/rooms/[roomId]/present/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/present/route.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for POST /api/rooms/:roomId/present.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    presentParticipant: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  presentParticipant,
+  RoomNotFoundError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomParticipantOwnerConflictError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedPresent = vi.mocked(presentParticipant);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/present`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeWorkerAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "drone-1",
+    agent_role: "drone",
+    capabilities: ["rooms.contribute", "rooms.watch"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("POST /api/rooms/:roomId/present", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedPresent.mockReset();
+  });
+
+  it("requires rooms.contribute capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.contribute" },
+    );
+  });
+
+  it("happy path → returns sequence; role + agentId server-derived", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockResolvedValue(3);
+    const res = await POST(
+      makeRequest({ sequenceObservedByClient: 1, intentHint: "review" }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).sequence).toBe(3);
+    expect(mockedPresent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "12345",
+        roomId: VALID_ROOM_ID,
+        role: "drone", // server-derived from envelope, not body
+        agentId: "drone-1", // server-derived from envelope
+        sequenceObservedByClient: 1,
+        intentHint: "review",
+      }),
+    );
+  });
+
+  it("rejects missing sequenceObservedByClient → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(makeRequest({}), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_sequence");
+  });
+
+  it("rejects negative sequence → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(makeRequest({ sequenceObservedByClient: -1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-string intentHint → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(
+      makeRequest({ sequenceObservedByClient: 1, intentHint: 42 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_intent_hint");
+  });
+
+  it("body=null → 400 invalid_body_shape", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(makeRequest(null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+    expect(mockedPresent).not.toHaveBeenCalled();
+  });
+
+  it("RoomNotFoundError → 404", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("RoomEventIdempotencyReplayError → 200 with replay flag", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockRejectedValue(
+      new RoomEventIdempotencyReplayError(VALID_ROOM_ID, 5),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sequence).toBe(5);
+    expect(body.replay).toBe(true);
+  });
+
+  it("RoomEventStatusPreconditionError → 409 status_precondition_failed", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockRejectedValue(
+      new RoomEventStatusPreconditionError(VALID_ROOM_ID, "awaiting_rsvp", "closed"),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("status_precondition_failed");
+  });
+
+  it("RoomParticipantOwnerConflictError → 409 owner_conflict", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockRejectedValue(
+      new RoomParticipantOwnerConflictError(
+        VALID_ROOM_ID,
+        "drone",
+        "other-drone",
+        "drone-1",
+      ),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("owner_conflict");
+    expect(body.existingAgentId).toBe("other-drone");
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/present/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/present/route.test.ts
@@ -25,6 +25,7 @@ import {
   RoomNotFoundError,
   RoomEventIdempotencyReplayError,
   RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
   RoomParticipantOwnerConflictError,
 } from "@/server/war-room";
 import { POST } from "./route";
@@ -174,6 +175,22 @@ describe("POST /api/rooms/:roomId/present", () => {
     });
     expect(res.status).toBe(409);
     expect((await res.json()).code).toBe("status_precondition_failed");
+  });
+
+  it("RoomEventBodyTooLargeError → 400 event_body_too_large with sizeBytes (closes #521 builder R1 #2)", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockRejectedValue(new RoomEventBodyTooLargeError(9000));
+    const res = await POST(
+      makeRequest({
+        sequenceObservedByClient: 1,
+        intentHint: "x".repeat(9000), // overflows event-body 8 KiB cap
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("event_body_too_large");
+    expect(body.sizeBytes).toBe(9000);
   });
 
   it("RoomParticipantOwnerConflictError → 409 owner_conflict", async () => {

--- a/web/src/app/api/rooms/[roomId]/present/route.ts
+++ b/web/src/app/api/rooms/[roomId]/present/route.ts
@@ -1,0 +1,134 @@
+/**
+ * POST /api/rooms/:roomId/present — worker RSVPs to a room.
+ *
+ * Capability: `rooms.contribute`. The role and agent_id are
+ * server-derived from the bearer envelope; clients cannot
+ * impersonate another role's RSVP.
+ *
+ * Body: `{ sequenceObservedByClient: number, intentHint?: string }`
+ *
+ * Response: `{ sequence: number }` — the participant_presented event's seq.
+ *
+ * Errors:
+ *   - 400 — malformed body / missing sequenceObservedByClient
+ *   - 401 / 403 — auth / capability
+ *   - 404 — room not found
+ *   - 409 — owner conflict (different agent already holds this role's
+ *     slot), idempotency replay (returns 200 with replay flag),
+ *     status precondition (room not in awaiting_rsvp/awaiting_contributions)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
+import {
+  presentParticipant,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomParticipantOwnerConflictError,
+} from "@/server/war-room";
+
+interface PresentRequestBody {
+  sequenceObservedByClient?: number;
+  intentHint?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.contribute",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as PresentRequestBody;
+
+  if (
+    typeof body.sequenceObservedByClient !== "number" ||
+    !Number.isFinite(body.sequenceObservedByClient) ||
+    body.sequenceObservedByClient < 0
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_sequence",
+        message:
+          "sequenceObservedByClient must be a non-negative integer (the seq the watcher observed when it decided to RSVP).",
+      },
+      { status: 400 },
+    );
+  }
+  if (
+    body.intentHint !== undefined &&
+    typeof body.intentHint !== "string"
+  ) {
+    return NextResponse.json(
+      { code: "invalid_intent_hint", message: "intentHint must be a string." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const sequence = await presentParticipant({
+      installationId: auth.installationId,
+      roomId,
+      role: auth.agent_role,
+      agentId: auth.name,
+      sequenceObservedByClient: body.sequenceObservedByClient,
+      intentHint: body.intentHint,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence }, { status: 200 });
+  } catch (err) {
+    return mapWriteError(err, roomId);
+  }
+}
+
+function mapWriteError(err: unknown, roomId: string): NextResponse {
+  if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+    return NextResponse.json(
+      { code: "room_not_found", message: `Room ${roomId} not found.` },
+      { status: 404 },
+    );
+  }
+  if (err instanceof RoomEventIdempotencyReplayError) {
+    // Same convention as /event: replay is benign, return 200 with
+    // the prior sequence so the worker treats it as success.
+    return NextResponse.json(
+      { sequence: err.existingSequence, replay: true },
+      { status: 200 },
+    );
+  }
+  if (err instanceof RoomEventStatusPreconditionError) {
+    return NextResponse.json(
+      {
+        code: "status_precondition_failed",
+        message: err.message,
+        actualStatus: err.actualStatus,
+      },
+      { status: 409 },
+    );
+  }
+  if (err instanceof RoomParticipantOwnerConflictError) {
+    return NextResponse.json(
+      {
+        code: "owner_conflict",
+        message: err.message,
+        existingAgentId: err.existingAgentId,
+      },
+      { status: 409 },
+    );
+  }
+  throw err;
+}

--- a/web/src/app/api/rooms/[roomId]/present/route.ts
+++ b/web/src/app/api/rooms/[roomId]/present/route.ts
@@ -27,6 +27,7 @@ import {
   RoomIdFormatError,
   RoomEventIdempotencyReplayError,
   RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
   RoomParticipantOwnerConflictError,
 } from "@/server/war-room";
 
@@ -34,6 +35,15 @@ interface PresentRequestBody {
   sequenceObservedByClient?: number;
   intentHint?: string;
 }
+
+// Carry-forward (#521 builder R1 #1, will be tracked in follow-up
+// issue): G5 (design L861-877) calls for per-runner `agent_id`.
+// Currently `agentId = auth.name` (bearer token name), so subscriber-
+// mode fleets sharing one token collapse to a single owner for the
+// first-wins gate. Drone's review noted that fixing this requires a
+// storage-layer split between agent_id (first-wins) and actor_id
+// (audit) — too invasive for this slice. Will be addressed before
+// Phase H fleet migration.
 
 export async function POST(
   request: NextRequest,
@@ -96,6 +106,19 @@ export async function POST(
 }
 
 function mapWriteError(err: unknown, roomId: string): NextResponse {
+  if (err instanceof RoomEventBodyTooLargeError) {
+    // Closes #521 builder R1 #2: a large intentHint (or other
+    // body field) would otherwise bubble out as an unhandled 500.
+    // assertEventBodySize fires for serialized event bodies > 8 KiB.
+    return NextResponse.json(
+      {
+        code: "event_body_too_large",
+        message: err.message,
+        sizeBytes: err.sizeBytes,
+      },
+      { status: 400 },
+    );
+  }
   if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
     return NextResponse.json(
       { code: "room_not_found", message: `Room ${roomId} not found.` },

--- a/web/src/app/api/rooms/[roomId]/timeout/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/timeout/route.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for POST /api/rooms/:roomId/timeout — watchdog timeout.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    timeoutParticipant: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  timeoutParticipant,
+  RoomNotFoundError,
+  RoomEventIdempotencyReplayError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+  RoomEventStatusPreconditionError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedTimeout = vi.mocked(timeoutParticipant);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/timeout`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeBotAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "bot-queen",
+    agent_role: "queen",
+    capabilities: ["rooms.update"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("POST /api/rooms/:roomId/timeout", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedTimeout.mockReset();
+  });
+
+  it("requires rooms.update", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.update" },
+    );
+  });
+
+  it("happy path → returns sequence; watchdog identity from envelope, subject from body", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    mockedTimeout.mockResolvedValue(8);
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 5 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).sequence).toBe(8);
+    expect(mockedTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subjectRole: "drone",      // from body
+        watchdogRole: "queen",      // from envelope (NOT body)
+        watchdogAgentId: "bot-queen",
+        sequenceObservedByClient: 5,
+      }),
+    );
+  });
+
+  it("rejects missing subjectRole → 400", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_subject_role");
+  });
+
+  it("RoomParticipantStatePreconditionError → 409 (covers stale-watchdog-loses-to-resolve race)", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    mockedTimeout.mockRejectedValue(
+      new RoomParticipantStatePreconditionError(
+        VALID_ROOM_ID,
+        "drone",
+        ["pending"],
+        "resolved", // worker resolved between scan and EVAL
+      ),
+    );
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("participant_state_precondition");
+    expect(body.actualState).toBe("resolved");
+  });
+
+  it("RoomEventStatusPreconditionError → 409 (room moved to deciding before timeout)", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    mockedTimeout.mockRejectedValue(
+      new RoomEventStatusPreconditionError(
+        VALID_ROOM_ID,
+        "awaiting_contributions",
+        "deciding",
+      ),
+    );
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("status_precondition_failed");
+  });
+
+  it("idempotency replay → 200", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    mockedTimeout.mockRejectedValue(
+      new RoomEventIdempotencyReplayError(VALID_ROOM_ID, 5),
+    );
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).replay).toBe(true);
+  });
+
+  it("RoomParticipantNotFoundError → 409", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    mockedTimeout.mockRejectedValue(
+      new RoomParticipantNotFoundError(VALID_ROOM_ID, "drone"),
+    );
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("RoomNotFoundError → 404", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    mockedTimeout.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(
+      makeRequest({ subjectRole: "drone", sequenceObservedByClient: 1 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/timeout/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/timeout/route.test.ts
@@ -111,6 +111,24 @@ describe("POST /api/rooms/:roomId/timeout", () => {
     expect((await res.json()).code).toBe("invalid_subject_role");
   });
 
+  it("rejects malformed subjectRole at boundary → 400 invalid_subject_role (closes #521 builder R1 #3)", async () => {
+    mockedAuth.mockResolvedValue(makeBotAuth());
+    // ROLE_REGEX is `/^[a-z][a-z0-9_-]{0,31}$/`. "DRONE" (uppercase)
+    // and "drone!!" both fail format. Without route-layer validation
+    // these reached assertRoleFormat in storage which throws a plain
+    // Error → unhandled 500.
+    for (const bad of ["DRONE", "drone!!", "1drone", "a".repeat(33)]) {
+      const res = await POST(
+        makeRequest({ subjectRole: bad, sequenceObservedByClient: 1 }),
+        { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+      );
+      expect(res.status, `bad: ${bad}`).toBe(400);
+      expect((await res.json()).code).toBe("invalid_subject_role");
+    }
+    // Storage primitive should NEVER have been called for any of them
+    expect(mockedTimeout).not.toHaveBeenCalled();
+  });
+
   it("RoomParticipantStatePreconditionError → 409 (covers stale-watchdog-loses-to-resolve race)", async () => {
     mockedAuth.mockResolvedValue(makeBotAuth());
     mockedTimeout.mockRejectedValue(

--- a/web/src/app/api/rooms/[roomId]/timeout/route.ts
+++ b/web/src/app/api/rooms/[roomId]/timeout/route.ts
@@ -1,0 +1,142 @@
+/**
+ * POST /api/rooms/:roomId/timeout — watchdog times out a participant.
+ *
+ * Capability: `rooms.update`. The bot/queen module's manager loop
+ * is the canonical caller, NOT workers — `actor_role` and `actor_id`
+ * are the watchdog's identity (server-derived from the bearer
+ * envelope), and `subjectRole` (the role being timed out) comes
+ * from the request body.
+ *
+ * Body: `{ subjectRole: string, sequenceObservedByClient: number }`
+ *
+ * Status precondition: only fires while the room is still in
+ * `awaiting_contributions`. If the queen has already moved status
+ * to `deciding`, this returns 409 — the watchdog re-scans next tick.
+ *
+ * Participant-state precondition: only times out `pending`. Re-reads
+ * are protected against racing a worker's resolve.
+ *
+ * Response: `{ sequence: number }`
+ *
+ * Errors: 400 (validation), 401/403, 404, 409.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
+import {
+  timeoutParticipant,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+} from "@/server/war-room";
+
+interface TimeoutRequestBody {
+  subjectRole?: string;
+  sequenceObservedByClient?: number;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.update",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as TimeoutRequestBody;
+
+  if (typeof body.subjectRole !== "string" || body.subjectRole.length === 0) {
+    return NextResponse.json(
+      {
+        code: "invalid_subject_role",
+        message: "subjectRole (the role being timed out) is required.",
+      },
+      { status: 400 },
+    );
+  }
+  if (
+    typeof body.sequenceObservedByClient !== "number" ||
+    !Number.isFinite(body.sequenceObservedByClient) ||
+    body.sequenceObservedByClient < 0
+  ) {
+    return NextResponse.json(
+      { code: "invalid_sequence", message: "sequenceObservedByClient required (non-negative integer)." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const sequence = await timeoutParticipant({
+      installationId: auth.installationId,
+      roomId,
+      subjectRole: body.subjectRole,
+      // Watchdog identity comes from the bearer — same pattern as
+      // /event's actor_role/actor_id derivation. The bot's manager
+      // loop has a `rooms.update` token; operator UI also reaches
+      // here for manual timeouts (rare).
+      watchdogRole: auth.agent_role,
+      watchdogAgentId: auth.name,
+      sequenceObservedByClient: body.sequenceObservedByClient,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence }, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    if (err instanceof RoomEventIdempotencyReplayError) {
+      return NextResponse.json(
+        { sequence: err.existingSequence, replay: true },
+        { status: 200 },
+      );
+    }
+    if (err instanceof RoomParticipantNotFoundError) {
+      return NextResponse.json(
+        { code: "participant_not_found", message: err.message },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomParticipantStatePreconditionError) {
+      // Per design L1055, only `pending` is valid for timeout. A
+      // stale watchdog tick that read `pending` BEFORE a worker's
+      // resolve will land here — caller logs and re-scans.
+      return NextResponse.json(
+        {
+          code: "participant_state_precondition",
+          message: err.message,
+          actualState: err.actualState,
+          allowedStates: err.allowedStates,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomEventStatusPreconditionError) {
+      return NextResponse.json(
+        {
+          code: "status_precondition_failed",
+          message: err.message,
+          actualStatus: err.actualStatus,
+        },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/timeout/route.ts
+++ b/web/src/app/api/rooms/[roomId]/timeout/route.ts
@@ -26,12 +26,15 @@ import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
 import { parseJsonBody } from "@/server/request-utils";
 import {
   timeoutParticipant,
+  validateRoleFormat,
   RoomNotFoundError,
   RoomIdFormatError,
   RoomEventIdempotencyReplayError,
   RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
   RoomParticipantNotFoundError,
   RoomParticipantStatePreconditionError,
+  RoomRoleFormatError,
 } from "@/server/war-room";
 
 interface TimeoutRequestBody {
@@ -68,6 +71,21 @@ export async function POST(
       { status: 400 },
     );
   }
+  // Format validation at the route boundary (closes #521 builder R1
+  // #3). Without this, a malformed subjectRole would reach
+  // timeoutParticipant's internal assertRoleFormat which throws a
+  // plain Error → unhandled 500.
+  try {
+    validateRoleFormat(body.subjectRole);
+  } catch (err) {
+    if (err instanceof RoomRoleFormatError) {
+      return NextResponse.json(
+        { code: "invalid_subject_role", message: err.message },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
   if (
     typeof body.sequenceObservedByClient !== "number" ||
     !Number.isFinite(body.sequenceObservedByClient) ||
@@ -95,6 +113,15 @@ export async function POST(
     });
     return NextResponse.json({ sequence }, { status: 200 });
   } catch (err) {
+    if (err instanceof RoomEventBodyTooLargeError) {
+      // Closes #521 builder R1 #2 for /timeout — body holds
+      // subject_role inline so an unusually long role (defensive
+      // path) could push the event over 8 KiB.
+      return NextResponse.json(
+        { code: "event_body_too_large", message: err.message, sizeBytes: err.sizeBytes },
+        { status: 400 },
+      );
+    }
     if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
       return NextResponse.json(
         { code: "room_not_found", message: `Room ${roomId} not found.` },

--- a/web/src/app/api/rooms/[roomId]/withdraw/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/withdraw/route.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for POST /api/rooms/:roomId/withdraw.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    withdrawParticipant: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  withdrawParticipant,
+  RoomNotFoundError,
+  RoomEventIdempotencyReplayError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+  RoomEventStatusPreconditionError,
+} from "@/server/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedWithdraw = vi.mocked(withdrawParticipant);
+
+const VALID_ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `https://www.hivemoot.dev/api/rooms/${VALID_ROOM_ID}/withdraw`,
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeWorkerAuth() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "drone-1",
+    agent_role: "drone",
+    capabilities: ["rooms.contribute"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+describe("POST /api/rooms/:roomId/withdraw", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedWithdraw.mockReset();
+  });
+
+  it("requires rooms.contribute", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.contribute" },
+    );
+  });
+
+  it("happy path → returns sequence; role/agentId server-derived", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockResolvedValue(4);
+    const res = await POST(
+      makeRequest({ sequenceObservedByClient: 1, reason: "subject too small" }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).sequence).toBe(4);
+    expect(mockedWithdraw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "drone",
+        agentId: "drone-1",
+        reason: "subject too small",
+      }),
+    );
+  });
+
+  it("RoomParticipantNotFoundError → 409 participant_not_found", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockRejectedValue(
+      new RoomParticipantNotFoundError(VALID_ROOM_ID, "drone"),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("participant_not_found");
+  });
+
+  it("RoomParticipantStatePreconditionError → 409 with actualState + allowedStates", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockRejectedValue(
+      new RoomParticipantStatePreconditionError(
+        VALID_ROOM_ID,
+        "drone",
+        ["pending", "resolved"],
+        "withdrew",
+      ),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("participant_state_precondition");
+    expect(body.actualState).toBe("withdrew");
+    expect(body.allowedStates).toEqual(["pending", "resolved"]);
+  });
+
+  it("RoomEventStatusPreconditionError → 409 status_precondition_failed", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockRejectedValue(
+      new RoomEventStatusPreconditionError(
+        VALID_ROOM_ID,
+        "awaiting_contributions",
+        "deciding",
+      ),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("status_precondition_failed");
+  });
+
+  it("idempotency replay → 200 with replay flag", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockRejectedValue(
+      new RoomEventIdempotencyReplayError(VALID_ROOM_ID, 7),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).replay).toBe(true);
+  });
+
+  it("RoomNotFoundError → 404", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedWithdraw.mockRejectedValue(
+      new RoomNotFoundError("12345", VALID_ROOM_ID),
+    );
+    const res = await POST(makeRequest({ sequenceObservedByClient: 1 }), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("body=null → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(makeRequest(null), {
+      params: Promise.resolve({ roomId: VALID_ROOM_ID }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/withdraw/route.ts
+++ b/web/src/app/api/rooms/[roomId]/withdraw/route.ts
@@ -1,0 +1,132 @@
+/**
+ * POST /api/rooms/:roomId/withdraw — worker explicitly withdraws
+ * their RSVP.
+ *
+ * Capability: `rooms.contribute`. Role + agent_id are server-derived
+ * from the bearer; idempotent on already-withdrawn rooms via the
+ * idempotency key derivation.
+ *
+ * Body: `{ sequenceObservedByClient: number, reason?: string }`
+ *
+ * Response: `{ sequence: number }`
+ *
+ * Errors: same shape as /present plus 409 participant_state_precondition
+ * (worker tries to withdraw without first /presenting, or after
+ * already resolved/withdrew/timed_out).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
+import {
+  withdrawParticipant,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomEventIdempotencyReplayError,
+  RoomEventStatusPreconditionError,
+  RoomParticipantOwnerConflictError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+} from "@/server/war-room";
+
+interface WithdrawRequestBody {
+  sequenceObservedByClient?: number;
+  reason?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.contribute",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as WithdrawRequestBody;
+
+  if (
+    typeof body.sequenceObservedByClient !== "number" ||
+    !Number.isFinite(body.sequenceObservedByClient) ||
+    body.sequenceObservedByClient < 0
+  ) {
+    return NextResponse.json(
+      { code: "invalid_sequence", message: "sequenceObservedByClient must be a non-negative integer." },
+      { status: 400 },
+    );
+  }
+  if (body.reason !== undefined && typeof body.reason !== "string") {
+    return NextResponse.json(
+      { code: "invalid_reason", message: "reason must be a string." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const sequence = await withdrawParticipant({
+      installationId: auth.installationId,
+      roomId,
+      role: auth.agent_role,
+      agentId: auth.name,
+      sequenceObservedByClient: body.sequenceObservedByClient,
+      reason: body.reason,
+      redis: auth.redis,
+    });
+    return NextResponse.json({ sequence }, { status: 200 });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    if (err instanceof RoomEventIdempotencyReplayError) {
+      return NextResponse.json(
+        { sequence: err.existingSequence, replay: true },
+        { status: 200 },
+      );
+    }
+    if (err instanceof RoomParticipantNotFoundError) {
+      return NextResponse.json(
+        {
+          code: "participant_not_found",
+          message: err.message,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomParticipantStatePreconditionError) {
+      return NextResponse.json(
+        {
+          code: "participant_state_precondition",
+          message: err.message,
+          actualState: err.actualState,
+          allowedStates: err.allowedStates,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomEventStatusPreconditionError) {
+      return NextResponse.json(
+        { code: "status_precondition_failed", message: err.message, actualStatus: err.actualStatus },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomParticipantOwnerConflictError) {
+      return NextResponse.json(
+        { code: "owner_conflict", message: err.message, existingAgentId: err.existingAgentId },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/withdraw/route.ts
+++ b/web/src/app/api/rooms/[roomId]/withdraw/route.ts
@@ -24,6 +24,7 @@ import {
   RoomIdFormatError,
   RoomEventIdempotencyReplayError,
   RoomEventStatusPreconditionError,
+  RoomEventBodyTooLargeError,
   RoomParticipantOwnerConflictError,
   RoomParticipantNotFoundError,
   RoomParticipantStatePreconditionError,
@@ -83,6 +84,12 @@ export async function POST(
     });
     return NextResponse.json({ sequence }, { status: 200 });
   } catch (err) {
+    if (err instanceof RoomEventBodyTooLargeError) {
+      return NextResponse.json(
+        { code: "event_body_too_large", message: err.message, sizeBytes: err.sizeBytes },
+        { status: 400 },
+      );
+    }
     if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
       return NextResponse.json(
         { code: "room_not_found", message: `Room ${roomId} not found.` },

--- a/web/src/app/api/rooms/watching/route.test.ts
+++ b/web/src/app/api/rooms/watching/route.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for GET /api/rooms/watching — role-bound watch list.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    listRooms: vi.fn(),
+    getRoomParticipants: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  listRooms,
+  getRoomParticipants,
+  type RoomCoreWithId,
+  type RoomParticipant,
+} from "@/server/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedListRooms = vi.mocked(listRooms);
+const mockedGetParticipants = vi.mocked(getRoomParticipants);
+
+const RID_A = "01234567-89ab-4cde-9012-3456789abcde";
+const RID_B = "fedcba98-7654-4321-89ab-fedcba987654";
+const RID_C = "11111111-2222-4333-9444-555555555555";
+
+function makeRequest(): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/rooms/watching", {
+    method: "GET",
+    headers: { authorization: "Bearer hmt_test" },
+  });
+}
+
+function makeWorkerAuth(role = "drone") {
+  const fakeRedis = {
+    get: vi.fn(async (_key: string) => 5),
+  } as never;
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "drone-1",
+    agent_role: role,
+    capabilities: ["rooms.watch", "rooms.read", "rooms.contribute"],
+    redis: fakeRedis,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+function room(
+  id: string,
+  status: "awaiting_rsvp" | "awaiting_contributions" | "deciding" | "closed",
+): RoomCoreWithId {
+  return {
+    roomId: id,
+    manager: "bot-queen",
+    subject_type: "pr_review",
+    subject_ref: `hivemoot/hivemoot#${id.slice(-3)}`,
+    opened_at: "2026-04-28T07:00:00.000Z",
+    timing_config: {
+      max_age_secs: 3600,
+      rsvp_deadline_secs: 600,
+      contribution_deadline_secs: 1200,
+    },
+    status,
+  };
+}
+
+function participant(
+  role: string,
+  status: RoomParticipant["status"],
+  withdrew_at_sequence?: number,
+): RoomParticipant {
+  return {
+    agent_id: `${role}-1`,
+    role,
+    status,
+    rsvp_at: "2026-04-28T07:00:00.000Z",
+    ...(withdrew_at_sequence !== undefined ? { withdrew_at_sequence } : {}),
+  };
+}
+
+describe("GET /api/rooms/watching", () => {
+  beforeEach(() => {
+    mockedAuth.mockReset();
+    mockedListRooms.mockReset();
+    mockedGetParticipants.mockReset();
+  });
+
+  it("requires rooms.watch capability", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 403 }),
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      { requires: "rooms.watch" },
+    );
+  });
+
+  it("excludes closed rooms — status filter applied BEFORE participant fetch", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedListRooms.mockResolvedValue([room(RID_A, "closed")]);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    expect((await res.json()).rooms).toEqual([]);
+    // Closed room → never read participants
+    expect(mockedGetParticipants).not.toHaveBeenCalled();
+  });
+
+  it("excludes deciding rooms — workers shouldn't act on synthesis-in-progress", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedListRooms.mockResolvedValue([room(RID_A, "deciding")]);
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.rooms).toEqual([]);
+    expect(mockedGetParticipants).not.toHaveBeenCalled();
+  });
+
+  it("includes awaiting_rsvp room when role has no participant slot", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_rsvp")]);
+    mockedGetParticipants.mockResolvedValue({}); // no slot for drone
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rooms).toHaveLength(1);
+    expect(body.rooms[0].core.roomId).toBe(RID_A);
+    expect(body.rooms[0].currentSequence).toBe(5);
+  });
+
+  it("includes awaiting_contributions room where drone is `pending`", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    mockedGetParticipants.mockResolvedValue({
+      drone: participant("drone", "pending"),
+    });
+    const res = await GET(makeRequest());
+    expect((await res.json()).rooms).toHaveLength(1);
+  });
+
+  it("EXCLUDES room where drone is already `resolved` (already contributed)", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    mockedGetParticipants.mockResolvedValue({
+      drone: participant("drone", "resolved"),
+    });
+    const res = await GET(makeRequest());
+    expect((await res.json()).rooms).toEqual([]);
+  });
+
+  it("EXCLUDES room where drone is `timed_out`", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    mockedGetParticipants.mockResolvedValue({
+      drone: participant("drone", "timed_out"),
+    });
+    const res = await GET(makeRequest());
+    expect((await res.json()).rooms).toEqual([]);
+  });
+
+  it("EXCLUDES `withdrew` room when no new events past withdrew_at_sequence", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    // withdrew_at_sequence == currentSequence (5) → no new events; excluded.
+    mockedGetParticipants.mockResolvedValue({
+      drone: participant("drone", "withdrew", 5),
+    });
+    const res = await GET(makeRequest());
+    expect((await res.json()).rooms).toEqual([]);
+  });
+
+  it("INCLUDES `withdrew` room when room has new events past withdrew_at_sequence (re-RSVP eligible per design L780-783)", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    // withdrew at seq 2; current seq is 5 → 3 new events past withdrawal.
+    mockedGetParticipants.mockResolvedValue({
+      drone: participant("drone", "withdrew", 2),
+    });
+    const res = await GET(makeRequest());
+    expect((await res.json()).rooms).toHaveLength(1);
+  });
+
+  it("ROLE BOUNDARY: drone role doesn't see `builder`-resolved rooms; sees them when bearer is builder", async () => {
+    // Same room state, two different bearer roles.
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    mockedGetParticipants.mockResolvedValue({
+      builder: participant("builder", "resolved"),
+    });
+
+    // Drone bearer: no slot → eligible
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    const droneRes = await GET(makeRequest());
+    expect((await droneRes.json()).rooms).toHaveLength(1);
+
+    // Builder bearer: resolved → excluded
+    mockedAuth.mockReset();
+    mockedAuth.mockResolvedValue(makeWorkerAuth("builder"));
+    mockedGetParticipants.mockReset();
+    mockedGetParticipants.mockResolvedValue({
+      builder: participant("builder", "resolved"),
+    });
+    const builderRes = await GET(makeRequest());
+    expect((await builderRes.json()).rooms).toEqual([]);
+  });
+
+  it("returns enriched response (core + participants + currentSequence) so worker doesn't need follow-up reads", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([room(RID_A, "awaiting_contributions")]);
+    const participants = { drone: participant("drone", "pending") };
+    mockedGetParticipants.mockResolvedValue(participants);
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.rooms[0]).toEqual(
+      expect.objectContaining({
+        core: expect.objectContaining({ roomId: RID_A, status: "awaiting_contributions" }),
+        participants,
+        currentSequence: 5,
+      }),
+    );
+  });
+
+  it("scopes to bearer's installation only", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedListRooms.mockResolvedValue([]);
+    await GET(makeRequest());
+    expect(mockedListRooms).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+
+  it("multi-room mix: filters per-role correctly across rooms", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth("drone"));
+    mockedListRooms.mockResolvedValue([
+      room(RID_A, "awaiting_contributions"), // drone pending → include
+      room(RID_B, "awaiting_contributions"), // drone resolved → exclude
+      room(RID_C, "closed"),                  // closed → exclude (status filter)
+    ]);
+    mockedGetParticipants.mockImplementation(
+      async (args: { roomId: string }): Promise<Record<string, RoomParticipant>> => {
+        if (args.roomId === RID_A)
+          return { drone: participant("drone", "pending") };
+        if (args.roomId === RID_B)
+          return { drone: participant("drone", "resolved") };
+        return {};
+      },
+    );
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.rooms).toHaveLength(1);
+    expect(body.rooms[0].core.roomId).toBe(RID_A);
+  });
+});

--- a/web/src/app/api/rooms/watching/route.ts
+++ b/web/src/app/api/rooms/watching/route.ts
@@ -1,0 +1,112 @@
+/**
+ * GET /api/rooms/watching — list rooms eligible for THIS bearer's
+ * role to RSVP / contribute on.
+ *
+ * Capability: `rooms.watch`. Workers (drone / builder / guard /
+ * etc.) call this on their watcher tick to discover rooms they
+ * should attend to. Cross-installation isolation is enforced via
+ * the bearer's `installationId`; per-role visibility via the
+ * `canRoleRsvpToRoom` predicate from war-room.ts.
+ *
+ * Filter (per WAR_ROOM_DESIGN.md L780-790):
+ *   - Status ∈ {awaiting_rsvp, awaiting_contributions} (closed and
+ *     deciding rooms hidden — workers shouldn't act on either)
+ *   - Per-role: include if NOT already terminally done (resolved /
+ *     timed_out), AND if withdrew, only if room has new events
+ *     past withdrew_at_sequence
+ *
+ * Response:
+ *   {
+ *     rooms: Array<{
+ *       core: RoomCore,
+ *       participants: Record<role, RoomParticipant>,
+ *       currentSequence: number
+ *     }>
+ *   }
+ *
+ * The enriched response (core + participants + currentSequence) lets
+ * workers make RSVP decisions without a follow-up read — compensates
+ * for `rooms.read_all` not being on the worker preset.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  listRooms,
+  getRoomParticipants,
+  canRoleRsvpToRoom,
+  seqKey,
+  type RoomCoreWithId,
+  type RoomParticipant,
+} from "@/server/war-room";
+
+const MAX_LIMIT = 100;
+
+interface WatchingRoom {
+  core: RoomCoreWithId;
+  participants: Record<string, RoomParticipant>;
+  currentSequence: number;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.watch",
+  });
+  if (!auth.ok) return auth.response;
+
+  // Listing is bounded — we hard-cap at 100 to keep the
+  // worker-watcher tick latency predictable. listRooms is
+  // newest-first, so a fleet under burst load surfaces the most
+  // recent rooms first.
+  const allRooms = await listRooms({
+    installationId: auth.installationId,
+    redis: auth.redis,
+    limit: MAX_LIMIT,
+  });
+
+  // Filter to open statuses BEFORE the per-room participant fetches —
+  // closed/deciding rooms are excluded by status alone, no need to
+  // pull their participants hash + currentSequence.
+  const openRooms = allRooms.filter(
+    (r) => r.status === "awaiting_rsvp" || r.status === "awaiting_contributions",
+  );
+
+  if (openRooms.length === 0) {
+    return NextResponse.json({ rooms: [] }, { status: 200 });
+  }
+
+  // Fan out per-room participants + currentSequence reads in
+  // parallel. For typical fleet sizes (<20 open rooms) this is one
+  // round-trip; the filter cuts almost all the data fetched on a
+  // typical tick where the worker has nothing to do.
+  const fanout = await Promise.all(
+    openRooms.map(async (room) => {
+      const [participants, seqRaw] = await Promise.all([
+        getRoomParticipants({ roomId: room.roomId, redis: auth.redis }),
+        auth.redis.get<string | number>(seqKey(room.roomId)),
+      ]);
+      const currentSequence =
+        typeof seqRaw === "number"
+          ? seqRaw
+          : typeof seqRaw === "string"
+            ? Number.parseInt(seqRaw, 10)
+            : 0;
+      return { room, participants, currentSequence };
+    }),
+  );
+
+  const watching: WatchingRoom[] = [];
+  for (const { room, participants, currentSequence } of fanout) {
+    if (
+      canRoleRsvpToRoom({
+        participants,
+        bearerRole: auth.agent_role,
+        currentSequence,
+      })
+    ) {
+      watching.push({ core: room, participants, currentSequence });
+    }
+  }
+
+  return NextResponse.json({ rooms: watching }, { status: 200 });
+}

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -259,6 +259,21 @@ export interface RoomCore extends RoomCoreData {
 }
 
 /**
+ * `RoomCore` enriched with its `roomId`. Returned by `listRooms` so
+ * callers can correlate core records with sibling keys (events,
+ * participants, contributions) without a second lookup. The base
+ * `RoomCore` intentionally omits `roomId` (the room hash key is the
+ * roomId, so it's redundant on `getRoomCore` — the caller already
+ * knows it).
+ *
+ * Used by `GET /api/rooms` and `GET /api/rooms/watching` so the
+ * wire response associates each core with its identifier.
+ */
+export interface RoomCoreWithId extends RoomCore {
+  roomId: string;
+}
+
+/**
  * Decision metadata captured at queen-close time. Body content is
  * the synthesis (markdown) the queen produced; runner identifies
  * which queen instance ran the synthesis (for forensic correlation
@@ -892,7 +907,7 @@ export async function listRooms(args: {
   installationId: string;
   redis: Redis;
   limit?: number;
-}): Promise<RoomCore[]> {
+}): Promise<RoomCoreWithId[]> {
   const limit = args.limit ?? 50;
   const indexKey = installationIndexKey(args.installationId);
 
@@ -911,7 +926,7 @@ export async function listRooms(args: {
     ),
   );
 
-  const out: RoomCore[] = [];
+  const out: RoomCoreWithId[] = [];
   const orphans: string[] = [];
   for (let i = 0; i < fanout.length; i++) {
     const core = parseRoomCoreFields(fanout[i]);
@@ -919,7 +934,10 @@ export async function listRooms(args: {
       orphans.push(roomIds[i]);
       continue;
     }
-    out.push(core);
+    // Attach roomId so callers can correlate with sibling keys
+    // (participants, events, contributions) without a second
+    // round-trip. /watching uses this for its enriched response.
+    out.push({ ...core, roomId: roomIds[i] });
   }
 
   // Best-effort cleanup of orphaned installation-index entries.
@@ -3516,4 +3534,64 @@ export async function getRoomContributions(args: {
         : value;
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Worker visibility (D.1.b-iii)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether a role can act on a room — used by GET
+ * /api/rooms/watching to filter the list to rooms a worker bearer
+ * should attend to.
+ *
+ * Per WAR_ROOM_DESIGN.md L780-790, /watching surfaces rooms where
+ * the role is EITHER:
+ *   - Not yet a participant (eligible to RSVP)
+ *   - A participant whose work is incomplete (still needs to
+ *     contribute or react to a subject change)
+ *
+ * Excluded:
+ *   - `resolved` — already contributed; no further action needed
+ *   - `timed_out` — terminal, watcher has nothing to do
+ *   - `withdrew` AT current sequence — withdrew with no new events
+ *     since (re-RSVP only on subject_updated post-withdrawal)
+ *
+ * Closed/terminated rooms are excluded by the caller's status filter
+ * (this predicate assumes the room is open).
+ */
+export function canRoleRsvpToRoom(args: {
+  participants: Record<string, RoomParticipant>;
+  bearerRole: string;
+  currentSequence: number;
+}): boolean {
+  const slot = args.participants[args.bearerRole];
+  if (!slot) {
+    // No participant entry yet — role can still RSVP fresh.
+    return true;
+  }
+  switch (slot.status) {
+    case "pending":
+      // Still in the contribution window — visible.
+      return true;
+    case "resolved":
+      // Already contributed — done, hide from watching.
+      return false;
+    case "timed_out":
+      // Terminal for this role — watchdog already moved on.
+      return false;
+    case "withdrew":
+      // Re-RSVP gated on new events past withdrew_at_sequence
+      // (closes design L780-783). If withdrew_at_sequence is
+      // unset we conservatively treat the slot as not-visible
+      // (the field is set by transitionRoomParticipant on withdraw,
+      // so absence means a malformed slot — fail closed).
+      if (typeof slot.withdrew_at_sequence !== "number") return false;
+      return args.currentSequence > slot.withdrew_at_sequence;
+    default:
+      // Defensive: an unknown status (future enum addition) is
+      // hidden. The caller's status filter should also have
+      // excluded the room, but belt + braces.
+      return false;
+  }
 }

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -2278,6 +2278,36 @@ function assertRoleFormat(role: string): void {
   }
 }
 
+/**
+ * Validate role at the BODY boundary. Distinct from the internal
+ * `assertRoleFormat` — this version is for caller-supplied role
+ * strings (e.g., `/timeout`'s `subjectRole` body field) that must
+ * be validated before hitting storage. Throws a typed
+ * `RoomRoleFormatError` so route handlers can map to 400.
+ *
+ * Closes #521 builder R1 #3: the prior `/timeout` only checked
+ * non-empty string; an invalid `subjectRole` reached
+ * `assertRoleFormat` inside `timeoutParticipant` and threw a plain
+ * Error → unhandled 500 instead of the documented 400 path.
+ */
+export function validateRoleFormat(role: string): void {
+  if (typeof role !== "string" || !ROLE_REGEX.test(role)) {
+    throw new RoomRoleFormatError(role);
+  }
+}
+
+/** Thrown by `validateRoleFormat` on a malformed body-supplied role. */
+export class RoomRoleFormatError extends Error {
+  public readonly invalidRole: unknown;
+  constructor(invalidRole: unknown) {
+    super(
+      `Role ${JSON.stringify(String(invalidRole))} failed format validation: must match /^[a-z][a-z0-9_-]{0,31}$/.`,
+    );
+    this.name = "RoomRoleFormatError";
+    this.invalidRole = invalidRole;
+  }
+}
+
 /** Throw if event body exceeds the 8 KiB cap. Measured on the
  * UTF-8 byte length of the serialized JSON (NOT the surrogate-pair
  * character count). */


### PR DESCRIPTION
Fixes #520

## Summary

Six endpoints completing the V1 HTTP API. Workers can now RSVP / contribute / withdraw, the manager can time out stale participants, and `/watching` gives workers a role-bound list of rooms to attend to (closing #517 builder's \`canReadRoomForBearer\` carry-forward).

| Endpoint | Capability | Caller |
|---|---|---|
| `POST /api/rooms/:id/present` | `rooms.contribute` | Worker — RSVP |
| `POST /api/rooms/:id/withdraw` | `rooms.contribute` | Worker — withdraw RSVP |
| `POST /api/rooms/:id/contributions` | `rooms.contribute` | Worker — submit contribution |
| `DELETE /api/rooms/:id/contributions` | `rooms.contribute` | Worker — withdraw tombstone |
| `POST /api/rooms/:id/timeout` | `rooms.update` | Manager — watchdog |
| `GET /api/rooms/watching` | `rooms.watch` | Worker — role-bound list |

## What it looks like

**Cross-installation isolation + impersonation prevention:**
- `installationId`: from bearer envelope (canonical)
- `role` and `agentId`: server-derived from envelope on writes (NEVER from body) — a worker bearer cannot impersonate another role's RSVP / contribution / withdraw

**`/timeout` two-actor pattern:**
```ts
{
  watchdogRole, watchdogAgentId  // from envelope (manager bearer)
  subjectRole                     // from body (the role being timed out)
}
```

**`/watching` visibility predicate (per design L780-790):**

| Bearer's slot | Decision |
|---|---|
| No participant entry | ✅ eligible (fresh RSVP) |
| `pending` | ✅ in window |
| `resolved` | ❌ already done |
| `timed_out` | ❌ terminal |
| `withdrew` + `currentSequence == withdrew_at_sequence` | ❌ no new events since withdrawal |
| `withdrew` + `currentSequence > withdrew_at_sequence` | ✅ re-RSVP eligible (subject_updated event landed) |

`/watching` returns enriched rooms `{core, participants, currentSequence}` so workers can RSVP without follow-up reads (compensates for `rooms.read_all` not being on the worker preset).

**Storage-layer additions:**
- `RoomCoreWithId` type — `listRooms` now returns rooms with `roomId` attached. Existing tests continue to pass (synthetic fakes don't break).
- `canRoleRsvpToRoom(participants, bearerRole, currentSequence)` predicate.

**Idempotency-replay convention** (consistent across all writes):
Replay → 200 with `{sequence: priorSeq, replay: true}` instead of 409. Matches D.1.b-ii's `/event` pattern — the prior write already landed, so retry is success.

## Test plan

- [x] Typecheck (`tsc --noEmit`) clean
- [x] **1291 tests passing** (was 1240, +51 net)
- [x] Per-endpoint coverage:
  - `/present`: 10 tests (capability gate, server-derived role, validation, idempotency replay, owner conflict, status precondition)
  - `/withdraw`: 8 tests (capability, happy path, participant_not_found / state_precondition / owner_conflict / status_precondition / idempotency replay)
  - `/contributions` POST: 8 tests (capability, body validation, ContributionValidationError, raw_md_too_large with sizeBytes, participant_not_found, idempotency replay)
  - `/contributions` DELETE: 4 tests (capability, happy path, participant_state_precondition, body shape)
  - `/timeout`: 8 tests (capability, watchdog identity from envelope, subject from body, stale-watchdog-loses-to-resolve race, status precondition, idempotency replay)
  - `/watching`: 13 tests (capability, status filter, all 5 visibility-predicate paths, role boundary, multi-room mix, enriched response shape)
- [ ] Reviewer fleet sign-off

## What's next

D.1.b is now complete. Next: **D.1.c** — Vercel Cron watchdog driver (60s scan of `awaiting_contributions` / `deciding` rooms; emits `participant_timed_out` for past-deadline pending participants and TERMINATE on past-max_age rooms). After that, Phases E-I (bot webhook → queen synthesis → fleet migration → dashboard) can run in parallel.