### PR TITLE
Phase G'.4 — GitHub posting integration (DecisionPoster)

### DIFF
--- a/bot/api/lib/queen/decision-poster.test.ts
+++ b/bot/api/lib/queen/decision-poster.test.ts
@@ -167,6 +167,79 @@ describe("GitHubDecisionPoster.postDecision — malformed subject_ref", () => {
   });
 });
 
+describe("GitHubDecisionPoster.postDecision — strict subject_ref regex (R1 #540)", () => {
+  // Closes #540 builder R1: prior regex `^([^/]+)/([^#]+)#(\d+)$`
+  // was too permissive. Tightened to GitHub's actual charset.
+
+  it.each([
+    ["owner/repo/extra#1", "extra path segment"],
+    ["owner with spaces/repo#42", "spaces in owner"],
+    ["owner/repo with spaces#42", "spaces in repo"],
+    ["owner//repo#42", "double slash"],
+    ["owner/repo#0", "PR number zero"],
+    ["owner/repo#01", "leading-zero PR number"],
+    ["owner/repo#042", "leading-zero PR number multi-digit"],
+    ["/repo#42", "missing owner"],
+    ["owner/#42", "missing repo"],
+    ["owner/repo#", "missing PR number"],
+    ["owner/repo#42 ", "trailing space"],
+    ["owner/repo#42\n", "trailing newline"],
+    [" owner/repo#42", "leading space"],
+    ["owner/repo#-1", "negative PR number"],
+    ["owner/repo#1.5", "non-integer PR number"],
+    ["owner/répo#42", "non-ASCII char in repo"],
+    ["owner/re*po#42", "asterisk in repo"],
+  ])("rejects %j (%s)", async (badRef) => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    await expect(
+      poster.postDecision({ ...PR_ARGS, subjectRef: badRef }),
+    ).rejects.toBeInstanceOf(DecisionPostError);
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["org/repo#1", { owner: "org", repo: "repo", prNumber: 1 }],
+    ["a/b#42", { owner: "a", repo: "b", prNumber: 42 }],
+    [
+      "my-org/my-repo#100",
+      { owner: "my-org", repo: "my-repo", prNumber: 100 },
+    ],
+    [
+      "my.org/my.repo#7",
+      { owner: "my.org", repo: "my.repo", prNumber: 7 },
+    ],
+    [
+      "my_org/my_repo#9999",
+      { owner: "my_org", repo: "my_repo", prNumber: 9999 },
+    ],
+    ["1org/2repo#1", { owner: "1org", repo: "2repo", prNumber: 1 }],
+  ])("accepts %j", async (goodRef, expected) => {
+    const { octokit, createCommentFn } = makeOctokit({
+      htmlUrl: "https://github.com/example/example/pull/1",
+    });
+    const poster = new GitHubDecisionPoster({ octokit });
+    await poster.postDecision({ ...PR_ARGS, subjectRef: goodRef });
+    expect(createCommentFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: expected.owner,
+        repo: expected.repo,
+        issue_number: expected.prNumber,
+      }),
+    );
+  });
+
+  it("rejects oversized subject_ref (DOS guard)", async () => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    const huge = "a".repeat(300);
+    await expect(
+      poster.postDecision({ ...PR_ARGS, subjectRef: `${huge}/repo#1` }),
+    ).rejects.toBeInstanceOf(DecisionPostError);
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+});
+
 describe("RecordingDecisionPoster", () => {
   it("records calls and returns a fake URL for pr_review", async () => {
     const poster = new RecordingDecisionPoster();

--- a/bot/api/lib/queen/decision-poster.test.ts
+++ b/bot/api/lib/queen/decision-poster.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for `GitHubDecisionPoster` and `RecordingDecisionPoster`
+ * (G'.4). Mocks the octokit's `createComment` so the tests don't
+ * make network calls.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  DecisionPostError,
+  GitHubDecisionPoster,
+  RecordingDecisionPoster,
+  type CommentingOctokit,
+  type PostDecisionArgs,
+} from "./decision-poster.js";
+
+function makeOctokit(opts: {
+  htmlUrl?: string;
+  throws?: unknown;
+} = {}): { octokit: CommentingOctokit; createCommentFn: ReturnType<typeof vi.fn> } {
+  const createCommentFn = vi.fn().mockImplementation(async () => {
+    if (opts.throws) throw opts.throws;
+    return {
+      data: {
+        html_url: opts.htmlUrl,
+      },
+    };
+  });
+  const octokit: CommentingOctokit = {
+    rest: {
+      issues: {
+        createComment: createCommentFn,
+      },
+    },
+  };
+  return { octokit, createCommentFn };
+}
+
+const PR_ARGS: PostDecisionArgs = {
+  subjectType: "pr_review",
+  subjectRef: "owner/repo#42",
+  content: "## Synthesis — owner/repo#42\n\n**Verdict:** `APPROVE`\n\nLGTM.",
+  roomId: "01234567-89ab-4cde-9012-3456789abcde",
+};
+
+describe("GitHubDecisionPoster.postDecision — pr_review subjects", () => {
+  it("posts a comment with the decision content and returns html_url", async () => {
+    const { octokit, createCommentFn } = makeOctokit({
+      htmlUrl: "https://github.com/owner/repo/pull/42#issuecomment-123",
+    });
+    const poster = new GitHubDecisionPoster({ octokit });
+    const result = await poster.postDecision(PR_ARGS);
+    expect(result.attempted).toBe(true);
+    expect(result.commentUrl).toBe(
+      "https://github.com/owner/repo/pull/42#issuecomment-123",
+    );
+    expect(createCommentFn).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      issue_number: 42,
+      body: PR_ARGS.content,
+    });
+  });
+
+  it("returns null commentUrl when API response lacks html_url", async () => {
+    // Defensive: GitHub API spec says html_url is always returned,
+    // but if a future API version changes shape we don't want to
+    // crash; null is the sentinel.
+    const { octokit } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    const result = await poster.postDecision(PR_ARGS);
+    expect(result.attempted).toBe(true);
+    expect(result.commentUrl).toBeNull();
+  });
+
+  it("propagates octokit errors (caller's manager loop maps to postsFailed++)", async () => {
+    const { octokit } = makeOctokit({
+      throws: new Error("API rate limit exceeded"),
+    });
+    const poster = new GitHubDecisionPoster({ octokit });
+    await expect(poster.postDecision(PR_ARGS)).rejects.toThrow(
+      /API rate limit/,
+    );
+  });
+
+  it("parses owner/repo with hyphens and dots", async () => {
+    const { octokit, createCommentFn } = makeOctokit({
+      htmlUrl: "https://github.com/x/y.z-2/pull/9#issuecomment-1",
+    });
+    const poster = new GitHubDecisionPoster({ octokit });
+    await poster.postDecision({
+      ...PR_ARGS,
+      subjectRef: "my-org/repo.with.dots-and-dashes#9",
+    });
+    expect(createCommentFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "my-org",
+        repo: "repo.with.dots-and-dashes",
+        issue_number: 9,
+      }),
+    );
+  });
+});
+
+describe("GitHubDecisionPoster.postDecision — non-pr_review subjects (V1 skip)", () => {
+  it("skips mention_response (V1: pr_review only)", async () => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    const result = await poster.postDecision({
+      ...PR_ARGS,
+      subjectType: "mention_response",
+    });
+    expect(result.attempted).toBe(false);
+    expect(result.commentUrl).toBeNull();
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+
+  it("skips issue_triage (V1: pr_review only)", async () => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    const result = await poster.postDecision({
+      ...PR_ARGS,
+      subjectType: "issue_triage",
+    });
+    expect(result.attempted).toBe(false);
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHubDecisionPoster.postDecision — malformed subject_ref", () => {
+  it("throws DecisionPostError on shape mismatch (no slash)", async () => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    await expect(
+      poster.postDecision({ ...PR_ARGS, subjectRef: "no-slash#42" }),
+    ).rejects.toBeInstanceOf(DecisionPostError);
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+
+  it("throws DecisionPostError on missing PR number", async () => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    await expect(
+      poster.postDecision({ ...PR_ARGS, subjectRef: "owner/repo#" }),
+    ).rejects.toBeInstanceOf(DecisionPostError);
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+
+  it("throws DecisionPostError on non-numeric PR number", async () => {
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    await expect(
+      poster.postDecision({ ...PR_ARGS, subjectRef: "owner/repo#abc" }),
+    ).rejects.toBeInstanceOf(DecisionPostError);
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
+
+  it("DecisionPostError carries the roomId for log correlation", async () => {
+    const { octokit } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    try {
+      await poster.postDecision({ ...PR_ARGS, subjectRef: "bad" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecisionPostError);
+      expect((err as DecisionPostError).roomId).toBe(PR_ARGS.roomId);
+    }
+  });
+});
+
+describe("RecordingDecisionPoster", () => {
+  it("records calls and returns a fake URL for pr_review", async () => {
+    const poster = new RecordingDecisionPoster();
+    const result = await poster.postDecision(PR_ARGS);
+    expect(poster.calls).toHaveLength(1);
+    expect(poster.calls[0]).toEqual(PR_ARGS);
+    expect(result.attempted).toBe(true);
+    expect(result.commentUrl).toContain(PR_ARGS.roomId);
+  });
+
+  it("returns attempted=false for non-pr_review subjects", async () => {
+    const poster = new RecordingDecisionPoster();
+    const result = await poster.postDecision({
+      ...PR_ARGS,
+      subjectType: "mention_response",
+    });
+    expect(result.attempted).toBe(false);
+    expect(result.commentUrl).toBeNull();
+    // Still records the call (so tests can verify the loop tried).
+    expect(poster.calls).toHaveLength(1);
+  });
+});

--- a/bot/api/lib/queen/decision-poster.ts
+++ b/bot/api/lib/queen/decision-poster.ts
@@ -133,18 +133,43 @@ export class DecisionPostError extends Error {
 
 /**
  * Parse a `pr_review` subject_ref of the form `{owner}/{repo}#{prNumber}`.
- * Mirrors the format documented at WAR_ROOM_DESIGN.md L165-167.
+ * Mirrors the format documented at WAR_ROOM_DESIGN.md L165-167 and
+ * the storage layer's regex at room-create time.
+ *
+ * Strict regex (closes #540 builder R1):
+ *   - owner / repo: `[A-Za-z0-9._-]+` (GitHub's allowed charset for
+ *     org / repo names; rejects spaces, slashes-other-than-the-
+ *     separator, and unicode)
+ *   - PR number: `[1-9][0-9]*` (no leading zeros; positive integer)
+ *   - Anchored at start AND end of input (no trailing whitespace,
+ *     no extra path segments)
+ *
+ * Storage validates this same shape at room-create time, so a
+ * failure here is a defense-in-depth signal: log + throw with
+ * `DecisionPostError` so the manager loop counts as `postsFailed`
+ * rather than reaching Octokit with a malformed ref and getting
+ * a confusing GitHub 404.
  */
+const PR_SUBJECT_REF_REGEX = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)#([1-9][0-9]*)$/;
+
 function parsePrSubjectRef(
   ref: string,
 ):
   | { ok: true; owner: string; repo: string; prNumber: number }
   | { ok: false; reason: string } {
-  const match = /^([^/]+)\/([^#]+)#(\d+)$/.exec(ref);
+  // Defense-in-depth: explicit length cap to keep regex backtracking
+  // bounded even though the regex is linear-time.
+  if (ref.length === 0 || ref.length > 256) {
+    return { ok: false, reason: "shape_mismatch" };
+  }
+  const match = PR_SUBJECT_REF_REGEX.exec(ref);
   if (!match) return { ok: false, reason: "shape_mismatch" };
   const [, owner, repo, prNumberStr] = match;
   const prNumber = Number(prNumberStr);
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    // Unreachable given the regex (which already enforces positive
+    // non-zero-leading integers), but defensive against Number()
+    // edge cases on extreme inputs.
     return { ok: false, reason: "invalid_pr_number" };
   }
   return { ok: true, owner, repo, prNumber };

--- a/bot/api/lib/queen/decision-poster.ts
+++ b/bot/api/lib/queen/decision-poster.ts
@@ -1,0 +1,170 @@
+/**
+ * DecisionPoster — posts the queen's synthesized decision back to
+ * GitHub once a war room has been closed.
+ *
+ * Same dependency-injection shape as `Synthesizer`: the manager
+ * loop (G'.2) calls `poster.postDecision(...)` after a successful
+ * `closeRoom`, but the implementation is swappable for tests +
+ * deployment variations.
+ *
+ * V1 scope: pr_review subjects only. mention_response and
+ * issue_triage land in V1.1 alongside their respective workflows.
+ *
+ * Failure model: a post failure does NOT undo the room close. The
+ * decision is durably stored on the room (closeRoom succeeded);
+ * operators can manually re-post or wait for V1.1 retry. The
+ * manager loop counts `postsFailed` separately so ops can alert.
+ */
+
+import type { Logger } from "../logger.js";
+import { logger as defaultLogger } from "../logger.js";
+
+export interface PostDecisionArgs {
+  subjectType: "pr_review" | "mention_response" | "issue_triage";
+  subjectRef: string;
+  /** Markdown content to post. Already includes verdict header +
+   * LLM prose + footer per G'.3's deterministic assembly. */
+  content: string;
+  /** RoomId for log correlation. */
+  roomId: string;
+}
+
+export interface PostDecisionResult {
+  /** Whether the post path was attempted. False when the subject
+   * type isn't supported in V1 (mention_response, issue_triage).
+   * The manager loop should treat this as a no-op, not an error. */
+  attempted: boolean;
+  /** Issue/PR comment URL on success. Null when not attempted OR
+   * the underlying GitHub call returned no html_url (defensive). */
+  commentUrl: string | null;
+}
+
+export interface DecisionPoster {
+  postDecision(args: PostDecisionArgs): Promise<PostDecisionResult>;
+}
+
+/**
+ * Octokit shape we depend on. Narrow interface so tests don't need
+ * the full Octokit class — a hand-rolled fake satisfying this is
+ * enough.
+ */
+export interface CommentingOctokit {
+  rest: {
+    issues: {
+      createComment: (params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        body: string;
+      }) => Promise<{
+        data: {
+          html_url?: string;
+        };
+      }>;
+    };
+  };
+}
+
+export interface GitHubDecisionPosterConfig {
+  octokit: CommentingOctokit;
+  logger?: Logger;
+}
+
+export class GitHubDecisionPoster implements DecisionPoster {
+  private octokit: CommentingOctokit;
+  private logger: Logger;
+
+  constructor(config: GitHubDecisionPosterConfig) {
+    this.octokit = config.octokit;
+    this.logger = config.logger ?? defaultLogger;
+  }
+
+  async postDecision(args: PostDecisionArgs): Promise<PostDecisionResult> {
+    if (args.subjectType !== "pr_review") {
+      this.logger.info(
+        `[queen.poster] skip subject_type=${args.subjectType} roomId=${args.roomId} (V1: pr_review only)`,
+      );
+      return { attempted: false, commentUrl: null };
+    }
+
+    const parsed = parsePrSubjectRef(args.subjectRef);
+    if (!parsed.ok) {
+      this.logger.warn(
+        `[queen.poster] subject_ref parse failed roomId=${args.roomId} subject_ref=${args.subjectRef} reason=${parsed.reason}`,
+      );
+      throw new DecisionPostError(
+        `Invalid pr_review subject_ref: ${parsed.reason}`,
+        args.roomId,
+      );
+    }
+
+    this.logger.info(
+      `[queen.poster] posting roomId=${args.roomId} repo=${parsed.owner}/${parsed.repo} pr=${parsed.prNumber} bytes=${new TextEncoder().encode(args.content).length}`,
+    );
+
+    const response = await this.octokit.rest.issues.createComment({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: parsed.prNumber,
+      body: args.content,
+    });
+
+    const url = response?.data?.html_url ?? null;
+    this.logger.info(
+      `[queen.poster] posted roomId=${args.roomId} url=${url ?? "no_url"}`,
+    );
+    return { attempted: true, commentUrl: url };
+  }
+}
+
+/**
+ * Error class that wraps post failures with the roomId so the
+ * manager loop can correlate.
+ */
+export class DecisionPostError extends Error {
+  constructor(
+    message: string,
+    public readonly roomId: string,
+  ) {
+    super(message);
+    this.name = "DecisionPostError";
+  }
+}
+
+/**
+ * Parse a `pr_review` subject_ref of the form `{owner}/{repo}#{prNumber}`.
+ * Mirrors the format documented at WAR_ROOM_DESIGN.md L165-167.
+ */
+function parsePrSubjectRef(
+  ref: string,
+):
+  | { ok: true; owner: string; repo: string; prNumber: number }
+  | { ok: false; reason: string } {
+  const match = /^([^/]+)\/([^#]+)#(\d+)$/.exec(ref);
+  if (!match) return { ok: false, reason: "shape_mismatch" };
+  const [, owner, repo, prNumberStr] = match;
+  const prNumber = Number(prNumberStr);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return { ok: false, reason: "invalid_pr_number" };
+  }
+  return { ok: true, owner, repo, prNumber };
+}
+
+/**
+ * Test/observability poster that records calls without making any
+ * network requests.
+ */
+export class RecordingDecisionPoster implements DecisionPoster {
+  public readonly calls: PostDecisionArgs[] = [];
+
+  async postDecision(args: PostDecisionArgs): Promise<PostDecisionResult> {
+    this.calls.push(args);
+    if (args.subjectType !== "pr_review") {
+      return { attempted: false, commentUrl: null };
+    }
+    return {
+      attempted: true,
+      commentUrl: `https://github.com/recorded/${args.roomId}/posted`,
+    };
+  }
+}

--- a/bot/api/lib/queen/manager-loop.test.ts
+++ b/bot/api/lib/queen/manager-loop.test.ts
@@ -10,6 +10,10 @@ import { describe, expect, it } from "vitest";
 import { runQueenManagerLoop } from "./manager-loop.js";
 import { StubSynthesizer, type Synthesizer } from "./synthesizer.js";
 import {
+  RecordingDecisionPoster,
+  type DecisionPoster,
+} from "./decision-poster.js";
+import {
   WarRoomApiError,
   type RoomContribution,
   type RoomListEntry,
@@ -920,5 +924,173 @@ describe("runQueenManagerLoop — R1 #536 guard NB2 (room GC mid-tick)", () => {
     expect(result.claimed).toBe(1);
     expect(result.errors).toBe(1);
     expect(result.closed).toBe(0);
+  });
+});
+
+describe("runQueenManagerLoop — G'.4 decisionPoster integration", () => {
+  it("calls poster.postDecision after successful close (postsSucceeded++)", async () => {
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const poster = new RecordingDecisionPoster();
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      decisionPoster: poster,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.closed).toBe(1);
+    expect(result.postsSucceeded).toBe(1);
+    expect(result.postsFailed).toBe(0);
+    expect(poster.calls).toHaveLength(1);
+    expect(poster.calls[0].roomId).toBe(ROOM_ID);
+    expect(poster.calls[0].subjectType).toBe("pr_review");
+    expect(poster.calls[0].subjectRef).toBe("owner/repo#42");
+    // Content matches what closeRoom received (the assembled markdown).
+    expect(poster.calls[0].content).toContain("01234567-89ab-4cde-9012-3456789abcde");
+  });
+
+  it("does NOT post when decisionPoster is omitted (counters stay 0)", async () => {
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+    });
+    expect(result.closed).toBe(1);
+    expect(result.postsSucceeded).toBe(0);
+    expect(result.postsFailed).toBe(0);
+    expect(result.postsSkipped).toBe(0);
+  });
+
+  it("post failure → postsFailed++ but room stays closed", async () => {
+    // The decision is durably stored at closeRoom time; a post
+    // failure is observable via the counter, but we don't rewind
+    // the close. Operators can manually re-post or wait for V1.1
+    // retry.
+    const failingPoster: DecisionPoster = {
+      async postDecision() {
+        throw new Error("GitHub 502 upstream");
+      },
+    };
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      decisionPoster: failingPoster,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.closed).toBe(1);
+    expect(result.postsSucceeded).toBe(0);
+    expect(result.postsFailed).toBe(1);
+  });
+
+  it("postsSkipped++ when poster reports attempted=false (non-pr_review)", async () => {
+    // Subject_type is mention_response (a hypothetical V1.1 case).
+    // Poster returns attempted=false; loop counts as skipped, NOT
+    // failed.
+    const skippingPoster: DecisionPoster = {
+      async postDecision() {
+        return { attempted: false, commentUrl: null };
+      },
+    };
+    const { client } = makeFakeClient({
+      rooms: [
+        makeRoom({
+          subject_type: "mention_response",
+          subject_ref: "owner/repo#42",
+        }),
+      ],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      decisionPoster: skippingPoster,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.closed).toBe(1);
+    expect(result.postsSucceeded).toBe(0);
+    expect(result.postsFailed).toBe(0);
+    expect(result.postsSkipped).toBe(1);
+  });
+
+  it("does NOT call poster when close fails (no decision to post)", async () => {
+    const { client } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: { [ROOM_ID]: { guard: resolvedParticipant("guard") } },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+      closeThrowsByRoomId: {
+        [ROOM_ID]: new WarRoomApiError(409, "sequence_drift", "drift", {}),
+      },
+    });
+    const poster = new RecordingDecisionPoster();
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      decisionPoster: poster,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.closed).toBe(0);
+    expect(result.conflicts).toBe(1);
+    expect(poster.calls).toEqual([]);
+  });
+
+  it("counts each room's post outcome independently across one tick", async () => {
+    const happyId = "happy-room";
+    const failPostId = "fail-post-room";
+    const skipId = "skip-room";
+
+    const conditionalPoster: DecisionPoster = {
+      async postDecision(args) {
+        if (args.roomId === failPostId) throw new Error("API down");
+        if (args.roomId === skipId) {
+          return { attempted: false, commentUrl: null };
+        }
+        return {
+          attempted: true,
+          commentUrl: `https://github.com/x/${args.roomId}`,
+        };
+      },
+    };
+
+    const { client } = makeFakeClient({
+      rooms: [
+        makeRoom({ roomId: happyId }),
+        makeRoom({ roomId: failPostId }),
+        makeRoom({ roomId: skipId }),
+      ],
+      participants: {
+        [happyId]: { guard: resolvedParticipant("guard") },
+        [failPostId]: { guard: resolvedParticipant("guard") },
+        [skipId]: { guard: resolvedParticipant("guard") },
+      },
+      contributions: {
+        [happyId]: { guard: presentContribution() },
+        [failPostId]: { guard: presentContribution() },
+        [skipId]: { guard: presentContribution() },
+      },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      decisionPoster: conditionalPoster,
+      runnerId: RUNNER_ID,
+    });
+    expect(result.closed).toBe(3);
+    expect(result.postsSucceeded).toBe(1);
+    expect(result.postsFailed).toBe(1);
+    expect(result.postsSkipped).toBe(1);
   });
 });

--- a/bot/api/lib/queen/manager-loop.ts
+++ b/bot/api/lib/queen/manager-loop.ts
@@ -57,6 +57,7 @@ import type {
   WarRoomClient,
   WarRoomApiError,
 } from "../war-room-client.js";
+import type { DecisionPoster } from "./decision-poster.js";
 import type { Synthesizer } from "./synthesizer.js";
 
 const DEFAULT_MAX_ROOMS_PER_TICK = 100;
@@ -92,6 +93,14 @@ const BENIGN_CONFLICT_CODES: ReadonlySet<string> = new Set([
 export interface QueenManagerLoopArgs {
   client: WarRoomClient;
   synthesizer: Synthesizer;
+  /** Optional decision poster (G'.4). When provided, the loop calls
+   * `poster.postDecision(...)` after a successful `closeRoom` so the
+   * synthesized markdown lands on the GitHub PR thread. Failures
+   * count as `postsFailed` and DO NOT undo the room close — the
+   * decision is durably stored on the room either way. When omitted
+   * (e.g. in unit tests, or pre-G'.5 deployments without an
+   * Octokit), close path runs unchanged and post counters stay 0. */
+  decisionPoster?: DecisionPoster;
   /** Stable runner identity (passed as `queenRunner` on
    * `claimSynthesis` and folded into the decision payload's
    * `synthesis_runner` field). Operator-set; e.g.
@@ -145,6 +154,16 @@ export interface QueenManagerLoopResult {
    * Closes #536 builder R1: prior code unconditionally treated
    * `withdrew` as synthesis-permitting, racing the re-RSVP path. */
   staleClaimsAbandoned: number;
+  /** Decisions successfully posted to GitHub via `decisionPoster`.
+   * Set to 0 when no poster configured. Closes #538 follow-on G'.4. */
+  postsSucceeded: number;
+  /** Post attempts that threw. The room close already succeeded; the
+   * decision is stored. V1 logs + counts; V1.1 may add retry. */
+  postsFailed: number;
+  /** Posts intentionally skipped (subject_type not yet supported in
+   * V1). Tracked separately from postsSucceeded so ops can alert on
+   * `mentions / triages reaching the queen` independently. */
+  postsSkipped: number;
   /** Non-benign errors: synthesizer threw, decision_too_large 400,
    * wire failure, unfamiliar 409 code. Loop continues; ops alert. */
   errors: number;
@@ -168,6 +187,9 @@ export async function runQueenManagerLoop(
     closed: 0,
     conflicts: 0,
     staleClaimsAbandoned: 0,
+    postsSucceeded: 0,
+    postsFailed: 0,
+    postsSkipped: 0,
     errors: 0,
   };
 
@@ -192,6 +214,7 @@ export async function runQueenManagerLoop(
         room,
         client: args.client,
         synthesizer: args.synthesizer,
+        decisionPoster: args.decisionPoster,
         runnerId: args.runnerId,
         nowMs: args.nowMs ?? Date.now(),
         log,
@@ -247,12 +270,13 @@ async function processOneRoom(args: {
   room: RoomListEntry;
   client: WarRoomClient;
   synthesizer: Synthesizer;
+  decisionPoster: DecisionPoster | undefined;
   runnerId: string;
   nowMs: number;
   log: ManagerLoopLogger;
   result: QueenManagerLoopResult;
 }): Promise<void> {
-  const { room, client, synthesizer, runnerId, nowMs, log, result } = args;
+  const { room, client, synthesizer, decisionPoster, runnerId, nowMs, log, result } = args;
 
   // 1. Pre-claim eligibility.
   let participantsResp;
@@ -421,6 +445,35 @@ async function processOneRoom(args: {
       error: errMeta(err),
     });
     result.errors += 1;
+    return;
+  }
+
+  // 6. Post the decision to GitHub (G'.4). Failure does NOT undo the
+  //    close — the decision is durably stored. Counted separately so
+  //    ops can alert on post-only failures without conflating with
+  //    storage errors.
+  if (decisionPoster === undefined) {
+    return;
+  }
+  try {
+    const postResult = await decisionPoster.postDecision({
+      subjectType: room.subject_type,
+      subjectRef: room.subject_ref,
+      content,
+      roomId: room.roomId,
+    });
+    if (postResult.attempted) {
+      result.postsSucceeded += 1;
+    } else {
+      result.postsSkipped += 1;
+    }
+  } catch (err) {
+    result.postsFailed += 1;
+    log.error("queen.manager_loop.post_failed", {
+      roomId: room.roomId,
+      subjectRef: room.subject_ref,
+      error: errMeta(err),
+    });
   }
 }
 


### PR DESCRIPTION
Fixes #539

## Summary

Fourth slice of Phase G'. After the queen synthesizes a decision and closes the room, the manager loop posts the synthesized markdown to the originating GitHub PR thread. The synthesizer-pattern repeats for posting: optional `DecisionPoster` on `QueenManagerLoopArgs`, narrow `CommentingOctokit` interface for testability, swappable for staging deployments that want to exercise the close path without touching real PRs.

## What's new

```
bot/api/lib/queen/
├── decision-poster.ts       — DecisionPoster interface + GitHub impl + Recording impl + parser
└── decision-poster.test.ts  — 14 tests (happy path + skip paths + parse failures)
manager-loop.ts changes      — optional decisionPoster + new counters + post step
manager-loop.test.ts         — 6 new integration tests
```

### Failure model

Post failure does NOT undo the room close. The decision is durably stored at `closeRoom` time; a failed post is observable via `postsFailed++` so ops can alert. Operators can manually re-post using the stored decision body, or wait for V1.1 retry.

Three counters split the post path:
- `postsSucceeded` — `attempted: true` and the comment landed
- `postsFailed` — poster threw (network, rate limit, etc.)
- `postsSkipped` — `attempted: false` from the poster (V1: non-pr_review subjects)

This split matters because `postsSucceeded == 0` is normal under stub mode (no LLM, no poster wired), but `postsFailed > 0` after G'.5 ships should page.

### Subject_ref parsing

For `pr_review` rooms, the `subject_ref` follows `{owner}/{repo}#{prNumber}` per WAR_ROOM_DESIGN.md L165-167. The poster's `parsePrSubjectRef` mirrors this format. Malformed values throw `DecisionPostError` carrying the `roomId` for log correlation; storage validates the format at room-create time so this path should be unreachable in practice.

## What's NOT in this slice

| Slice | Scope |
|---|---|
| G'.5 | Vercel cron route + bearer wiring + `App.getInstallationOctokit` call site (the actual octokit instantiation) |
| V1.1 | Post retry on transient failures; mention_response + issue_triage subject types |

## Test plan

- [x] `tsc --noEmit` clean
- [x] Queen tests: 99 (was 81, +18)
- [x] Full bot suite: 1868 (was 1850, +18)
- [x] Lint clean
- [ ] Reviewer fleet sign-off