### PR TITLE
Phase G'.2 — queen manager-loop scaffold + stub synthesizer

### DIFF
--- a/bot/api/lib/queen/manager-loop.test.ts
+++ b/bot/api/lib/queen/manager-loop.test.ts
@@ -58,8 +58,18 @@ function presentContribution(): RoomContribution {
 interface FakeOptions {
   rooms?: RoomListEntry[];
   listRoomsThrows?: unknown;
+  /** Pre-claim participants snapshot (used for the eligibility check). */
   participants?: Record<string, Record<string, RoomParticipant>>;
+  /** Optional post-claim snapshot (used for the withdraw-finality
+   * check). Defaults to the pre-claim view when unset. Lets tests
+   * simulate a re-RSVP that lands between claim and re-read. */
+  participantsPostClaim?: Record<string, Record<string, RoomParticipant>>;
+  /** Throw a specific error on the Nth call to `getRoomParticipants`
+   * for a given roomId. `[ first-call err, second-call err, ... ]`.
+   * Empty / undefined = success. */
+  participantsThrowsByRoomId?: Record<string, unknown[]>;
   contributions?: Record<string, Record<string, RoomContribution>>;
+  contributionsThrowsByRoomId?: Record<string, unknown>;
   claimThrowsByRoomId?: Record<string, unknown>;
   closeThrowsByRoomId?: Record<string, unknown>;
   claimThroughSequence?: number;
@@ -67,6 +77,7 @@ interface FakeOptions {
 
 interface FakeCalls {
   listRoomsCalls: { limit?: number }[];
+  participantsCallsByRoomId: Record<string, number>;
   claimCalls: { roomId: string; queenRunner: string }[];
   closeCalls: {
     roomId: string;
@@ -83,6 +94,7 @@ function makeFakeClient(opts: FakeOptions): {
 } {
   const calls: FakeCalls = {
     listRoomsCalls: [],
+    participantsCallsByRoomId: {},
     claimCalls: [],
     closeCalls: [],
   };
@@ -95,12 +107,25 @@ function makeFakeClient(opts: FakeOptions): {
       return opts.rooms ?? [];
     },
     async getRoomParticipants(roomId: string) {
+      const idx = calls.participantsCallsByRoomId[roomId] ?? 0;
+      calls.participantsCallsByRoomId[roomId] = idx + 1;
+      const errors = opts.participantsThrowsByRoomId?.[roomId];
+      if (errors && errors[idx] !== undefined) throw errors[idx];
+      // First call (idx=0) → pre-claim. Subsequent → post-claim if
+      // configured, else fall back to pre-claim view.
+      const useView =
+        idx === 0
+          ? opts.participants?.[roomId]
+          : (opts.participantsPostClaim?.[roomId] ??
+              opts.participants?.[roomId]);
       return {
         roomId,
-        participants: opts.participants?.[roomId] ?? {},
+        participants: useView ?? {},
       };
     },
     async getRoomContributions(roomId: string) {
+      const t = opts.contributionsThrowsByRoomId?.[roomId];
+      if (t) throw t;
       return {
         roomId,
         contributions: opts.contributions?.[roomId] ?? {},
@@ -248,17 +273,25 @@ describe("runQueenManagerLoop — eligibility check", () => {
     expect(calls.claimCalls).toEqual([]);
   });
 
-  it("treats withdrew/timed_out as eligible (only pending blocks)", async () => {
+  it("treats withdrew (final) + timed_out as eligible alongside resolved", async () => {
+    // R1 #536 builder B1: withdrew is only synthesis-permitting if
+    // withdrew_at_sequence >= claim's throughSequence. The claim
+    // returns 7 here; withdraw was at 7 too → final, room closes.
     const { client, calls } = makeFakeClient({
       rooms: [makeRoom()],
       participants: {
         [ROOM_ID]: {
           guard: resolvedParticipant("guard"),
-          builder: { ...resolvedParticipant("builder"), status: "withdrew" },
+          builder: {
+            ...resolvedParticipant("builder"),
+            status: "withdrew",
+            withdrew_at_sequence: 7,
+          },
           drone: { ...resolvedParticipant("drone"), status: "timed_out" },
         },
       },
       contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      claimThroughSequence: 7,
     });
     const result = await runQueenManagerLoop({
       client,
@@ -268,8 +301,36 @@ describe("runQueenManagerLoop — eligibility check", () => {
     expect(result.eligible).toBe(1);
     expect(result.claimed).toBe(1);
     expect(result.closed).toBe(1);
+    expect(result.staleClaimsAbandoned).toBe(0);
     expect(calls.claimCalls).toHaveLength(1);
     expect(calls.closeCalls).toHaveLength(1);
+  });
+
+  it("blocks rooms with no resolved participant (R1 guard NB4)", async () => {
+    // Synthesizing on all-withdrew/all-timed_out is meaningless —
+    // there's literally no useful input. Let the watchdog terminate
+    // the room with `expired` reason via `max_age_secs`.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          builder: {
+            ...resolvedParticipant("builder"),
+            status: "withdrew",
+            withdrew_at_sequence: 7,
+          },
+          drone: { ...resolvedParticipant("drone"), status: "timed_out" },
+        },
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.scannedAwaitingContributions).toBe(1);
+    expect(result.eligible).toBe(0);
+    expect(calls.claimCalls).toEqual([]);
   });
 });
 
@@ -566,5 +627,264 @@ describe("runQueenManagerLoop — decision payload shape", () => {
     expect(calls.closeCalls[0].synthesisRunner).toBe("queen-prod-deploy-abc");
     expect(calls.closeCalls[0].synthesizedAt).toBe("2026-04-28T22:00:00.000Z");
     expect(calls.closeCalls[0].expectedThroughSequence).toBe(99);
+  });
+});
+
+describe("runQueenManagerLoop — R1 #536 builder B1 (post-claim withdraw validation)", () => {
+  it("abandons claim when withdrew_at_sequence < throughSequence", async () => {
+    // Drone withdrew at seq 2; subject_updated landed at seq 5; claim
+    // returns throughSequence=5. Per the worker /watching contract,
+    // drone is now re-eligible. The loop must abandon the claim
+    // (no closeRoom) — the watchdog reverts after TTL.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          drone: {
+            ...resolvedParticipant("drone"),
+            status: "withdrew",
+            withdrew_at_sequence: 2,
+          },
+        },
+      },
+      claimThroughSequence: 5,
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.eligible).toBe(1);
+    expect(result.claimed).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(result.staleClaimsAbandoned).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("closes when all withdraws are final (withdrew_at_sequence >= throughSequence)", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          drone: {
+            ...resolvedParticipant("drone"),
+            status: "withdrew",
+            withdrew_at_sequence: 5,
+          },
+        },
+      },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      claimThroughSequence: 5,
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.staleClaimsAbandoned).toBe(0);
+    expect(result.closed).toBe(1);
+    expect(calls.closeCalls).toHaveLength(1);
+  });
+
+  it("abandons defensively when withdrew has no withdrew_at_sequence", async () => {
+    // Defensive: a withdrew participant lacking `withdrew_at_sequence`
+    // shouldn't happen on the wire (storage always emits it), but we
+    // can't prove finality without the field — abandon.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          drone: {
+            ...resolvedParticipant("drone"),
+            status: "withdrew",
+            withdrew_at_sequence: undefined,
+          },
+        },
+      },
+      claimThroughSequence: 5,
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.staleClaimsAbandoned).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("abandons when re-RSVP between claim and re-read flips withdrew→pending", async () => {
+    // Pre-claim: drone shows withdrew @ seq 5 (finality OK).
+    // Post-claim re-read: drone shows pending (worker re-RSVPd
+    // between claim and re-read). Defense: the post-claim
+    // withdrawalsAreFinal check passes (only checks withdrew status),
+    // but a `pending` post-claim is NOT final synthesis state. We
+    // currently still close — guard NB4 covers this in the
+    // pre-claim check; verify here that the re-read sees the new
+    // state for synthesis input.
+    //
+    // Note: this behavior is intentional for V1 — the queen claims
+    // based on the pre-claim eligibility view, and re-RSVPs
+    // post-claim are caught only when they manifest as withdraws
+    // becoming non-final. A re-RSVP that flips withdrew → pending
+    // post-claim races through. That's a known limitation; V1.1 may
+    // re-check the full eligibility against the post-claim view.
+    //
+    // For now, test that the loop's behavior is at least
+    // deterministic: close goes through with the claim's
+    // throughSequence; if a real event lands, sequence_drift fires.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          drone: {
+            ...resolvedParticipant("drone"),
+            status: "withdrew",
+            withdrew_at_sequence: 5,
+          },
+        },
+      },
+      participantsPostClaim: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          drone: pendingParticipant("drone"),
+        },
+      },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      claimThroughSequence: 5,
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    // Withdraw-finality only checks withdrew status; drone is
+    // pending now, so the check passes (no withdrews to validate).
+    // V1 closes; V1.1 may tighten further.
+    expect(result.closed).toBe(1);
+    expect(calls.closeCalls).toHaveLength(1);
+  });
+
+  it("staleClaimsAbandoned starts at zero and increments only on stale withdraws", async () => {
+    const { client } = makeFakeClient({ rooms: [] });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.staleClaimsAbandoned).toBe(0);
+  });
+});
+
+describe("runQueenManagerLoop — R1 #536 guard B1 (invalid_status_for_claim)", () => {
+  it("invalid_status_for_claim 409 → conflicts++ (NOT errors)", async () => {
+    // Watchdog terminated this room (max_age expiry) between our
+    // listRooms and claimSynthesis. Routine ops; do not page.
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      claimThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(
+          409,
+          "invalid_status_for_claim",
+          "room status is closed",
+          {},
+        ),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.conflicts).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+});
+
+describe("runQueenManagerLoop — R1 #536 guard NB2 (room GC mid-tick)", () => {
+  it("404 room_not_found on pre-claim getRoomParticipants → conflicts++", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participantsThrowsByRoomId: {
+        [ROOM_ID]: [new WarRoomApiError(404, "room_not_found", "gone", {})],
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.conflicts).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(calls.claimCalls).toEqual([]);
+  });
+
+  it("404 room_not_found on post-claim getRoomParticipants → conflicts++", async () => {
+    // First call (pre-claim) succeeds; second call (post-claim
+    // re-read) returns 404 because the watchdog terminated the room
+    // between claim and re-read. The loop counts as a conflict and
+    // does NOT call closeRoom.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      participantsThrowsByRoomId: {
+        [ROOM_ID]: [
+          undefined as unknown,
+          new WarRoomApiError(404, "room_not_found", "gone", {}),
+        ],
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.claimed).toBe(1);
+    expect(result.conflicts).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("404 room_not_found on getRoomContributions → conflicts++", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributionsThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(404, "room_not_found", "gone", {}),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.claimed).toBe(1);
+    expect(result.conflicts).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("non-404 contributions read failure → errors++ (logged separately from synthesize_failed)", async () => {
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributionsThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(500, "internal", "boom", {}),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.claimed).toBe(1);
+    expect(result.errors).toBe(1);
+    expect(result.closed).toBe(0);
   });
 });

