### PR TITLE
Phase D.1.c — Vercel Cron watchdog

### DIFF
--- a/web/src/app/api/internal/queen/tick/route.test.ts
+++ b/web/src/app/api/internal/queen/tick/route.test.ts
@@ -26,7 +26,8 @@ vi.mock("@/server/queen-tick", () => ({
 
 import * as upstash from "@upstash/redis";
 import { runQueenTick } from "@/server/queen-tick";
-import { POST, GET } from "./route";
+import { GET, POST } from "./route";
+import { NextRequest as NextRequestType } from "next/server";
 
 const fakeRedis = (upstash as never as { __fakeRedis: { set: ReturnType<typeof vi.fn>; eval: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> } }).__fakeRedis;
 const mockedTick = vi.mocked(runQueenTick);
@@ -58,11 +59,13 @@ describe("POST /api/internal/queen/tick", () => {
     mockedTick.mockReset();
   });
 
-  it("returns 500 when CRON_SECRET is unset (server misconfiguration fail-loud)", async () => {
+  it("CRON_SECRET unset → 401 empty body (closes #524 guard B2 — no probe oracle)", async () => {
     vi.stubEnv("CRON_SECRET", "");
     const res = await POST(makeRequest({ installationId: "12345" }));
-    expect(res.status).toBe(500);
-    expect((await res.json()).code).toBe("server_misconfiguration");
+    expect(res.status).toBe(401);
+    // CRITICAL — body must be empty so an unauthenticated caller
+    // can't differentiate "fresh deployment" from "wrong bearer".
+    expect(await res.text()).toBe("");
   });
 
   it("rejects missing Authorization header → 401 with empty body (no oracle per design L967)", async () => {
@@ -90,6 +93,14 @@ describe("POST /api/internal/queen/tick", () => {
     expect((await res.json()).code).toBe("invalid_installation_id");
   });
 
+  it("rejects non-numeric installationId → 400 (closes #524 guard N4)", async () => {
+    for (const bad of ["abc", "12345; DROP", "12-345", " 12345"]) {
+      const res = await POST(makeRequest({ installationId: bad }));
+      expect(res.status, `bad: ${bad}`).toBe(400);
+      expect((await res.json()).code).toBe("invalid_installation_id");
+    }
+  });
+
   it("rejects null body → 400 invalid_body_shape", async () => {
     const res = await POST(makeRequest(null));
     expect(res.status).toBe(400);
@@ -107,6 +118,7 @@ describe("POST /api/internal/queen/tick", () => {
       scannedAwaitingContributions: 3,
       timedOutParticipants: 2,
       errors: 0,
+      roomsUnscanned: 0,
     });
 
     const res = await POST(makeRequest({ installationId: "12345" }));
@@ -173,6 +185,7 @@ describe("POST /api/internal/queen/tick", () => {
       scannedAwaitingContributions: 0,
       timedOutParticipants: 0,
       errors: 0,
+      roomsUnscanned: 0,
     });
 
     const res = await POST(makeRequest({ installationId: "12345" }));
@@ -192,6 +205,7 @@ describe("POST /api/internal/queen/tick", () => {
       scannedAwaitingContributions: 0,
       timedOutParticipants: 0,
       errors: 0,
+      roomsUnscanned: 0,
     });
 
     const res1 = await POST(makeRequest({ installationId: "12345" }));
@@ -202,10 +216,83 @@ describe("POST /api/internal/queen/tick", () => {
   });
 });
 
-describe("GET /api/internal/queen/tick", () => {
-  it("returns 405 method_not_allowed", async () => {
-    const res = await GET();
-    expect(res.status).toBe(405);
-    expect(res.headers.get("Allow")).toBe("POST");
+// GET is the actual Vercel Cron entrypoint per #524 builder B3.
+// Vercel sends GET with `Authorization: Bearer ${CRON_SECRET}` and
+// no body; installationId comes from the query string so the
+// `vercel.json` `crons` entry can fully specify the target.
+describe("GET /api/internal/queen/tick (Vercel Cron entrypoint)", () => {
+  function makeGetRequest(opts?: {
+    authHeader?: string;
+    installationIdQuery?: string;
+  }): NextRequestType {
+    const headers: Record<string, string> = {};
+    headers.authorization =
+      opts?.authHeader !== undefined ? opts.authHeader : `Bearer ${CRON_SECRET}`;
+    const url =
+      opts?.installationIdQuery !== undefined
+        ? `https://www.hivemoot.dev/api/internal/queen/tick?installationId=${opts.installationIdQuery}`
+        : "https://www.hivemoot.dev/api/internal/queen/tick";
+    return new NextRequest(url, { method: "GET", headers });
+  }
+
+  beforeEach(() => {
+    vi.stubEnv("CRON_SECRET", CRON_SECRET);
+    fakeRedis.set.mockReset();
+    fakeRedis.eval.mockReset();
+    mockedTick.mockReset();
+  });
+
+  it("Vercel-style GET with Bearer header runs the tick (closes #524 builder B3)", async () => {
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockResolvedValue(1);
+    mockedTick.mockResolvedValue({
+      scannedDeciding: 0,
+      recovered: 0,
+      scannedOpen: 0,
+      expired: 0,
+      scannedAwaitingContributions: 0,
+      timedOutParticipants: 0,
+      errors: 0,
+      roomsUnscanned: 0,
+    });
+
+    const res = await GET(makeGetRequest({ installationIdQuery: "12345" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(false);
+    expect(mockedTick).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+
+  it("GET without bearer → 401 empty body", async () => {
+    const req = new NextRequest(
+      "https://www.hivemoot.dev/api/internal/queen/tick?installationId=12345",
+      { method: "GET" },
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("");
+  });
+
+  it("GET with wrong bearer → 401 empty body", async () => {
+    const res = await GET(
+      makeGetRequest({
+        installationIdQuery: "12345",
+        authHeader: "Bearer wrong",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("GET with missing installationId query → 400", async () => {
+    const res = await GET(makeGetRequest({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_installation_id");
+  });
+
+  it("GET with non-numeric installationId → 400 (regex enforced)", async () => {
+    const res = await GET(makeGetRequest({ installationIdQuery: "abc" }));
+    expect(res.status).toBe(400);
   });
 });

--- a/web/src/app/api/internal/queen/tick/route.test.ts
+++ b/web/src/app/api/internal/queen/tick/route.test.ts
@@ -242,7 +242,7 @@ describe("GET /api/internal/queen/tick (Vercel Cron entrypoint)", () => {
     mockedTick.mockReset();
   });
 
-  it("Vercel-style GET with Bearer header runs the tick (closes #524 builder B3)", async () => {
+  it("Vercel-style GET with Bearer header + ?installationId query runs the tick (closes #524 builder B3)", async () => {
     fakeRedis.set.mockResolvedValue("OK");
     fakeRedis.eval.mockResolvedValue(1);
     mockedTick.mockResolvedValue({
@@ -265,6 +265,68 @@ describe("GET /api/internal/queen/tick (Vercel Cron entrypoint)", () => {
     );
   });
 
+  it("GET reads HIVEMOOT_TICK_INSTALLATION_ID env when no query param (closes #524 R2 N1 — Vercel cron path is static)", async () => {
+    vi.stubEnv("HIVEMOOT_TICK_INSTALLATION_ID", "67890");
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockResolvedValue(1);
+    mockedTick.mockResolvedValue({
+      scannedDeciding: 0,
+      recovered: 0,
+      scannedOpen: 0,
+      expired: 0,
+      scannedAwaitingContributions: 0,
+      timedOutParticipants: 0,
+      errors: 0,
+      roomsUnscanned: 0,
+    });
+
+    // No query param — pure cron-shaped GET
+    const req = new NextRequest("https://www.hivemoot.dev/api/internal/queen/tick", {
+      method: "GET",
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(mockedTick).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "67890" }),
+    );
+  });
+
+  it("GET query param wins over env (manual-test override)", async () => {
+    vi.stubEnv("HIVEMOOT_TICK_INSTALLATION_ID", "67890");
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockResolvedValue(1);
+    mockedTick.mockResolvedValue({
+      scannedDeciding: 0,
+      recovered: 0,
+      scannedOpen: 0,
+      expired: 0,
+      scannedAwaitingContributions: 0,
+      timedOutParticipants: 0,
+      errors: 0,
+      roomsUnscanned: 0,
+    });
+
+    const res = await GET(makeGetRequest({ installationIdQuery: "12345" }));
+    expect(res.status).toBe(200);
+    expect(mockedTick).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+
+  it("GET with no query AND no env → 500 no_installation_id (fail loud, ops-visible)", async () => {
+    vi.stubEnv("HIVEMOOT_TICK_INSTALLATION_ID", "");
+    const req = new NextRequest("https://www.hivemoot.dev/api/internal/queen/tick", {
+      method: "GET",
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe("no_installation_id");
+    // Tick body NOT invoked
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
   it("GET without bearer → 401 empty body", async () => {
     const req = new NextRequest(
       "https://www.hivemoot.dev/api/internal/queen/tick?installationId=12345",
@@ -285,10 +347,15 @@ describe("GET /api/internal/queen/tick (Vercel Cron entrypoint)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("GET with missing installationId query → 400", async () => {
+  it("GET with missing installationId query → 500 no_installation_id when env also unset", async () => {
+    vi.stubEnv("HIVEMOOT_TICK_INSTALLATION_ID", "");
     const res = await GET(makeGetRequest({}));
-    expect(res.status).toBe(400);
-    expect((await res.json()).code).toBe("invalid_installation_id");
+    // Behavior change in R3: with the env-var fallback, no query
+    // AND no env → 500 misconfig (fail-loud for ops); the prior 400
+    // code was unreachable because cron requests never include a
+    // query param.
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe("no_installation_id");
   });
 
   it("GET with non-numeric installationId → 400 (regex enforced)", async () => {

--- a/web/src/app/api/internal/queen/tick/route.test.ts
+++ b/web/src/app/api/internal/queen/tick/route.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for POST /api/internal/queen/tick — Vercel Cron route.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@upstash/redis", () => {
+  const fakeRedis = {
+    set: vi.fn(),
+    eval: vi.fn(),
+    get: vi.fn(),
+  };
+  return {
+    Redis: { fromEnv: vi.fn(() => fakeRedis) },
+    __fakeRedis: fakeRedis,
+  };
+});
+
+vi.mock("@/server/queen-tick", () => ({
+  runQueenTick: vi.fn(),
+  queenTickLockKey: (id: string) => `hive:v1:lock:queen-tick:${id}`,
+  QUEEN_TICK_LOCK_RELEASE_SCRIPT: "MOCK_RELEASE_SCRIPT",
+  QUEEN_TICK_LOCK_TTL_SECS: 55,
+}));
+
+import * as upstash from "@upstash/redis";
+import { runQueenTick } from "@/server/queen-tick";
+import { POST, GET } from "./route";
+
+const fakeRedis = (upstash as never as { __fakeRedis: { set: ReturnType<typeof vi.fn>; eval: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> } }).__fakeRedis;
+const mockedTick = vi.mocked(runQueenTick);
+
+const CRON_SECRET = "test-cron-secret";
+
+function makeRequest(body: unknown, opts?: { authHeader?: string }): NextRequest {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (opts?.authHeader !== undefined) {
+    headers.authorization = opts.authHeader;
+  } else {
+    headers.authorization = `Bearer ${CRON_SECRET}`;
+  }
+  return new NextRequest("https://www.hivemoot.dev/api/internal/queen/tick", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/queen/tick", () => {
+  beforeEach(() => {
+    vi.stubEnv("CRON_SECRET", CRON_SECRET);
+    fakeRedis.set.mockReset();
+    fakeRedis.eval.mockReset();
+    fakeRedis.get.mockReset();
+    mockedTick.mockReset();
+  });
+
+  it("returns 500 when CRON_SECRET is unset (server misconfiguration fail-loud)", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+    const res = await POST(makeRequest({ installationId: "12345" }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe("server_misconfiguration");
+  });
+
+  it("rejects missing Authorization header → 401 with empty body (no oracle per design L967)", async () => {
+    const req = new NextRequest("https://www.hivemoot.dev/api/internal/queen/tick", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ installationId: "12345" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    // Body must be empty per design — no probing differential
+    expect(await res.text()).toBe("");
+  });
+
+  it("rejects wrong bearer → 401 empty body", async () => {
+    const res = await POST(
+      makeRequest({ installationId: "12345" }, { authHeader: "Bearer wrong" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects missing installationId → 400", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_installation_id");
+  });
+
+  it("rejects null body → 400 invalid_body_shape", async () => {
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_body_shape");
+  });
+
+  it("happy path: acquires lock, runs tick, releases lock", async () => {
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockResolvedValue(1);
+    mockedTick.mockResolvedValue({
+      scannedDeciding: 2,
+      recovered: 1,
+      scannedOpen: 5,
+      expired: 1,
+      scannedAwaitingContributions: 3,
+      timedOutParticipants: 2,
+      errors: 0,
+    });
+
+    const res = await POST(makeRequest({ installationId: "12345" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(false);
+    expect(body.runnerId).toMatch(/^vercel\./);
+    expect(body.result.recovered).toBe(1);
+    expect(body.result.expired).toBe(1);
+    expect(body.result.timedOutParticipants).toBe(2);
+
+    // Lock acquisition: SET key value NX EX 55
+    expect(fakeRedis.set).toHaveBeenCalledWith(
+      "hive:v1:lock:queen-tick:12345",
+      expect.stringMatching(/^vercel\./),
+      { nx: true, ex: 55 },
+    );
+    // Lock release via eval (compare-and-DEL Lua)
+    expect(fakeRedis.eval).toHaveBeenCalledWith(
+      "MOCK_RELEASE_SCRIPT",
+      ["hive:v1:lock:queen-tick:12345"],
+      [expect.stringMatching(/^vercel\./)],
+    );
+  });
+
+  it("lock contention → 200 skipped (overlapping fires no-op)", async () => {
+    fakeRedis.set.mockResolvedValue(null); // SET NX returns null on contention
+    const res = await POST(makeRequest({ installationId: "12345" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(true);
+    expect(body.reason).toBe("lock_contention");
+    // Tick body NOT invoked
+    expect(mockedTick).not.toHaveBeenCalled();
+    // Lock NOT released — we never held it
+    expect(fakeRedis.eval).not.toHaveBeenCalled();
+  });
+
+  it("tick error → 500, but lock STILL released in finally", async () => {
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockResolvedValue(1);
+    mockedTick.mockRejectedValue(new Error("Redis cluster down"));
+
+    const res = await POST(makeRequest({ installationId: "12345" }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe("tick_failed");
+    // CRITICAL — the lock release happens in finally, otherwise
+    // the next tick would skip-on-contention until TTL expires.
+    expect(fakeRedis.eval).toHaveBeenCalledWith(
+      "MOCK_RELEASE_SCRIPT",
+      expect.any(Array),
+      expect.any(Array),
+    );
+  });
+
+  it("release error is swallowed (lock will TTL out regardless)", async () => {
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockRejectedValue(new Error("Redis hiccup"));
+    mockedTick.mockResolvedValue({
+      scannedDeciding: 0,
+      recovered: 0,
+      scannedOpen: 0,
+      expired: 0,
+      scannedAwaitingContributions: 0,
+      timedOutParticipants: 0,
+      errors: 0,
+    });
+
+    const res = await POST(makeRequest({ installationId: "12345" }));
+    // Tick result was successful — release error is logged-and-continue
+    expect(res.status).toBe(200);
+    expect((await res.json()).skipped).toBe(false);
+  });
+
+  it("unique runnerId per request (lock value must be unguessable for compare-and-DEL safety)", async () => {
+    fakeRedis.set.mockResolvedValue("OK");
+    fakeRedis.eval.mockResolvedValue(1);
+    mockedTick.mockResolvedValue({
+      scannedDeciding: 0,
+      recovered: 0,
+      scannedOpen: 0,
+      expired: 0,
+      scannedAwaitingContributions: 0,
+      timedOutParticipants: 0,
+      errors: 0,
+    });
+
+    const res1 = await POST(makeRequest({ installationId: "12345" }));
+    const res2 = await POST(makeRequest({ installationId: "12345" }));
+    const r1 = await res1.json();
+    const r2 = await res2.json();
+    expect(r1.runnerId).not.toBe(r2.runnerId);
+  });
+});
+
+describe("GET /api/internal/queen/tick", () => {
+  it("returns 405 method_not_allowed", async () => {
+    const res = await GET();
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("POST");
+  });
+});

--- a/web/src/app/api/internal/queen/tick/route.ts
+++ b/web/src/app/api/internal/queen/tick/route.ts
@@ -1,28 +1,34 @@
 /**
- * POST /api/internal/queen/tick — Vercel Cron-driven war-room watchdog.
+ * GET / POST /api/internal/queen/tick — Vercel Cron-driven war-room watchdog.
  *
  * Auth: `Authorization: Bearer ${CRON_SECRET}` per Vercel's
  * documented cron pattern. NOT V1 capability auth — this is a
  * platform-level invocation, no user-bearer involved (closes
  * design L963-969). Missing or mismatched bearer → 401 with no body
- * so an external caller can't probe for the env var.
+ * so an external caller can't probe for the env var. Misconfig
+ * (CRON_SECRET unset) ALSO returns 401 with the misconfig logged
+ * server-side (closes #524 guard B2 — no oracle for "fresh
+ * deployment" vs "wrong bearer").
  *
- * Per-installation serialization: uses
- * `QUEEN_TICK_LOCK_RELEASE_SCRIPT` compare-and-DEL pattern with a
- * 55s TTL. Overlapping fires no-op cleanly (200 with `skipped`
- * field set), no double-work, no double-LLM-calls (Phase G' will
- * use this gate).
+ * Method:
+ *   - **GET** — Vercel Cron's actual invocation method. Reads
+ *     `installationId` from the query string (`?installationId=X`)
+ *     so the cron entry in `web/vercel.json` can fully specify the
+ *     target. Closes #524 builder B3 — Vercel Cron sends GET, not
+ *     POST, and supplies no body. The prior POST-only route was
+ *     untriggerable in production.
+ *   - **POST** — manual/test invocation. Reads `installationId`
+ *     from JSON body. Same auth + lock semantics.
  *
- * Body: `{ installationId: string }` — caller specifies which
- * installation to tick. (Future enhancement: scan all
- * installations server-side; for V1 the cron config issues one
- * tick per installation.)
+ * Per-installation serialization: SET key runnerId NX EX 55 +
+ * compare-and-DEL Lua release. Overlapping fires no-op cleanly
+ * (200 with `skipped` field set), no double-work.
  *
  * Response: `{ skipped: boolean, result?: QueenTickResult }`
  *
  * Errors:
- *   - 401 — no/wrong bearer (response body is null per design L967)
- *   - 400 — malformed body / missing installationId
+ *   - 401 — no/wrong bearer OR CRON_SECRET unset (empty body, no oracle)
+ *   - 400 — malformed body / missing installationId / wrong shape
  *   - 500 — unhandled error during tick (logged structured)
  */
 
@@ -40,6 +46,12 @@ interface TickRequestBody {
   installationId?: string;
 }
 
+/** GitHub installation IDs are numeric. Pinning the format prevents
+ * non-numeric values from reaching `listRooms` / lock-key
+ * interpolation (closes #524 guard N4 — defense-in-depth even
+ * though the cron-bearer holder is trusted). */
+const INSTALLATION_ID_REGEX = /^\d+$/;
+
 function getCronSecret(): string | null {
   const v = process.env.CRON_SECRET;
   return typeof v === "string" && v.length > 0 ? v : null;
@@ -53,44 +65,55 @@ function makeRunnerId(): string {
   return `vercel.${Date.now()}.${Math.random().toString(36).slice(2, 10)}`;
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
-  const authHeader = request.headers.get("authorization");
+/** Auth check shared by both verbs. Returns the validated CRON_SECRET
+ * on success, or a NextResponse to short-circuit on failure.
+ *
+ * The misconfig path (CRON_SECRET unset) also returns 401 — same
+ * response as wrong-bearer — so an external probe can't differentiate
+ * "deployment isn't configured" from "your bearer is wrong" (closes
+ * #524 guard B2). The misconfig is logged server-side so ops sees it
+ * via Vercel logs / dashboard.
+ */
+function checkCronAuth(request: NextRequest): NextResponse | null {
   const expected = getCronSecret();
   if (expected === null) {
-    return NextResponse.json(
-      {
-        code: "server_misconfiguration",
-        message: "CRON_SECRET is not set in this deployment.",
-      },
-      { status: 500 },
+    console.error(
+      "[queen-tick] CRON_SECRET is not set in this deployment — refusing all requests. Add CRON_SECRET to the env (Vercel dashboard → Settings → Environment Variables).",
     );
+    return new NextResponse(null, { status: 401 });
   }
+  const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${expected}`) {
     return new NextResponse(null, { status: 401 });
   }
+  return null;
+}
 
-  const parsed = await parseJsonBody(request);
-  if (!parsed.ok) {
-    return NextResponse.json(
-      { code: parsed.code, message: parsed.message },
-      { status: 400 },
-    );
-  }
-  const body = parsed.body as TickRequestBody;
+function rejectInvalidInstallationId(
+  installationId: string | null | undefined,
+): NextResponse | null {
   if (
-    typeof body.installationId !== "string" ||
-    body.installationId.length === 0
+    typeof installationId !== "string" ||
+    installationId.length === 0 ||
+    !INSTALLATION_ID_REGEX.test(installationId)
   ) {
     return NextResponse.json(
       {
         code: "invalid_installation_id",
-        message: "Body must include `installationId` (non-empty string).",
+        message:
+          "installationId must be a non-empty numeric string (GitHub installation IDs).",
       },
       { status: 400 },
     );
   }
-  const installationId = body.installationId;
+  return null;
+}
 
+/**
+ * Run the tick under the per-installation lock, return the response.
+ * Shared body for GET + POST so both verbs run identical logic.
+ */
+async function runTickWithLock(installationId: string): Promise<NextResponse> {
   const redis = getRedis();
   const lockKey = queenTickLockKey(installationId);
   const runnerId = makeRunnerId();
@@ -140,12 +163,41 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 }
 
-export async function GET(): Promise<NextResponse> {
-  return NextResponse.json(
-    {
-      code: "method_not_allowed",
-      message: "POST /api/internal/queen/tick only.",
-    },
-    { status: 405, headers: { Allow: "POST" } },
-  );
+/**
+ * GET — Vercel Cron's actual entry point. `installationId` from
+ * query string lets the `vercel.json` `crons` entry fully specify
+ * the target via path: `path: "/api/internal/queen/tick?installationId=12345"`.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authReject = checkCronAuth(request);
+  if (authReject) return authReject;
+
+  const url = new URL(request.url);
+  const installationId = url.searchParams.get("installationId");
+  const reject = rejectInvalidInstallationId(installationId);
+  if (reject) return reject;
+
+  return await runTickWithLock(installationId as string);
+}
+
+/**
+ * POST — manual/test invocation. Reads `installationId` from JSON
+ * body. Same auth + lock as GET.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const authReject = checkCronAuth(request);
+  if (authReject) return authReject;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as TickRequestBody;
+  const reject = rejectInvalidInstallationId(body.installationId);
+  if (reject) return reject;
+
+  return await runTickWithLock(body.installationId as string);
 }

--- a/web/src/app/api/internal/queen/tick/route.ts
+++ b/web/src/app/api/internal/queen/tick/route.ts
@@ -164,20 +164,54 @@ async function runTickWithLock(installationId: string): Promise<NextResponse> {
 }
 
 /**
- * GET — Vercel Cron's actual entry point. `installationId` from
- * query string lets the `vercel.json` `crons` entry fully specify
- * the target via path: `path: "/api/internal/queen/tick?installationId=12345"`.
+ * GET — Vercel Cron's actual entry point.
+ *
+ * Installation selection (closes #524 guard R2 N1):
+ *   1. `?installationId=X` query param wins if present (manual test
+ *      override OR explicit per-cron-entry routing if multi-installation
+ *      lands later).
+ *   2. Otherwise read `HIVEMOOT_TICK_INSTALLATION_ID` env var
+ *      (provisioned via Vercel dashboard).
+ *   3. Neither set → 500 misconfig (fail loud — ops sees it via Vercel
+ *      logs; the cron isn't user-visible so no probe-oracle concern
+ *      like the auth path).
+ *
+ * Vercel does NOT interpolate env vars in `vercel.json` cron paths,
+ * so the path stays static (`/api/internal/queen/tick`) and the route
+ * reads the env var at request time. Multi-installation is a clean
+ * follow-up: comma-separated list + server-side iteration, no path
+ * change needed.
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const authReject = checkCronAuth(request);
   if (authReject) return authReject;
 
   const url = new URL(request.url);
-  const installationId = url.searchParams.get("installationId");
+  const queryInstallationId = url.searchParams.get("installationId");
+  const installationId =
+    queryInstallationId ?? process.env.HIVEMOOT_TICK_INSTALLATION_ID ?? null;
+
+  if (installationId === null || installationId.length === 0) {
+    // Misconfig — neither query nor env supplied an installation. The
+    // cron-bearer holder is already authenticated, so this is fail-loud
+    // not a probe surface (unlike the CRON_SECRET=null path).
+    console.error(
+      "[queen-tick] no installationId — neither ?installationId query nor HIVEMOOT_TICK_INSTALLATION_ID env var is set. Configure via Vercel dashboard → Settings → Environment Variables.",
+    );
+    return NextResponse.json(
+      {
+        code: "no_installation_id",
+        message:
+          "No installationId resolved — neither ?installationId query nor HIVEMOOT_TICK_INSTALLATION_ID env var is set.",
+      },
+      { status: 500 },
+    );
+  }
+
   const reject = rejectInvalidInstallationId(installationId);
   if (reject) return reject;
 
-  return await runTickWithLock(installationId as string);
+  return await runTickWithLock(installationId);
 }
 
 /**

--- a/web/src/app/api/internal/queen/tick/route.ts
+++ b/web/src/app/api/internal/queen/tick/route.ts
@@ -1,0 +1,151 @@
+/**
+ * POST /api/internal/queen/tick — Vercel Cron-driven war-room watchdog.
+ *
+ * Auth: `Authorization: Bearer ${CRON_SECRET}` per Vercel's
+ * documented cron pattern. NOT V1 capability auth — this is a
+ * platform-level invocation, no user-bearer involved (closes
+ * design L963-969). Missing or mismatched bearer → 401 with no body
+ * so an external caller can't probe for the env var.
+ *
+ * Per-installation serialization: uses
+ * `QUEEN_TICK_LOCK_RELEASE_SCRIPT` compare-and-DEL pattern with a
+ * 55s TTL. Overlapping fires no-op cleanly (200 with `skipped`
+ * field set), no double-work, no double-LLM-calls (Phase G' will
+ * use this gate).
+ *
+ * Body: `{ installationId: string }` — caller specifies which
+ * installation to tick. (Future enhancement: scan all
+ * installations server-side; for V1 the cron config issues one
+ * tick per installation.)
+ *
+ * Response: `{ skipped: boolean, result?: QueenTickResult }`
+ *
+ * Errors:
+ *   - 401 — no/wrong bearer (response body is null per design L967)
+ *   - 400 — malformed body / missing installationId
+ *   - 500 — unhandled error during tick (logged structured)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { Redis } from "@upstash/redis";
+import { parseJsonBody } from "@/server/request-utils";
+import {
+  runQueenTick,
+  queenTickLockKey,
+  QUEEN_TICK_LOCK_RELEASE_SCRIPT,
+  QUEEN_TICK_LOCK_TTL_SECS,
+} from "@/server/queen-tick";
+
+interface TickRequestBody {
+  installationId?: string;
+}
+
+function getCronSecret(): string | null {
+  const v = process.env.CRON_SECRET;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function getRedis(): Redis {
+  return Redis.fromEnv();
+}
+
+function makeRunnerId(): string {
+  return `vercel.${Date.now()}.${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const authHeader = request.headers.get("authorization");
+  const expected = getCronSecret();
+  if (expected === null) {
+    return NextResponse.json(
+      {
+        code: "server_misconfiguration",
+        message: "CRON_SECRET is not set in this deployment.",
+      },
+      { status: 500 },
+    );
+  }
+  if (authHeader !== `Bearer ${expected}`) {
+    return new NextResponse(null, { status: 401 });
+  }
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as TickRequestBody;
+  if (
+    typeof body.installationId !== "string" ||
+    body.installationId.length === 0
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_installation_id",
+        message: "Body must include `installationId` (non-empty string).",
+      },
+      { status: 400 },
+    );
+  }
+  const installationId = body.installationId;
+
+  const redis = getRedis();
+  const lockKey = queenTickLockKey(installationId);
+  const runnerId = makeRunnerId();
+
+  const acquired = await redis.set(lockKey, runnerId, {
+    nx: true,
+    ex: QUEEN_TICK_LOCK_TTL_SECS,
+  });
+  if (acquired === null) {
+    return NextResponse.json(
+      { skipped: true, reason: "lock_contention" },
+      { status: 200 },
+    );
+  }
+
+  try {
+    const result = await runQueenTick({ installationId, redis });
+    return NextResponse.json(
+      { skipped: false, runnerId, result },
+      { status: 200 },
+    );
+  } catch (err) {
+    console.error(
+      `[queen-tick] unhandled error installation=${installationId} runner=${runnerId}:`,
+      err,
+    );
+    return NextResponse.json(
+      {
+        code: "tick_failed",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  } finally {
+    try {
+      await redis.eval(
+        QUEEN_TICK_LOCK_RELEASE_SCRIPT,
+        [lockKey],
+        [runnerId],
+      );
+    } catch (releaseErr) {
+      console.warn(
+        `[queen-tick] lock release error installation=${installationId} runner=${runnerId}:`,
+        releaseErr,
+      );
+    }
+  }
+}
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json(
+    {
+      code: "method_not_allowed",
+      message: "POST /api/internal/queen/tick only.",
+    },
+    { status: 405, headers: { Allow: "POST" } },
+  );
+}

--- a/web/src/server/queen-tick.test.ts
+++ b/web/src/server/queen-tick.test.ts
@@ -8,8 +8,8 @@ import {
   queenTickLockKey,
   QUEEN_TICK_LOCK_RELEASE_SCRIPT,
   QUEEN_TICK_LOCK_TTL_SECS,
-  WATCHDOG_ACTOR_ROLE,
-  WATCHDOG_ACTOR_ID,
+  WATCHDOG_TERMINATE_ACTOR,
+  WATCHDOG_TIMEOUT_ACTOR,
 } from "./queen-tick";
 
 vi.mock("@/server/war-room", async () => {
@@ -90,7 +90,11 @@ function participant(
   };
 }
 
-const fakeRedis = { get: vi.fn(async () => 5) } as never;
+const fakeRedis = {
+  get: vi.fn(async () => 5),
+  zcard: vi.fn(async () => 0),
+};
+const fakeRedisAsRedis = fakeRedis as never;
 
 describe("runQueenTick — recovery scan", () => {
   beforeEach(() => {
@@ -114,7 +118,7 @@ describe("runQueenTick — recovery scan", () => {
 
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.scannedDeciding).toBe(2);
@@ -135,7 +139,7 @@ describe("runQueenTick — recovery scan", () => {
     );
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.scannedDeciding).toBe(1);
@@ -163,7 +167,7 @@ describe("runQueenTick — expire scan", () => {
 
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.expired).toBe(1);
@@ -171,8 +175,10 @@ describe("runQueenTick — expire scan", () => {
       expect.objectContaining({
         roomId: RID_A,
         reason: "expired",
-        actorRole: WATCHDOG_ACTOR_ROLE,
-        actorId: WATCHDOG_ACTOR_ID,
+        // Watchdog terminate uses the SYSTEM/vercel-cron pair per
+        // RoomEvent JSDoc spec — closes #524 guard B1.
+        actorRole: "system",
+        actorId: "vercel-cron",
         subject: { type: "pr_review", ref: `hivemoot/hivemoot#${RID_A.slice(-3)}` },
       }),
     );
@@ -185,7 +191,7 @@ describe("runQueenTick — expire scan", () => {
     mockedParticipants.mockResolvedValue({});
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.expired).toBe(0);
@@ -204,7 +210,7 @@ describe("runQueenTick — expire scan", () => {
 
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.expired).toBe(1);
@@ -220,7 +226,7 @@ describe("runQueenTick — expire scan", () => {
 
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.errors).toBe(0); // benign race
@@ -232,7 +238,7 @@ describe("runQueenTick — expire scan", () => {
     ]);
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.scannedOpen).toBe(0);
@@ -266,7 +272,7 @@ describe("runQueenTick — timeout scan", () => {
 
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.scannedAwaitingContributions).toBe(1);
@@ -276,8 +282,11 @@ describe("runQueenTick — timeout scan", () => {
       expect.objectContaining({
         roomId: RID_A,
         subjectRole: "drone",
-        watchdogRole: WATCHDOG_ACTOR_ROLE,
-        watchdogAgentId: WATCHDOG_ACTOR_ID,
+        // Watchdog timeout uses the MANAGER/watchdog pair per
+        // RoomEvent JSDoc spec — closes #524 guard B1. Distinct
+        // from terminate's SYSTEM/vercel-cron pair.
+        watchdogRole: "manager",
+        watchdogAgentId: "watchdog",
       }),
     );
   });
@@ -288,7 +297,7 @@ describe("runQueenTick — timeout scan", () => {
     ]);
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.scannedAwaitingContributions).toBe(0);
@@ -316,7 +325,7 @@ describe("runQueenTick — timeout scan", () => {
     );
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.timedOutParticipants).toBe(0);
@@ -336,7 +345,7 @@ describe("runQueenTick — timeout scan", () => {
     });
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.expired).toBe(1);
@@ -361,7 +370,7 @@ describe("runQueenTick — orchestration + bounds", () => {
     mockedList.mockResolvedValue([]);
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result).toEqual({
@@ -372,6 +381,7 @@ describe("runQueenTick — orchestration + bounds", () => {
       scannedAwaitingContributions: 0,
       timedOutParticipants: 0,
       errors: 0,
+      roomsUnscanned: 0,
     });
   });
 
@@ -379,7 +389,7 @@ describe("runQueenTick — orchestration + bounds", () => {
     mockedList.mockResolvedValue([]);
     await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
       maxRoomsPerTick: 25,
     });
@@ -392,7 +402,7 @@ describe("runQueenTick — orchestration + bounds", () => {
     mockedList.mockResolvedValue([]);
     await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(mockedList).toHaveBeenCalledWith(
@@ -418,7 +428,7 @@ describe("runQueenTick — orchestration + bounds", () => {
 
     const result = await runQueenTick({
       installationId: "12345",
-      redis: fakeRedis,
+      redis: fakeRedisAsRedis,
       nowMs: NOW,
     });
     expect(result.scannedDeciding).toBe(1);
@@ -427,6 +437,58 @@ describe("runQueenTick — orchestration + bounds", () => {
     expect(result.timedOutParticipants).toBe(1);
     expect(result.scannedOpen).toBe(3); // all 3 are open status
     expect(result.errors).toBe(0);
+  });
+});
+
+describe("runQueenTick — roomsUnscanned counter (closes #524 guard N2 + builder backlog)", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+    mockedRecover.mockReset();
+    mockedTerm.mockReset();
+    mockedTimeout.mockReset();
+    mockedParticipants.mockReset();
+    fakeRedis.zcard.mockReset();
+  });
+
+  it("roomsUnscanned=0 when total fits within cap (steady state)", async () => {
+    mockedList.mockResolvedValue([room(RID_A, "awaiting_rsvp")]);
+    fakeRedis.zcard.mockResolvedValue(1);
+    mockedParticipants.mockResolvedValue({});
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedisAsRedis,
+      nowMs: NOW,
+    });
+    expect(result.roomsUnscanned).toBe(0);
+  });
+
+  it("roomsUnscanned=N when index has more rooms than cap (backlog visible)", async () => {
+    // listRooms returns 100 (capped); index has 250 → 150 unscanned
+    const slice = Array.from({ length: 100 }, (_, i) =>
+      room(`${i}`.padStart(8, "0") + "-89ab-4cde-9012-3456789abcde", "awaiting_rsvp"),
+    );
+    mockedList.mockResolvedValue(slice);
+    fakeRedis.zcard.mockResolvedValue(250);
+    mockedParticipants.mockResolvedValue({});
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedisAsRedis,
+      nowMs: NOW,
+    });
+    expect(result.roomsUnscanned).toBe(150);
+  });
+
+  it("roomsUnscanned=0 when zcard fails (defensive — never negative)", async () => {
+    mockedList.mockResolvedValue([room(RID_A, "awaiting_rsvp")]);
+    fakeRedis.zcard.mockRejectedValue(new Error("Redis hiccup"));
+    mockedParticipants.mockResolvedValue({});
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedisAsRedis,
+      nowMs: NOW,
+    });
+    // Caught by .catch(() => 0) → 0 - 1 = -1 → max(0, -1) = 0
+    expect(result.roomsUnscanned).toBe(0);
   });
 });
 

--- a/web/src/server/queen-tick.test.ts
+++ b/web/src/server/queen-tick.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Tests for queen-tick — the war-room watchdog body.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  runQueenTick,
+  queenTickLockKey,
+  QUEEN_TICK_LOCK_RELEASE_SCRIPT,
+  QUEEN_TICK_LOCK_TTL_SECS,
+  WATCHDOG_ACTOR_ROLE,
+  WATCHDOG_ACTOR_ID,
+} from "./queen-tick";
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    listRooms: vi.fn(),
+    getRoomParticipants: vi.fn(),
+    recoverDeciding: vi.fn(),
+    terminateRoom: vi.fn(),
+    timeoutParticipant: vi.fn(),
+  };
+});
+
+import {
+  listRooms,
+  getRoomParticipants,
+  recoverDeciding,
+  terminateRoom,
+  timeoutParticipant,
+  RoomTransitionInvalidStatusError,
+  RoomAlreadyClosedError,
+  RoomParticipantStatePreconditionError,
+  type RoomCoreWithId,
+  type RoomParticipant,
+} from "@/server/war-room";
+
+const mockedList = vi.mocked(listRooms);
+const mockedParticipants = vi.mocked(getRoomParticipants);
+const mockedRecover = vi.mocked(recoverDeciding);
+const mockedTerm = vi.mocked(terminateRoom);
+const mockedTimeout = vi.mocked(timeoutParticipant);
+
+const RID_A = "01234567-89ab-4cde-9012-3456789abcde";
+const RID_B = "fedcba98-7654-4321-89ab-fedcba987654";
+const RID_C = "11111111-2222-4333-9444-555555555555";
+
+const NOW = 1735574400000; // 2025-12-30T16:00:00Z
+
+function room(
+  roomId: string,
+  status: "awaiting_rsvp" | "awaiting_contributions" | "deciding" | "closed",
+  options?: {
+    openedAtSecondsAgo?: number;
+    maxAgeSecs?: number;
+    contributionDeadlineSecs?: number;
+  },
+): RoomCoreWithId {
+  const opts = options ?? {};
+  const openedAtMs = NOW - (opts.openedAtSecondsAgo ?? 0) * 1000;
+  return {
+    roomId,
+    manager: "bot-queen",
+    subject_type: "pr_review",
+    subject_ref: `hivemoot/hivemoot#${roomId.slice(-3)}`,
+    opened_at: new Date(openedAtMs).toISOString(),
+    timing_config: {
+      max_age_secs: opts.maxAgeSecs ?? 3600,
+      rsvp_deadline_secs: 600,
+      contribution_deadline_secs: opts.contributionDeadlineSecs ?? 1200,
+    },
+    status,
+  };
+}
+
+function participant(
+  role: string,
+  status: RoomParticipant["status"],
+  rsvpAtSecondsAgo: number,
+): RoomParticipant {
+  return {
+    agent_id: `${role}-1`,
+    role,
+    status,
+    rsvp_at: new Date(NOW - rsvpAtSecondsAgo * 1000).toISOString(),
+  };
+}
+
+const fakeRedis = { get: vi.fn(async () => 5) } as never;
+
+describe("runQueenTick — recovery scan", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+    mockedRecover.mockReset();
+    mockedTerm.mockReset();
+    mockedTimeout.mockReset();
+    mockedParticipants.mockReset();
+  });
+
+  it("scans deciding rooms and counts recoveries", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "deciding"),
+      room(RID_B, "deciding"),
+      room(RID_C, "awaiting_contributions"), // Not deciding — skip
+    ]);
+    mockedParticipants.mockResolvedValue({});
+    mockedRecover
+      .mockResolvedValueOnce({ recovered: true, sequence: 7 })
+      .mockResolvedValueOnce({ recovered: false, reason: "claim_active" });
+
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.scannedDeciding).toBe(2);
+    expect(result.recovered).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it("RoomTransitionInvalidStatusError is benign skip (status moved mid-tick)", async () => {
+    mockedList.mockResolvedValue([room(RID_A, "deciding")]);
+    mockedParticipants.mockResolvedValue({});
+    mockedRecover.mockRejectedValue(
+      new RoomTransitionInvalidStatusError(
+        RID_A,
+        "recover_deciding",
+        ["deciding"],
+        "closed",
+      ),
+    );
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.scannedDeciding).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+});
+
+describe("runQueenTick — expire scan", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+    mockedRecover.mockReset();
+    mockedTerm.mockReset();
+    mockedTimeout.mockReset();
+    mockedParticipants.mockReset();
+  });
+
+  it("terminates rooms past max_age_secs as `expired` with watchdog actor", async () => {
+    // Room opened 4000s ago, max_age 3600s → 400s past expiry.
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_rsvp", { openedAtSecondsAgo: 4000, maxAgeSecs: 3600 }),
+    ]);
+    mockedParticipants.mockResolvedValue({});
+    mockedTerm.mockResolvedValue(7);
+
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.expired).toBe(1);
+    expect(mockedTerm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: RID_A,
+        reason: "expired",
+        actorRole: WATCHDOG_ACTOR_ROLE,
+        actorId: WATCHDOG_ACTOR_ID,
+        subject: { type: "pr_review", ref: `hivemoot/hivemoot#${RID_A.slice(-3)}` },
+      }),
+    );
+  });
+
+  it("does NOT terminate rooms within max_age", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_rsvp", { openedAtSecondsAgo: 100, maxAgeSecs: 3600 }),
+    ]);
+    mockedParticipants.mockResolvedValue({});
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.expired).toBe(0);
+    expect(mockedTerm).not.toHaveBeenCalled();
+  });
+
+  it("expires DECIDING rooms past max_age (claim DEL'd, queen aborts)", async () => {
+    // Stuck-deciding room past max_age. Recover would also fire but
+    // claim is active → recover skips, expire fires.
+    mockedList.mockResolvedValue([
+      room(RID_A, "deciding", { openedAtSecondsAgo: 4000, maxAgeSecs: 3600 }),
+    ]);
+    mockedParticipants.mockResolvedValue({});
+    mockedRecover.mockResolvedValue({ recovered: false, reason: "claim_active" });
+    mockedTerm.mockResolvedValue(8);
+
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.expired).toBe(1);
+    expect(result.scannedDeciding).toBe(1);
+  });
+
+  it("RoomAlreadyClosedError on terminate is benign (race with operator force-close)", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_rsvp", { openedAtSecondsAgo: 4000, maxAgeSecs: 3600 }),
+    ]);
+    mockedParticipants.mockResolvedValue({});
+    mockedTerm.mockRejectedValue(new RoomAlreadyClosedError(RID_A, "closed"));
+
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.errors).toBe(0); // benign race
+  });
+
+  it("skips closed rooms entirely (status filter)", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "closed", { openedAtSecondsAgo: 9999, maxAgeSecs: 60 }),
+    ]);
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.scannedOpen).toBe(0);
+    expect(result.expired).toBe(0);
+  });
+});
+
+describe("runQueenTick — timeout scan", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+    mockedRecover.mockReset();
+    mockedTerm.mockReset();
+    mockedTimeout.mockReset();
+    mockedParticipants.mockReset();
+  });
+
+  it("times out pending participants past contribution_deadline", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_contributions", {
+        openedAtSecondsAgo: 1500,
+        maxAgeSecs: 3600,
+        contributionDeadlineSecs: 1200,
+      }),
+    ]);
+    mockedParticipants.mockResolvedValue({
+      drone: participant("drone", "pending", 1300), // 100s past 1200s deadline
+      builder: participant("builder", "pending", 100), // well within
+      guard: participant("guard", "resolved", 1300), // not pending — skip
+    });
+    mockedTimeout.mockResolvedValue(7);
+
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.scannedAwaitingContributions).toBe(1);
+    expect(result.timedOutParticipants).toBe(1);
+    expect(mockedTimeout).toHaveBeenCalledTimes(1);
+    expect(mockedTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: RID_A,
+        subjectRole: "drone",
+        watchdogRole: WATCHDOG_ACTOR_ROLE,
+        watchdogAgentId: WATCHDOG_ACTOR_ID,
+      }),
+    );
+  });
+
+  it("does NOT scan participants on awaiting_rsvp rooms (per design L1055 timeout is contribution-deadline only)", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_rsvp", { openedAtSecondsAgo: 100 }),
+    ]);
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.scannedAwaitingContributions).toBe(0);
+    expect(mockedParticipants).not.toHaveBeenCalled();
+    expect(mockedTimeout).not.toHaveBeenCalled();
+  });
+
+  it("RoomParticipantStatePreconditionError on timeout is benign (worker resolved between scan and EVAL)", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_contributions", {
+        openedAtSecondsAgo: 1500,
+        contributionDeadlineSecs: 1200,
+      }),
+    ]);
+    mockedParticipants.mockResolvedValue({
+      drone: participant("drone", "pending", 1300),
+    });
+    mockedTimeout.mockRejectedValue(
+      new RoomParticipantStatePreconditionError(
+        RID_A,
+        "drone",
+        ["pending"],
+        "resolved",
+      ),
+    );
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.timedOutParticipants).toBe(0);
+    expect(result.errors).toBe(0); // race is benign, not an error
+  });
+
+  it("does NOT run timeout scan on a just-expired room (continue after expire)", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "awaiting_contributions", {
+        openedAtSecondsAgo: 4000,
+        maxAgeSecs: 3600,
+      }),
+    ]);
+    mockedTerm.mockResolvedValue(8);
+    mockedParticipants.mockResolvedValue({
+      drone: participant("drone", "pending", 1300),
+    });
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.expired).toBe(1);
+    // After expiring the room, the timeout scan should NOT have
+    // run on this room (continue after expire).
+    expect(mockedParticipants).not.toHaveBeenCalled();
+    expect(mockedTimeout).not.toHaveBeenCalled();
+    expect(result.timedOutParticipants).toBe(0);
+  });
+});
+
+describe("runQueenTick — orchestration + bounds", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+    mockedRecover.mockReset();
+    mockedTerm.mockReset();
+    mockedTimeout.mockReset();
+    mockedParticipants.mockReset();
+  });
+
+  it("returns full counter shape", async () => {
+    mockedList.mockResolvedValue([]);
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result).toEqual({
+      scannedDeciding: 0,
+      recovered: 0,
+      scannedOpen: 0,
+      expired: 0,
+      scannedAwaitingContributions: 0,
+      timedOutParticipants: 0,
+      errors: 0,
+    });
+  });
+
+  it("respects maxRoomsPerTick cap (passed to listRooms)", async () => {
+    mockedList.mockResolvedValue([]);
+    await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+      maxRoomsPerTick: 25,
+    });
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25 }),
+    );
+  });
+
+  it("default cap is 100", async () => {
+    mockedList.mockResolvedValue([]);
+    await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 100 }),
+    );
+  });
+
+  it("end-to-end: deciding+recovery + awaiting+timeout + expire — all three counters advance", async () => {
+    mockedList.mockResolvedValue([
+      room(RID_A, "deciding"), // recovery
+      room(RID_B, "awaiting_contributions", {
+        openedAtSecondsAgo: 1500,
+        contributionDeadlineSecs: 1200,
+      }), // timeout
+      room(RID_C, "awaiting_rsvp", { openedAtSecondsAgo: 4000, maxAgeSecs: 3600 }), // expire
+    ]);
+    mockedParticipants.mockResolvedValue({
+      drone: participant("drone", "pending", 1300),
+    });
+    mockedRecover.mockResolvedValue({ recovered: true, sequence: 7 });
+    mockedTerm.mockResolvedValue(8);
+    mockedTimeout.mockResolvedValue(9);
+
+    const result = await runQueenTick({
+      installationId: "12345",
+      redis: fakeRedis,
+      nowMs: NOW,
+    });
+    expect(result.scannedDeciding).toBe(1);
+    expect(result.recovered).toBe(1);
+    expect(result.expired).toBe(1);
+    expect(result.timedOutParticipants).toBe(1);
+    expect(result.scannedOpen).toBe(3); // all 3 are open status
+    expect(result.errors).toBe(0);
+  });
+});
+
+describe("queen-tick lock primitives", () => {
+  it("queenTickLockKey is per-installation scoped", () => {
+    expect(queenTickLockKey("12345")).toBe("hive:v1:lock:queen-tick:12345");
+    expect(queenTickLockKey("99999")).toBe("hive:v1:lock:queen-tick:99999");
+  });
+
+  it("LOCK_TTL is 55s — just under the 60s cron interval (design L1016)", () => {
+    expect(QUEEN_TICK_LOCK_TTL_SECS).toBe(55);
+  });
+
+  it("RELEASE_SCRIPT is compare-and-DEL (closes design R3 B6: SET NX returns OK/null, not stored value)", () => {
+    expect(QUEEN_TICK_LOCK_RELEASE_SCRIPT).toContain("redis.call");
+    expect(QUEEN_TICK_LOCK_RELEASE_SCRIPT).toContain("get");
+    expect(QUEEN_TICK_LOCK_RELEASE_SCRIPT).toContain("del");
+    expect(QUEEN_TICK_LOCK_RELEASE_SCRIPT).toContain("KEYS[1]");
+    expect(QUEEN_TICK_LOCK_RELEASE_SCRIPT).toContain("ARGV[1]");
+  });
+});

