### PR TITLE
Phase E.2 — subject_updated events on PR synchronize/closed

### DIFF
--- a/bot/api/github/webhooks/index.ts
+++ b/bot/api/github/webhooks/index.ts
@@ -31,7 +31,7 @@ import { parseCommand, executeCommand, retryQueuedSquash, autoGatherIfEligible }
 import { getLLMReadiness } from "../../lib/llm/provider.js";
 import { registerHandlerDispatcher } from "../../handlers/dispatcher.js";
 import { handlerEventMap } from "../../handlers/registry.js";
-import { maybeCreatePrReviewRoom } from "../../lib/war-room-routing.js";
+import { maybeCreatePrReviewRoom, maybeEmitSubjectUpdated } from "../../lib/war-room-routing.js";
 
 /**
  * Hivemoot Bot - Governance Automation
@@ -342,6 +342,20 @@ export function app(probotApp: Probot): void {
           graphql: context.octokit,
         });
       }
+
+      // Phase E.2 — emit subject_updated event for war-room workers.
+      // Same non-fatal contract as E.1: failures log + return; never
+      // break the existing intake flow. The deterministic roomId
+      // derivation (derivePrRoomId) means we hit the same room as
+      // the E.1 create call without any lookup.
+      await maybeEmitSubjectUpdated({
+        owner,
+        repo,
+        prNumber: number,
+        changeKind: "synchronize",
+        headSha: context.payload.pull_request.head?.sha,
+        log: context.log,
+      });
     } catch (error) {
       context.log.error({ err: error, pr: number, repo: fullName }, "Failed to process PR update");
       throw error;
@@ -643,6 +657,20 @@ export function app(probotApp: Probot): void {
         const prRef = { owner, repo, prNumber: number };
         await prs.removeGovernanceLabels(prRef);
         await recalculateLeaderboardForPR(context.octokit, context.log, owner, repo, number);
+
+        // Phase E.2 — emit subject_updated event signaling the PR
+        // closed without merge. Workers' triage logic can short-
+        // circuit on this; the watchdog will eventually expire the
+        // room via max_age. Explicit terminate-on-close lands in a
+        // future slice (capability scoping needed — bot doesn't
+        // have rooms.force_close in the queen preset).
+        await maybeEmitSubjectUpdated({
+          owner,
+          repo,
+          prNumber: number,
+          changeKind: "closed",
+          log: context.log,
+        });
       } catch (error) {
         context.log.error({ err: error, pr: number, repo: fullName }, "Failed to process closed PR");
         throw error;
@@ -685,6 +713,17 @@ export function app(probotApp: Probot): void {
           }
         }
       }
+
+      // Phase E.2 — subject_updated for merged PRs. Same rationale
+      // as the closed-without-merge path: workers see the event
+      // and short-circuit. Watchdog handles eventual room expiry.
+      await maybeEmitSubjectUpdated({
+        owner,
+        repo,
+        prNumber: number,
+        changeKind: "closed",
+        log: context.log,
+      });
     } catch (error) {
       context.log.error({ err: error, pr: number, repo: fullName }, "Failed to process merged PR");
       throw error;

--- a/bot/api/lib/war-room-client.test.ts
+++ b/bot/api/lib/war-room-client.test.ts
@@ -201,3 +201,89 @@ describe("prSubjectRef helper", () => {
       .toEqual({ type: "pr_review", ref: "hivemoot/hivemoot#42" });
   });
 });
+
+describe("WarRoomClient.appendEvent (E.2)", () => {
+  const ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+  it("happy path → 200 returns sequence", async () => {
+    const fetchSpy = makeFetch({ status: 200, body: { sequence: 5 } });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const result = await client.appendEvent({
+      roomId: ROOM_ID,
+      eventType: "subject_updated",
+      body: { change_kind: "synchronize" },
+      idempotencyKey: "stable-key",
+    });
+    expect(result.sequence).toBe(5);
+  });
+
+  it("hits the correct path with roomId URI-encoded", async () => {
+    const fetchSpy = makeFetch({ status: 200, body: { sequence: 1 } });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.appendEvent({
+      roomId: ROOM_ID,
+      eventType: "subject_updated",
+      body: {},
+      idempotencyKey: "k",
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://www.hivemoot.dev/api/rooms/${ROOM_ID}/event`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("body includes event_type, body, idempotencyKey", async () => {
+    const fetchSpy = makeFetch({ status: 200, body: { sequence: 1 } });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.appendEvent({
+      roomId: ROOM_ID,
+      eventType: "subject_updated",
+      body: { change_kind: "synchronize", head_sha: "abc" },
+      idempotencyKey: "key-1",
+    });
+    const callArgs = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).toEqual({
+      event_type: "subject_updated",
+      body: { change_kind: "synchronize", head_sha: "abc" },
+      idempotencyKey: "key-1",
+    });
+  });
+
+  it("replay (200 with replay flag) deserializes correctly", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { sequence: 3, replay: true },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const result = await client.appendEvent({
+      roomId: ROOM_ID,
+      eventType: "subject_updated",
+      body: {},
+      idempotencyKey: "k",
+    });
+    expect(result.sequence).toBe(3);
+    expect(result.replay).toBe(true);
+  });
+
+  it("404 room_not_found → WarRoomApiError(code='room_not_found')", async () => {
+    const fetchSpy = makeFetch({
+      status: 404,
+      body: { code: "room_not_found", message: "missing" },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.appendEvent({
+        roomId: ROOM_ID,
+        eventType: "subject_updated",
+        body: {},
+        idempotencyKey: "k",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WarRoomApiError);
+      expect((err as WarRoomApiError).code).toBe("room_not_found");
+      expect((err as WarRoomApiError).status).toBe(404);
+    }
+  });
+});

--- a/bot/api/lib/war-room-client.ts
+++ b/bot/api/lib/war-room-client.ts
@@ -187,6 +187,57 @@ export class WarRoomClient {
     throw new WarRoomApiError(response.status, code, message, parsed);
   }
 
+  /**
+   * Append a meta-event to a room's event log. Used by the bot's
+   * webhook routing for `subject_updated` (PR rebased / new
+   * commits) and `queen_question` events. The route's whitelist
+   * enforces these are the only event types accepted via this
+   * generic surface (lifecycle events go through their dedicated
+   * endpoints).
+   *
+   * Idempotency: the route accepts either a caller-supplied
+   * `idempotencyKey` OR a `sequenceObservedByClient` for server-side
+   * derivation. The bot doesn't track sequence numbers, so it
+   * passes a stable hash-derived key per (roomId, action, payload-fingerprint).
+   *
+   * Returns the event's sequence on success. On replay (server
+   * already processed this idempotency key), the route returns
+   * `{ sequence, replay: true }` — both shapes deserialize cleanly.
+   */
+  async appendEvent(args: {
+    roomId: string;
+    eventType: "subject_updated" | "queen_question";
+    body: Record<string, unknown>;
+    idempotencyKey: string;
+  }): Promise<{ sequence: number; replay?: boolean }> {
+    const response = await this.request(
+      "POST",
+      `/api/rooms/${encodeURIComponent(args.roomId)}/event`,
+      {
+        event_type: args.eventType,
+        body: args.body,
+        idempotencyKey: args.idempotencyKey,
+      },
+    );
+
+    if (response.ok) {
+      return (await response.json()) as { sequence: number; replay?: boolean };
+    }
+
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = (await response.json()) as Record<string, unknown>;
+    } catch {
+      // Non-JSON error body — fall through.
+    }
+    const code = typeof parsed.code === "string" ? parsed.code : "unknown";
+    const message =
+      typeof parsed.message === "string"
+        ? parsed.message
+        : `War-room API ${response.status} (${code})`;
+    throw new WarRoomApiError(response.status, code, message, parsed);
+  }
+
   /** Internal: shared request shape. */
   private async request(
     method: "GET" | "POST" | "DELETE",

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { maybeCreatePrReviewRoom } from "./war-room-routing.js";
+import {
+  maybeCreatePrReviewRoom,
+  maybeEmitSubjectUpdated,
+  derivePrRoomId,
+} from "./war-room-routing.js";
 import { WarRoomApiError } from "./war-room-client.js";
 
 vi.mock("./war-room-client.js", async () => {
@@ -85,15 +89,23 @@ describe("maybeCreatePrReviewRoom", () => {
     });
 
     // Round-trip equality: the roomId returned by the helper must
-    // be the same UUIDv4 it passed into createRoom. If a future
-    // refactor breaks this thread-through, this test catches it.
+    // be the same UUIDv4-shaped value it passed into createRoom.
+    // E.2 changed the source from randomUUID() to the deterministic
+    // derivePrRoomId helper — same PR identity always maps to the
+    // same roomId across opened/synchronize/closed events.
     expect(typeof result.roomId).toBe("string");
     expect(result.roomId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
+    const expectedRoomId = derivePrRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+    });
+    expect(result.roomId).toBe(expectedRoomId);
     expect(createRoom).toHaveBeenCalledWith({
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#42" },
-      roomId: result.roomId,
+      roomId: expectedRoomId,
     });
     expect(log.info).toHaveBeenCalledWith(
       expect.objectContaining({ roomId: result.roomId }),
@@ -210,5 +222,189 @@ describe("maybeCreatePrReviewRoom", () => {
         log,
       }),
     ).resolves.toEqual({ roomId: null, skipped: "api_error" });
+  });
+});
+
+describe("derivePrRoomId (E.2 deterministic helper)", () => {
+  it("same PR identity → same roomId across calls", () => {
+    const a = derivePrRoomId({ owner: "hivemoot", repo: "hivemoot", prNumber: 42 });
+    const b = derivePrRoomId({ owner: "hivemoot", repo: "hivemoot", prNumber: 42 });
+    expect(a).toBe(b);
+  });
+
+  it("different PRs → different roomIds", () => {
+    const a = derivePrRoomId({ owner: "hivemoot", repo: "hivemoot", prNumber: 42 });
+    const b = derivePrRoomId({ owner: "hivemoot", repo: "hivemoot", prNumber: 43 });
+    const c = derivePrRoomId({ owner: "hivemoot", repo: "colony", prNumber: 42 });
+    const d = derivePrRoomId({ owner: "other", repo: "hivemoot", prNumber: 42 });
+    expect(new Set([a, b, c, d]).size).toBe(4);
+  });
+
+  it("output matches storage layer's UUIDv4 regex (so rooms.create accepts it)", () => {
+    const id = derivePrRoomId({ owner: "x", repo: "y", prNumber: 1 });
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe("maybeEmitSubjectUpdated", () => {
+  beforeEach(() => {
+    delete process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+    log.info.mockReset();
+    log.warn.mockReset();
+    log.error.mockReset();
+    mockedClientCtor.mockReset();
+  });
+
+  it("skips with `no_token` when env var unset", async () => {
+    const result = await maybeEmitSubjectUpdated({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      changeKind: "synchronize",
+      log,
+    });
+    expect(result).toEqual({ sequence: null, skipped: "no_token" });
+    expect(mockedClientCtor).not.toHaveBeenCalled();
+  });
+
+  it("happy path: sends subject_updated with deterministic roomId + idempotencyKey", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const appendEvent = vi.fn(async () => ({ sequence: 5, replay: false }));
+    mockedClientCtor.mockImplementation(
+      function (this: { appendEvent: typeof appendEvent }) {
+        this.appendEvent = appendEvent;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeEmitSubjectUpdated({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      changeKind: "synchronize",
+      headSha: "abc123def",
+      log,
+    });
+    expect(result.sequence).toBe(5);
+
+    const expectedRoomId = derivePrRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+    });
+    expect(appendEvent).toHaveBeenCalledWith({
+      roomId: expectedRoomId,
+      eventType: "subject_updated",
+      body: { change_kind: "synchronize", head_sha: "abc123def" },
+      idempotencyKey: `bot.subject_updated.${expectedRoomId}.synchronize.abc123def`,
+    });
+  });
+
+  it("idempotency key derives from headSha — same sha twice = same key (re-delivery dedupe)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const appendEvent = vi.fn(async () => ({ sequence: 5 }));
+    mockedClientCtor.mockImplementation(
+      function (this: { appendEvent: typeof appendEvent }) {
+        this.appendEvent = appendEvent;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    await maybeEmitSubjectUpdated({
+      owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+      changeKind: "synchronize", headSha: "sha-A", log,
+    });
+    await maybeEmitSubjectUpdated({
+      owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+      changeKind: "synchronize", headSha: "sha-A", log,
+    });
+    await maybeEmitSubjectUpdated({
+      owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+      changeKind: "synchronize", headSha: "sha-B", log,
+    });
+
+    const calls = appendEvent.mock.calls;
+    expect(calls[0][0].idempotencyKey).toBe(calls[1][0].idempotencyKey);
+    expect(calls[0][0].idempotencyKey).not.toBe(calls[2][0].idempotencyKey);
+  });
+
+  it("room_not_found 404 → returns skipped:'no_room' (PR opened pre-war-room)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const appendEvent = vi.fn(async () => {
+      throw new WarRoomApiError(404, "room_not_found", "missing", {});
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { appendEvent: typeof appendEvent }) {
+        this.appendEvent = appendEvent;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeEmitSubjectUpdated({
+      owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+      changeKind: "synchronize", log,
+    });
+    expect(result).toEqual({ sequence: null, skipped: "no_room" });
+  });
+
+  it("status_precondition_failed (queen claimed) → skipped:'api_error', logged warn", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const appendEvent = vi.fn(async () => {
+      throw new WarRoomApiError(
+        409,
+        "status_precondition_failed",
+        "deciding",
+        { actualStatus: "deciding" },
+      );
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { appendEvent: typeof appendEvent }) {
+        this.appendEvent = appendEvent;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeEmitSubjectUpdated({
+      owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+      changeKind: "synchronize", log,
+    });
+    expect(result).toEqual({ sequence: null, skipped: "api_error" });
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  it("changeKind 'closed' (no headSha) is supported", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const appendEvent = vi.fn(async () => ({ sequence: 7 }));
+    mockedClientCtor.mockImplementation(
+      function (this: { appendEvent: typeof appendEvent }) {
+        this.appendEvent = appendEvent;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    const result = await maybeEmitSubjectUpdated({
+      owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+      changeKind: "closed", log,
+    });
+    expect(result.sequence).toBe(7);
+    const callArgs = appendEvent.mock.calls[0][0];
+    expect(callArgs.body).toEqual({ change_kind: "closed" });
+    expect(callArgs.idempotencyKey).toContain("no-sha");
+  });
+
+  it("never throws — webhook handler relies on this for non-fatal contract", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "hmt_x";
+    const appendEvent = vi.fn(async () => {
+      throw new TypeError("totally unexpected");
+    });
+    mockedClientCtor.mockImplementation(
+      function (this: { appendEvent: typeof appendEvent }) {
+        this.appendEvent = appendEvent;
+      } as unknown as typeof WarRoomClient,
+    );
+
+    await expect(
+      maybeEmitSubjectUpdated({
+        owner: "hivemoot", repo: "hivemoot", prNumber: 42,
+        changeKind: "synchronize", log,
+      }),
+    ).resolves.toEqual({ sequence: null, skipped: "api_error" });
   });
 });

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -27,7 +27,47 @@
 
 import { WarRoomClient, WarRoomApiError, prSubjectRef } from "./war-room-client.js";
 import type { Logger } from "pino";
-import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
+
+/**
+ * Derive a deterministic UUIDv4-shaped roomId from a PR's identity.
+ * Both `pull_request.opened` (E.1) and `pull_request.synchronize`
+ * (E.2) call this with the same arguments and get the same roomId
+ * — so the bot can act on the room across webhook events without
+ * first looking it up.
+ *
+ * Why deterministic: webhooks for the same PR fire from different
+ * bot processes / deliveries. Without a deterministic derivation,
+ * each fire would mint a fresh UUID, hitting the storage layer's
+ * `subject_already_open` 409 every time and forcing an extra
+ * round-trip to recover the existing roomId.
+ *
+ * SHA-256(`${owner}/${repo}#${prNumber}`) → first 32 hex chars,
+ * formatted as UUIDv4 (set version + variant bits per RFC 4122).
+ * The storage layer's regex
+ * `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`
+ * enforces UUIDv4 format; this helper produces a string that
+ * matches that regex while remaining stable per PR.
+ */
+export function derivePrRoomId(args: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}): string {
+  const subject = `${args.owner}/${args.repo}#${args.prNumber}`;
+  const hash = createHash("sha256").update(subject).digest("hex");
+  // Format hex chars as UUID: 8-4-4-4-12.
+  // Then patch the version nibble (13th hex char → "4") and the
+  // variant nibble (17th hex char → 8/9/a/b) to satisfy UUIDv4.
+  const chars = hash.slice(0, 32).split("");
+  chars[12] = "4"; // version 4
+  // Variant bits: top two bits of byte 8 must be 10. Mask the high
+  // nibble: 0b10xx → "8" | "9" | "a" | "b".
+  const variantNibble = (parseInt(chars[16], 16) & 0x3) | 0x8;
+  chars[16] = variantNibble.toString(16);
+  const joined = chars.join("");
+  return `${joined.slice(0, 8)}-${joined.slice(8, 12)}-${joined.slice(12, 16)}-${joined.slice(16, 20)}-${joined.slice(20, 32)}`;
+}
 
 interface MaybeCreatePrReviewRoomArgs {
   owner: string;
@@ -96,18 +136,16 @@ export async function maybeCreatePrReviewRoom(
     prNumber: args.prNumber,
   });
 
-  // Bot-side mint of the roomId (closes #526 guard B1). The server
-  // accepts a caller-supplied roomId via POST /api/rooms body and
-  // falls back to its own crypto.randomUUID() if omitted. The
-  // 201 response serializes RoomCore (NOT RoomCoreWithId) — no
-  // roomId in the body — so threading the minted value through
-  // makes the contract self-consistent: caller knows the roomId
-  // before the round-trip, no response-shape dependency.
-  //
-  // Future E.x slices (subject_updated, terminate, post-PR-comment
-  // referencing the room) get the roomId for free via this return
-  // value.
-  const roomId = randomUUID();
+  // Deterministic roomId derived from the PR identity (E.2).
+  // Same `owner/repo#N` always maps to the same UUIDv4-shaped id,
+  // so synchronize / closed events can hit the same room without
+  // a server-side lookup. Closes #526 guard B1 (no dependency on
+  // the POST 201 response shape — bot owns the id end-to-end).
+  const roomId = derivePrRoomId({
+    owner: args.owner,
+    repo: args.repo,
+    prNumber: args.prNumber,
+  });
 
   try {
     await client.createRoom({ subject, roomId });
@@ -167,6 +205,159 @@ export async function maybeCreatePrReviewRoom(
       "[war-room] createRoom transient error — skipping (will retry on next webhook delivery)",
     );
     return { roomId: null, skipped: "api_error" };
+  }
+}
+
+interface MaybeEmitSubjectUpdatedArgs {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  /** What changed — included in the event body for forensic /
+   * worker-triage signal. */
+  changeKind: "synchronize" | "closed" | "reopened";
+  /** Optional: head SHA after the change (for synchronize events).
+   * Lets workers' triage logic detect "did the diff actually
+   * change" vs "noise event". */
+  headSha?: string;
+  log: Pick<Logger, "info" | "warn" | "error">;
+}
+
+interface MaybeEmitSubjectUpdatedResult {
+  /** Sequence the event landed at, OR null when skipped. */
+  sequence: number | null;
+  skipped?: "no_token" | "api_error" | "no_room";
+}
+
+/**
+ * Emit a `subject_updated` event on the war-room corresponding to
+ * a PR (synchronize / closed / reopened). Returns null + skipped
+ * code when:
+ *   - `HIVEMOOT_BOT_AGENT_TOKEN` env unset (war-room disabled)
+ *   - The room doesn't exist (PR never had a war-room — likely a
+ *     PR opened before war-room integration was enabled, or
+ *     transient API failure on E.1's create call)
+ *   - Status precondition fail (room is `closed` or `deciding` —
+ *     queen has the claim or it's already terminal)
+ *   - Network / 5xx (transient; webhook re-delivery doesn't fire
+ *     because the helper still returns 200 to GitHub)
+ *
+ * Idempotency: caller-supplied key derives from a stable
+ * `(roomId, action, headSha)` tuple — webhook re-deliveries with
+ * the same head SHA don't duplicate events.
+ *
+ * Status precondition (`awaiting_rsvp` / `awaiting_contributions`
+ * only): if the queen has claimed the room (status `deciding`),
+ * the bot's webhook event is buffered until queen releases — that
+ * deferral mechanism is Phase G' (queen module). For E.2, a
+ * `status_precondition_failed` 409 is logged + skipped; no
+ * automatic retry.
+ */
+export async function maybeEmitSubjectUpdated(
+  args: MaybeEmitSubjectUpdatedArgs,
+): Promise<MaybeEmitSubjectUpdatedResult> {
+  const token = process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+  if (!token) {
+    args.log.info(
+      { owner: args.owner, repo: args.repo, pr: args.prNumber },
+      "[war-room] HIVEMOOT_BOT_AGENT_TOKEN unset — skipping subject_updated",
+    );
+    return { sequence: null, skipped: "no_token" };
+  }
+
+  let client: WarRoomClient;
+  try {
+    client = new WarRoomClient({ log: args.log });
+  } catch (err) {
+    args.log.error(
+      { err, owner: args.owner, repo: args.repo, pr: args.prNumber },
+      "[war-room] failed to construct WarRoomClient — skipping subject_updated",
+    );
+    return { sequence: null, skipped: "api_error" };
+  }
+
+  const roomId = derivePrRoomId({
+    owner: args.owner,
+    repo: args.repo,
+    prNumber: args.prNumber,
+  });
+
+  // Idempotency key derived from (roomId, action, headSha). Same
+  // PR + same head SHA = same key, so re-delivery of the same
+  // synchronize event doesn't duplicate the audit entry.
+  const idempotencyKey = `bot.subject_updated.${roomId}.${args.changeKind}.${args.headSha ?? "no-sha"}`;
+
+  const body: Record<string, unknown> = {
+    change_kind: args.changeKind,
+  };
+  if (args.headSha !== undefined) body.head_sha = args.headSha;
+
+  try {
+    const result = await client.appendEvent({
+      roomId,
+      eventType: "subject_updated",
+      body,
+      idempotencyKey,
+    });
+    args.log.info(
+      {
+        owner: args.owner,
+        repo: args.repo,
+        pr: args.prNumber,
+        roomId,
+        sequence: result.sequence,
+        replay: result.replay ?? false,
+        changeKind: args.changeKind,
+      },
+      "[war-room] emitted subject_updated event",
+    );
+    return { sequence: result.sequence };
+  } catch (err) {
+    if (err instanceof WarRoomApiError) {
+      if (err.code === "room_not_found") {
+        // Room doesn't exist for this PR — likely the PR was
+        // opened before war-room integration was enabled, or
+        // E.1's create call failed transiently. Log + skip.
+        args.log.info(
+          {
+            owner: args.owner,
+            repo: args.repo,
+            pr: args.prNumber,
+            roomId,
+            changeKind: args.changeKind,
+          },
+          "[war-room] room not found for PR — likely opened pre-war-room or E.1 failed; skipping subject_updated",
+        );
+        return { sequence: null, skipped: "no_room" };
+      }
+      // Status precondition (`closed` / `deciding`), validation,
+      // etc. — log + skip.
+      args.log.warn(
+        {
+          err,
+          status: err.status,
+          code: err.code,
+          owner: args.owner,
+          repo: args.repo,
+          pr: args.prNumber,
+          roomId,
+          changeKind: args.changeKind,
+        },
+        "[war-room] API rejected subject_updated — skipping (queen-claimed or terminal room)",
+      );
+      return { sequence: null, skipped: "api_error" };
+    }
+    args.log.warn(
+      {
+        err,
+        owner: args.owner,
+        repo: args.repo,
+        pr: args.prNumber,
+        roomId,
+        changeKind: args.changeKind,
+      },
+      "[war-room] subject_updated transient error — skipping (no auto-retry; see file docstring)",
+    );
+    return { sequence: null, skipped: "api_error" };
   }
 }
 


### PR DESCRIPTION
Fixes #527

## Summary

Second slice of Phase E. The bot now emits \`subject_updated\` events to the war-room API on \`pull_request.synchronize\` (PR rebased / new commits pushed) and \`pull_request.closed\` (both merged + non-merged paths). Workers' triage logic uses these events to detect "did the diff change since I last looked" and short-circuit on dead PRs.

## What it looks like

**Deterministic roomId** (closes the "how does synchronize find E.1's room" question):

```
derivePrRoomId({ owner, repo, prNumber })
  → SHA-256(\`\${owner}/\${repo}#\${prNumber}\`)
  → patch version+variant nibbles → UUIDv4 format
  → e.g. "deadbeef-cafe-4f00-9abc-def123456789"
```

Same input ALWAYS produces same output. \`maybeCreatePrReviewRoom\` (E.1) and \`maybeEmitSubjectUpdated\` (E.2) call it with the same args; both hit the same room. No server-side lookup needed across webhook events.

**Refactor**: E.1's \`maybeCreatePrReviewRoom\` switched from \`randomUUID()\` to \`derivePrRoomId(...)\`. The bot still owns the roomId end-to-end (no dependency on POST /api/rooms response shape), but now it's predictable across events.

**Idempotency on re-delivery:**

```
idempotencyKey = \`bot.subject_updated.\${roomId}.\${change_kind}.\${headSha ?? "no-sha"}\`
```

Same PR + same head SHA = same key. Webhook re-delivery for the same synchronize event hits the storage layer's idempotency check and returns 200 with \`replay: true\`. New commits = new SHA = new key = new event.

**Status precondition handling:**

| Server response | Bot behavior |
|---|---|
| 200 (event landed) | log info, return sequence |
| 200 \`replay: true\` (idempotency dedupe) | log info, return sequence |
| 404 \`room_not_found\` (PR opened pre-war-room) | log info, skipped: 'no_room' |
| 409 \`status_precondition_failed\` (queen claimed OR room closed) | log warn, skipped: 'api_error' |
| 5xx / network error | log warn, skipped: 'api_error' |

The deferred-on-deciding mechanism (queen has the claim → buffer events) is Phase G' (queen module). For E.2, status_precondition_failed is logged + dropped; no auto-retry.

**Wire-up:**

```typescript
// pull_request.synchronize
await maybeEmitSubjectUpdated({
  owner, repo, prNumber: number,
  changeKind: "synchronize",
  headSha: context.payload.pull_request.head?.sha,
  log: context.log,
});

// pull_request.closed (both merged and non-merged paths)
await maybeEmitSubjectUpdated({
  owner, repo, prNumber: number,
  changeKind: "closed",
  log: context.log,
});
```

Same non-fatal contract as E.1 — failures here can't break the existing intake/governance/automerge flow.

## Out of scope (future slices)

- E.3 — \`mention_response\` room creation on @hivemoot mentions
- Explicit terminate-on-close — capability scoping needed (bot's queen preset doesn't include \`rooms.force_close\`); watchdog handles eventual room expiry via \`max_age_secs\`

## Test plan

- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Full bot suite passes: **1748 tests** (was 1733, +15)
- [x] derivePrRoomId determinism: same PR → same id; different PRs → different ids; output matches storage UUIDv4 regex
- [x] WarRoomClient.appendEvent (5 tests): happy path, URI-encoded path, body shape, replay deserialization, 404 error mapping
- [x] maybeEmitSubjectUpdated (7 tests): no-token skip, happy path with deterministic roomId+idempotency key, dedupe semantics across deliveries, room_not_found → no_room, status_precondition_failed → api_error, no-headSha closed event, never-throws contract
- [x] E.1 happy-path test updated to assert deterministic roomId
- [ ] Reviewer fleet sign-off