### PR TITLE
Phase E.1 — bot creates war rooms on PR opened

### DIFF
--- a/bot/api/github/webhooks/index.ts
+++ b/bot/api/github/webhooks/index.ts
@@ -31,6 +31,7 @@ import { parseCommand, executeCommand, retryQueuedSquash, autoGatherIfEligible }
 import { getLLMReadiness } from "../../lib/llm/provider.js";
 import { registerHandlerDispatcher } from "../../handlers/dispatcher.js";
 import { handlerEventMap } from "../../handlers/registry.js";
+import { maybeCreatePrReviewRoom } from "../../lib/war-room-routing.js";
 
 /**
  * Hivemoot Bot - Governance Automation
@@ -229,6 +230,20 @@ export function app(probotApp: Probot): void {
           graphql: context.octokit,
         });
       }
+
+      // Phase E.1 — war-room routing. Non-fatal: a failure here
+      // never breaks the existing intake / governance flow; the
+      // routing helper logs + returns gracefully on errors. Gated
+      // on `HIVEMOOT_BOT_AGENT_TOKEN` env var so the integration
+      // is opt-in until Phase H fleet migration. Idempotent on
+      // webhook re-delivery (server returns 409 subject_already_open
+      // → routing helper reuses existingRoomId).
+      await maybeCreatePrReviewRoom({
+        owner,
+        repo,
+        prNumber: number,
+        log: context.log,
+      });
     } catch (error) {
       context.log.error({ err: error, pr: number, repo: fullName }, "Failed to process PR");
       throw error;

--- a/bot/api/lib/war-room-client.test.ts
+++ b/bot/api/lib/war-room-client.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for WarRoomClient.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  WarRoomClient,
+  WarRoomApiError,
+  prSubjectRef,
+} from "./war-room-client.js";
+
+const TOKEN = "hmt_test_bearer";
+const BASE_URL = "https://www.hivemoot.dev";
+
+function makeFetch(response: {
+  status: number;
+  body?: unknown;
+  ok?: boolean;
+}): typeof fetch {
+  return vi.fn(async () => {
+    const ok =
+      response.ok ?? (response.status >= 200 && response.status < 300);
+    return {
+      ok,
+      status: response.status,
+      json: async () => response.body ?? {},
+    } as Response;
+  }) as never;
+}
+
+describe("WarRoomClient — construction", () => {
+  beforeEach(() => {
+    delete process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+    delete process.env.HIVEMOOT_API_BASE_URL;
+  });
+
+  it("throws when no agent token is supplied via option or env", () => {
+    expect(() => new WarRoomClient()).toThrow(/HIVEMOOT_BOT_AGENT_TOKEN/);
+  });
+
+  it("accepts agentToken via option", () => {
+    expect(() => new WarRoomClient({ agentToken: TOKEN })).not.toThrow();
+  });
+
+  it("accepts agentToken via env", () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = TOKEN;
+    expect(() => new WarRoomClient()).not.toThrow();
+  });
+
+  it("rejects baseUrl without scheme", () => {
+    expect(
+      () => new WarRoomClient({ agentToken: TOKEN, baseUrl: "hivemoot.dev" }),
+    ).toThrow(/must start with http/);
+  });
+
+  it("strips trailing slash from baseUrl", () => {
+    const fetchSpy = makeFetch({ status: 201, body: { roomId: "x" } });
+    const client = new WarRoomClient({
+      agentToken: TOKEN,
+      baseUrl: "https://www.hivemoot.dev/",
+      fetch: fetchSpy,
+    });
+    void client.createRoom({
+      subject: { type: "pr_review", ref: "x/y#1" },
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://www.hivemoot.dev/api/rooms",
+      expect.anything(),
+    );
+  });
+});
+
+describe("WarRoomClient.createRoom", () => {
+  it("happy path → 201 returns RoomCoreResponse", async () => {
+    const fetchSpy = makeFetch({
+      status: 201,
+      body: {
+        roomId: "01234567-89ab-4cde-9012-3456789abcde",
+        manager: "bot-queen",
+        subject_type: "pr_review",
+        subject_ref: "owner/repo#42",
+        status: "awaiting_rsvp",
+        opened_at: "2026-04-28T10:00:00.000Z",
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const room = await client.createRoom({
+      subject: { type: "pr_review", ref: "owner/repo#42" },
+    });
+    expect(room.subject_ref).toBe("owner/repo#42");
+    expect(room.status).toBe("awaiting_rsvp");
+  });
+
+  it("sends Authorization: Bearer header", async () => {
+    const fetchSpy = makeFetch({ status: 201, body: { roomId: "x" } });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.createRoom({
+      subject: { type: "pr_review", ref: "owner/repo#1" },
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: `Bearer ${TOKEN}`,
+        }),
+      }),
+    );
+  });
+
+  it("includes optional manager / timing / roomId in body", async () => {
+    const fetchSpy = makeFetch({ status: 201, body: { roomId: "x" } });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.createRoom({
+      subject: { type: "pr_review", ref: "owner/repo#1" },
+      manager: "queen-1",
+      timing: { max_age_secs: 7200 },
+      roomId: "01234567-89ab-4cde-9012-3456789abcde",
+    });
+    const callArgs = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body.manager).toBe("queen-1");
+    expect(body.timing.max_age_secs).toBe(7200);
+    expect(body.roomId).toBe("01234567-89ab-4cde-9012-3456789abcde");
+  });
+
+  it("subject_already_open 409 → WarRoomApiError(code='subject_already_open')", async () => {
+    const fetchSpy = makeFetch({
+      status: 409,
+      body: {
+        code: "subject_already_open",
+        message: "Already open",
+        existingRoomId: "EXISTING_ID",
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.createRoom({
+        subject: { type: "pr_review", ref: "owner/repo#1" },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WarRoomApiError);
+      const apiErr = err as WarRoomApiError;
+      expect(apiErr.code).toBe("subject_already_open");
+      expect(apiErr.status).toBe(409);
+      expect(apiErr.response.existingRoomId).toBe("EXISTING_ID");
+    }
+  });
+
+  it("non-JSON 5xx → WarRoomApiError(code='unknown')", async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error("not json");
+      },
+    })) as never;
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.createRoom({
+        subject: { type: "pr_review", ref: "owner/repo#1" },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WarRoomApiError);
+      expect((err as WarRoomApiError).code).toBe("unknown");
+      expect((err as WarRoomApiError).status).toBe(502);
+    }
+  });
+
+  it("AbortError on timeout → throws timeout error with timeoutMs in message", async () => {
+    const fetchSpy = vi.fn(async (_url: string, opts: RequestInit) => {
+      // Simulate slow response by waiting for the abort signal.
+      await new Promise<void>((_, reject) => {
+        opts.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+      // unreachable
+      return {} as Response;
+    }) as never;
+    const client = new WarRoomClient({
+      agentToken: TOKEN,
+      fetch: fetchSpy,
+      timeoutMs: 10,
+    });
+    await expect(
+      client.createRoom({
+        subject: { type: "pr_review", ref: "owner/repo#1" },
+      }),
+    ).rejects.toThrow(/timed out after 10ms/);
+  });
+});
+
+describe("prSubjectRef helper", () => {
+  it("returns canonical pr_review subject ref", () => {
+    expect(prSubjectRef({ owner: "hivemoot", repo: "hivemoot", prNumber: 42 }))
+      .toEqual({ type: "pr_review", ref: "hivemoot/hivemoot#42" });
+  });
+});

--- a/bot/api/lib/war-room-client.ts
+++ b/bot/api/lib/war-room-client.ts
@@ -198,12 +198,16 @@ export class WarRoomClient {
     const timeoutHandle = setTimeout(() => controller.abort(), this.timeoutMs);
 
     try {
+      const headers: Record<string, string> = {
+        authorization: `Bearer ${this.agentToken}`,
+      };
+      // Only send Content-Type when there's a body — closes #526
+      // guard N2 (the prior ternary `body ? json : json` was a
+      // dead-code refactor leftover).
+      if (body) headers["content-type"] = "application/json";
       const response = await this.fetchImpl(url, {
         method,
-        headers: {
-          authorization: `Bearer ${this.agentToken}`,
-          "content-type": body ? "application/json" : "application/json",
-        },
+        headers,
         body: body ? JSON.stringify(body) : undefined,
         signal: controller.signal,
       });

--- a/bot/api/lib/war-room-client.ts
+++ b/bot/api/lib/war-room-client.ts
@@ -1,0 +1,249 @@
+/**
+ * War-room HTTP client — wraps the hivemoot.dev war-room API
+ * (`/api/rooms/*`) for the bot's webhook handlers.
+ *
+ * Bot integration model: GitHub webhook → routing logic in
+ * `bot/api/github/webhooks/index.ts` → `WarRoomClient.createRoom`
+ * (and similar) → 201 with `roomId`. Workers and the queen module
+ * pick up from there.
+ *
+ * Configuration (env-driven, evaluated at construction time):
+ *   - `HIVEMOOT_API_BASE_URL` — default `https://www.hivemoot.dev`
+ *   - `HIVEMOOT_BOT_AGENT_TOKEN` — V1 capability bearer (must hold
+ *     `rooms.create`, `rooms.update`, `rooms.close`, `rooms.read_all`
+ *     for full bot operation; a `rooms.create`-only token is
+ *     sufficient for E.1)
+ *
+ * Error model: thrown errors carry the wire `code` field from the
+ * server's JSON body so handlers can distinguish:
+ *   - `subject_already_open` (idempotent re-delivery) — caller
+ *     swallows + uses the existingRoomId
+ *   - validation 400s — config/programmer error, log + skip
+ *   - 5xx — transient, caller may retry on next webhook
+ *
+ * Out of scope for E.1 (lands in subsequent slices):
+ *   - subject_updated event emission on PR synchronize
+ *   - terminateRoom on PR closed/merged
+ *   - mention_response room creation
+ *   - retry/backoff (start simple; webhook re-delivery handles it)
+ */
+
+import type { Logger } from "pino";
+
+/** Subject types supported by the war-room storage layer. Mirrors
+ * the V1 contract from `web/src/server/war-room.ts:SubjectType`. */
+export type WarRoomSubjectType =
+  | "pr_review"
+  | "mention_response"
+  | "issue_triage";
+
+export interface WarRoomSubjectRef {
+  type: WarRoomSubjectType;
+  /** Format depends on type — see WAR_ROOM_DESIGN.md L165-167.
+   *   - pr_review: `{owner}/{repo}#{prNumber}`
+   *   - mention_response: `{owner}/{repo}#{issueOrPrNumber}`
+   *   - issue_triage: `{owner}/{repo}#{issueNumber}` */
+  ref: string;
+}
+
+export interface WarRoomTimingConfig {
+  max_age_secs?: number;
+  rsvp_deadline_secs?: number;
+  contribution_deadline_secs?: number;
+}
+
+export interface CreateRoomArgs {
+  subject: WarRoomSubjectRef;
+  manager?: string;
+  timing?: WarRoomTimingConfig;
+  /** Optional caller-supplied roomId (UUIDv4 lowercase). When
+   * omitted, the server mints one. The bot typically lets the
+   * server mint so PR comments can reference whatever roomId came
+   * back. */
+  roomId?: string;
+}
+
+export interface RoomCoreResponse {
+  manager: string;
+  subject_type: WarRoomSubjectType;
+  subject_ref: string;
+  status: "awaiting_rsvp" | "awaiting_contributions" | "deciding" | "closed";
+  opened_at: string;
+  // Server may return additional fields; this is the minimum the
+  // bot needs. Extending the response type is non-breaking.
+}
+
+/**
+ * Thrown when the API returns a 4xx/5xx with a structured error
+ * body. `code` matches the server's wire `code` field.
+ */
+export class WarRoomApiError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+  public readonly response: Record<string, unknown>;
+  constructor(
+    status: number,
+    code: string,
+    message: string,
+    response: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "WarRoomApiError";
+    this.status = status;
+    this.code = code;
+    this.response = response;
+  }
+}
+
+export interface WarRoomClientOptions {
+  baseUrl?: string;
+  agentToken?: string;
+  /** Hard timeout per request in ms. Default 5000 — webhook
+   * handlers shouldn't block longer; a hung API call would stall
+   * the bot's queue. */
+  timeoutMs?: number;
+  /** Optional logger (Probot context.log shape — uses
+   * `info`/`warn`/`error`). Defaults to console for tests. */
+  log?: Pick<Logger, "info" | "warn" | "error">;
+  /** Override fetch (for tests). Defaults to globalThis.fetch. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Construct a client. Throws at construction time if required env
+ * vars are missing — fails loud rather than at first webhook call.
+ */
+export class WarRoomClient {
+  private readonly baseUrl: string;
+  private readonly agentToken: string;
+  private readonly timeoutMs: number;
+  private readonly log: Pick<Logger, "info" | "warn" | "error">;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: WarRoomClientOptions = {}) {
+    const baseUrl =
+      options.baseUrl ??
+      process.env.HIVEMOOT_API_BASE_URL ??
+      "https://www.hivemoot.dev";
+    const agentToken =
+      options.agentToken ?? process.env.HIVEMOOT_BOT_AGENT_TOKEN ?? "";
+
+    if (agentToken.length === 0) {
+      throw new Error(
+        "WarRoomClient requires HIVEMOOT_BOT_AGENT_TOKEN env var (or `agentToken` option). Provision a V1 capability bearer with `rooms.create` (queen preset) via /api/agent-tokens.",
+      );
+    }
+    if (!/^https?:\/\//.test(baseUrl)) {
+      throw new Error(
+        `WarRoomClient baseUrl ${JSON.stringify(baseUrl)} must start with http:// or https://.`,
+      );
+    }
+
+    this.baseUrl = baseUrl.replace(/\/$/, ""); // strip trailing slash
+    this.agentToken = agentToken;
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.log = options.log ?? consoleLogger();
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Create a war room for a subject (PR / issue / mention). Returns
+   * the room core record on success. On `subject_already_open` the
+   * server returns 409 with `existingRoomId` in the body — this
+   * client surfaces that as `WarRoomApiError(code="subject_already_open")`
+   * so the caller can extract `error.response.existingRoomId` and
+   * treat the call as idempotent (the bot's webhook re-delivery
+   * path).
+   *
+   * Network/5xx errors throw plain `Error` — the bot's webhook
+   * handler should log + return; GitHub will re-deliver on its own
+   * cadence.
+   */
+  async createRoom(args: CreateRoomArgs): Promise<RoomCoreResponse> {
+    const body: Record<string, unknown> = { subject: args.subject };
+    if (args.manager !== undefined) body.manager = args.manager;
+    if (args.timing !== undefined) body.timing = args.timing;
+    if (args.roomId !== undefined) body.roomId = args.roomId;
+
+    const response = await this.request("POST", "/api/rooms", body);
+
+    if (response.ok) {
+      return (await response.json()) as RoomCoreResponse;
+    }
+
+    // Structured error → WarRoomApiError so callers can branch on
+    // `code`. The 409 `subject_already_open` path is idempotent.
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = (await response.json()) as Record<string, unknown>;
+    } catch {
+      // Non-JSON error body — fall through with empty parsed.
+    }
+    const code = typeof parsed.code === "string" ? parsed.code : "unknown";
+    const message =
+      typeof parsed.message === "string"
+        ? parsed.message
+        : `War-room API ${response.status} (${code})`;
+    throw new WarRoomApiError(response.status, code, message, parsed);
+  }
+
+  /** Internal: shared request shape. */
+  private async request(
+    method: "GET" | "POST" | "DELETE",
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await this.fetchImpl(url, {
+        method,
+        headers: {
+          authorization: `Bearer ${this.agentToken}`,
+          "content-type": body ? "application/json" : "application/json",
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+      return response;
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new Error(
+          `War-room API ${method} ${path} timed out after ${this.timeoutMs}ms.`,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function consoleLogger(): Pick<Logger, "info" | "warn" | "error"> {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  return {
+    info: ((..._args: any[]) => undefined) as Logger["info"],
+    warn: ((..._args: any[]) => undefined) as Logger["warn"],
+    error: ((..._args: any[]) => undefined) as Logger["error"],
+  };
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+/**
+ * Build the canonical `subject_ref` for a PR. Use this everywhere
+ * a PR's identity needs to be passed to the war-room API — keeps
+ * the `{owner}/{repo}#{prNumber}` format centrally enforced (it
+ * MUST match the storage layer's regex at `repoFromSubjectRef`).
+ */
+export function prSubjectRef(args: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}): WarRoomSubjectRef {
+  return {
+    type: "pr_review",
+    ref: `${args.owner}/${args.repo}#${args.prNumber}`,
+  };
+}

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -52,15 +52,20 @@ describe("maybeCreatePrReviewRoom", () => {
     );
   });
 
-  it("happy path: 201 → returns roomId", async () => {
+  it("happy path: 201 — bot mints roomId + threads it through (closes #526 B1)", async () => {
     process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    // CRITICAL: server's POST /api/rooms 201 response serializes
+    // RoomCore (NOT RoomCoreWithId), so the body has NO roomId
+    // field. The bot mints the roomId and passes it as args.roomId;
+    // the round-trip identity check is what we pin here so the next
+    // contract drift is caught.
     const createRoom = vi.fn(async () => ({
-      roomId: ROOM_ID,
       manager: "bot-queen",
       subject_type: "pr_review",
       subject_ref: "hivemoot/hivemoot#42",
       status: "awaiting_rsvp",
       opened_at: "2026-04-28T10:00:00.000Z",
+      // NOTE: no `roomId` here — pinning the actual server contract.
     }));
     // Class-mock pattern: prototype-chain a fake class that returns
     // an object with createRoom. The naive `mockImplementation`
@@ -78,12 +83,20 @@ describe("maybeCreatePrReviewRoom", () => {
       prNumber: 42,
       log,
     });
-    expect(result.roomId).toBe(ROOM_ID);
+
+    // Round-trip equality: the roomId returned by the helper must
+    // be the same UUIDv4 it passed into createRoom. If a future
+    // refactor breaks this thread-through, this test catches it.
+    expect(typeof result.roomId).toBe("string");
+    expect(result.roomId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
     expect(createRoom).toHaveBeenCalledWith({
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#42" },
+      roomId: result.roomId,
     });
     expect(log.info).toHaveBeenCalledWith(
-      expect.objectContaining({ roomId: ROOM_ID }),
+      expect.objectContaining({ roomId: result.roomId }),
       expect.stringContaining("created pr_review room"),
     );
   });

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for war-room-routing helpers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { maybeCreatePrReviewRoom } from "./war-room-routing.js";
+import { WarRoomApiError } from "./war-room-client.js";
+
+vi.mock("./war-room-client.js", async () => {
+  const real = await vi.importActual<typeof import("./war-room-client.js")>(
+    "./war-room-client.js",
+  );
+  return {
+    ...real,
+    WarRoomClient: vi.fn(),
+  };
+});
+
+import { WarRoomClient } from "./war-room-client.js";
+
+const mockedClientCtor = vi.mocked(WarRoomClient);
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+const ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+describe("maybeCreatePrReviewRoom", () => {
+  beforeEach(() => {
+    delete process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+    log.info.mockReset();
+    log.warn.mockReset();
+    log.error.mockReset();
+    mockedClientCtor.mockReset();
+  });
+
+  it("skips with `no_token` reason when env var is unset", async () => {
+    const result = await maybeCreatePrReviewRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "no_token" });
+    expect(mockedClientCtor).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ pr: 42 }),
+      expect.stringContaining("HIVEMOOT_BOT_AGENT_TOKEN unset"),
+    );
+  });
+
+  it("happy path: 201 → returns roomId", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const createRoom = vi.fn(async () => ({
+      roomId: ROOM_ID,
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "hivemoot/hivemoot#42",
+      status: "awaiting_rsvp",
+      opened_at: "2026-04-28T10:00:00.000Z",
+    }));
+    // Class-mock pattern: prototype-chain a fake class that returns
+    // an object with createRoom. The naive `mockImplementation`
+    // path makes `new` return undefined when the implementation is
+    // arrow-fn'd → object-spread-new doesn't bind properly.
+    mockedClientCtor.mockImplementation(
+      function (this: { createRoom: typeof createRoom }) {
+        this.createRoom = createRoom;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeCreatePrReviewRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      log,
+    });
+    expect(result.roomId).toBe(ROOM_ID);
+    expect(createRoom).toHaveBeenCalledWith({
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#42" },
+    });
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ roomId: ROOM_ID }),
+      expect.stringContaining("created pr_review room"),
+    );
+  });
+
+  it("subject_already_open 409 → reuses existingRoomId (idempotent on webhook re-delivery)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const createRoom = vi.fn(async () => {
+      throw new WarRoomApiError(
+        409,
+        "subject_already_open",
+        "Already open",
+        { existingRoomId: ROOM_ID },
+      );
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { createRoom: typeof createRoom }) {
+        this.createRoom = createRoom;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeCreatePrReviewRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      log,
+    });
+    expect(result.roomId).toBe(ROOM_ID);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ existingRoomId: ROOM_ID }),
+      expect.stringContaining("subject_already_open"),
+    );
+  });
+
+  it("4xx (validation error) → returns skipped:'api_error', logs error", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const createRoom = vi.fn(async () => {
+      throw new WarRoomApiError(400, "invalid_subject", "bad", {});
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { createRoom: typeof createRoom }) {
+        this.createRoom = createRoom;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeCreatePrReviewRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "api_error" });
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("network/5xx error → returns skipped:'api_error', logs warn (transient)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const createRoom = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { createRoom: typeof createRoom }) {
+        this.createRoom = createRoom;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeCreatePrReviewRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "api_error" });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ pr: 42 }),
+      expect.stringContaining("transient error"),
+    );
+  });
+
+  it("client construction error → skipped:'api_error', non-fatal", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    mockedClientCtor.mockImplementation(() => {
+      throw new Error("invalid baseUrl");
+    });
+
+    const result = await maybeCreatePrReviewRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "api_error" });
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("never throws — webhook handler relies on this for non-fatal contract", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const createRoom = vi.fn(async () => {
+      throw new TypeError("totally unexpected");
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { createRoom: typeof createRoom }) {
+        this.createRoom = createRoom;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    await expect(
+      maybeCreatePrReviewRoom({
+        owner: "hivemoot",
+        repo: "hivemoot",
+        prNumber: 42,
+        log,
+      }),
+    ).resolves.toEqual({ roomId: null, skipped: "api_error" });
+  });
+});

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -12,12 +12,22 @@
  *     409 is treated as success; the existing room is reused.
  *   - Non-fatal on error — war-room failures are logged but never
  *     thrown, so a 500 from the API can't break the PR's existing