--- a/bot/api/lib/queen/manager-loop.test.ts
+++ b/bot/api/lib/queen/manager-loop.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Tests for `runQueenManagerLoop` (G'.2). Uses a hand-rolled
+ * `FakeWarRoomClient` rather than vitest mocks so behavior contracts
+ * stay legible (the queen's invariants — claim-then-close, sequence
+ * pinning, error fan-out — are subtle enough that mock-method-call
+ * trees obscure intent).
+ */
+
+import { describe, expect, it } from "vitest";
+import { runQueenManagerLoop } from "./manager-loop.js";
+import { StubSynthesizer, type Synthesizer } from "./synthesizer.js";
+import {
+  WarRoomApiError,
+  type RoomContribution,
+  type RoomListEntry,
+  type RoomParticipant,
+  type WarRoomClient,
+} from "../war-room-client.js";
+
+const ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+const RUNNER_ID = "queen-test-runner";
+
+function makeRoom(overrides: Partial<RoomListEntry> = {}): RoomListEntry {
+  return {
+    roomId: ROOM_ID,
+    manager: "bot-queen",
+    subject_type: "pr_review",
+    subject_ref: "owner/repo#42",
+    status: "awaiting_contributions",
+    opened_at: "2026-04-28T20:00:00Z",
+    ...overrides,
+  };
+}
+
+function resolvedParticipant(role: string): RoomParticipant {
+  return {
+    agent_id: `${role}-runner-1`,
+    role,
+    status: "resolved",
+    rsvp_at: "2026-04-28T20:01:00Z",
+    resolved_at: "2026-04-28T20:05:00Z",
+  };
+}
+
+function pendingParticipant(role: string): RoomParticipant {
+  return {
+    agent_id: `${role}-runner-1`,
+    role,
+    status: "pending",
+    rsvp_at: "2026-04-28T20:01:00Z",
+  };
+}
+
+function presentContribution(): RoomContribution {
+  return { raw_md: "LGTM", contributed_at: "2026-04-28T20:05:00Z" };
+}
+
+interface FakeOptions {
+  rooms?: RoomListEntry[];
+  listRoomsThrows?: unknown;
+  participants?: Record<string, Record<string, RoomParticipant>>;
+  contributions?: Record<string, Record<string, RoomContribution>>;
+  claimThrowsByRoomId?: Record<string, unknown>;
+  closeThrowsByRoomId?: Record<string, unknown>;
+  claimThroughSequence?: number;
+}
+
+interface FakeCalls {
+  listRoomsCalls: { limit?: number }[];
+  claimCalls: { roomId: string; queenRunner: string }[];
+  closeCalls: {
+    roomId: string;
+    expectedThroughSequence: number;
+    decisionContent: string;
+    synthesisRunner: string;
+    synthesizedAt: string;
+  }[];
+}
+
+function makeFakeClient(opts: FakeOptions): {
+  client: WarRoomClient;
+  calls: FakeCalls;
+} {
+  const calls: FakeCalls = {
+    listRoomsCalls: [],
+    claimCalls: [],
+    closeCalls: [],
+  };
+  const claimSeq = opts.claimThroughSequence ?? 7;
+
+  const client = {
+    async listRooms(args: { limit?: number } = {}) {
+      calls.listRoomsCalls.push(args);
+      if (opts.listRoomsThrows) throw opts.listRoomsThrows;
+      return opts.rooms ?? [];
+    },
+    async getRoomParticipants(roomId: string) {
+      return {
+        roomId,
+        participants: opts.participants?.[roomId] ?? {},
+      };
+    },
+    async getRoomContributions(roomId: string) {
+      return {
+        roomId,
+        contributions: opts.contributions?.[roomId] ?? {},
+      };
+    },
+    async claimSynthesis(args: { roomId: string; queenRunner: string }) {
+      calls.claimCalls.push(args);
+      const t = opts.claimThrowsByRoomId?.[args.roomId];
+      if (t) throw t;
+      return { throughSequence: claimSeq, claimTtlSecs: 300 };
+    },
+    async closeRoom(args: {
+      roomId: string;
+      expectedThroughSequence: number;
+      decision: {
+        content: string;
+        synthesis_runner: string;
+        synthesized_at: string;
+        sequence_closed: number;
+      };
+    }) {
+      calls.closeCalls.push({
+        roomId: args.roomId,
+        expectedThroughSequence: args.expectedThroughSequence,
+        decisionContent: args.decision.content,
+        synthesisRunner: args.decision.synthesis_runner,
+        synthesizedAt: args.decision.synthesized_at,
+      });
+      const t = opts.closeThrowsByRoomId?.[args.roomId];
+      if (t) throw t;
+      return { closedSequence: args.expectedThroughSequence };
+    },
+  } as unknown as WarRoomClient;
+
+  return { client, calls };
+}
+
+describe("runQueenManagerLoop — listing & filtering", () => {
+  it("returns all-zero counters when listRooms returns empty", async () => {
+    const { client, calls } = makeFakeClient({ rooms: [] });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.totalRoomsScanned).toBe(0);
+    expect(result.scannedAwaitingContributions).toBe(0);
+    expect(result.eligible).toBe(0);
+    expect(result.claimed).toBe(0);
+    expect(result.closed).toBe(0);
+    expect(result.conflicts).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(calls.listRoomsCalls).toHaveLength(1);
+  });
+
+  it("listRooms failure increments errors and returns early", async () => {
+    const { client } = makeFakeClient({
+      listRoomsThrows: new Error("upstream 502"),
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.errors).toBe(1);
+    expect(result.totalRoomsScanned).toBe(0);
+  });
+
+  it("ignores rooms not in awaiting_contributions", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [
+        makeRoom({ roomId: "a", status: "awaiting_rsvp" }),
+        makeRoom({ roomId: "b", status: "deciding" }),
+        makeRoom({ roomId: "c", status: "closed" }),
+        makeRoom({ roomId: "d", status: "expired" }),
+      ],
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.totalRoomsScanned).toBe(4);
+    expect(result.scannedAwaitingContributions).toBe(0);
+    expect(calls.claimCalls).toEqual([]);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("forwards maxRoomsPerTick to listRooms", async () => {
+    const { client, calls } = makeFakeClient({ rooms: [] });
+    await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+      maxRoomsPerTick: 25,
+    });
+    expect(calls.listRoomsCalls[0]).toEqual({ limit: 25 });
+  });
+
+  it("default maxRoomsPerTick is 100", async () => {
+    const { client, calls } = makeFakeClient({ rooms: [] });
+    await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(calls.listRoomsCalls[0]).toEqual({ limit: 100 });
+  });
+});
+
+describe("runQueenManagerLoop — eligibility check", () => {
+  it("skips rooms with any pending participant", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          builder: pendingParticipant("builder"),
+        },
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.scannedAwaitingContributions).toBe(1);
+    expect(result.eligible).toBe(0);
+    expect(calls.claimCalls).toEqual([]);
+  });
+
+  it("treats rooms with empty participants as not eligible", async () => {
+    // Defensive: an awaiting_contributions room with no RSVPs is a
+    // bug or race. Don't claim it — let the watchdog expire it.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: {} },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.eligible).toBe(0);
+    expect(calls.claimCalls).toEqual([]);
+  });
+
+  it("treats withdrew/timed_out as eligible (only pending blocks)", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          builder: { ...resolvedParticipant("builder"), status: "withdrew" },
+          drone: { ...resolvedParticipant("drone"), status: "timed_out" },
+        },
+      },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.eligible).toBe(1);
+    expect(result.claimed).toBe(1);
+    expect(result.closed).toBe(1);
+    expect(calls.claimCalls).toHaveLength(1);
+    expect(calls.closeCalls).toHaveLength(1);
+  });
+});
+
+describe("runQueenManagerLoop — happy path", () => {
+  it("claims, synthesizes, closes one room", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      claimThroughSequence: 12,
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+      nowMs: Date.parse("2026-04-28T20:30:00Z"),
+    });
+    expect(result.eligible).toBe(1);
+    expect(result.claimed).toBe(1);
+    expect(result.closed).toBe(1);
+    expect(result.conflicts).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(calls.claimCalls).toEqual([
+      { roomId: ROOM_ID, queenRunner: RUNNER_ID },
+    ]);
+    expect(calls.closeCalls).toHaveLength(1);
+    const closed = calls.closeCalls[0];
+    expect(closed.roomId).toBe(ROOM_ID);
+    expect(closed.expectedThroughSequence).toBe(12);
+    expect(closed.synthesisRunner).toBe(RUNNER_ID);
+    expect(closed.synthesizedAt).toBe("2026-04-28T20:30:00.000Z");
+    expect(closed.decisionContent).toContain(ROOM_ID);
+  });
+
+  it("processes multiple eligible rooms in one tick", async () => {
+    const room2 = makeRoom({ roomId: "room-2" });
+    const room3 = makeRoom({ roomId: "room-3" });
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom(), room2, room3],
+      participants: {
+        [ROOM_ID]: { guard: resolvedParticipant("guard") },
+        "room-2": { builder: resolvedParticipant("builder") },
+        "room-3": { drone: resolvedParticipant("drone") },
+      },
+      contributions: {
+        [ROOM_ID]: { guard: presentContribution() },
+        "room-2": { builder: presentContribution() },
+        "room-3": { drone: presentContribution() },
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.scannedAwaitingContributions).toBe(3);
+    expect(result.eligible).toBe(3);
+    expect(result.closed).toBe(3);
+    expect(calls.claimCalls).toHaveLength(3);
+    expect(calls.closeCalls).toHaveLength(3);
+  });
+});
+
+describe("runQueenManagerLoop — claim conflicts", () => {
+  function claimFails(code: string, status = 409): WarRoomApiError {
+    return new WarRoomApiError(status, code, `claim ${code}`, {});
+  }
+
+  it("claim_already_held → conflicts++ (no synthesis, no close)", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      claimThrowsByRoomId: { [ROOM_ID]: claimFails("claim_already_held") },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.eligible).toBe(1);
+    expect(result.claimed).toBe(0);
+    expect(result.conflicts).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("non-benign claim error → errors++", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      claimThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(500, "internal", "boom", {}),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.errors).toBe(1);
+    expect(result.conflicts).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("non-WarRoomApiError thrown by claim → errors++", async () => {
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      claimThrowsByRoomId: { [ROOM_ID]: new Error("network down") },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.errors).toBe(1);
+    expect(result.conflicts).toBe(0);
+  });
+});
+
+describe("runQueenManagerLoop — synthesizer failure", () => {
+  it("synthesizer throws → errors++, no close call", async () => {
+    const failing: Synthesizer = {
+      async synthesize() {
+        throw new Error("LLM upstream timeout");
+      },
+    };
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: failing,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.claimed).toBe(1);
+    expect(result.errors).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+});
+
+describe("runQueenManagerLoop — close conflicts", () => {
+  function closeFails(code: string, status = 409): WarRoomApiError {
+    return new WarRoomApiError(status, code, `close ${code}`, {});
+  }
+
+  for (const code of [
+    "sequence_drift",
+    "claim_lost",
+    "claim_through_seq_mismatch",
+  ]) {
+    it(`closeRoom 409 ${code} → conflicts++`, async () => {
+      const { client } = makeFakeClient({
+        rooms: [makeRoom()],
+        participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+        contributions: { [ROOM_ID]: { guard: presentContribution() } },
+        closeThrowsByRoomId: { [ROOM_ID]: closeFails(code) },
+      });
+      const result = await runQueenManagerLoop({
+        client,
+        synthesizer: new StubSynthesizer(),
+        runnerId: RUNNER_ID,
+      });
+      expect(result.claimed).toBe(1);
+      expect(result.conflicts).toBe(1);
+      expect(result.closed).toBe(0);
+      expect(result.errors).toBe(0);
+    });
+  }
+
+  it("closeRoom 400 decision_too_large → errors++ (NOT a conflict)", async () => {
+    // 400 is a different status; the loop treats only 409+benign-code
+    // as a conflict. decision_too_large is a synthesizer/storage
+    // boundary error — alert ops, don't silently swallow.
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      closeThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(
+          400,
+          "decision_too_large",
+          "decision exceeds 64 KiB",
+          { sizeBytes: 70_000 },
+        ),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.errors).toBe(1);
+    expect(result.conflicts).toBe(0);
+  });
+
+  it("close 409 with unfamiliar code → errors++ (closed conflict set)", async () => {
+    // Defensive: only the four documented benign codes count as
+    // conflicts. A new 409 code introduced server-side without
+    // updating the loop should fail loud, not silent.
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      closeThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(409, "unknown_new_code", "?", {}),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.errors).toBe(1);
+    expect(result.conflicts).toBe(0);
+  });
+});
+
+describe("runQueenManagerLoop — mixed outcomes", () => {
+  it("counts each room's outcome independently in one tick", async () => {
+    // Three rooms: one happy, one claim-conflict, one synthesizer-error.
+    const happyId = "happy-room";
+    const conflictId = "conflict-room";
+    const errorId = "error-room";
+
+    let synthCallCount = 0;
+    const conditionalSynth: Synthesizer = {
+      async synthesize(input) {
+        synthCallCount += 1;
+        if (input.roomId === errorId) throw new Error("LLM down");
+        return new StubSynthesizer().synthesize(input);
+      },
+    };
+
+    const { client } = makeFakeClient({
+      rooms: [
+        makeRoom({ roomId: happyId }),
+        makeRoom({ roomId: conflictId }),
+        makeRoom({ roomId: errorId }),
+      ],
+      participants: {
+        [happyId]: { guard: resolvedParticipant("guard") },
+        [conflictId]: { guard: resolvedParticipant("guard") },
+        [errorId]: { guard: resolvedParticipant("guard") },
+      },
+      contributions: {
+        [happyId]: { guard: presentContribution() },
+        [conflictId]: { guard: presentContribution() },
+        [errorId]: { guard: presentContribution() },
+      },
+      claimThrowsByRoomId: {
+        [conflictId]: new WarRoomApiError(
+          409,
+          "claim_already_held",
+          "race",
+          {},
+        ),
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: conditionalSynth,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.totalRoomsScanned).toBe(3);
+    expect(result.eligible).toBe(3);
+    expect(result.claimed).toBe(2); // happy + error (NOT the conflict)
+    expect(result.closed).toBe(1); // happy only
+    expect(result.conflicts).toBe(1); // conflict-room
+    expect(result.errors).toBe(1); // error-room (synthesizer threw)
+    expect(synthCallCount).toBe(2); // happy + error (NOT the conflict)
+  });
+});
+
+describe("runQueenManagerLoop — decision payload shape", () => {
+  it("uses runnerId as synthesis_runner and nowMs as synthesized_at", async () => {
+    const fixedNow = Date.parse("2026-04-28T22:00:00Z");
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      claimThroughSequence: 99,
+    });
+    await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: "queen-prod-deploy-abc",
+      nowMs: fixedNow,
+    });
+    expect(calls.closeCalls[0].synthesisRunner).toBe("queen-prod-deploy-abc");
+    expect(calls.closeCalls[0].synthesizedAt).toBe("2026-04-28T22:00:00.000Z");
+    expect(calls.closeCalls[0].expectedThroughSequence).toBe(99);
+  });
+});

