### PR TITLE
Phase F.1 — war-room HTTP client for worker runtime

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/http.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/http.py
@@ -95,3 +95,48 @@ def post_json(
         except json.JSONDecodeError:
             parsed = None
         return exc.code, parsed, raw
+
+
+def get_json(
+    url: str,
+    bearer: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> tuple[int, dict | None, bytes]:
+    """GET a URL with bearer auth, parse the response as JSON.
+
+    Mirrors `post_json` semantics — same redirect refusal, same
+    URL-scheme guard, same error → status-tuple shape. Used by
+    the war-room watcher plugin's `/api/rooms/watching` poll
+    (Phase F).
+    """
+    if not (url.startswith("http://") or url.startswith("https://")):
+        raise ValueError(f"bad URL scheme: {url}")
+
+    req = urllib.request.Request(url, method="GET")
+    if bearer:
+        req.add_header("Authorization", f"Bearer {bearer}")
+    if extra_headers:
+        for key, value in extra_headers.items():
+            req.add_header(key, value)
+
+    try:
+        with _OPENER.open(req, timeout=timeout) as resp:
+            raw = resp.read()
+            try:
+                parsed = json.loads(raw) if raw else None
+            except json.JSONDecodeError:
+                parsed = None
+            return resp.status, parsed, raw
+    except urllib.error.HTTPError as exc:
+        raw = b""
+        try:
+            raw = exc.read()
+        except Exception:
+            pass
+        try:
+            parsed = json.loads(raw) if raw else None
+        except json.JSONDecodeError:
+            parsed = None
+        return exc.code, parsed, raw

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
@@ -1,0 +1,32 @@
+"""War-room watcher plugin — agent runtime side.
+
+Phase F of the post-apiarist-V1 ultra plan. Workers (drone /
+builder / guard / etc.) poll `/api/rooms/watching` to discover
+rooms eligible for their role, then RSVP and contribute.
+
+V1 layering:
+  * `api` — HTTP client wrapping `/api/rooms/*` (this slice F.1)
+  * `trigger` — poll loop that drives watcher tick (future F.2)
+  * `dispatch` — per-room triage + heavy-contribution dispatch
+    (future F.3)
+
+The HTTP client uses the same shared transport (`..http`) and
+auth helper (`..auth`) as the existing tasks/health plugins.
+"""
+
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api import (
+    WatchingRoom,
+    list_watching_rooms,
+    present_to_room,
+    submit_contribution,
+    withdraw_participant,
+)
+
+
+__all__ = (
+    "WatchingRoom",
+    "list_watching_rooms",
+    "present_to_room",
+    "submit_contribution",
+    "withdraw_participant",
+)

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -1,0 +1,264 @@
+"""War-room API client — worker side.
+
+GETs `/api/rooms/watching` for the role-bound list of rooms this
+worker should attend to, and POSTs the lifecycle events
+(`/present`, `/contributions`, `/withdraw`).
+
+Auth: `rooms.watch` for `/watching`; `rooms.contribute` for the
+write paths. Both come from the worker's V1 capability bearer
+(provisioned via `apiary.secrets.yaml` and threaded through the
+existing ``..auth.resolve_agent_token`` helper).
+
+Transport: shared ``..http`` client. Same redirect refusal +
+URL-scheme guard as the tasks plugin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from hivemoot_agent.plugins_builtin.hivemoot.http import (
+    DEFAULT_TIMEOUT_SECS,
+    get_json,
+    post_json,
+)
+
+
+__all__ = (
+    "WatchingRoom",
+    "list_watching_rooms",
+    "present_to_room",
+    "submit_contribution",
+    "withdraw_participant",
+)
+
+
+@dataclass
+class WatchingRoom:
+    """One room from the `/watching` enriched response.
+
+    The watching endpoint pre-filters by the bearer's `agent_role`
+    via `canRoleRsvpToRoom` (storage layer). Workers don't need
+    to compute eligibility themselves — every room here is one
+    the role SHOULD act on.
+
+    Carries enough context (`core` + `participants` + `current_sequence`)
+    that the worker can decide RSVP-vs-contribute without a
+    follow-up read on the API.
+    """
+
+    room_id: str
+    status: str
+    subject_type: str
+    subject_ref: str
+    manager: str
+    opened_at: str
+    current_sequence: int
+    participants: dict[str, Any] = field(default_factory=dict)
+
+
+def _parse_room(entry: dict) -> WatchingRoom:
+    """Parse one `/watching` response entry. Defensive — server
+    may add fields; this client tolerates extras silently and
+    rejects only on missing-required."""
+    core = entry.get("core") or {}
+    participants = entry.get("participants") or {}
+    current_sequence = entry.get("currentSequence", 0)
+
+    room_id = str(core.get("roomId", "")).strip()
+    if not room_id:
+        raise RuntimeError(
+            "watching response entry missing core.roomId: "
+            f"{str(entry)[:200]}"
+        )
+    return WatchingRoom(
+        room_id=room_id,
+        status=str(core.get("status", "")),
+        subject_type=str(core.get("subject_type", "")),
+        subject_ref=str(core.get("subject_ref", "")),
+        manager=str(core.get("manager", "")),
+        opened_at=str(core.get("opened_at", "")),
+        current_sequence=int(current_sequence)
+        if isinstance(current_sequence, (int, str))
+        else 0,
+        participants=participants if isinstance(participants, dict) else {},
+    )
+
+
+def list_watching_rooms(
+    base_url: str,
+    bearer: str,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> list[WatchingRoom]:
+    """GET `{base_url}/api/rooms/watching`.
+
+    Returns the list of rooms eligible for the bearer's role.
+    Empty list when there's nothing to attend to (steady state
+    for an idle fleet).
+
+    Raises:
+        RuntimeError on non-200 status / malformed body. Trigger
+        loop's outer try/except engages backoff.
+    """
+    url = f"{base_url.rstrip('/')}/api/rooms/watching"
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+
+    if status != 200:
+        raise RuntimeError(
+            f"watching returned status {status}: "
+            f"{raw.decode(errors='replace')[:200]}"
+        )
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("watching response was not a JSON object")
+
+    rooms_raw = parsed.get("rooms")
+    if rooms_raw is None:
+        return []
+    if not isinstance(rooms_raw, list):
+        raise RuntimeError(
+            f"watching response `rooms` must be a list, got {type(rooms_raw).__name__}"
+        )
+
+    out: list[WatchingRoom] = []
+    for entry in rooms_raw:
+        if not isinstance(entry, dict):
+            continue
+        out.append(_parse_room(entry))
+    return out
+
+
+def present_to_room(
+    base_url: str,
+    room_id: str,
+    sequence_observed_by_client: int,
+    bearer: str,
+    *,
+    intent_hint: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> int:
+    """POST `{base_url}/api/rooms/{room_id}/present`.
+
+    The role + agent_id are server-derived from the bearer envelope —
+    the client doesn't pass them in the body. Sequence is the
+    `current_sequence` the worker observed on `/watching` (used for
+    idempotency).
+
+    Returns the sequence the `participant_presented` event landed at.
+
+    Raises:
+        RuntimeError on non-2xx / malformed body. Caller branches
+        on error message to detect benign races (e.g., status
+        moved, owner conflict from a sibling runner).
+    """
+    url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/present"
+    body: dict[str, Any] = {
+        "sequenceObservedByClient": sequence_observed_by_client,
+    }
+    if intent_hint is not None:
+        body["intentHint"] = intent_hint
+
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+
+    if status != 200:
+        raise RuntimeError(
+            f"present returned status {status}: "
+            f"{raw.decode(errors='replace')[:200]}"
+        )
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("present response was not a JSON object")
+
+    seq = parsed.get("sequence")
+    if not isinstance(seq, int):
+        raise RuntimeError(
+            f"present response missing/invalid `sequence`: {str(parsed)[:200]}"
+        )
+    return seq
+
+
+def submit_contribution(
+    base_url: str,
+    room_id: str,
+    sequence_observed_by_client: int,
+    contribution_body: dict[str, Any],
+    raw_md: str,
+    bearer: str,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> int:
+    """POST `{base_url}/api/rooms/{room_id}/contributions`.
+
+    Submits a typed contribution body (verdict + summary + findings)
+    plus the worker's raw markdown analysis. Both bounded server-
+    side (body schema + 32 KiB raw_md cap).
+
+    Returns the sequence the `contribution_submitted` event landed at.
+    """
+    url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/contributions"
+    body = {
+        "sequenceObservedByClient": sequence_observed_by_client,
+        "body": contribution_body,
+        "rawMd": raw_md,
+    }
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+
+    if status != 200:
+        raise RuntimeError(
+            f"contributions returned status {status}: "
+            f"{raw.decode(errors='replace')[:200]}"
+        )
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("contributions response was not a JSON object")
+
+    seq = parsed.get("sequence")
+    if not isinstance(seq, int):
+        raise RuntimeError(
+            f"contributions response missing/invalid `sequence`: {str(parsed)[:200]}"
+        )
+    return seq
+
+
+def withdraw_participant(
+    base_url: str,
+    room_id: str,
+    sequence_observed_by_client: int,
+    bearer: str,
+    *,
+    reason: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> int:
+    """POST `{base_url}/api/rooms/{room_id}/withdraw`.
+
+    Worker explicitly withdraws their RSVP — used when triage
+    determines no contribution is warranted (PR too small, out
+    of scope, etc.). Distinct from `submit_contribution` (a
+    contribution that opts out via `verdict: COMMENT`).
+
+    Returns the sequence the `participant_withdrawn` event landed at.
+    """
+    url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/withdraw"
+    body: dict[str, Any] = {
+        "sequenceObservedByClient": sequence_observed_by_client,
+    }
+    if reason is not None:
+        body["reason"] = reason
+
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+
+    if status != 200:
+        raise RuntimeError(
+            f"withdraw returned status {status}: "
+            f"{raw.decode(errors='replace')[:200]}"
+        )
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("withdraw response was not a JSON object")
+
+    seq = parsed.get("sequence")
+    if not isinstance(seq, int):
+        raise RuntimeError(
+            f"withdraw response missing/invalid `sequence`: {str(parsed)[:200]}"
+        )
+    return seq

--- a/agent/cli/tests/test_hivemoot_war_rooms_api.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_api.py
@@ -1,0 +1,336 @@
+"""Tests for cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import api as wr_api
+from hivemoot_agent.plugins_builtin.hivemoot import http as hm_http
+
+
+def _fake_response(status: int = 200, body: bytes = b"") -> MagicMock:
+    cm = MagicMock()
+    resp = cm.__enter__.return_value
+    resp.status = status
+    resp.read.return_value = body
+    cm.__exit__.return_value = False
+    return cm
+
+
+class ListWatchingRoomsTests(unittest.TestCase):
+    """GET /api/rooms/watching parsing."""
+
+    def test_returns_empty_when_rooms_array_missing(self) -> None:
+        body = json.dumps({}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            self.assertEqual(
+                wr_api.list_watching_rooms("https://api.example", "tok"),
+                [],
+            )
+
+    def test_returns_empty_when_rooms_array_empty(self) -> None:
+        body = json.dumps({"rooms": []}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            self.assertEqual(
+                wr_api.list_watching_rooms("https://api.example", "tok"),
+                [],
+            )
+
+    def test_parses_full_room_response(self) -> None:
+        room_id = "01234567-89ab-4cde-9012-3456789abcde"
+        body = json.dumps({
+            "rooms": [
+                {
+                    "core": {
+                        "roomId": room_id,
+                        "status": "awaiting_contributions",
+                        "subject_type": "pr_review",
+                        "subject_ref": "hivemoot/hivemoot#42",
+                        "manager": "bot-queen",
+                        "opened_at": "2026-04-28T07:00:00.000Z",
+                    },
+                    "participants": {
+                        "drone": {
+                            "agent_id": "drone-1",
+                            "role": "drone",
+                            "status": "pending",
+                            "rsvp_at": "2026-04-28T07:01:00.000Z",
+                        },
+                    },
+                    "currentSequence": 5,
+                },
+            ],
+        }).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            result = wr_api.list_watching_rooms("https://api.example", "tok")
+        self.assertEqual(len(result), 1)
+        room = result[0]
+        self.assertEqual(room.room_id, room_id)
+        self.assertEqual(room.status, "awaiting_contributions")
+        self.assertEqual(room.subject_ref, "hivemoot/hivemoot#42")
+        self.assertEqual(room.current_sequence, 5)
+        self.assertIn("drone", room.participants)
+
+    def test_skips_non_dict_entries_silently(self) -> None:
+        room_id = "01234567-89ab-4cde-9012-3456789abcde"
+        body = json.dumps({
+            "rooms": [
+                "not-an-object",
+                {"core": {"roomId": room_id, "status": "awaiting_rsvp",
+                          "subject_type": "pr_review", "subject_ref": "x/y#1",
+                          "manager": "m", "opened_at": "t"},
+                 "participants": {}, "currentSequence": 1},
+            ],
+        }).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            result = wr_api.list_watching_rooms("https://api.example", "tok")
+        self.assertEqual(len(result), 1)
+
+    def test_raises_on_missing_room_id(self) -> None:
+        body = json.dumps({
+            "rooms": [{
+                "core": {"status": "awaiting_rsvp"},
+                "participants": {},
+                "currentSequence": 0,
+            }],
+        }).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.list_watching_rooms("https://api.example", "tok")
+        self.assertIn("missing core.roomId", str(cm.exception))
+
+    def test_raises_on_non_200(self) -> None:
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(403, b"forbidden"),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.list_watching_rooms("https://api.example", "tok")
+        self.assertIn("status 403", str(cm.exception))
+
+    def test_raises_on_non_object_body(self) -> None:
+        body = b"[]"
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.list_watching_rooms("https://api.example", "tok")
+        self.assertIn("not a JSON object", str(cm.exception))
+
+    def test_strips_trailing_slash_from_base_url(self) -> None:
+        body = json.dumps({"rooms": []}).encode()
+        captured = {}
+
+        def fake_open(req, timeout):  # type: ignore[no-untyped-def]
+            captured["url"] = req.full_url
+            return _fake_response(200, body)
+
+        with patch.object(hm_http._OPENER, "open", side_effect=fake_open):
+            wr_api.list_watching_rooms("https://api.example/", "tok")
+        self.assertEqual(captured["url"], "https://api.example/api/rooms/watching")
+
+
+class PresentToRoomTests(unittest.TestCase):
+    """POST /api/rooms/{id}/present semantics."""
+
+    ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde"
+
+    def test_happy_path_returns_sequence(self) -> None:
+        body = json.dumps({"sequence": 5}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            result = wr_api.present_to_room(
+                "https://api.example", self.ROOM_ID, 1, "tok",
+            )
+        self.assertEqual(result, 5)
+
+    def test_includes_intent_hint_when_provided(self) -> None:
+        body = json.dumps({"sequence": 1}).encode()
+        captured = {}
+
+        def fake_open(req, timeout):  # type: ignore[no-untyped-def]
+            captured["body"] = req.data
+            return _fake_response(200, body)
+
+        with patch.object(hm_http._OPENER, "open", side_effect=fake_open):
+            wr_api.present_to_room(
+                "https://api.example", self.ROOM_ID, 3, "tok",
+                intent_hint="review for security",
+            )
+        sent = json.loads(captured["body"])
+        self.assertEqual(sent["intentHint"], "review for security")
+        self.assertEqual(sent["sequenceObservedByClient"], 3)
+
+    def test_omits_intent_hint_when_none(self) -> None:
+        body = json.dumps({"sequence": 1}).encode()
+        captured = {}
+
+        def fake_open(req, timeout):  # type: ignore[no-untyped-def]
+            captured["body"] = req.data
+            return _fake_response(200, body)
+
+        with patch.object(hm_http._OPENER, "open", side_effect=fake_open):
+            wr_api.present_to_room(
+                "https://api.example", self.ROOM_ID, 3, "tok",
+            )
+        sent = json.loads(captured["body"])
+        self.assertNotIn("intentHint", sent)
+
+    def test_raises_on_409_owner_conflict(self) -> None:
+        body = json.dumps({"code": "owner_conflict"}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(409, body),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.present_to_room(
+                    "https://api.example", self.ROOM_ID, 1, "tok",
+                )
+        self.assertIn("status 409", str(cm.exception))
+
+    def test_raises_on_response_missing_sequence(self) -> None:
+        body = json.dumps({}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.present_to_room(
+                    "https://api.example", self.ROOM_ID, 1, "tok",
+                )
+        self.assertIn("invalid `sequence`", str(cm.exception))
+
+
+class SubmitContributionTests(unittest.TestCase):
+    ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde"
+
+    def test_happy_path_returns_sequence(self) -> None:
+        body = json.dumps({"sequence": 8}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            result = wr_api.submit_contribution(
+                "https://api.example",
+                self.ROOM_ID,
+                5,
+                {"verdict": "APPROVE", "summary": "ok"},
+                "# Verdict\n\nApprove.",
+                "tok",
+            )
+        self.assertEqual(result, 8)
+
+    def test_sends_full_body_shape(self) -> None:
+        body = json.dumps({"sequence": 1}).encode()
+        captured = {}
+
+        def fake_open(req, timeout):  # type: ignore[no-untyped-def]
+            captured["body"] = req.data
+            return _fake_response(200, body)
+
+        contribution_body = {
+            "verdict": "REQUEST_CHANGES",
+            "summary": "needs work",
+            "findings": [{"area": "security", "severity": "blocker"}],
+        }
+        with patch.object(hm_http._OPENER, "open", side_effect=fake_open):
+            wr_api.submit_contribution(
+                "https://api.example",
+                self.ROOM_ID,
+                3,
+                contribution_body,
+                "raw markdown body",
+                "tok",
+            )
+        sent = json.loads(captured["body"])
+        self.assertEqual(sent["sequenceObservedByClient"], 3)
+        self.assertEqual(sent["body"], contribution_body)
+        self.assertEqual(sent["rawMd"], "raw markdown body")
+
+    def test_raises_on_400_validation_error(self) -> None:
+        body = json.dumps({"code": "invalid_contribution_body"}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(400, body),
+        ):
+            with self.assertRaises(RuntimeError):
+                wr_api.submit_contribution(
+                    "https://api.example",
+                    self.ROOM_ID,
+                    1,
+                    {"verdict": "approve"},  # lowercase = invalid
+                    "x",
+                    "tok",
+                )
+
+
+class WithdrawParticipantTests(unittest.TestCase):
+    ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde"
+
+    def test_happy_path_returns_sequence(self) -> None:
+        body = json.dumps({"sequence": 4}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(200, body),
+        ):
+            result = wr_api.withdraw_participant(
+                "https://api.example", self.ROOM_ID, 2, "tok",
+            )
+        self.assertEqual(result, 4)
+
+    def test_includes_reason_when_provided(self) -> None:
+        body = json.dumps({"sequence": 1}).encode()
+        captured = {}
+
+        def fake_open(req, timeout):  # type: ignore[no-untyped-def]
+            captured["body"] = req.data
+            return _fake_response(200, body)
+
+        with patch.object(hm_http._OPENER, "open", side_effect=fake_open):
+            wr_api.withdraw_participant(
+                "https://api.example", self.ROOM_ID, 1, "tok",
+                reason="out of scope",
+            )
+        sent = json.loads(captured["body"])
+        self.assertEqual(sent["reason"], "out of scope")
+
+
+class GetJsonTransportTests(unittest.TestCase):
+    """Sanity checks on the new shared `get_json` helper that the
+    war-room watcher depends on. Mirrors the post_json invariants."""
+
+    def test_refuses_non_http_scheme(self) -> None:
+        with self.assertRaises(ValueError):
+            hm_http.get_json("file:///etc/passwd", "tok")
+
+    def test_refuses_redirect_to_protect_bearer(self) -> None:
+        # _NoRedirectHandler raises on 301/302/303/307/308. The
+        # _OPENER under test is the same singleton, so any GET that
+        # hits a redirect would surface as an HTTPError.
+        import urllib.error
+        cm = MagicMock()
+        cm.__enter__.side_effect = urllib.error.HTTPError(
+            "https://api.example/x", 302,
+            "redirect not followed (would leak Authorization): Found",
+            {}, None,
+        )
+        with patch.object(hm_http._OPENER, "open", return_value=cm):
+            status, parsed, raw = hm_http.get_json(
+                "https://api.example/x", "tok",
+            )
+        self.assertEqual(status, 302)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #529

## Summary

First slice of Phase F (worker runtime mode). Introduces the agent-side HTTP client wrapping \`/api/rooms/*\` — the wire layer that subsequent F slices (F.2 trigger / poll loop, F.3 triage + heavy contribution) will compose into a full watcher plugin.

## What it looks like

**Module structure:**

\`\`\`
agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/
├── __init__.py    # public surface re-exports
└── api.py         # HTTP client + WatchingRoom dataclass

agent/cli/hivemoot_agent/plugins_builtin/hivemoot/http.py
└── + get_json     # mirrors post_json (redirect refusal, scheme guard)
\`\`\`

**Public surface:**

| Function | Endpoint | Capability needed |
|---|---|---|
| \`list_watching_rooms(base_url, bearer)\` | \`GET /api/rooms/watching\` | \`rooms.watch\` |
| \`present_to_room(...)\` | \`POST /api/rooms/:id/present\` | \`rooms.contribute\` |
| \`submit_contribution(...)\` | \`POST /api/rooms/:id/contributions\` | \`rooms.contribute\` |
| \`withdraw_participant(...)\` | \`POST /api/rooms/:id/withdraw\` | \`rooms.contribute\` |

All four already in the worker preset (\`rooms.watch\`, \`rooms.read\`, \`rooms.contribute\` from PRESETS.worker).

**\`WatchingRoom\` dataclass** — parsed view of one \`/watching\` entry:

\`\`\`python
@dataclass
class WatchingRoom:
    room_id: str
    status: str
    subject_type: str
    subject_ref: str
    manager: str
    opened_at: str
    current_sequence: int
    participants: dict[str, Any]
\`\`\`

The \`/watching\` endpoint pre-filters by the bearer's role via \`canRoleRsvpToRoom\` (storage layer, D.1.b-iii), so the worker doesn't compute eligibility itself — every room here is one the role SHOULD act on.

**Defensive parsing:**
- Missing \`rooms\` array → empty list (not error)
- Non-dict entries silently skipped
- Missing \`core.roomId\` → RuntimeError (would corrupt downstream state if accepted)
- Non-200 status → RuntimeError with status code + body slice
- Non-JSON-object body → RuntimeError

**Security invariants** (inherited from shared \`..http\`):
- Redirects refused → bearer never forwarded to redirect target
- Only http(s) URL schemes accepted
- Tight 10s default timeout

## Out of scope (subsequent F slices)

| Slice | Scope |
|---|---|
| F.2 | Trigger / poll loop with per-(room, role, sequence) state tracking |
| F.3 | Triage decision (cheap-model LLM call: RSVP-vs-withdraw) + heavy contribution dispatch |
| F.4 | Plugin manifest wiring + worker config schema |

## Test plan

- [x] Typecheck implicit via Python imports (loads cleanly)
- [x] Full agent suite passes: **518 tests** (was 498, +20)
- [x] \`list_watching_rooms\` (8 tests): empty rooms array, missing rooms field, full parse, non-dict entries skipped, missing roomId raises, non-200 raises, non-JSON-object raises, trailing-slash strip
- [x] \`present_to_room\` (5 tests): happy path, intent_hint included, intent_hint omitted when None, 409 owner_conflict surfaces, missing sequence raises
- [x] \`submit_contribution\` (3 tests): happy path, full body shape (verdict + summary + findings + rawMd), 400 validation surfaces
- [x] \`withdraw_participant\` (2 tests): happy path, optional reason
- [x] \`get_json\` (2 tests): rejects file:// scheme, redirect → 302 with no bearer leak
- [ ] Reviewer fleet sign-off