- *     intake / governance flow. GitHub re-delivers webhooks on its
- *     own cadence; we'll get another shot.
+ *     intake / governance flow.
+ *
+ * **Recovery story (closes #526 guard N1):** because the routing
+ * helper SWALLOWS errors and returns 200 to GitHub, GitHub does NOT
+ * automatically re-deliver. A single transient war-room API failure
+ * on `pull_request.opened` means the war-room is never created for
+ * that PR until E.2 (`pull_request.synchronize` re-attempt) or
+ * operator intervention. Re-throwing on 5xx is the alternative —
+ * but that re-runs the existing intake/comment-posting flow, whose
+ * idempotency under repeat deliveries isn't asserted today. Tracked
+ * as a follow-up; pre-Phase H opt-in posture limits blast radius.
  */
 
 import { WarRoomClient, WarRoomApiError, prSubjectRef } from "./war-room-client.js";
 import type { Logger } from "pino";
+import { randomUUID } from "node:crypto";
 
 interface MaybeCreatePrReviewRoomArgs {
   owner: string;
@@ -86,18 +96,31 @@ export async function maybeCreatePrReviewRoom(
     prNumber: args.prNumber,
   });
 
+  // Bot-side mint of the roomId (closes #526 guard B1). The server
+  // accepts a caller-supplied roomId via POST /api/rooms body and
+  // falls back to its own crypto.randomUUID() if omitted. The
+  // 201 response serializes RoomCore (NOT RoomCoreWithId) — no
+  // roomId in the body — so threading the minted value through
+  // makes the contract self-consistent: caller knows the roomId
+  // before the round-trip, no response-shape dependency.
+  //
+  // Future E.x slices (subject_updated, terminate, post-PR-comment
+  // referencing the room) get the roomId for free via this return
+  // value.
+  const roomId = randomUUID();
+
   try {
-    const room = await client.createRoom({ subject });
+    await client.createRoom({ subject, roomId });
     args.log.info(
       {
         owner: args.owner,
         repo: args.repo,
         pr: args.prNumber,
-        roomId: extractRoomIdFromCore(room),
+        roomId,
       },
       "[war-room] created pr_review room",
     );
-    return { roomId: extractRoomIdFromCore(room) };
+    return { roomId };
   } catch (err) {
     if (err instanceof WarRoomApiError) {
       // Idempotent re-delivery — server already has a room for this
@@ -147,22 +170,3 @@ export async function maybeCreatePrReviewRoom(
   }
 }
 
-/**
- * Server returns the RoomCore record on POST /api/rooms 201 — the
- * response shape includes `roomId` as a top-level field (mirrored
- * from the storage layer's `RoomCoreWithId` type added in
- * D.1.b-iii). Extract it defensively in case the wire shape adds
- * fields.
- */
-function extractRoomIdFromCore(room: unknown): string {
-  if (typeof room !== "object" || room === null) return "";
-  const roomId = (room as Record<string, unknown>).roomId;
-  if (typeof roomId !== "string") {
-    // Server response without roomId — log + return empty; caller
-    // will surface it as a regular result with no roomId, since
-    // the room WAS created (server returned 201). The bot just
-    // can't reference it.
-    return "";
-  }
-  return roomId;
-}

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -1,0 +1,168 @@
+/**
+ * War-room routing helpers — wrap `WarRoomClient` calls with the
+ * bot's "auth-gated, idempotency-aware, non-fatal-on-error" policy.
+ *
+ * Design intent (Phase E):
+ *   - Construction is LAZY — missing `HIVEMOOT_BOT_AGENT_TOKEN`
+ *     env var doesn't crash module load. The bot's existing
+ *     governance features keep working without war-room
+ *     integration; war-room is opt-in via env config until
+ *     Phase H fleet migration.
+ *   - Idempotent on webhook re-delivery — a `subject_already_open`
+ *     409 is treated as success; the existing room is reused.
+ *   - Non-fatal on error — war-room failures are logged but never
+ *     thrown, so a 500 from the API can't break the PR's existing
+ *     intake / governance flow. GitHub re-delivers webhooks on its
+ *     own cadence; we'll get another shot.
+ */
+
+import { WarRoomClient, WarRoomApiError, prSubjectRef } from "./war-room-client.js";
+import type { Logger } from "pino";
+
+interface MaybeCreatePrReviewRoomArgs {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  log: Pick<Logger, "info" | "warn" | "error">;
+}
+
+interface MaybeCreatePrReviewRoomResult {
+  /** The war-room roomId (newly created OR reused via the
+   * idempotent 409 path). `null` when the bot has no agent token
+   * configured (war-room is disabled in this deployment). */
+  roomId: string | null;
+  /** Why the room wasn't created when `roomId === null`. Useful for
+   * test assertions; logged at info. */
+  skipped?: "no_token" | "api_error";
+}
+
+/**
+ * Create a `pr_review` war room for an opened PR. Returns null and
+ * logs a structured info line when:
+ *   - `HIVEMOOT_BOT_AGENT_TOKEN` env is unset (bot opted out)
+ *   - The API call fails with a 5xx / network error (transient;
+ *     GitHub will re-deliver the webhook)
+ *
+ * On `subject_already_open` 409 (re-delivery for a PR we already
+ * have a room for), returns the `existingRoomId` from the response
+ * — the bot treats this as success.
+ */
+export async function maybeCreatePrReviewRoom(
+  args: MaybeCreatePrReviewRoomArgs,
+): Promise<MaybeCreatePrReviewRoomResult> {
+  const token = process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+  if (!token) {
+    args.log.info(
+      {
+        owner: args.owner,
+        repo: args.repo,
+        pr: args.prNumber,
+      },
+      "[war-room] HIVEMOOT_BOT_AGENT_TOKEN unset — skipping war-room creation. Set the env var to enable Phase E webhook routing.",
+    );
+    return { roomId: null, skipped: "no_token" };
+  }
+
+  let client: WarRoomClient;
+  try {
+    client = new WarRoomClient({ log: args.log });
+  } catch (err) {
+    // Construction can throw (invalid baseUrl etc.) — log and skip.
+    args.log.error(
+      {
+        err,
+        owner: args.owner,
+        repo: args.repo,
+        pr: args.prNumber,
+      },
+      "[war-room] failed to construct WarRoomClient — skipping war-room creation.",
+    );
+    return { roomId: null, skipped: "api_error" };
+  }
+
+  const subject = prSubjectRef({
+    owner: args.owner,
+    repo: args.repo,
+    prNumber: args.prNumber,
+  });
+
+  try {
+    const room = await client.createRoom({ subject });
+    args.log.info(
+      {
+        owner: args.owner,
+        repo: args.repo,
+        pr: args.prNumber,
+        roomId: extractRoomIdFromCore(room),
+      },
+      "[war-room] created pr_review room",
+    );
+    return { roomId: extractRoomIdFromCore(room) };
+  } catch (err) {
+    if (err instanceof WarRoomApiError) {
+      // Idempotent re-delivery — server already has a room for this
+      // subject, reuse the existing roomId.
+      if (err.code === "subject_already_open") {
+        const existingRoomId = err.response.existingRoomId;
+        if (typeof existingRoomId === "string") {
+          args.log.info(
+            {
+              owner: args.owner,
+              repo: args.repo,
+              pr: args.prNumber,
+              existingRoomId,
+            },
+            "[war-room] subject_already_open — reusing existing room (webhook re-delivery)",
+          );
+          return { roomId: existingRoomId };
+        }
+      }
+      // Other 4xx → caller config / programmer error. Log loud +
+      // skip; don't retry on next webhook (it'll fail the same way).
+      args.log.error(
+        {
+          err,
+          status: err.status,
+          code: err.code,
+          owner: args.owner,
+          repo: args.repo,
+          pr: args.prNumber,
+        },
+        "[war-room] API rejected createRoom — skipping",
+      );
+      return { roomId: null, skipped: "api_error" };
+    }
+    // Network / 5xx → transient. Log + skip; webhook re-delivery
+    // will retry.
+    args.log.warn(
+      {
+        err,
+        owner: args.owner,
+        repo: args.repo,
+        pr: args.prNumber,
+      },
+      "[war-room] createRoom transient error — skipping (will retry on next webhook delivery)",
+    );
+    return { roomId: null, skipped: "api_error" };
+  }
+}
+
+/**
+ * Server returns the RoomCore record on POST /api/rooms 201 — the
+ * response shape includes `roomId` as a top-level field (mirrored
+ * from the storage layer's `RoomCoreWithId` type added in
+ * D.1.b-iii). Extract it defensively in case the wire shape adds
+ * fields.
+ */
+function extractRoomIdFromCore(room: unknown): string {
+  if (typeof room !== "object" || room === null) return "";
+  const roomId = (room as Record<string, unknown>).roomId;
+  if (typeof roomId !== "string") {
+    // Server response without roomId — log + return empty; caller
+    // will surface it as a regular result with no roomId, since
+    // the room WAS created (server returned 201). The bot just
+    // can't reference it.
+    return "";
+  }
+  return roomId;
+}


### PR DESCRIPTION
Fixes #525

## Summary

First slice of Phase E (bot webhook event routing). Adds the bot-side war-room HTTP client + the simplest webhook integration: \`pull_request.opened\` → \`createRoom(pr_review)\`.

## What it looks like

**Architecture:**

```
GitHub webhook (PR opened)
    ↓
bot/api/github/webhooks/index.ts (existing handler)
    ↓
[existing intake/governance flow runs first]
    ↓
maybeCreatePrReviewRoom (NEW)
    ↓ (HIVEMOOT_BOT_AGENT_TOKEN set?)
WarRoomClient.createRoom (NEW)
    ↓
POST hivemoot.dev/api/rooms (Phase D.1.b-ii)
    ↓
RoomCore { roomId, ... }
```

**Auth-gated, idempotency-aware, non-fatal-on-error policy:**

| Condition | Behavior |
|---|---|
| \`HIVEMOOT_BOT_AGENT_TOKEN\` unset | log info + skip (war-room is opt-in until Phase H) |
| 201 (created) | log info, return roomId |
| 409 \`subject_already_open\` (webhook re-delivery) | log info, reuse \`existingRoomId\` |
| 4xx (validation) | log error + skip (config bug; don't retry) |
| 5xx / network error | log warn + skip (transient; webhook re-delivery handles retry) |
| Anything else | swallow + log (NEVER throw — webhook contract) |

**Why non-fatal:** the bot's existing PR intake / governance / automerge flow MUST keep working even if the war-room API is down. The integration is additive, not coupled.

**Sample log lines:**

```
[INFO] [war-room] HIVEMOOT_BOT_AGENT_TOKEN unset — skipping war-room creation. Set the env var to enable Phase E webhook routing.
[INFO] [war-room] created pr_review room  { owner, repo, pr, roomId }
[INFO] [war-room] subject_already_open — reusing existing room (webhook re-delivery)  { ..., existingRoomId }
[WARN] [war-room] createRoom transient error — skipping (will retry on next webhook delivery)
```

## What's NOT in this slice

| Future slice | Scope |
|---|---|
| E.2 | \`subject_updated\` event emission on \`pull_request.synchronize\` (PR rebased / new commits) |
| E.3 | \`terminateRoom\` on \`pull_request.closed\` (room cleanup on PR close/merge) |
| E.4 | \`mention_response\` room creation on issue/PR comment with @hivemoot |
| Phase H | Per-repo opt-in via repoConfig (controls which installations roll forward to war-room model) |

## Test plan

- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Full bot suite passes: **1733 tests** (was 1714, +19)
- [x] WarRoomClient (12 tests):
  - Construction guards: missing token, missing scheme, trailing slash strip
  - Auth header: \`Bearer \${token}\`
  - Body shape: subject + optional manager/timing/roomId
  - Error mapping: subject_already_open 409 → typed error with existingRoomId; non-JSON 5xx → unknown code; AbortError → timeout message
- [x] maybeCreatePrReviewRoom (7 tests):
  - No-token → skipped
  - Happy path returns roomId
  - Idempotent re-delivery via 409 path
  - 4xx → skipped:'api_error' + log.error
  - 5xx/network → skipped:'api_error' + log.warn
  - Construction error → skipped:'api_error' + log.error
  - Unexpected error type → never throws (webhook contract)
- [ ] Reviewer fleet sign-off

## Deployment notes

After merge, set \`HIVEMOOT_BOT_AGENT_TOKEN\` in the bot's deployment env (Vercel dashboard → Settings → Environment Variables). The token must be a V1 capability bearer with at least \`rooms.create\` (queen preset includes this). Until set, the integration silently no-ops.