--- a/bot/api/lib/queen/manager-loop.test.ts
+++ b/bot/api/lib/queen/manager-loop.test.ts
@@ -717,26 +717,18 @@ describe("runQueenManagerLoop — R1 #536 builder B1 (post-claim withdraw valida
     expect(calls.closeCalls).toEqual([]);
   });
 
-  it("abandons when re-RSVP between claim and re-read flips withdrew→pending", async () => {
-    // Pre-claim: drone shows withdrew @ seq 5 (finality OK).
-    // Post-claim re-read: drone shows pending (worker re-RSVPd
-    // between claim and re-read). Defense: the post-claim
-    // withdrawalsAreFinal check passes (only checks withdrew status),
-    // but a `pending` post-claim is NOT final synthesis state. We
-    // currently still close — guard NB4 covers this in the
-    // pre-claim check; verify here that the re-read sees the new
-    // state for synthesis input.
+  it("abandons when re-RSVP between pre-claim read and claim flips withdrew→pending", async () => {
+    // Pre-claim: drone shows withdrew @ seq 5 (eligibility passes:
+    // 1 resolved + 1 final-withdrew).
+    // Between read and claim: drone re-RSVPs. The `presentParticipant`
+    // script rewrites the slot to `pending` and clears
+    // `withdrew_at_sequence` (war-room.ts:2718, :2754).
+    // Post-claim re-read: drone shows `pending`. The claim's
+    // throughSequence already covers the re-RSVP event, so
+    // sequence_drift won't fire at close.
     //
-    // Note: this behavior is intentional for V1 — the queen claims
-    // based on the pre-claim eligibility view, and re-RSVPs
-    // post-claim are caught only when they manifest as withdraws
-    // becoming non-final. A re-RSVP that flips withdrew → pending
-    // post-claim races through. That's a known limitation; V1.1 may
-    // re-check the full eligibility against the post-claim view.
-    //
-    // For now, test that the loop's behavior is at least
-    // deterministic: close goes through with the claim's
-    // throughSequence; if a real event lands, sequence_drift fires.
+    // R2 #536 builder: re-run isSynthesisEligible on the post-claim
+    // view. `pending` blocks → abandon, no close.
     const { client, calls } = makeFakeClient({
       rooms: [makeRoom()],
       participants: {
@@ -756,6 +748,50 @@ describe("runQueenManagerLoop — R1 #536 builder B1 (post-claim withdraw valida
         },
       },
       contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      claimThroughSequence: 6,
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.eligible).toBe(1);
+    expect(result.claimed).toBe(1);
+    expect(result.staleClaimsAbandoned).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
+  });
+
+  it("abandons when post-claim view loses its only resolved participant", async () => {
+    // Edge case: pre-claim has 1 resolved + 1 withdrew (eligible).
+    // Between pre-claim and post-claim, the resolved participant
+    // somehow becomes timed_out (storage doesn't currently allow
+    // this transition, but defensive in case scripts change). The
+    // post-claim view has 0 resolved → eligibility fails → abandon.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: {
+          guard: resolvedParticipant("guard"),
+          drone: {
+            ...resolvedParticipant("drone"),
+            status: "withdrew",
+            withdrew_at_sequence: 5,
+          },
+        },
+      },
+      participantsPostClaim: {
+        [ROOM_ID]: {
+          guard: { ...resolvedParticipant("guard"), status: "timed_out" },
+          drone: {
+            ...resolvedParticipant("drone"),
+            status: "withdrew",
+            withdrew_at_sequence: 5,
+          },
+        },
+      },
+      contributions: { [ROOM_ID]: {} },
       claimThroughSequence: 5,
     });
     const result = await runQueenManagerLoop({
@@ -763,11 +799,9 @@ describe("runQueenManagerLoop — R1 #536 builder B1 (post-claim withdraw valida
       synthesizer: new StubSynthesizer(),
       runnerId: RUNNER_ID,
     });
-    // Withdraw-finality only checks withdrew status; drone is
-    // pending now, so the check passes (no withdrews to validate).
-    // V1 closes; V1.1 may tighten further.
-    expect(result.closed).toBe(1);
-    expect(calls.closeCalls).toHaveLength(1);
+    expect(result.staleClaimsAbandoned).toBe(1);
+    expect(result.closed).toBe(0);
+    expect(calls.closeCalls).toEqual([]);
   });
 
   it("staleClaimsAbandoned starts at zero and increments only on stale withdraws", async () => {

--- a/bot/api/lib/queen/manager-loop.ts
+++ b/bot/api/lib/queen/manager-loop.ts
@@ -63,9 +63,27 @@ const DEFAULT_MAX_ROOMS_PER_TICK = 100;
 
 /** Wire codes the loop treats as benign 409 conflict modes (skip +
  * count, do not error). The list is closed; any other 409 code is
- * counted as an error so an unfamiliar conflict surfaces to ops. */
+ * counted as an error so an unfamiliar conflict surfaces to ops.
+ *
+ * Documented benign 409 codes from the route layer:
+ *   - `claim_already_held` (`/decide`): another queen runner won the
+ *     race to claim this room.
+ *   - `invalid_status_for_claim` (`/decide`): the room flipped to a
+ *     non-`awaiting_contributions` status between this loop's
+ *     `listRooms` and `claimSynthesis` — most commonly the watchdog
+ *     terminating an `awaiting_contributions` room past `max_age` or
+ *     an operator force-close. Routine ops, NOT an error condition.
+ *   - `sequence_drift` (`/close`): new events landed mid-synthesis;
+ *     watchdog or next tick re-surfaces.
+ *   - `claim_lost` (`/close`): force-close raced.
+ *   - `claim_through_seq_mismatch` (`/close`): another runner
+ *     re-claimed during synthesis.
+ *
+ * Closes #536 guard B1: `invalid_status_for_claim` was missing,
+ * causing routine watchdog activity to alert under G'.5. */
 const BENIGN_CONFLICT_CODES: ReadonlySet<string> = new Set([
   "claim_already_held",
+  "invalid_status_for_claim",
   "sequence_drift",
   "claim_lost",
   "claim_through_seq_mismatch",
@@ -118,6 +136,15 @@ export interface QueenManagerLoopResult {
    * `sequence_drift` / `claim_lost` / `claim_through_seq_mismatch`
    * (close phase). */
   conflicts: number;
+  /** Claims that succeeded but were abandoned (no `closeRoom` issued)
+   * because post-claim re-validation showed a `withdrew` participant
+   * is now re-eligible per the worker's `/watching` contract — i.e.
+   * `withdrew_at_sequence < throughSequence`. The watchdog's
+   * `recoverDeciding` scan reverts the room after the claim TTL
+   * (~5min default) and the role gets surfaced again to workers.
+   * Closes #536 builder R1: prior code unconditionally treated
+   * `withdrew` as synthesis-permitting, racing the re-RSVP path. */
+  staleClaimsAbandoned: number;
   /** Non-benign errors: synthesizer threw, decision_too_large 400,
    * wire failure, unfamiliar 409 code. Loop continues; ops alert. */
   errors: number;
@@ -140,6 +167,7 @@ export async function runQueenManagerLoop(
     claimed: 0,
     closed: 0,
     conflicts: 0,
+    staleClaimsAbandoned: 0,
     errors: 0,
   };
 
@@ -185,16 +213,35 @@ export async function runQueenManagerLoop(
 }
 
 /**
- * Process a single `awaiting_contributions` room. Outcomes (mutates
- * `result`):
- *   - eligibility-fail (any participant pending) → no counter change
- *   - claim succeeds + synthesize + close → eligible++, claimed++,
- *     closed++
- *   - claim conflict (already held) → eligible++, conflicts++
- *   - close conflict (sequence_drift / claim_lost / mismatch) →
- *     eligible++, claimed++, conflicts++
- *   - synthesizer error / decision_too_large / wire fail →
- *     eligible++ (and claimed++ if claim succeeded), errors++
+ * Process a single `awaiting_contributions` room.
+ *
+ * State machine (mutates `result`):
+ *
+ *   1. **Pre-claim eligibility.** Read participants. Skip if any are
+ *      `pending` OR if there's no `resolved` participant at all
+ *      (synthesis on all-withdrew/all-timed_out is meaningless —
+ *      let the watchdog `expired` path handle it).
+ *   2. **Claim.** `claimSynthesis` → `throughSequence`. Benign 409
+ *      (claim_already_held, invalid_status_for_claim) → conflicts++.
+ *   3. **Post-claim withdraw validation.** Re-read participants. For
+ *      each `withdrew`, check `withdrew_at_sequence >= throughSequence`.
+ *      A withdrew participant whose seq is LESS THAN the claim's
+ *      throughSequence is re-eligible per the worker `/watching`
+ *      contract (`canRoleRsvpToRoom`) — closing now would race the
+ *      worker's re-RSVP. Abandon: return without `closeRoom`. The
+ *      watchdog's `recoverDeciding` reverts the claim after TTL.
+ *      Closes #536 builder B1.
+ *   4. **Synthesize.** Fetch contributions, hand to synthesizer.
+ *      Either I/O failure logs as `contributions_read_failed`, the
+ *      synthesizer's own throw logs as `synthesize_failed` (closes
+ *      #536 guard NB3 — distinct keys for ops triage).
+ *   5. **Close.** Pass `expectedThroughSequence` from the claim;
+ *      server enforces drift detection. Benign 409s map to
+ *      conflicts++, anything else to errors++.
+ *
+ * 404 `room_not_found` from any read step is treated as a benign
+ * conflict (room GC'd between `listRooms` and the read — closes
+ * #536 guard NB2).
  */
 async function processOneRoom(args: {
   room: RoomListEntry;
@@ -207,17 +254,30 @@ async function processOneRoom(args: {
 }): Promise<void> {
   const { room, client, synthesizer, runnerId, nowMs, log, result } = args;
 
-  const participantsResp = await client.getRoomParticipants(room.roomId);
-  if (!allParticipantsResolved(participantsResp.participants)) {
+  // 1. Pre-claim eligibility.
+  let participantsResp;
+  try {
+    participantsResp = await client.getRoomParticipants(room.roomId);
+  } catch (err) {
+    if (isRoomGone(err)) {
+      result.conflicts += 1;
+      log.info("queen.manager_loop.room_gc_pre_claim", {
+        roomId: room.roomId,
+      });
+      return;
+    }
+    throw err;
+  }
+  if (!isSynthesisEligible(participantsResp.participants)) {
     log.info("queen.manager_loop.room_not_ready", {
       roomId: room.roomId,
-      pending: countPending(participantsResp.participants),
+      ...participantStatusBreakdown(participantsResp.participants),
     });
     return;
   }
   result.eligible += 1;
 
-  // Claim phase.
+  // 2. Claim.
   let throughSequence: number;
   try {
     const claim = await client.claimSynthesis({
@@ -243,14 +303,56 @@ async function processOneRoom(args: {
     return;
   }
 
-  // Synthesize.
+  // 3. Post-claim withdraw validation.
+  let postClaimParticipants;
+  try {
+    postClaimParticipants = await client.getRoomParticipants(room.roomId);
+  } catch (err) {
+    if (isRoomGone(err)) {
+      result.conflicts += 1;
+      log.info("queen.manager_loop.room_gc_post_claim", {
+        roomId: room.roomId,
+      });
+      return;
+    }
+    throw err;
+  }
+  if (!withdrawalsAreFinal(postClaimParticipants.participants, throughSequence)) {
+    result.staleClaimsAbandoned += 1;
+    log.info("queen.manager_loop.claim_abandoned_stale_withdraw", {
+      roomId: room.roomId,
+      throughSequence,
+    });
+    return;
+  }
+
+  // 4a. Read contributions for synthesis.
+  let contributionsResp;
+  try {
+    contributionsResp = await client.getRoomContributions(room.roomId);
+  } catch (err) {
+    if (isRoomGone(err)) {
+      result.conflicts += 1;
+      log.info("queen.manager_loop.room_gc_pre_synthesis", {
+        roomId: room.roomId,
+      });
+      return;
+    }
+    log.error("queen.manager_loop.contributions_read_failed", {
+      roomId: room.roomId,
+      error: errMeta(err),
+    });
+    result.errors += 1;
+    return;
+  }
+
+  // 4b. Synthesize.
   let content: string;
   try {
-    const contributionsResp = await client.getRoomContributions(room.roomId);
     const synthesis = await synthesizer.synthesize({
       roomId: room.roomId,
       room: stripRoomId(room),
-      participants: participantsResp.participants,
+      participants: postClaimParticipants.participants,
       contributions: contributionsResp.contributions,
       throughSequence,
     });
@@ -261,14 +363,10 @@ async function processOneRoom(args: {
       error: errMeta(err),
     });
     result.errors += 1;
-    // Note: leaving the claim outstanding. The watchdog's
-    // recoverDeciding scan will revert it after the claim TTL
-    // (~5min default per storage spec). V1.1 may add an explicit
-    // `failed_synthesis` terminate path here.
     return;
   }
 
-  // Close.
+  // 5. Close.
   try {
     await client.closeRoom({
       roomId: room.roomId,
@@ -302,18 +400,85 @@ async function processOneRoom(args: {
   }
 }
 
-function allParticipantsResolved(
+/**
+ * Pre-claim eligibility predicate. The room is eligible for synthesis
+ * when:
+ *   1. There's at least one participant.
+ *   2. NO participant is `pending` (still working).
+ *   3. At LEAST one participant is `resolved` (has actual input —
+ *      otherwise the synthesizer is producing a decision out of all-
+ *      withdrew/all-timed_out, which is meaningless. Closes #536
+ *      guard NB4. Watchdog's `expired` terminate path handles those
+ *      rooms via `max_age_secs`).
+ */
+function isSynthesisEligible(
   participants: Record<string, RoomParticipant>,
 ): boolean {
-  // Empty hash → not eligible (no one RSVP'd, nothing to synthesize).
-  // Pending → blocks. resolved / withdrew / timed_out → permits.
   const entries = Object.values(participants);
   if (entries.length === 0) return false;
-  return entries.every((p) => p.status !== "pending");
+  let hasResolved = false;
+  for (const p of entries) {
+    if (p.status === "pending") return false;
+    if (p.status === "resolved") hasResolved = true;
+  }
+  return hasResolved;
 }
 
-function countPending(participants: Record<string, RoomParticipant>): number {
-  return Object.values(participants).filter((p) => p.status === "pending").length;
+/**
+ * Post-claim withdraw-finality predicate. Closes #536 builder B1.
+ *
+ * The worker's `/watching` endpoint re-includes a withdrawn role
+ * when the room has events past `withdrew_at_sequence` — meaning
+ * the role can re-RSVP and contribute again. Synthesizing in that
+ * window races the re-RSVP path.
+ *
+ * After `claimSynthesis` succeeds, the claim's `throughSequence` is
+ * the latest event seq at claim time. For each `withdrew`
+ * participant, compare `withdrew_at_sequence` against `throughSequence`:
+ *
+ *   - `withdrew_at_sequence >= throughSequence` → withdrawal is final
+ *     (no events past it). Permits close.
+ *   - `withdrew_at_sequence < throughSequence` → events have advanced
+ *     past the withdraw point; participant is re-eligible per the
+ *     worker contract. Block close.
+ *   - `withdrew_at_sequence` undefined → defensive block (we can't
+ *     prove finality without the seq).
+ *
+ * "Block" here means abandon the claim — return without `closeRoom`.
+ * The watchdog's `recoverDeciding` reverts the claim after TTL,
+ * surfacing the room to workers + queen on the next pass.
+ */
+function withdrawalsAreFinal(
+  participants: Record<string, RoomParticipant>,
+  throughSequence: number,
+): boolean {
+  for (const p of Object.values(participants)) {
+    if (p.status !== "withdrew") continue;
+    if (p.withdrew_at_sequence === undefined) return false;
+    if (p.withdrew_at_sequence < throughSequence) return false;
+  }
+  return true;
+}
+
+function participantStatusBreakdown(
+  participants: Record<string, RoomParticipant>,
+): { pending: number; resolved: number; withdrew: number; timed_out: number } {
+  const counts = { pending: 0, resolved: 0, withdrew: 0, timed_out: 0 };
+  for (const p of Object.values(participants)) {
+    counts[p.status] += 1;
+  }
+  return counts;
+}
+
+function isRoomGone(err: unknown): err is WarRoomApiError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    "code" in err &&
+    (err as WarRoomApiError).status === 404 &&
+    (err as WarRoomApiError).code === "room_not_found"
+  );
 }
 
 /** Extract the bare `RoomCoreResponse` from a `RoomListEntry` for

--- a/bot/api/lib/queen/manager-loop.ts
+++ b/bot/api/lib/queen/manager-loop.ts
@@ -303,7 +303,22 @@ async function processOneRoom(args: {
     return;
   }
 
-  // 3. Post-claim withdraw validation.
+  // 3. Post-claim re-validate participants. Two distinct races we
+  //    have to catch:
+  //
+  //    a. Re-RSVP between pre-claim read and `claimSynthesis`. The
+  //       `presentParticipant` script (war-room.ts:2718, :2754)
+  //       rewrites the slot to `pending` and clears
+  //       `withdrew_at_sequence` — so the post-claim read shows
+  //       `pending`, NOT `withdrew`. `withdrawalsAreFinal` alone
+  //       wouldn't catch this. Closes #536 builder R2.
+  //    b. The withdraw is no longer final (events past
+  //       `withdrew_at_sequence`). The participant can re-RSVP per
+  //       the worker `/watching` contract; closing now races.
+  //       Closes #536 builder B1.
+  //
+  //    Both abandon the claim — return without `closeRoom`. The
+  //    watchdog's `recoverDeciding` reverts the claim after TTL.
   let postClaimParticipants;
   try {
     postClaimParticipants = await client.getRoomParticipants(room.roomId);
@@ -316,6 +331,15 @@ async function processOneRoom(args: {
       return;
     }
     throw err;
+  }
+  if (!isSynthesisEligible(postClaimParticipants.participants)) {
+    result.staleClaimsAbandoned += 1;
+    log.info("queen.manager_loop.claim_abandoned_post_claim_re_rsvp", {
+      roomId: room.roomId,
+      throughSequence,
+      ...participantStatusBreakdown(postClaimParticipants.participants),
+    });
+    return;
   }
   if (!withdrawalsAreFinal(postClaimParticipants.participants, throughSequence)) {
     result.staleClaimsAbandoned += 1;

--- a/bot/api/lib/queen/manager-loop.ts
+++ b/bot/api/lib/queen/manager-loop.ts
@@ -1,0 +1,353 @@
+/**
+ * Queen manager loop — the bot-side body of the war-room synthesis
+ * cycle.
+ *
+ * Driven by Vercel Cron (G'.5) every ~60s. Per tick:
+ *
+ *   1. **List rooms** for the bearer's installation.
+ *   2. **Filter** to status `awaiting_contributions`. Rooms in
+ *      `awaiting_rsvp` aren't ready (no contributions to synthesize);
+ *      rooms in `deciding` are owned by another runner OR by the
+ *      watchdog's recovery path; `closed` / `expired` are terminal.
+ *   3. **Eligibility check** per candidate room: fetch the
+ *      materialized participants, confirm every entry's status is
+ *      `resolved`. Pending / withdrew / timed_out are not synthesis-
+ *      eligible (a withdrew/timed_out is fine if every OTHER
+ *      participant is resolved — only `pending` blocks).
+ *   4. **Claim** the synthesis lane via `claimSynthesis`. Returns a
+ *      `throughSequence` cutoff. 409 `claim_already_held` is a
+ *      benign race (another queen runner won it) → skip + count.
+ *   5. **Synthesize** by handing the room state to the configured
+ *      `Synthesizer`. The synthesizer is dependency-injected so
+ *      G'.3 swaps in the real LLM without touching this loop.
+ *   6. **Close** with the synthesis content + the claim's
+ *      `throughSequence`. The server compares against the live seq
+ *      and returns 409 `sequence_drift` if new events landed mid-
+ *      synthesis (the watchdog's recovery path will surface the
+ *      room next tick). 409 `claim_lost` (force-close raced) and
+ *      `claim_through_seq_mismatch` (re-claimed) are also benign
+ *      conflict modes the loop counts and skips.
+ *
+ * Errors that aren't benign 409s (synthesizer threw, wire/network
+ * failures, decision_too_large 400) increment `errors` and the loop
+ * continues to the next room — one bad room never stalls the
+ * fleet's synthesis pipeline.
+ *
+ * Idempotency / safety:
+ *   - The claim primitive is server-side atomic (DECIDE_CLAIM Lua).
+ *     Two cron firings overlapping is fine: the second sees
+ *     `claim_already_held` and skips.
+ *   - Close is sequence-pinned, so re-running synthesis on the same
+ *     room never double-applies a decision.
+ *   - The watchdog's recovery scan reverts orphaned `deciding` rooms
+ *     when a queen runner crashes between claim and close — this
+ *     loop doesn't need to handle that itself.
+ *
+ * NOT in this slice (G'.2):
+ *   - The Vercel cron route + auth + bearer wiring (G'.5).
+ *   - Real LLM synthesis (G'.3 — wires `AiSdkSynthesizer`).
+ *   - GitHub posting of the decision (G'.4 — post the markdown to
+ *     the PR thread once the room closes).
+ */
+
+import type {
+  RoomCoreResponse,
+  RoomListEntry,
+  RoomParticipant,
+  WarRoomClient,
+  WarRoomApiError,
+} from "../war-room-client.js";
+import type { Synthesizer } from "./synthesizer.js";
+
+const DEFAULT_MAX_ROOMS_PER_TICK = 100;
+
+/** Wire codes the loop treats as benign 409 conflict modes (skip +
+ * count, do not error). The list is closed; any other 409 code is
+ * counted as an error so an unfamiliar conflict surfaces to ops. */
+const BENIGN_CONFLICT_CODES: ReadonlySet<string> = new Set([
+  "claim_already_held",
+  "sequence_drift",
+  "claim_lost",
+  "claim_through_seq_mismatch",
+]);
+
+export interface QueenManagerLoopArgs {
+  client: WarRoomClient;
+  synthesizer: Synthesizer;
+  /** Stable runner identity (passed as `queenRunner` on
+   * `claimSynthesis` and folded into the decision payload's
+   * `synthesis_runner` field). Operator-set; e.g.
+   * `"queen-vercel-{deploymentId}"`. Used by the watchdog's
+   * recovery path to attribute orphaned claims. */
+  runnerId: string;
+  /** Cap on rooms processed per tick (defensive). The Vercel
+   * function timeout is the real constraint; this is a back-stop.
+   * Default 100 — matches the watchdog's `maxRoomsPerTick`. */
+  maxRoomsPerTick?: number;
+  /** Now in ms since epoch. Defaults to `Date.now()`. Tests pass a
+   * fixed value for determinism. */
+  nowMs?: number;
+  /** Optional logger. Falls back to no-op. */
+  log?: ManagerLoopLogger;
+}
+
+export interface ManagerLoopLogger {
+  info: (message: string, meta?: Record<string, unknown>) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+  error: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+/**
+ * Outcome counts emitted by `runQueenManagerLoop`. The Vercel route
+ * (G'.5) surfaces these in its JSON response so operators can alert
+ * on `errors > 0` or correlate `closed` against PR-comment posting.
+ */
+export interface QueenManagerLoopResult {
+  /** Total rooms returned by `listRooms` this tick (capped at
+   * maxRoomsPerTick). */
+  totalRoomsScanned: number;
+  /** Subset in `awaiting_contributions`. */
+  scannedAwaitingContributions: number;
+  /** Subset where every participant resolved (synthesis-eligible). */
+  eligible: number;
+  /** Eligible rooms where claim succeeded (drives synthesis call). */
+  claimed: number;
+  /** Rooms successfully closed with a synthesis decision. */
+  closed: number;
+  /** Benign races: `claim_already_held` (claim phase),
+   * `sequence_drift` / `claim_lost` / `claim_through_seq_mismatch`
+   * (close phase). */
+  conflicts: number;
+  /** Non-benign errors: synthesizer threw, decision_too_large 400,
+   * wire failure, unfamiliar 409 code. Loop continues; ops alert. */
+  errors: number;
+}
+
+/**
+ * Run one queen manager-loop tick. Returns aggregate counters; per-
+ * room errors are logged-and-continue.
+ */
+export async function runQueenManagerLoop(
+  args: QueenManagerLoopArgs,
+): Promise<QueenManagerLoopResult> {
+  const log = args.log ?? noopLogger();
+  const maxRooms = args.maxRoomsPerTick ?? DEFAULT_MAX_ROOMS_PER_TICK;
+
+  const result: QueenManagerLoopResult = {
+    totalRoomsScanned: 0,
+    scannedAwaitingContributions: 0,
+    eligible: 0,
+    claimed: 0,
+    closed: 0,
+    conflicts: 0,
+    errors: 0,
+  };
+
+  let rooms: RoomListEntry[];
+  try {
+    rooms = await args.client.listRooms({ limit: maxRooms });
+  } catch (err) {
+    // List failure is loop-fatal for this tick (no rooms to process)
+    // but not session-fatal — next cron firing retries.
+    log.error("queen.manager_loop.list_rooms_failed", { error: errMeta(err) });
+    result.errors += 1;
+    return result;
+  }
+  result.totalRoomsScanned = rooms.length;
+
+  for (const room of rooms) {
+    if (room.status !== "awaiting_contributions") continue;
+    result.scannedAwaitingContributions += 1;
+
+    try {
+      await processOneRoom({
+        room,
+        client: args.client,
+        synthesizer: args.synthesizer,
+        runnerId: args.runnerId,
+        nowMs: args.nowMs ?? Date.now(),
+        log,
+        result,
+      });
+    } catch (err) {
+      // Belt-and-suspenders: processOneRoom swallows expected
+      // conflict modes. Anything reaching here is unexpected.
+      log.error("queen.manager_loop.unexpected_error", {
+        roomId: room.roomId,
+        error: errMeta(err),
+      });
+      result.errors += 1;
+    }
+  }
+
+  log.info("queen.manager_loop.tick_complete", { ...result });
+  return result;
+}
+
+/**
+ * Process a single `awaiting_contributions` room. Outcomes (mutates
+ * `result`):
+ *   - eligibility-fail (any participant pending) → no counter change
+ *   - claim succeeds + synthesize + close → eligible++, claimed++,
+ *     closed++
+ *   - claim conflict (already held) → eligible++, conflicts++
+ *   - close conflict (sequence_drift / claim_lost / mismatch) →
+ *     eligible++, claimed++, conflicts++
+ *   - synthesizer error / decision_too_large / wire fail →
+ *     eligible++ (and claimed++ if claim succeeded), errors++
+ */
+async function processOneRoom(args: {
+  room: RoomListEntry;
+  client: WarRoomClient;
+  synthesizer: Synthesizer;
+  runnerId: string;
+  nowMs: number;
+  log: ManagerLoopLogger;
+  result: QueenManagerLoopResult;
+}): Promise<void> {
+  const { room, client, synthesizer, runnerId, nowMs, log, result } = args;
+
+  const participantsResp = await client.getRoomParticipants(room.roomId);
+  if (!allParticipantsResolved(participantsResp.participants)) {
+    log.info("queen.manager_loop.room_not_ready", {
+      roomId: room.roomId,
+      pending: countPending(participantsResp.participants),
+    });
+    return;
+  }
+  result.eligible += 1;
+
+  // Claim phase.
+  let throughSequence: number;
+  try {
+    const claim = await client.claimSynthesis({
+      roomId: room.roomId,
+      queenRunner: runnerId,
+    });
+    throughSequence = claim.throughSequence;
+    result.claimed += 1;
+  } catch (err) {
+    if (isBenignConflict(err)) {
+      result.conflicts += 1;
+      log.info("queen.manager_loop.claim_conflict", {
+        roomId: room.roomId,
+        code: (err as WarRoomApiError).code,
+      });
+      return;
+    }
+    log.error("queen.manager_loop.claim_failed", {
+      roomId: room.roomId,
+      error: errMeta(err),
+    });
+    result.errors += 1;
+    return;
+  }
+
+  // Synthesize.
+  let content: string;
+  try {
+    const contributionsResp = await client.getRoomContributions(room.roomId);
+    const synthesis = await synthesizer.synthesize({
+      roomId: room.roomId,
+      room: stripRoomId(room),
+      participants: participantsResp.participants,
+      contributions: contributionsResp.contributions,
+      throughSequence,
+    });
+    content = synthesis.content;
+  } catch (err) {
+    log.error("queen.manager_loop.synthesize_failed", {
+      roomId: room.roomId,
+      error: errMeta(err),
+    });
+    result.errors += 1;
+    // Note: leaving the claim outstanding. The watchdog's
+    // recoverDeciding scan will revert it after the claim TTL
+    // (~5min default per storage spec). V1.1 may add an explicit
+    // `failed_synthesis` terminate path here.
+    return;
+  }
+
+  // Close.
+  try {
+    await client.closeRoom({
+      roomId: room.roomId,
+      expectedThroughSequence: throughSequence,
+      decision: {
+        synthesized_at: new Date(nowMs).toISOString(),
+        synthesis_runner: runnerId,
+        content,
+        sequence_closed: throughSequence,
+      },
+    });
+    result.closed += 1;
+    log.info("queen.manager_loop.room_closed", {
+      roomId: room.roomId,
+      throughSequence,
+    });
+  } catch (err) {
+    if (isBenignConflict(err)) {
+      result.conflicts += 1;
+      log.info("queen.manager_loop.close_conflict", {
+        roomId: room.roomId,
+        code: (err as WarRoomApiError).code,
+      });
+      return;
+    }
+    log.error("queen.manager_loop.close_failed", {
+      roomId: room.roomId,
+      error: errMeta(err),
+    });
+    result.errors += 1;
+  }
+}
+
+function allParticipantsResolved(
+  participants: Record<string, RoomParticipant>,
+): boolean {
+  // Empty hash → not eligible (no one RSVP'd, nothing to synthesize).
+  // Pending → blocks. resolved / withdrew / timed_out → permits.
+  const entries = Object.values(participants);
+  if (entries.length === 0) return false;
+  return entries.every((p) => p.status !== "pending");
+}
+
+function countPending(participants: Record<string, RoomParticipant>): number {
+  return Object.values(participants).filter((p) => p.status === "pending").length;
+}
+
+/** Extract the bare `RoomCoreResponse` from a `RoomListEntry` for
+ * synthesizer input. Drops the `roomId` (synthesizer gets it as a
+ * top-level input field) so the type matches the wire shape returned
+ * by `getRoomCore`. */
+function stripRoomId(room: RoomListEntry): RoomCoreResponse {
+  const { roomId: _ignored, ...rest } = room;
+  void _ignored;
+  return rest;
+}
+
+function isBenignConflict(err: unknown): err is WarRoomApiError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    "code" in err &&
+    (err as WarRoomApiError).status === 409 &&
+    BENIGN_CONFLICT_CODES.has((err as WarRoomApiError).code)
+  );
+}
+
+function errMeta(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message };
+  }
+  return { value: String(err) };
+}
+
+function noopLogger(): ManagerLoopLogger {
+  return {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+}

--- a/bot/api/lib/queen/synthesizer.test.ts
+++ b/bot/api/lib/queen/synthesizer.test.ts
@@ -82,6 +82,30 @@ describe("StubSynthesizer", () => {
     expect(out.content).toContain("0 present, 0 withdrawn");
   });
 
+  it("breaks down participants by status (R1 #536 guard NB4)", async () => {
+    // Prior label `Participants resolved: ${total}` counted withdrew
+    // + timed_out as "resolved" — wrong on the wire. New shape:
+    // `${resolved} resolved, ${withdrew} withdrew, ${timed_out} timed out`.
+    const input: SynthesisInput = {
+      roomId: "room-id",
+      room: ROOM,
+      participants: {
+        guard: { ...PARTICIPANT, role: "guard", status: "resolved" },
+        builder: {
+          ...PARTICIPANT,
+          role: "builder",
+          status: "withdrew",
+          withdrew_at_sequence: 5,
+        },
+        drone: { ...PARTICIPANT, role: "drone", status: "timed_out" },
+      },
+      contributions: { guard: PRESENT_CONTRIBUTION },
+      throughSequence: 5,
+    };
+    const out = await synth.synthesize(input);
+    expect(out.content).toContain("1 resolved, 1 withdrew, 1 timed out");
+  });
+
   it("flags itself as stub mode in the body", async () => {
     // The body must clearly identify itself as stub output so an
     // operator scanning closed-room decisions can confirm the queen

--- a/bot/api/lib/queen/synthesizer.test.ts
+++ b/bot/api/lib/queen/synthesizer.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for `StubSynthesizer` (G'.2). The real LLM-backed
+ * synthesizer arrives in G'.3 and gets its own test suite.
+ */
+
+import { describe, expect, it } from "vitest";
+import { StubSynthesizer, type SynthesisInput } from "./synthesizer.js";
+import type {
+  RoomContribution,
+  RoomCoreResponse,
+  RoomParticipant,
+} from "../war-room-client.js";
+
+const ROOM: RoomCoreResponse = {
+  manager: "bot-queen",
+  subject_type: "pr_review",
+  subject_ref: "owner/repo#42",
+  status: "deciding",
+  opened_at: "2026-04-28T20:00:00Z",
+};
+
+const PARTICIPANT: RoomParticipant = {
+  agent_id: "guard-runner-1",
+  role: "guard",
+  status: "resolved",
+  rsvp_at: "2026-04-28T20:01:00Z",
+  resolved_at: "2026-04-28T20:05:00Z",
+};
+
+const PRESENT_CONTRIBUTION: RoomContribution = {
+  raw_md: "Looks good.",
+  contributed_at: "2026-04-28T20:05:00Z",
+};
+
+const WITHDRAWN: RoomContribution = {
+  withdrawn: true,
+  contributed_at: "2026-04-28T20:06:00Z",
+};
+
+describe("StubSynthesizer", () => {
+  const synth = new StubSynthesizer();
+
+  it("returns markdown including the roomId, subject, throughSequence", async () => {
+    const input: SynthesisInput = {
+      roomId: "01234567-89ab-4cde-9012-3456789abcde",
+      room: ROOM,
+      participants: { guard: PARTICIPANT },
+      contributions: { guard: PRESENT_CONTRIBUTION },
+      throughSequence: 7,
+    };
+    const out = await synth.synthesize(input);
+    expect(out.content).toContain("01234567-89ab-4cde-9012-3456789abcde");
+    expect(out.content).toContain("pr_review");
+    expect(out.content).toContain("owner/repo#42");
+    expect(out.content).toContain("Through sequence:** 7");
+  });
+
+  it("counts present vs withdrawn contributions separately", async () => {
+    const input: SynthesisInput = {
+      roomId: "room-id",
+      room: ROOM,
+      participants: { guard: PARTICIPANT, builder: PARTICIPANT },
+      contributions: {
+        guard: PRESENT_CONTRIBUTION,
+        builder: WITHDRAWN,
+      },
+      throughSequence: 5,
+    };
+    const out = await synth.synthesize(input);
+    expect(out.content).toContain("1 present, 1 withdrawn");
+  });
+
+  it("handles zero contributions gracefully", async () => {
+    const input: SynthesisInput = {
+      roomId: "room-id",
+      room: ROOM,
+      participants: {},
+      contributions: {},
+      throughSequence: 0,
+    };
+    const out = await synth.synthesize(input);
+    expect(out.content).toContain("0 present, 0 withdrawn");
+  });
+
+  it("flags itself as stub mode in the body", async () => {
+    // The body must clearly identify itself as stub output so an
+    // operator scanning closed-room decisions can confirm the queen
+    // hasn't yet been wired to a real LLM. G'.3 replaces this with
+    // real synthesis output.
+    const out = await synth.synthesize({
+      roomId: "x",
+      room: ROOM,
+      participants: {},
+      contributions: {},
+      throughSequence: 0,
+    });
+    expect(out.content).toContain("stub");
+    expect(out.content).toContain("G'.3");
+  });
+});

--- a/bot/api/lib/queen/synthesizer.ts
+++ b/bot/api/lib/queen/synthesizer.ts
@@ -74,7 +74,15 @@ export interface Synthesizer {
  */
 export class StubSynthesizer implements Synthesizer {
   async synthesize(input: SynthesisInput): Promise<SynthesisOutput> {
-    const participantCount = Object.keys(input.participants).length;
+    // Closes #536 guard NB4: prior label was `Participants resolved:
+    // ${total}` which counted withdrew + timed_out as "resolved" —
+    // wrong on the wire. Break the count down by status so operators
+    // scanning closed-room decisions see honest numbers (and so G'.3
+    // has the breakdown when the real LLM prompt is built).
+    const counts = { resolved: 0, withdrew: 0, timed_out: 0, pending: 0 };
+    for (const p of Object.values(input.participants)) {
+      counts[p.status] += 1;
+    }
     const contributionCount = Object.values(input.contributions).filter(
       (c) => !c.withdrawn,
     ).length;
@@ -88,7 +96,7 @@ export class StubSynthesizer implements Synthesizer {
       `**Subject:** ${input.room.subject_type} \`${input.room.subject_ref}\``,
       `**Through sequence:** ${input.throughSequence}`,
       "",
-      `**Participants resolved:** ${participantCount}`,
+      `**Participants:** ${counts.resolved} resolved, ${counts.withdrew} withdrew, ${counts.timed_out} timed out`,
       `**Contributions:** ${contributionCount} present, ${withdrawnCount} withdrawn`,
       "",
       `_The queen module is operating in stub mode; this room was synthesized by the manager loop without invoking an LLM. See WAR_ROOM_DESIGN.md and Phase G'.3._`,

--- a/bot/api/lib/queen/synthesizer.ts
+++ b/bot/api/lib/queen/synthesizer.ts
@@ -1,0 +1,98 @@
+/**
+ * Synthesizer — abstraction over the queen's decision-generation
+ * step.
+ *
+ * The manager loop (G'.2) reads a room's participants + contributions
+ * after claiming the synthesis lane, hands them to a `Synthesizer`,
+ * and writes the resulting markdown back via `closeRoom`. The
+ * abstraction is here so:
+ *
+ *   1. **G'.3** can swap a real LLM synthesizer (`AiSdkSynthesizer`)
+ *      in without touching the loop's claim/close mechanics.
+ *   2. **Tests** can use a `StubSynthesizer` (no LLM calls, fast,
+ *      deterministic) to exercise the loop end-to-end.
+ *
+ * The synthesizer NEVER calls the war-room API directly — it
+ * receives all room state through `SynthesisInput` and returns the
+ * decision body. The manager loop is the only thing that crosses
+ * the wire. This separation is what makes G'.3 a focused PR
+ * (LLM-call wiring only) rather than a re-plumb.
+ */
+
+import type {
+  RoomCoreResponse,
+  RoomContribution,
+  RoomParticipant,
+} from "../war-room-client.js";
+
+/**
+ * Everything the synthesizer needs to produce a decision. The
+ * manager loop materializes this from the war-room client's reads
+ * (`getRoomCore` + `getRoomParticipants` + `getRoomContributions`)
+ * AFTER `claimSynthesis` succeeds — so `throughSequence` is the
+ * cutoff seq the close path will verify.
+ */
+export interface SynthesisInput {
+  roomId: string;
+  /** Room core record (manager, subject, status, opened_at, etc.). */
+  room: RoomCoreResponse;
+  /** Materialized participant hash (role → state). All participants
+   * in `awaiting_contributions` are guaranteed `resolved` by the
+   * loop's eligibility check before this is invoked. */
+  participants: Record<string, RoomParticipant>;
+  /** Materialized contribution hash (role → body or tombstone). */
+  contributions: Record<string, RoomContribution>;
+  /** The sequence the queen claimed through. Future events past this
+   * cutoff are ignored; close-time drift detection compares
+   * `expectedThroughSequence` (= this) against the live seq. */
+  throughSequence: number;
+}
+
+export interface SynthesisOutput {
+  /** The decision body — markdown, ≤ 64 KiB UTF-8 bytes per the
+   * server's `RoomDecisionTooLargeError` cap. Synthesizers that risk
+   * exceeding this should truncate (or return a structured error
+   * the loop maps to a `failed_synthesis` terminate — V1.1). */
+  content: string;
+}
+
+export interface Synthesizer {
+  synthesize(input: SynthesisInput): Promise<SynthesisOutput>;
+}
+
+/**
+ * StubSynthesizer — placeholder that returns a deterministic
+ * markdown body without calling any LLM. Used by the manager loop's
+ * tests AND by the production deployment until G'.3 ships the real
+ * synthesizer (so the queen route can be wired + cron exercised
+ * end-to-end before the LLM dependency lands).
+ *
+ * The body includes enough context (roomId, participant + contribution
+ * counts, throughSequence) that operators can confirm the loop ran
+ * by inspecting closed rooms, without the body looking like a real
+ * decision.
+ */
+export class StubSynthesizer implements Synthesizer {
+  async synthesize(input: SynthesisInput): Promise<SynthesisOutput> {
+    const participantCount = Object.keys(input.participants).length;
+    const contributionCount = Object.values(input.contributions).filter(
+      (c) => !c.withdrawn,
+    ).length;
+    const withdrawnCount = Object.values(input.contributions).filter(
+      (c) => c.withdrawn,
+    ).length;
+    const lines = [
+      `## Synthesis (stub — G'.3 replaces this with real LLM)`,
+      "",
+      `**Room:** \`${input.roomId}\``,
+      `**Subject:** ${input.room.subject_type} \`${input.room.subject_ref}\``,
+      `**Through sequence:** ${input.throughSequence}`,
+      "",
+      `**Participants resolved:** ${participantCount}`,
+      `**Contributions:** ${contributionCount} present, ${withdrawnCount} withdrawn`,
+      "",
+      `_The queen module is operating in stub mode; this room was synthesized by the manager loop without invoking an LLM. See WAR_ROOM_DESIGN.md and Phase G'.3._`,
+    ];
+    return { content: lines.join("\n") };
+  }
+}

--- a/bot/api/lib/war-room-client.ts
+++ b/bot/api/lib/war-room-client.ts
@@ -265,19 +265,9 @@ export class WarRoomClient {
     }
 
     // Structured error → WarRoomApiError so callers can branch on
-    // `code`. The 409 `subject_already_open` path is idempotent.
-    let parsed: Record<string, unknown> = {};
-    try {
-      parsed = (await response.json()) as Record<string, unknown>;
-    } catch {
-      // Non-JSON error body — fall through with empty parsed.
-    }
-    const code = typeof parsed.code === "string" ? parsed.code : "unknown";
-    const message =
-      typeof parsed.message === "string"
-        ? parsed.message
-        : `War-room API ${response.status} (${code})`;
-    throw new WarRoomApiError(response.status, code, message, parsed);
+    // `code`. The 409 `subject_already_open` path is idempotent —
+    // caller extracts `error.response.existingRoomId`.
+    throw await this._toApiError(response);
   }
 
   /**
@@ -317,18 +307,7 @@ export class WarRoomClient {
       return (await response.json()) as { sequence: number; replay?: boolean };
     }
 
-    let parsed: Record<string, unknown> = {};
-    try {
-      parsed = (await response.json()) as Record<string, unknown>;
-    } catch {
-      // Non-JSON error body — fall through.
-    }
-    const code = typeof parsed.code === "string" ? parsed.code : "unknown";
-    const message =
-      typeof parsed.message === "string"
-        ? parsed.message
-        : `War-room API ${response.status} (${code})`;
-    throw new WarRoomApiError(response.status, code, message, parsed);
+    throw await this._toApiError(response);
   }
 
   // ─── Queen-side reads (G'.1) ─────────────────────────────────────────


### PR DESCRIPTION
Fixes #535

## Summary

Second slice of Phase G' (queen module). Adds the bot-side state machine that drives a war room from `awaiting_contributions` → `claimSynthesis` → synthesize → `closeRoom`. Synthesis is stubbed (deterministic markdown, no LLM); G'.3 swaps in the real LLM via the same `Synthesizer` interface without touching the loop.

This PR has two commits:
1. **Cleanup** (`da2ede5`): fold `createRoom` + `appendEvent` inline error mapping into `_toApiError` — deferred from PR #534 guard NB5.
2. **G'.2 scaffold** (`4b2edce`): the manager loop + synthesizer interface + stub + 25 tests.

## What's new

```
bot/api/lib/queen/
├── manager-loop.ts        — runQueenManagerLoop + per-room state machine
├── manager-loop.test.ts   — 21 tests (filtering, eligibility, conflicts, errors, mixed outcomes)
├── synthesizer.ts         — Synthesizer interface + StubSynthesizer
└── synthesizer.test.ts    — 4 tests on stub body
```

### Per-tick state machine

| Phase | Behavior |
|---|---|
| List | `listRooms({ limit: maxRoomsPerTick })`. Failure → errors++, return early. |
| Filter | Skip anything not `awaiting_contributions` (other states aren't synthesis candidates). |
| Eligibility | Fetch participants. Empty hash blocks. ANY `pending` blocks. `resolved` / `withdrew` / `timed_out` all permit. |
| Claim | `claimSynthesis(roomId, queenRunner)` → `throughSequence`. 409 `claim_already_held` → conflicts++ (benign race, another runner won it). |
| Synthesize | Hand state to `Synthesizer.synthesize(input)`. Throw → errors++, claim left for watchdog recovery. |
| Close | `closeRoom(expectedThroughSequence, decision)`. 409 `sequence_drift` / `claim_lost` / `claim_through_seq_mismatch` → conflicts++. 400 `decision_too_large` → errors++. Other 409 codes → errors++ (closed conflict-set, fail loud). |

### Counters

```typescript
{
  totalRoomsScanned: 3,        // listRooms returned
  scannedAwaitingContributions: 2,  // status filter passed
  eligible: 2,                 // all participants resolved
  claimed: 2,                  // claimSynthesis succeeded
  closed: 1,                   // happy path through close
  conflicts: 1,                // benign 409 (close-time race)
  errors: 0,                   // unexpected failures (synth/wire/400/unfamiliar 409)
}
```

## What it looks like (stub synthesis output)

```markdown
## Synthesis (stub — G'.3 replaces this with real LLM)

**Room:** `01234567-89ab-4cde-9012-3456789abcde`
**Subject:** pr_review `owner/repo#42`
**Through sequence:** 7

**Participants resolved:** 1
**Contributions:** 1 present, 0 withdrawn

_The queen module is operating in stub mode; this room was synthesized by the manager loop without invoking an LLM. See WAR_ROOM_DESIGN.md and Phase G'.3._
```

The body identifies itself as stub mode so an operator scanning closed-room decisions can confirm the loop ran without reading it as a real synthesis.

## What's NOT in this slice

| Slice | Scope |
|---|---|
| G'.3 | Real LLM synthesis (`AiSdkSynthesizer` — same `Synthesizer` interface) |
| G'.4 | GitHub posting of decision (post markdown to PR thread once room closes) |
| G'.5 | Vercel cron route + auth + bearer wiring (the Vercel function that calls `runQueenManagerLoop` per tick) |

## Test plan

- [x] `tsc --noEmit` clean
- [x] Queen tests: 25 (21 manager-loop + 4 synthesizer)
- [x] Full bot suite: 1794 tests pass (was 1769 in main, +25)
- [x] Lint clean on changed files (the one warning at war-room-client.ts:553 predates this PR — from #526)
- [ ] Reviewer fleet sign-off