### PR TITLE
Phase G'.1 — queen-side war-room client extensions

### DIFF
--- a/bot/api/lib/war-room-client.test.ts
+++ b/bot/api/lib/war-room-client.test.ts
@@ -287,3 +287,306 @@ describe("WarRoomClient.appendEvent (E.2)", () => {
     }
   });
 });
+
+describe("WarRoomClient queen-side reads (G'.1)", () => {
+  const ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+  it("listRooms returns the rooms array", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { rooms: [{ roomId: ROOM_ID, status: "awaiting_rsvp" }] },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const rooms = await client.listRooms();
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0].roomId).toBe(ROOM_ID);
+  });
+
+  it("listRooms passes limit query param", async () => {
+    const fetchSpy = makeFetch({ status: 200, body: { rooms: [] } });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.listRooms({ limit: 50 });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("?limit=50"),
+      expect.anything(),
+    );
+  });
+
+  it("listRooms returns empty array when rooms field missing", async () => {
+    const fetchSpy = makeFetch({ status: 200, body: {} });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    expect(await client.listRooms()).toEqual([]);
+  });
+
+  it("listRooms throws WarRoomApiError on 4xx/5xx", async () => {
+    const fetchSpy = makeFetch({
+      status: 403,
+      body: { code: "agent_auth_v1_missing_capability" },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.listRooms();
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WarRoomApiError);
+      expect((err as WarRoomApiError).status).toBe(403);
+    }
+  });
+
+  it("getRoomCore parses the response", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { roomId: ROOM_ID, status: "deciding" },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const room = await client.getRoomCore(ROOM_ID);
+    expect(room.roomId).toBe(ROOM_ID);
+    expect(room.status).toBe("deciding");
+  });
+
+  it("getRoomCore 404 → WarRoomApiError(code='room_not_found')", async () => {
+    const fetchSpy = makeFetch({
+      status: 404,
+      body: { code: "room_not_found" },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.getRoomCore(ROOM_ID);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as WarRoomApiError).code).toBe("room_not_found");
+    }
+  });
+
+  it("listRoomEvents passes since + limit query params", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { events: [], roomId: ROOM_ID },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.listRoomEvents({ roomId: ROOM_ID, since: 5, limit: 200 });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\?since=5&limit=200/),
+      expect.anything(),
+    );
+  });
+
+  it("listRoomEvents handles default no-query path", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { events: [], roomId: ROOM_ID },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.listRoomEvents({ roomId: ROOM_ID });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://www.hivemoot.dev/api/rooms/${ROOM_ID}/events`,
+      expect.anything(),
+    );
+  });
+
+  it("getRoomContributions parses the materialized hash", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: {
+        contributions: {
+          drone: {
+            agent_id: "drone-1",
+            role: "drone",
+            body: { verdict: "APPROVE", summary: "ok" },
+            raw_md: "# Verdict",
+          },
+        },
+        roomId: ROOM_ID,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const result = await client.getRoomContributions(ROOM_ID);
+    expect(result.contributions.drone).toBeDefined();
+    expect(result.contributions.drone.body?.verdict).toBe("APPROVE");
+  });
+
+  it("getRoomContributions returns withdrawn tombstones as-is", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: {
+        contributions: { drone: { withdrawn: true, contributed_at: "now" } },
+        roomId: ROOM_ID,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const result = await client.getRoomContributions(ROOM_ID);
+    expect(result.contributions.drone.withdrawn).toBe(true);
+  });
+
+  it("getRoomParticipants parses participant slots", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: {
+        participants: {
+          drone: {
+            agent_id: "drone-1",
+            role: "drone",
+            status: "resolved",
+            rsvp_at: "2026-04-28T07:00:00.000Z",
+            resolved_at: "2026-04-28T07:05:00.000Z",
+          },
+        },
+        roomId: ROOM_ID,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const result = await client.getRoomParticipants(ROOM_ID);
+    expect(result.participants.drone.status).toBe("resolved");
+  });
+});
+
+describe("WarRoomClient queen-side writes (G'.1)", () => {
+  const ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+
+  it("claimSynthesis returns throughSequence + claimTtlSecs", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { throughSequence: 7, claimTtlSecs: 360 },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const result = await client.claimSynthesis({
+      roomId: ROOM_ID,
+      queenRunner: "bot-queen.pid42.tick0",
+    });
+    expect(result.throughSequence).toBe(7);
+    expect(result.claimTtlSecs).toBe(360);
+  });
+
+  it("claimSynthesis sends body shape correctly", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { throughSequence: 1, claimTtlSecs: 360 },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.claimSynthesis({
+      roomId: ROOM_ID,
+      queenRunner: "bot-queen",
+      claimTtlSecs: 120,
+    });
+    const callArgs = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).toEqual({ queenRunner: "bot-queen", claimTtlSecs: 120 });
+  });
+
+  it("claimSynthesis omits claimTtlSecs when undefined", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { throughSequence: 1, claimTtlSecs: 360 },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    await client.claimSynthesis({
+      roomId: ROOM_ID,
+      queenRunner: "bot-queen",
+    });
+    const callArgs = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body).toEqual({ queenRunner: "bot-queen" });
+    expect(body).not.toHaveProperty("claimTtlSecs");
+  });
+
+  it("claimSynthesis 409 claim_already_held → typed error with full response body", async () => {
+    const fetchSpy = makeFetch({
+      status: 409,
+      body: {
+        code: "claim_already_held",
+        message: "another runner",
+        heldByRunner: "queen-A",
+        throughSequence: 5,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.claimSynthesis({
+        roomId: ROOM_ID,
+        queenRunner: "queen-B",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WarRoomApiError);
+      expect((err as WarRoomApiError).code).toBe("claim_already_held");
+      expect((err as WarRoomApiError).response.heldByRunner).toBe("queen-A");
+      expect((err as WarRoomApiError).response.throughSequence).toBe(5);
+    }
+  });
+
+  it("closeRoom sends decision + expectedThroughSequence", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: { closedSequence: 8 },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const decision = {
+      synthesized_at: "2026-04-28T08:00:00.000Z",
+      synthesis_runner: "bot-queen.pid42",
+      content: "## Synthesis\n\nApprove.",
+      sequence_closed: 7,
+    };
+    const result = await client.closeRoom({
+      roomId: ROOM_ID,
+      expectedThroughSequence: 7,
+      decision,
+    });
+    expect(result.closedSequence).toBe(8);
+    const callArgs = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body.expectedThroughSequence).toBe(7);
+    expect(body.decision).toEqual(decision);
+  });
+
+  it("closeRoom 409 sequence_drift surfaces lastSeq in response", async () => {
+    const fetchSpy = makeFetch({
+      status: 409,
+      body: {
+        code: "sequence_drift",
+        message: "drift",
+        expectedThroughSequence: 7,
+        lastSeq: 9,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.closeRoom({
+        roomId: ROOM_ID,
+        expectedThroughSequence: 7,
+        decision: {
+          synthesized_at: "x",
+          synthesis_runner: "y",
+          content: "z",
+          sequence_closed: 7,
+        },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as WarRoomApiError).code).toBe("sequence_drift");
+      expect((err as WarRoomApiError).response.lastSeq).toBe(9);
+    }
+  });
+
+  it("closeRoom 409 claim_lost surfaces (force-close raced)", async () => {
+    const fetchSpy = makeFetch({
+      status: 409,
+      body: { code: "claim_lost", message: "claim DELed" },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.closeRoom({
+        roomId: ROOM_ID,
+        expectedThroughSequence: 7,
+        decision: {
+          synthesized_at: "x",
+          synthesis_runner: "y",
+          content: "z",
+          sequence_closed: 7,
+        },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as WarRoomApiError).code).toBe("claim_lost");
+    }
+  });
+});

--- a/bot/api/lib/war-room-client.test.ts
+++ b/bot/api/lib/war-room-client.test.ts
@@ -333,15 +333,59 @@ describe("WarRoomClient queen-side reads (G'.1)", () => {
     }
   });
 
-  it("getRoomCore parses the response", async () => {
+  it("getRoomCore parses the bare RoomCore response (NO roomId)", async () => {
+    // Pin the wire contract: server route at
+    // `web/src/app/api/rooms/[roomId]/route.ts:45` returns the bare
+    // `RoomCore` from storage, which intentionally OMITS roomId per
+    // war-room.ts:264-267. Earlier R0 fixture mocked `{roomId,
+    // status}` and let the contract drift — closes #534 builder B1
+    // + guard B1.
     const fetchSpy = makeFetch({
       status: 200,
-      body: { roomId: ROOM_ID, status: "deciding" },
+      body: {
+        manager: "bot-queen",
+        subject_type: "pr_review",
+        subject_ref: "owner/repo#42",
+        status: "deciding",
+        opened_at: "2026-04-28T20:00:00Z",
+      },
     });
     const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
     const room = await client.getRoomCore(ROOM_ID);
-    expect(room.roomId).toBe(ROOM_ID);
     expect(room.status).toBe("deciding");
+    expect(room.manager).toBe("bot-queen");
+    // Critical assertion: the response does NOT carry roomId — the
+    // caller must use the id they passed to the call. Type-level
+    // this is enforced by `Promise<RoomCoreResponse>`; the runtime
+    // assertion guards against a fixture-shape regression.
+    expect((room as unknown as { roomId?: string }).roomId).toBeUndefined();
+  });
+
+  it("getRoomCore parses transition fields when present", async () => {
+    const fetchSpy = makeFetch({
+      status: 200,
+      body: {
+        manager: "bot-queen",
+        subject_type: "pr_review",
+        subject_ref: "owner/repo#42",
+        status: "closed",
+        opened_at: "2026-04-28T20:00:00Z",
+        closed_at: "2026-04-28T20:30:00Z",
+        deciding_through_sequence: 7,
+        decision: {
+          synthesized_at: "2026-04-28T20:29:00Z",
+          synthesis_runner: "queen-bot",
+          content: "## Decision\n\nLGTM.",
+          sequence_closed: 7,
+        },
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    const room = await client.getRoomCore(ROOM_ID);
+    expect(room.status).toBe("closed");
+    expect(room.closed_at).toBe("2026-04-28T20:30:00Z");
+    expect(room.deciding_through_sequence).toBe(7);
+    expect(room.decision?.content).toContain("LGTM");
   });
 
   it("getRoomCore 404 → WarRoomApiError(code='room_not_found')", async () => {
@@ -587,6 +631,75 @@ describe("WarRoomClient queen-side writes (G'.1)", () => {
       throw new Error("expected throw");
     } catch (err) {
       expect((err as WarRoomApiError).code).toBe("claim_lost");
+    }
+  });
+
+  it("closeRoom 409 claim_through_seq_mismatch surfaces (re-claimed)", async () => {
+    // Fourth 409 mode: the claim was DELed and a different runner
+    // re-claimed before this caller's close landed. Pins the wire
+    // shape returned by `web/src/app/api/rooms/[roomId]/close/route.ts`
+    // so the queen's manager-loop in G'.2 can branch on it.
+    const fetchSpy = makeFetch({
+      status: 409,
+      body: {
+        code: "claim_through_seq_mismatch",
+        message: "claim through seq does not match expected",
+        expectedThroughSequence: 7,
+        actualThroughSequence: 9,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.closeRoom({
+        roomId: ROOM_ID,
+        expectedThroughSequence: 7,
+        decision: {
+          synthesized_at: "x",
+          synthesis_runner: "y",
+          content: "z",
+          sequence_closed: 7,
+        },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      const apiErr = err as WarRoomApiError;
+      expect(apiErr.code).toBe("claim_through_seq_mismatch");
+      expect(apiErr.response.expectedThroughSequence).toBe(7);
+      expect(apiErr.response.actualThroughSequence).toBe(9);
+    }
+  });
+
+  it("closeRoom 400 decision_too_large surfaces sizeBytes", async () => {
+    // Server route at `close/route.ts:190-198` maps the storage's
+    // RoomDecisionTooLargeError to a 400 with `code:
+    // decision_too_large` + `sizeBytes`. The queen's G'.3 synthesis
+    // path needs to branch on this to truncate + retry.
+    const fetchSpy = makeFetch({
+      status: 400,
+      body: {
+        code: "decision_too_large",
+        message: "Decision exceeds 64 KiB",
+        sizeBytes: 70_000,
+      },
+    });
+    const client = new WarRoomClient({ agentToken: TOKEN, fetch: fetchSpy });
+    try {
+      await client.closeRoom({
+        roomId: ROOM_ID,
+        expectedThroughSequence: 7,
+        decision: {
+          synthesized_at: "x",
+          synthesis_runner: "y",
+          content: "z",
+          sequence_closed: 7,
+        },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      const apiErr = err as WarRoomApiError;
+      expect(apiErr.status).toBe(400);
+      expect(apiErr.code).toBe("decision_too_large");
+      expect(apiErr.response.sizeBytes).toBe(70_000);
     }
   });
 });

--- a/bot/api/lib/war-room-client.ts
+++ b/bot/api/lib/war-room-client.ts
@@ -9,10 +9,12 @@
  *
  * Configuration (env-driven, evaluated at construction time):
  *   - `HIVEMOOT_API_BASE_URL` — default `https://www.hivemoot.dev`
- *   - `HIVEMOOT_BOT_AGENT_TOKEN` — V1 capability bearer (must hold
- *     `rooms.create`, `rooms.update`, `rooms.close`, `rooms.read_all`
- *     for full bot operation; a `rooms.create`-only token is
- *     sufficient for E.1)
+ *   - `HIVEMOOT_BOT_AGENT_TOKEN` — V1 capability bearer. Required
+ *     capability set depends on which methods the caller invokes:
+ *       - E.1/E.2 (webhook routing): `rooms.create`, `rooms.update`
+ *       - G'.1+ (queen module): `rooms.read_all`, `rooms.decide`,
+ *         `rooms.close` (the queen preset already grants all of
+ *         these; see `agent-token-capabilities.ts`)
  *
  * Error model: thrown errors carry the wire `code` field from the
  * server's JSON body so handlers can distinguish:
@@ -63,28 +65,48 @@ export interface CreateRoomArgs {
   roomId?: string;
 }
 
+/**
+ * Canonical wire shape for a room's core record. Mirrors the storage
+ * layer's `RoomCore` type — the immutable RoomCoreData fields plus
+ * the optional mutable transition fields that progress with the
+ * room's lifecycle.
+ *
+ * `roomId` is intentionally absent: the server's `GET /api/rooms/:id`
+ * route returns the bare `RoomCore` (war-room.ts:242-259, the route
+ * at `web/src/app/api/rooms/[roomId]/route.ts:45`). For `listRooms`
+ * which DOES include the id, see `RoomListEntry`.
+ */
 export interface RoomCoreResponse {
   manager: string;
   subject_type: WarRoomSubjectType;
   subject_ref: string;
-  status: "awaiting_rsvp" | "awaiting_contributions" | "deciding" | "closed";
+  status:
+    | "awaiting_rsvp"
+    | "awaiting_contributions"
+    | "deciding"
+    | "closed"
+    | "expired";
   opened_at: string;
-  // Server may return additional fields; this is the minimum the
-  // bot needs. Extending the response type is non-breaking.
+  timing_config?: WarRoomTimingConfig;
+  /** Set when the room reaches a terminal state (closed | expired). */
+  closed_at?: string;
+  /** Set ONLY by `ROOM_TERMINATE_SCRIPT`. The queen's happy-path
+   * close sets `decision` instead. */
+  closed_reason?: "expired" | "failed_synthesis" | "force_close" | "manual";
+  /** Set by claim, verified by close to detect drift. */
+  deciding_through_sequence?: number;
+  /** Set ONLY by happy-path close. */
+  decision?: RoomDecision;
 }
 
 /**
- * Room entry from `GET /api/rooms` and `GET /api/rooms/:id` —
- * matches the storage layer's `RoomCoreWithId` type added in
- * D.1.b-iii. Distinct from `RoomCoreResponse` (createRoom 201)
- * which omits `roomId`.
+ * Room entry from `GET /api/rooms` — matches the storage layer's
+ * `RoomCoreWithId` type added in D.1.b-iii. Distinct from
+ * `RoomCoreResponse` (the bare core shape returned by createRoom 201
+ * AND `GET /api/rooms/:id`) which omits `roomId`.
  */
 export interface RoomListEntry extends RoomCoreResponse {
   roomId: string;
-  closed_at?: string;
-  closed_reason?: "expired" | "failed_synthesis" | "force_close" | "manual";
-  deciding_through_sequence?: number;
-  decision?: RoomDecision;
 }
 
 /**
@@ -114,12 +136,15 @@ export interface RoomParticipant {
 }
 
 /**
- * Materialized contribution entry. Withdrawn contributions surface
- * as tombstones with `withdrawn: true`.
+ * Materialized contribution entry. Mirrors the storage layer's
+ * write at `war-room.ts:2855-2859` — submitContribution writes
+ * `{body, raw_md, contributed_at}` for present contributions and
+ * `{withdrawn: true, contributed_at}` for tombstones. The contributor
+ * agent_id/role are NOT part of this payload — callers correlate
+ * via the hash key (the role) which `getRoomContributions` returns
+ * as `Record<string, RoomContribution>`.
  */
 export interface RoomContribution {
-  agent_id?: string;
-  role?: string;
   body?: Record<string, unknown>;
   raw_md?: string;
   contributed_at?: string;
@@ -331,9 +356,17 @@ export class WarRoomClient {
 
   /**
    * GET /api/rooms/:roomId — fetch one room's core record.
-   * 404 → `RoomNotFoundError(code: room_not_found)`.
+   * Capability: `rooms.read_all` (queen preset).
+   *
+   * Returns `RoomCoreResponse` WITHOUT `roomId`: the server route
+   * intentionally serializes the bare `RoomCore` (war-room.ts:264-267
+   * — "the room hash key is the roomId, so it's redundant — the
+   * caller already knows it"). Callers correlate by the roomId they
+   * passed in.
+   *
+   * 404 → `WarRoomApiError(code: "room_not_found")`.
    */
-  async getRoomCore(roomId: string): Promise<RoomListEntry> {
+  async getRoomCore(roomId: string): Promise<RoomCoreResponse> {
     const response = await this.request(
       "GET",
       `/api/rooms/${encodeURIComponent(roomId)}`,
@@ -341,13 +374,13 @@ export class WarRoomClient {
     if (!response.ok) {
       throw await this._toApiError(response);
     }
-    return (await response.json()) as RoomListEntry;
+    return (await response.json()) as RoomCoreResponse;
   }
 
   /**
    * GET /api/rooms/:roomId/events — append-only event log slice.
-   * `since` is the last seq the caller observed; events with
-   * `seq > since` are returned (default 0 = all).
+   * Capability: `rooms.read_all`. `since` is the last seq the caller
+   * observed; events with `seq > since` are returned (default 0 = all).
    */
   async listRoomEvents(args: {
     roomId: string;
@@ -370,7 +403,8 @@ export class WarRoomClient {
 
   /**
    * GET /api/rooms/:roomId/contributions — materialized contribution
-   * hash. The queen's synthesis prompt uses this.
+   * hash. Capability: `rooms.read_all`. The queen's synthesis prompt
+   * uses this.
    */
   async getRoomContributions(
     roomId: string,
@@ -390,8 +424,8 @@ export class WarRoomClient {
 
   /**
    * GET /api/rooms/:roomId/participants — materialized RSVP hash.
-   * Queen reads this to confirm "all participants resolved" before
-   * claiming synthesis.
+   * Capability: `rooms.read_all`. The queen reads this to confirm
+   * "all participants resolved" before claiming synthesis.
    */
   async getRoomParticipants(
     roomId: string,

--- a/bot/api/lib/war-room-client.ts
+++ b/bot/api/lib/war-room-client.ts
@@ -74,6 +74,74 @@ export interface RoomCoreResponse {
 }
 
 /**
+ * Room entry from `GET /api/rooms` and `GET /api/rooms/:id` —
+ * matches the storage layer's `RoomCoreWithId` type added in
+ * D.1.b-iii. Distinct from `RoomCoreResponse` (createRoom 201)
+ * which omits `roomId`.
+ */
+export interface RoomListEntry extends RoomCoreResponse {
+  roomId: string;
+  closed_at?: string;
+  closed_reason?: "expired" | "failed_synthesis" | "force_close" | "manual";
+  deciding_through_sequence?: number;
+  decision?: RoomDecision;
+}
+
+/**
+ * One event from a room's append-only log. Matches the storage
+ * layer's `RoomEvent` shape.
+ */
+export interface RoomEvent {
+  seq: number;
+  timestamp: string;
+  event_type: string;
+  actor_role: string;
+  actor_id: string;
+  body: Record<string, unknown>;
+}
+
+/**
+ * Materialized participant entry (latest-state-wins per role).
+ * Matches storage's `RoomParticipant`.
+ */
+export interface RoomParticipant {
+  agent_id: string;
+  role: string;
+  status: "pending" | "resolved" | "withdrew" | "timed_out";
+  rsvp_at: string;
+  resolved_at?: string;
+  withdrew_at_sequence?: number;
+}
+
+/**
+ * Materialized contribution entry. Withdrawn contributions surface
+ * as tombstones with `withdrawn: true`.
+ */
+export interface RoomContribution {
+  agent_id?: string;
+  role?: string;
+  body?: Record<string, unknown>;
+  raw_md?: string;
+  contributed_at?: string;
+  withdrawn?: boolean;
+}
+
+/**
+ * Decision payload passed on `/close` — what the queen synthesized.
+ * Mirrors the storage layer's `RoomDecision` type.
+ */
+export interface RoomDecision {
+  synthesized_at: string;
+  synthesis_runner: string;
+  /** Synthesis body (markdown). ≤ 64 KiB UTF-8 bytes per server cap. */
+  content: string;
+  /** Sequence the queen synthesized through (= throughSequence from
+   * the claim response). Server compares against the live seq at
+   * close time to detect drift. */
+  sequence_closed: number;
+}
+
+/**
  * Thrown when the API returns a 4xx/5xx with a structured error
  * body. `code` matches the server's wire `code` field.
  */
@@ -236,6 +304,198 @@ export class WarRoomClient {
         ? parsed.message
         : `War-room API ${response.status} (${code})`;
     throw new WarRoomApiError(response.status, code, message, parsed);
+  }
+
+  // ─── Queen-side reads (G'.1) ─────────────────────────────────────────
+
+  /**
+   * GET /api/rooms — list rooms for the bearer's installation.
+   * Used by the queen's manager loop to find rooms eligible for
+   * synthesis. Capability: `rooms.read_all` (queen preset).
+   *
+   * Returns the array as serialized; caller filters by status +
+   * participant resolution to identify synthesis candidates. Wire
+   * shape uses `RoomCoreWithId` (D.1.b-iii) so each room has a
+   * top-level `roomId` field — distinct from createRoom's 201
+   * which uses `RoomCore` without roomId.
+   */
+  async listRooms(args: { limit?: number } = {}): Promise<RoomListEntry[]> {
+    const query = args.limit !== undefined ? `?limit=${args.limit}` : "";
+    const response = await this.request("GET", `/api/rooms${query}`);
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    const body = (await response.json()) as { rooms?: RoomListEntry[] };
+    return Array.isArray(body.rooms) ? body.rooms : [];
+  }
+
+  /**
+   * GET /api/rooms/:roomId — fetch one room's core record.
+   * 404 → `RoomNotFoundError(code: room_not_found)`.
+   */
+  async getRoomCore(roomId: string): Promise<RoomListEntry> {
+    const response = await this.request(
+      "GET",
+      `/api/rooms/${encodeURIComponent(roomId)}`,
+    );
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    return (await response.json()) as RoomListEntry;
+  }
+
+  /**
+   * GET /api/rooms/:roomId/events — append-only event log slice.
+   * `since` is the last seq the caller observed; events with
+   * `seq > since` are returned (default 0 = all).
+   */
+  async listRoomEvents(args: {
+    roomId: string;
+    since?: number;
+    limit?: number;
+  }): Promise<{ events: RoomEvent[]; roomId: string }> {
+    const params = new URLSearchParams();
+    if (args.since !== undefined) params.set("since", String(args.since));
+    if (args.limit !== undefined) params.set("limit", String(args.limit));
+    const qs = params.toString();
+    const path =
+      `/api/rooms/${encodeURIComponent(args.roomId)}/events` +
+      (qs ? `?${qs}` : "");
+    const response = await this.request("GET", path);
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    return (await response.json()) as { events: RoomEvent[]; roomId: string };
+  }
+
+  /**
+   * GET /api/rooms/:roomId/contributions — materialized contribution
+   * hash. The queen's synthesis prompt uses this.
+   */
+  async getRoomContributions(
+    roomId: string,
+  ): Promise<{ contributions: Record<string, RoomContribution>; roomId: string }> {
+    const response = await this.request(
+      "GET",
+      `/api/rooms/${encodeURIComponent(roomId)}/contributions`,
+    );
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    return (await response.json()) as {
+      contributions: Record<string, RoomContribution>;
+      roomId: string;
+    };
+  }
+
+  /**
+   * GET /api/rooms/:roomId/participants — materialized RSVP hash.
+   * Queen reads this to confirm "all participants resolved" before
+   * claiming synthesis.
+   */
+  async getRoomParticipants(
+    roomId: string,
+  ): Promise<{ participants: Record<string, RoomParticipant>; roomId: string }> {
+    const response = await this.request(
+      "GET",
+      `/api/rooms/${encodeURIComponent(roomId)}/participants`,
+    );
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    return (await response.json()) as {
+      participants: Record<string, RoomParticipant>;
+      roomId: string;
+    };
+  }
+
+  // ─── Queen-side writes (G'.1) ────────────────────────────────────────
+
+  /**
+   * POST /api/rooms/:roomId/decide — atomically claim the synthesis
+   * lane. Capability: `rooms.decide`. Returns `{throughSequence,
+   * claimTtlSecs}`; the queen passes `throughSequence` back on
+   * `/close` for drift detection.
+   *
+   * 409 with code `claim_already_held` is the benign-conflict path
+   * (another queen runner won the race). Caller should log + skip
+   * — the manager loop's next tick will re-check.
+   */
+  async claimSynthesis(args: {
+    roomId: string;
+    queenRunner: string;
+    claimTtlSecs?: number;
+  }): Promise<{ throughSequence: number; claimTtlSecs: number }> {
+    const body: Record<string, unknown> = {
+      queenRunner: args.queenRunner,
+    };
+    if (args.claimTtlSecs !== undefined) {
+      body.claimTtlSecs = args.claimTtlSecs;
+    }
+    const response = await this.request(
+      "POST",
+      `/api/rooms/${encodeURIComponent(args.roomId)}/decide`,
+      body,
+    );
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    return (await response.json()) as {
+      throughSequence: number;
+      claimTtlSecs: number;
+    };
+  }
+
+  /**
+   * POST /api/rooms/:roomId/close — happy-path close with the
+   * queen's synthesized decision. Capability: `rooms.close`.
+   *
+   * Failure modes:
+   *   - 409 `sequence_drift`: new events landed since claim; queen
+   *     aborts GitHub post, manager loop re-claims on next tick
+   *   - 409 `claim_lost`: force-close raced; abort
+   *   - 409 `claim_through_seq_mismatch`: another runner re-claimed;
+   *     abort
+   *   - 400 `decision_too_large`: synthesis content exceeded 64 KiB
+   */
+  async closeRoom(args: {
+    roomId: string;
+    expectedThroughSequence: number;
+    decision: RoomDecision;
+  }): Promise<{ closedSequence: number }> {
+    const body = {
+      expectedThroughSequence: args.expectedThroughSequence,
+      decision: args.decision,
+    };
+    const response = await this.request(
+      "POST",
+      `/api/rooms/${encodeURIComponent(args.roomId)}/close`,
+      body,
+    );
+    if (!response.ok) {
+      throw await this._toApiError(response);
+    }
+    return (await response.json()) as { closedSequence: number };
+  }
+
+  /**
+   * Helper: convert a non-2xx Response into a `WarRoomApiError`.
+   * Mirrors the pattern used inline in createRoom/appendEvent;
+   * extracted here to keep the new G'.1 methods short.
+   */
+  private async _toApiError(response: Response): Promise<WarRoomApiError> {
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = (await response.json()) as Record<string, unknown>;
+    } catch {
+      // Non-JSON body — fall through.
+    }
+    const code = typeof parsed.code === "string" ? parsed.code : "unknown";
+    const message =
+      typeof parsed.message === "string"
+        ? parsed.message
+        : `War-room API ${response.status} (${code})`;
+    return new WarRoomApiError(response.status, code, message, parsed);
   }
 
   /** Internal: shared request shape. */


### PR DESCRIPTION
Fixes #533

## Summary

First slice of Phase G' (queen module). Extends `WarRoomClient` (worker-shaped from E.1/E.2) with the queen-perspective methods that the manager loop will call to scan rooms, read materialized state, atomically claim synthesis, and close rooms with a synthesized decision.

## What's new

**Reads (5 methods):**
- `listRooms({ limit? })` — `GET /api/rooms` (capability `rooms.read_all`)
- `getRoomCore(roomId)` — `GET /api/rooms/:roomId`
- `listRoomEvents({ roomId, since?, limit? })` — `GET /api/rooms/:roomId/events`
- `getRoomContributions(roomId)` — `GET /api/rooms/:roomId/contributions`
- `getRoomParticipants(roomId)` — `GET /api/rooms/:roomId/participants`

**Writes (2 methods):**
- `claimSynthesis({ roomId, queenRunner, claimTtlSecs? })` — `POST /api/rooms/:roomId/decide` (capability `rooms.decide`); returns `{ throughSequence, claimTtlSecs }` for drift-detection on close
- `closeRoom({ roomId, expectedThroughSequence, decision })` — `POST /api/rooms/:roomId/close` (capability `rooms.close`); 409 maps to `sequence_drift` / `claim_lost` / `claim_through_seq_mismatch`

**Wire-shape types** (5 new): `RoomListEntry` (extends `RoomCoreResponse` with `roomId`, mirroring D.1.b-iii's `RoomCoreWithId`), `RoomEvent`, `RoomParticipant`, `RoomContribution`, `RoomDecision`.

**Refactor**: extracted `_toApiError(response)` private helper for the new methods (pre-existing `createRoom` + `appendEvent` keep their inline mapping for now to minimize blast radius).

## What it looks like

Read flow (manager-loop poll):

```typescript
const client = new WarRoomClient({ baseUrl, agentToken });
const rooms = await client.listRooms({ limit: 50 });
const candidates = rooms.filter(r => r.status === "awaiting_contributions");
const participants = await client.getRoomParticipants(candidates[0].roomId);
// ...check all participants are resolved, then:
const claim = await client.claimSynthesis({
  roomId: candidates[0].roomId,
  queenRunner: "queen-bot-vercel",
});
// ...synthesize using claim.throughSequence as the cutoff seq...
await client.closeRoom({
  roomId: candidates[0].roomId,
  expectedThroughSequence: claim.throughSequence,
  decision: { synthesized_at, synthesis_runner, content, sequence_closed: claim.throughSequence },
});
```

Conflict-mode coverage:

| Wire 409 code | Caller meaning |
|---|---|
| `claim_already_held` | Another queen runner won the race — log + skip |
| `sequence_drift` | New events landed since claim — abort GitHub post |
| `claim_lost` | Force-close raced — abort |
| `claim_through_seq_mismatch` | Another runner re-claimed — abort |

## What's NOT in this slice

| Slice | Scope |
|---|---|
| G'.2 | Manager-loop scaffold + stub synthesizer (poll → claim → close cycle) |
| G'.3 | Real LLM synthesis using the existing AI SDK |
| G'.4 | GitHub posting integration (post the decision to the PR) |
| G'.5 | Queen vercel cron route + bearer wiring |

## Test plan

- [x] `tsc --noEmit` clean
- [x] `war-room-client.test.ts` passes (35 tests, +17 new)
- [x] Full bot suite passes (1766 tests, 55 files)
- [x] Lint clean on changed files (the one warning on line 540 predates this PR, from #526)
- [ ] Reviewer fleet sign-off