--- a/web/src/server/queen-tick.ts
+++ b/web/src/server/queen-tick.ts
@@ -1,0 +1,354 @@
+/**
+ * Queen tick — the war-room watchdog body.
+ *
+ * Driven by Vercel Cron every 60 seconds (per
+ * `WAR_ROOM_DESIGN.md` §"Manager loop" L954-1101). For each
+ * installation, a tick:
+ *
+ *   1. **Recovery scan** — for every room in `deciding` status,
+ *      call `recoverDeciding` to revert rooms whose synthesis
+ *      claim TTL has expired. Active claims are skipped (the
+ *      script's claim-existence check protects in-flight queens).
+ *
+ *   2. **Expire scan** — for every open room (awaiting_rsvp /
+ *      awaiting_contributions / deciding), if `now - opened_at >
+ *      max_age_secs` then call `terminateRoom(reason="expired")`.
+ *      A room past max_age in `deciding` is terminated too — the
+ *      claim DEL'd by terminate makes the queen's mid-flight close
+ *      return RoomCloseClaimLostError and abort cleanly.
+ *
+ *   3. **Timeout scan** — for every `awaiting_contributions` room,
+ *      iterate `pending` participants. If `now - rsvp_at >
+ *      contribution_deadline_secs`, call `timeoutParticipant`. The
+ *      script's participant-state precondition (`["pending"]`)
+ *      protects against racing a worker's `submitContribution`.
+ *
+ * NOT in this slice (D.1.c):
+ *   - Synthesis trigger — Phase G' (queen module). When all
+ *     participants in an `awaiting_contributions` room have
+ *     resolved, the queen's manager loop body claims + synthesizes
+ *     + closes. That code lives in `bot/api/lib/queen/`.
+ *   - RSVP→contributions transition — uses the design's
+ *     "rsvp_quiet_period_secs" field which isn't in the current
+ *     `TimingConfig`. Tracked separately.
+ *
+ * This module is pure orchestration over the war-room storage
+ * primitives — no side effects beyond the storage calls. The
+ * cron route (`POST /api/internal/queen/tick`) handles auth + lock
+ * acquisition and invokes `runQueenTick` once per installation.
+ */
+
+import {
+  type Redis,
+} from "@upstash/redis";
+import {
+  listRooms,
+  getRoomParticipants,
+  recoverDeciding,
+  terminateRoom,
+  timeoutParticipant,
+  type RoomCoreWithId,
+  type RoomParticipant,
+  type SubjectRef,
+  RoomNotFoundError,
+  RoomAlreadyClosedError,
+  RoomTransitionInvalidStatusError,
+  RoomEventStatusPreconditionError,
+  RoomParticipantNotFoundError,
+  RoomParticipantStatePreconditionError,
+  RoomEventIdempotencyReplayError,
+} from "@/server/war-room";
+
+/**
+ * Stable identity for the watchdog actor on its emitted events
+ * (recovery events, terminate events, timeout events). Distinct
+ * from any human/agent identity — events with these sentinels
+ * indicate "system-driven, no bearer behind it" per the
+ * `RoomEvent` JSDoc system-actor exception (#512 guard N5).
+ */
+export const WATCHDOG_ACTOR_ROLE = "manager";
+export const WATCHDOG_ACTOR_ID = "vercel-cron";
+
+/**
+ * Outcome counts emitted by `runQueenTick`. Each counter is
+ * advanced once per relevant primitive call. Surface in the cron
+ * route's response for operator dashboards + alerts.
+ */
+export interface QueenTickResult {
+  scannedDeciding: number;
+  recovered: number;
+  scannedOpen: number;
+  expired: number;
+  scannedAwaitingContributions: number;
+  timedOutParticipants: number;
+  errors: number;
+}
+
+interface QueenTickArgs {
+  installationId: string;
+  redis: Redis;
+  /** Now in ms since epoch. Defaults to `Date.now()`. Tests pass a
+   * fixed value for deterministic deadline arithmetic. */
+  nowMs?: number;
+  /** Cap on rooms processed per tick (defensive, prevents a single
+   * installation with many open rooms from exceeding the Vercel
+   * function timeout). Default 100 — matches the soft cap in
+   * `/api/rooms/watching`. Operators with > 100 open rooms are
+   * already in a degraded state and need triage; the watchdog
+   * processes the newest-first slice and the next tick handles
+   * the rest. */
+  maxRoomsPerTick?: number;
+}
+
+const DEFAULT_MAX_ROOMS_PER_TICK = 100;
+
+/**
+ * Run one watchdog tick for an installation. Returns aggregate
+ * counters; per-room errors are logged-and-continue (one bad room
+ * doesn't stall the rest).
+ *
+ * Idempotent across overlapping fires: each underlying primitive's
+ * idempotency key + status precondition makes a re-tick harmless.
+ * The cron route still serializes via per-installation lock to
+ * avoid wasted work.
+ */
+export async function runQueenTick(args: QueenTickArgs): Promise<QueenTickResult> {
+  const nowMs = args.nowMs ?? Date.now();
+  const maxRooms = args.maxRoomsPerTick ?? DEFAULT_MAX_ROOMS_PER_TICK;
+
+  const result: QueenTickResult = {
+    scannedDeciding: 0,
+    recovered: 0,
+    scannedOpen: 0,
+    expired: 0,
+    scannedAwaitingContributions: 0,
+    timedOutParticipants: 0,
+    errors: 0,
+  };
+
+  // listRooms returns ALL rooms newest-first (status-mixed). Filter
+  // on the result so the watchdog never reads more than it needs.
+  // This costs N HGETALL on the room hash which is unavoidable —
+  // the alternative (status-set SMEMBERS + HMGET) doesn't improve
+  // the round-trip count meaningfully and adds a code path.
+  const rooms = await listRooms({
+    installationId: args.installationId,
+    redis: args.redis,
+    limit: maxRooms,
+  });
+
+  // 1. Recovery scan — every `deciding` room.
+  for (const room of rooms) {
+    if (room.status !== "deciding") continue;
+    result.scannedDeciding += 1;
+    try {
+      const r = await recoverDeciding({
+        installationId: args.installationId,
+        roomId: room.roomId,
+        redis: args.redis,
+        nowMs,
+      });
+      if (r.recovered) result.recovered += 1;
+      // r.recovered === false means claim still active; skip.
+    } catch (err) {
+      // Status changed mid-tick (room moved out of deciding) →
+      // benign skip. Other errors → count and continue.
+      if (err instanceof RoomTransitionInvalidStatusError) continue;
+      if (err instanceof RoomNotFoundError) continue;
+      result.errors += 1;
+      // Best-effort log to stderr — production observability lives
+      // in Vercel logs (the cron route wraps this and emits a
+      // structured summary at completion).
+      console.warn(
+        `[queen-tick] recovery error room=${room.roomId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  // 2. Expire scan — every open room past max_age_secs.
+  // Plus 3. Timeout scan — every awaiting_contributions room.
+  // Combined into a single iteration to avoid double-traversing
+  // the room list. The two responsibilities don't conflict:
+  // expire-then-timeout means a stale room is closed first,
+  // saving the timeout-scan cost.
+  for (const room of rooms) {
+    const isOpen =
+      room.status === "awaiting_rsvp" ||
+      room.status === "awaiting_contributions" ||
+      room.status === "deciding";
+    if (!isOpen) continue;
+    result.scannedOpen += 1;
+
+    const openedAtMs = Date.parse(room.opened_at);
+    if (Number.isFinite(openedAtMs)) {
+      const ageSecs = (nowMs - openedAtMs) / 1000;
+      if (ageSecs > room.timing_config.max_age_secs) {
+        try {
+          const subject: SubjectRef = {
+            type: room.subject_type,
+            ref: room.subject_ref,
+          };
+          await terminateRoom({
+            installationId: args.installationId,
+            roomId: room.roomId,
+            reason: "expired",
+            subject,
+            actorRole: WATCHDOG_ACTOR_ROLE,
+            actorId: WATCHDOG_ACTOR_ID,
+            redis: args.redis,
+            nowMs,
+          });
+          result.expired += 1;
+          continue; // Don't run timeout scan on a just-expired room.
+        } catch (err) {
+          if (err instanceof RoomAlreadyClosedError) {
+            // Race: another caller force-closed this tick. Benign.
+            continue;
+          }
+          if (err instanceof RoomNotFoundError) continue;
+          result.errors += 1;
+          console.warn(
+            `[queen-tick] expire error room=${room.roomId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          continue;
+        }
+      }
+    }
+
+    // Timeout scan — only for awaiting_contributions rooms (per
+    // design L1055, `pending` participants are timed out by the
+    // watchdog when their contribution deadline elapsed).
+    if (room.status !== "awaiting_contributions") continue;
+    result.scannedAwaitingContributions += 1;
+
+    let participants: Record<string, RoomParticipant>;
+    try {
+      participants = await getRoomParticipants({
+        roomId: room.roomId,
+        redis: args.redis,
+      });
+    } catch (err) {
+      result.errors += 1;
+      console.warn(
+        `[queen-tick] participants read error room=${room.roomId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      continue;
+    }
+
+    // Need the room's current sequence to derive a stable
+    // idempotency key for the timeout (per
+    // deriveIdempotencyKey contract). Watcher's tick observes
+    // a sequence; if a fresh contribution lands between
+    // observation and EVAL, the storage primitive's
+    // participant-state precondition (`["pending"]`) returns 409
+    // and we re-scan next tick (no effect on the resolved slot).
+    // The cron tick reads `seq` separately for each room — one
+    // small extra round-trip but keeps the timeout-vs-resolve race
+    // resolution in the storage layer where it belongs.
+    let currentSequence = 0;
+    try {
+      const seqRaw = await args.redis.get<string | number>(
+        `hive:v1:room:${room.roomId}:seq`,
+      );
+      currentSequence =
+        typeof seqRaw === "number"
+          ? seqRaw
+          : typeof seqRaw === "string"
+            ? Number.parseInt(seqRaw, 10)
+            : 0;
+    } catch (err) {
+      result.errors += 1;
+      console.warn(
+        `[queen-tick] seq read error room=${room.roomId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      continue;
+    }
+
+    for (const [role, p] of Object.entries(participants)) {
+      if (p.status !== "pending") continue;
+      const rsvpAtMs = Date.parse(p.rsvp_at);
+      if (!Number.isFinite(rsvpAtMs)) continue;
+      const waitedSecs = (nowMs - rsvpAtMs) / 1000;
+      if (waitedSecs <= room.timing_config.contribution_deadline_secs) {
+        continue;
+      }
+
+      try {
+        await timeoutParticipant({
+          installationId: args.installationId,
+          roomId: room.roomId,
+          subjectRole: role,
+          watchdogRole: WATCHDOG_ACTOR_ROLE,
+          watchdogAgentId: WATCHDOG_ACTOR_ID,
+          sequenceObservedByClient: currentSequence,
+          redis: args.redis,
+          nowMs,
+        });
+        result.timedOutParticipants += 1;
+      } catch (err) {
+        // Expected race outcomes — the worker resolved or moved
+        // the room status between scan and EVAL. Don't count as
+        // errors; re-scan handles it on the next tick.
+        if (
+          err instanceof RoomParticipantStatePreconditionError ||
+          err instanceof RoomEventStatusPreconditionError ||
+          err instanceof RoomParticipantNotFoundError ||
+          err instanceof RoomEventIdempotencyReplayError ||
+          err instanceof RoomNotFoundError
+        ) {
+          continue;
+        }
+        result.errors += 1;
+        console.warn(
+          `[queen-tick] timeout error room=${room.roomId} role=${role}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compare-and-DEL release for the per-installation cron lock.
+ * Avoids the JS-level "if get === runnerId then del" anti-pattern
+ * that closes #519 guard's reference to the design's R3 B6 callout
+ * (the SET ... NX returns "OK"/null, NOT the stored value, so a
+ * naive compare always fails).
+ *
+ * Returns 1 if THIS runner held the lock and DEL'd it; 0 if the
+ * lock had been TTL'd and re-acquired by another runner (in which
+ * case we must NOT delete — that's another runner's lock).
+ *
+ * KEYS:
+ *   [1] lockKey
+ * ARGV:
+ *   [1] runnerId — must match the value SET at acquisition
+ */
+export const QUEEN_TICK_LOCK_RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
+
+/** Per-installation cron-tick lock key. Distinct from the per-room
+ * lock prefix used by individual storage primitives. */
+export function queenTickLockKey(installationId: string): string {
+  return `hive:v1:lock:queen-tick:${installationId}`;
+}
+
+/** Cron lock TTL — design L1016 specifies 55s (just under the 60s
+ * cron interval), so a crashed runner's lock auto-releases before
+ * the next fire. */
+export const QUEEN_TICK_LOCK_TTL_SECS = 55;

--- a/web/src/server/queen-tick.ts
+++ b/web/src/server/queen-tick.ts
@@ -47,7 +47,8 @@ import {
   recoverDeciding,
   terminateRoom,
   timeoutParticipant,
-  type RoomCoreWithId,
+  seqKey,
+  installationIndexKey,
   type RoomParticipant,
   type SubjectRef,
   RoomNotFoundError,
@@ -60,14 +61,36 @@ import {
 } from "@/server/war-room";
 
 /**
- * Stable identity for the watchdog actor on its emitted events
- * (recovery events, terminate events, timeout events). Distinct
- * from any human/agent identity — events with these sentinels
- * indicate "system-driven, no bearer behind it" per the
- * `RoomEvent` JSDoc system-actor exception (#512 guard N5).
+ * Watchdog actor sentinels — distinct pairs per emitted event
+ * type, matching the `RoomEvent` JSDoc spec at
+ * `web/src/server/war-room.ts:307-310`. Closes #524 guard B1: the
+ * prior single pair collapsed terminate into the queen-driven
+ * `manager` lane and lost the `watchdog` correlation key on
+ * timeout, breaking forensic filtering.
+ *
+ * Two pairs:
+ *   - **TERMINATE** (`actor_role="system"`, `actor_id="vercel-cron"`):
+ *     cron-fired expiry. The "system" role distinguishes
+ *     watchdog-driven terminate from the queen's `rooms.close`
+ *     happy-path close (which uses `actor_role="manager"`).
+ *   - **TIMEOUT** (`actor_role="manager"`, `actor_id="watchdog"`):
+ *     watchdog-triggered `participant_timed_out`. Same as the
+ *     `room_recovered` event the recovery script hardcodes.
+ *
+ * Recovery events use the script-internal sentinels
+ * (`actor_role="manager"`, `actor_id="watchdog"`) baked into
+ * `ROOM_RECOVER_DECIDING_SCRIPT` — no caller-side configuration
+ * needed.
  */
-export const WATCHDOG_ACTOR_ROLE = "manager";
-export const WATCHDOG_ACTOR_ID = "vercel-cron";
+export const WATCHDOG_TERMINATE_ACTOR = {
+  role: "system",
+  id: "vercel-cron",
+} as const;
+
+export const WATCHDOG_TIMEOUT_ACTOR = {
+  role: "manager",
+  id: "watchdog",
+} as const;
 
 /**
  * Outcome counts emitted by `runQueenTick`. Each counter is
@@ -82,6 +105,23 @@ export interface QueenTickResult {
   scannedAwaitingContributions: number;
   timedOutParticipants: number;
   errors: number;
+  /**
+   * Count of rooms in the installation index that the tick did NOT
+   * read this cycle. Closes #524 guard N2 + builder R1 escalation:
+   * `listRooms` returns newest-first capped at `maxRoomsPerTick`,
+   * so under backlog (>maxRoomsPerTick open rooms) the OLDEST
+   * rooms — exactly the ones expire/timeout scans care about —
+   * are skipped. Surfacing this count lets ops alert on
+   * `rooms_unscanned > 0` so degradation is observable rather than
+   * silent. Steady state (≤ cap rooms): always 0.
+   *
+   * Note: this counts rooms in the installation INDEX (sorted set),
+   * not just open rooms. Closed rooms in the retention window count
+   * too. Tighter "open rooms unscanned" requires a separate ZCARD on
+   * each status set — deferred to V1.1 if alerting on this metric
+   * shows false positives.
+   */
+  roomsUnscanned: number;
 }
 
 interface QueenTickArgs {
@@ -124,18 +164,32 @@ export async function runQueenTick(args: QueenTickArgs): Promise<QueenTickResult
     scannedAwaitingContributions: 0,
     timedOutParticipants: 0,
     errors: 0,
+    roomsUnscanned: 0,
   };
 
+  // ZCARD on the installation index in parallel with listRooms.
+  // Closes #524 guard N2 + builder R1 escalation: under backlog
+  // (>maxRoomsPerTick rooms), `listRooms` returns the newest slice
+  // and the OLDEST rooms — exactly the ones expire/timeout scans
+  // need — are skipped. Surfacing the unscanned count here lets
+  // ops alert on `rooms_unscanned > 0` so the degradation is
+  // observable, not silent.
+  //
   // listRooms returns ALL rooms newest-first (status-mixed). Filter
   // on the result so the watchdog never reads more than it needs.
   // This costs N HGETALL on the room hash which is unavoidable —
   // the alternative (status-set SMEMBERS + HMGET) doesn't improve
   // the round-trip count meaningfully and adds a code path.
-  const rooms = await listRooms({
-    installationId: args.installationId,
-    redis: args.redis,
-    limit: maxRooms,
-  });
+  const indexKey = installationIndexKey(args.installationId);
+  const [rooms, totalIndexed] = await Promise.all([
+    listRooms({
+      installationId: args.installationId,
+      redis: args.redis,
+      limit: maxRooms,
+    }),
+    args.redis.zcard(indexKey).catch(() => 0),
+  ]);
+  result.roomsUnscanned = Math.max(0, totalIndexed - rooms.length);
 
   // 1. Recovery scan — every `deciding` room.
   for (const room of rooms) {
@@ -155,6 +209,12 @@ export async function runQueenTick(args: QueenTickArgs): Promise<QueenTickResult
       // benign skip. Other errors → count and continue.
       if (err instanceof RoomTransitionInvalidStatusError) continue;
       if (err instanceof RoomNotFoundError) continue;
+      // Idempotency replay is benign too — defensive consistency
+      // with the timeout catch (closes #524 guard N3). Recovery
+      // shouldn't normally hit this since each tick generates a
+      // fresh idemKey, but a runner crash between EVAL-success
+      // and route-return could.
+      if (err instanceof RoomEventIdempotencyReplayError) continue;
       result.errors += 1;
       // Best-effort log to stderr — production observability lives
       // in Vercel logs (the cron route wraps this and emits a
@@ -195,8 +255,8 @@ export async function runQueenTick(args: QueenTickArgs): Promise<QueenTickResult
             roomId: room.roomId,
             reason: "expired",
             subject,
-            actorRole: WATCHDOG_ACTOR_ROLE,
-            actorId: WATCHDOG_ACTOR_ID,
+            actorRole: WATCHDOG_TERMINATE_ACTOR.role,
+            actorId: WATCHDOG_TERMINATE_ACTOR.id,
             redis: args.redis,
             nowMs,
           });
@@ -253,9 +313,10 @@ export async function runQueenTick(args: QueenTickArgs): Promise<QueenTickResult
     // resolution in the storage layer where it belongs.
     let currentSequence = 0;
     try {
-      const seqRaw = await args.redis.get<string | number>(
-        `hive:v1:room:${room.roomId}:seq`,
-      );
+      // Use the war-room.ts key helper instead of an inline string —
+      // closes #524 guard N1: hardcoded key conventions silently
+      // drift from the storage module if anyone refactors the prefix.
+      const seqRaw = await args.redis.get<string | number>(seqKey(room.roomId));
       currentSequence =
         typeof seqRaw === "number"
           ? seqRaw
@@ -286,8 +347,8 @@ export async function runQueenTick(args: QueenTickArgs): Promise<QueenTickResult
           installationId: args.installationId,
           roomId: room.roomId,
           subjectRole: role,
-          watchdogRole: WATCHDOG_ACTOR_ROLE,
-          watchdogAgentId: WATCHDOG_ACTOR_ID,
+          watchdogRole: WATCHDOG_TIMEOUT_ACTOR.role,
+          watchdogAgentId: WATCHDOG_TIMEOUT_ACTOR.id,
           sequenceObservedByClient: currentSequence,
           redis: args.redis,
           nowMs,

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -3,5 +3,12 @@
   "git": {
     "deploymentEnabled": false,
     "ignoreCommand": "exit 0"
-  }
+  },
+  "crons": [
+    {
+      "_comment": "War-room watchdog — 60s recovery/expire/timeout scan. Per WAR_ROOM_DESIGN.md L954-958, the design specifies 60s tick interval (1 minute). Per-installation cron entries: duplicate this entry with a different `installationId` query param when adding a second installation. Until per-installation entries are wired up, this single entry uses INSTALLATION_ID env-var substitution at deploy time (see deploy notes in apiary/run-hivemoot-docker.sh) — replaced before vercel.json is uploaded.",
+      "path": "/api/internal/queen/tick?installationId=$INSTALLATION_ID",
+      "schedule": "* * * * *"
+    }
+  ]
 }

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -6,8 +6,8 @@
   },
   "crons": [
     {
-      "_comment": "War-room watchdog — 60s recovery/expire/timeout scan. Per WAR_ROOM_DESIGN.md L954-958, the design specifies 60s tick interval (1 minute). Per-installation cron entries: duplicate this entry with a different `installationId` query param when adding a second installation. Until per-installation entries are wired up, this single entry uses INSTALLATION_ID env-var substitution at deploy time (see deploy notes in apiary/run-hivemoot-docker.sh) — replaced before vercel.json is uploaded.",
-      "path": "/api/internal/queen/tick?installationId=$INSTALLATION_ID",
+      "_comment": "War-room watchdog — 60s recovery/expire/timeout scan per WAR_ROOM_DESIGN.md L954-958. Vercel does NOT interpolate env vars in cron paths, so the path is static. Installation selection is read at request time from the HIVEMOOT_TICK_INSTALLATION_ID env var (provisioned via Vercel dashboard → Settings → Environment Variables). Multi-installation: future enhancement — comma-separated list with server-side iteration. Closes #524 guard R2 N1.",
+      "path": "/api/internal/queen/tick",
       "schedule": "* * * * *"
     }
   ]


### PR DESCRIPTION
Fixes #523

## Summary

The war-room watchdog. Closes Phase D's backend (D.1.a storage + D.1.b API + D.1.c watchdog → all primitives needed for V1 are now in place).

Three scans per tick, pure orchestration over the existing storage primitives — no new Lua scripts needed:

| Scan | Trigger | Calls |
|---|---|---|
| Recovery | `deciding` rooms | `recoverDeciding` (script's claim-existence check protects active queens) |
| Expire | Open rooms past `max_age_secs` | `terminateRoom(reason="expired")` |
| Timeout | `awaiting_contributions` rooms with pending participants past `contribution_deadline_secs` | `timeoutParticipant` |

## What it looks like

**Cron route shape** (`POST /api/internal/queen/tick`):

```
auth: Bearer ${CRON_SECRET}     ← Vercel cron pattern, NOT V1 capability
body: { installationId }
response: { skipped: false, runnerId, result: QueenTickResult }
       OR { skipped: true, reason: "lock_contention" }
       OR 401 (empty body, no oracle)
       OR 500 server_misconfiguration | tick_failed
```

**Per-installation Redlock pattern** (closes design R3 B6):

```
Acquire: SET key runnerId NX EX 55      ← null on contention → skip
Release: compare-and-DEL Lua            ← atomic, can't accidentally
                                          DEL another runner's lock
```

The "compare-and-DEL via Lua" matters because `SET ... NX` returns `"OK"`/`null`, NOT the stored value — a JS-level `if (acquired === runnerId) { del() }` always fails.

**Watchdog actor sentinels** (system-actor exception per #512 guard N5):

```
actor_role: "manager"
actor_id:   "vercel-cron"
```

No bearer behind the cron tick — events emit these sentinels per the `RoomEvent` JSDoc system-actor exception.

**Race semantics — every "scan-then-act" path is benign-on-race:**

| Race | Storage primitive's protection | Watchdog's response |
|---|---|---|
| Status changes mid-scan (e.g., queen claimed deciding) | `recoverDeciding` returns `RoomTransitionInvalidStatusError` | benign skip, no error count |
| Worker resolved between scan and timeout | `timeoutParticipant` returns `RoomParticipantStatePreconditionError` | benign skip |
| Operator force-closed between scan and expire | `terminateRoom` returns `RoomAlreadyClosedError` | benign skip |
| Worker resolved between scan and expire (room moved status) | `RoomEventStatusPreconditionError` / `RoomNotFoundError` | benign skip |

The watchdog never fights its own race; the storage primitives' state preconditions are the source of truth.

**`QueenTickResult` counters returned from each tick:**

```ts
{
  scannedDeciding: number;
  recovered: number;
  scannedOpen: number;
  expired: number;
  scannedAwaitingContributions: number;
  timedOutParticipants: number;
  errors: number;
}
```

Surface in observability for the `recovered_deciding_rooms_count` metric (design L1232) and the watchdog's general health.

## Out of scope (Phase G' / follow-up)

- **Synthesis trigger** — when all participants resolved, the queen claims + synthesizes (LLM) + closes. That code lives in `bot/api/lib/queen/` (Phase G'). The watchdog here provides the scaffolding (lock pattern, scan loop, action infrastructure) the queen module's tick will reuse.
- **RSVP→contributions transition** — needs `rsvp_quiet_period_secs` which isn't in the current `TimingConfig`. Tracked separately.

## Test plan

- [x] Typecheck (`tsc --noEmit`) clean
- [x] Full web suite passes: **1322 tests** (was 1293, +29)
- [x] Watchdog body coverage (18 tests):
  - Each scan's happy path + benign-race outcomes
  - Status filter (closed rooms never read)
  - Counter shape integrity
  - `maxRoomsPerTick` cap respected (default 100)
  - Combined end-to-end with all 3 scan types
- [x] Cron route coverage (11 tests):
  - Auth: missing-bearer (401 empty body), wrong-bearer (401), no-CRON_SECRET (500 fail-loud)
  - Body shape: missing installationId, null body
  - Lock acquisition with NX EX 55 + compare-and-DEL Lua release
  - Lock contention → 200 skipped (tick NOT invoked)
  - Tick error → 500 with lock STILL released in finally
  - Release error swallowed (lock TTLs out)
  - Unique runnerId per request
- [ ] Reviewer fleet sign-off

## What's next

D.1 is now complete — Phase D backend ships. Next workstreams (parallelizable):

- **Phase E** — Bot webhook event routing (PR opened → `pr_review` room creation, mention received → `mention_response` room)
- **Phase F** — Worker runtime mode (`war-room-watcher` plugin in `agent/cli/hivemoot_agent/plugins_builtin/`)
- **Phase G'** — Queen module in `bot/api/lib/queen/` (synthesis prompt + manager loop body that reuses this watchdog scaffolding)
- **Phase H** — Hive fleet migration (depends on F + G' landing)
- **Phase I** — Dashboard for war rooms (operator UI; cut from V1 minimum but unblocked once F+G' produce traffic)