### PR TITLE
Phase G'.5 — queen Vercel cron route + bearer wiring (final slice)

### DIFF
--- a/bot/api/queen/tick.test.ts
+++ b/bot/api/queen/tick.test.ts
@@ -364,3 +364,186 @@ describe("GET /api/queen/tick — error paths", () => {
     expect(JSON.parse(res._body).code).toBe("tick_failed");
   });
 });
+
+describe("makeManagerLoopLogAdapter (R1 #542 guard B1)", () => {
+  // Closes #542 guard B1: prior adapter signature was (msg) => ...
+  // which dropped the meta arg silently. Without this regression,
+  // a future refactor could reintroduce the same drop without
+  // tripping any test.
+  it("preserves structured meta when present", async () => {
+    const { makeManagerLoopLogAdapter } = await import("./tick.js");
+    const { logger: realLogger } = await import("../lib/logger.js");
+    const errorSpy = vi.spyOn(realLogger, "error").mockImplementation(() => {});
+    const adapter = makeManagerLoopLogAdapter();
+    adapter.error("manager_loop.unexpected_error", {
+      roomId: "room-123",
+      reason: "explosion",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("room-123"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("explosion"));
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[queen-tick]"),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("formats meta-less calls without trailing JSON", async () => {
+    const { makeManagerLoopLogAdapter } = await import("./tick.js");
+    const { logger: realLogger } = await import("../lib/logger.js");
+    const infoSpy = vi.spyOn(realLogger, "info").mockImplementation(() => {});
+    const adapter = makeManagerLoopLogAdapter();
+    adapter.info("queen.startup");
+    expect(infoSpy).toHaveBeenCalledWith("[queen-tick] queen.startup");
+    infoSpy.mockRestore();
+  });
+
+  it("handles empty meta object as meta-less", async () => {
+    const { makeManagerLoopLogAdapter } = await import("./tick.js");
+    const { logger: realLogger } = await import("../lib/logger.js");
+    const warnSpy = vi.spyOn(realLogger, "warn").mockImplementation(() => {});
+    const adapter = makeManagerLoopLogAdapter();
+    adapter.warn("warning", {});
+    expect(warnSpy).toHaveBeenCalledWith("[queen-tick] warning");
+    warnSpy.mockRestore();
+  });
+});
+
+describe("GET /api/queen/tick — per-installation lock (R1 #542 builder)", () => {
+  // Closes #542 builder R1: tick lock required by WAR_ROOM_DESIGN.md
+  // §971 to prevent overlapping fires from burning duplicate LLM
+  // credits at the 2-minute schedule + 5-minute maxDuration.
+  // Lock is best-effort: when Redis env unset, runs unlocked (V1
+  // single-installation dev). When Redis is reachable, SET NX EX
+  // 290 acquire + compare-and-DEL release.
+
+  beforeEach(() => {
+    delete process.env.HIVEMOOT_REDIS_REST_URL;
+    delete process.env.HIVEMOOT_REDIS_REST_TOKEN;
+  });
+
+  it("runs unlocked when Redis env is not configured", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("acquires lock via SET NX EX when Redis configured", async () => {
+    process.env.HIVEMOOT_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.HIVEMOOT_REDIS_REST_TOKEN = "fake-token";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: "OK" }), { status: 200 }),
+      ) // acquire
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: 1 }), { status: 200 }),
+      ); // release
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(fetchSpy.mock.calls[0][0]).toMatch(
+      /\/set\/queen%3Atick%3Alock%3Ainstallation%3A67890\/.*\?NX&EX=290/,
+    );
+    expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
+    fetchSpy.mockRestore();
+  });
+
+  it("returns skipped=true when another runner holds the lock (NX result null)", async () => {
+    process.env.HIVEMOOT_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.HIVEMOOT_REDIS_REST_TOKEN = "fake-token";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: null }), { status: 200 }),
+      );
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    const body = JSON.parse(res._body);
+    expect(body.skipped).toBe(true);
+    expect(body.reason).toBe("lock_contention");
+    expect(runQueenManagerLoopMock).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("releases lock with compare-and-DEL on successful tick completion", async () => {
+    process.env.HIVEMOOT_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.HIVEMOOT_REDIS_REST_TOKEN = "fake-token";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: "OK" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: 1 }), { status: 200 }),
+      );
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    // Second fetch is the release — POST to base URL with EVAL body.
+    const releaseCall = fetchSpy.mock.calls[1];
+    expect(releaseCall[0]).toBe("https://fake-redis.upstash.io");
+    const body = JSON.parse((releaseCall[1] as RequestInit).body as string);
+    expect(body[0]).toBe("EVAL");
+    expect(body[1]).toContain("redis.call");
+    fetchSpy.mockRestore();
+  });
+
+  it("releases lock even when manager loop throws", async () => {
+    process.env.HIVEMOOT_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.HIVEMOOT_REDIS_REST_TOKEN = "fake-token";
+    runQueenManagerLoopMock.mockRejectedValueOnce(new Error("loop crash"));
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: "OK" }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: 1 }), { status: 200 }),
+      );
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(500);
+    // Release was still attempted via finally.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const releaseCall = fetchSpy.mock.calls[1];
+    expect(JSON.parse((releaseCall[1] as RequestInit).body as string)[0]).toBe(
+      "EVAL",
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it("falls through to unlocked when acquire HTTP fails (availability)", async () => {
+    process.env.HIVEMOOT_REDIS_REST_URL = "https://fake-redis.upstash.io";
+    process.env.HIVEMOOT_REDIS_REST_TOKEN = "fake-token";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("ISE", { status: 500 }));
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
+    fetchSpy.mockRestore();
+  });
+});

--- a/bot/api/queen/tick.test.ts
+++ b/bot/api/queen/tick.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for the GET /api/queen/tick Vercel function (G'.5).
+ * Mocks the App + manager-loop dependencies so the tests don't make
+ * network calls or instantiate real Octokit clients.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IncomingMessage, ServerResponse } from "http";
+
+const {
+  runQueenManagerLoopMock,
+  createSynthesizerMock,
+  getAppConfigMock,
+  getInstallationOctokitMock,
+  AppCtorMock,
+} = vi.hoisted(() => ({
+  runQueenManagerLoopMock: vi.fn(),
+  createSynthesizerMock: vi.fn(),
+  getAppConfigMock: vi.fn(),
+  getInstallationOctokitMock: vi.fn(),
+  AppCtorMock: vi.fn(),
+}));
+
+vi.mock("../lib/queen/manager-loop.js", () => ({
+  runQueenManagerLoop: runQueenManagerLoopMock,
+}));
+
+vi.mock("../lib/queen/ai-sdk-synthesizer.js", () => ({
+  createSynthesizer: createSynthesizerMock,
+}));
+
+vi.mock("../lib/env-validation.js", () => ({
+  getAppConfig: getAppConfigMock,
+}));
+
+vi.mock("octokit", () => ({
+  App: AppCtorMock,
+}));
+
+import handler from "./tick.js";
+
+interface MockResponse extends ServerResponse {
+  _statusCode: number;
+  _body: string;
+  _headers: Record<string, string>;
+}
+
+function makeRequest(opts: {
+  method?: string;
+  url?: string;
+  authorization?: string | undefined;
+}): IncomingMessage {
+  const headers: Record<string, string> = {};
+  if (opts.authorization !== undefined) {
+    headers.authorization = opts.authorization;
+  }
+  return {
+    method: opts.method ?? "GET",
+    url: opts.url ?? "/api/queen/tick",
+    headers,
+  } as unknown as IncomingMessage;
+}
+
+function makeResponse(): MockResponse {
+  const r: MockResponse = {
+    statusCode: 0,
+    _statusCode: 0,
+    _body: "",
+    _headers: {},
+    setHeader(name: string, value: string) {
+      this._headers[name.toLowerCase()] = value;
+      return this;
+    },
+    end(body?: string) {
+      if (typeof body === "string") this._body = body;
+      this._statusCode = this.statusCode;
+      return this;
+    },
+  } as unknown as MockResponse;
+  return r;
+}
+
+const HAPPY_RESULT = {
+  totalRoomsScanned: 3,
+  scannedAwaitingContributions: 1,
+  eligible: 1,
+  claimed: 1,
+  closed: 1,
+  conflicts: 0,
+  staleClaimsAbandoned: 0,
+  postsSucceeded: 1,
+  postsFailed: 0,
+  postsSkipped: 0,
+  errors: 0,
+};
+
+beforeEach(() => {
+  runQueenManagerLoopMock.mockReset().mockResolvedValue(HAPPY_RESULT);
+  createSynthesizerMock.mockReset().mockResolvedValue({});
+  getAppConfigMock.mockReset().mockReturnValue({
+    appId: 12345,
+    privateKey: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+  });
+  getInstallationOctokitMock.mockReset().mockResolvedValue({
+    rest: { issues: { createComment: vi.fn() } },
+  });
+  AppCtorMock.mockReset().mockImplementation(function (this: unknown) {
+    (this as { getInstallationOctokit: typeof getInstallationOctokitMock }).getInstallationOctokit =
+      getInstallationOctokitMock;
+  });
+  process.env.CRON_SECRET = "test-secret";
+  process.env.HIVEMOOT_QUEEN_INSTALLATION_ID = "67890";
+  // WarRoomClient validates this at construction. Tests don't make
+  // real HTTP calls (the manager-loop is mocked), but the
+  // construction path runs.
+  process.env.HIVEMOOT_BOT_AGENT_TOKEN = "test-bearer-token";
+  delete process.env.HIVEMOOT_QUEEN_RUNNER_ID;
+  delete process.env.HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/queen/tick — auth", () => {
+  it("returns 401 when CRON_SECRET env var is unset (misconfig)", async () => {
+    delete process.env.CRON_SECRET;
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(401);
+    // Empty body — no oracle for "deployment misconfigured" vs "wrong bearer".
+    expect(res._body).toBe("");
+  });
+
+  it("returns 401 when authorization header is missing", async () => {
+    const res = makeResponse();
+    await handler(makeRequest({}), res);
+    expect(res._statusCode).toBe(401);
+    expect(res._body).toBe("");
+  });
+
+  it("returns 401 when authorization header is wrong", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer wrong-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(401);
+    expect(res._body).toBe("");
+  });
+
+  it("returns 401 for non-Bearer authorization scheme", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Basic test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(401);
+  });
+});
+
+describe("GET /api/queen/tick — method", () => {
+  it("returns 405 for POST", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({
+        method: "POST",
+        authorization: "Bearer test-secret",
+      }),
+      res,
+    );
+    expect(res._statusCode).toBe(405);
+    expect(JSON.parse(res._body)).toMatchObject({
+      code: "method_not_allowed",
+    });
+  });
+
+  it("returns 405 for DELETE", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({
+        method: "DELETE",
+        authorization: "Bearer test-secret",
+      }),
+      res,
+    );
+    expect(res._statusCode).toBe(405);
+  });
+});
+
+describe("GET /api/queen/tick — installationId resolution", () => {
+  it("returns 500 when neither query nor env supplies installationId", async () => {
+    delete process.env.HIVEMOOT_QUEEN_INSTALLATION_ID;
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(500);
+    expect(JSON.parse(res._body)).toMatchObject({
+      code: "no_installation_id",
+    });
+  });
+
+  it("returns 400 when installationId is non-numeric", async () => {
+    delete process.env.HIVEMOOT_QUEEN_INSTALLATION_ID;
+    const res = makeResponse();
+    await handler(
+      makeRequest({
+        authorization: "Bearer test-secret",
+        url: "/api/queen/tick?installationId=not-a-number",
+      }),
+      res,
+    );
+    expect(res._statusCode).toBe(400);
+    expect(JSON.parse(res._body)).toMatchObject({
+      code: "invalid_installation_id",
+    });
+  });
+
+  it("uses query param when provided (overrides env)", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({
+        authorization: "Bearer test-secret",
+        url: "/api/queen/tick?installationId=99999",
+      }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(getInstallationOctokitMock).toHaveBeenCalledWith(99999);
+    expect(JSON.parse(res._body).installationId).toBe("99999");
+  });
+
+  it("falls back to HIVEMOOT_QUEEN_INSTALLATION_ID env var", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(getInstallationOctokitMock).toHaveBeenCalledWith(67890);
+    expect(JSON.parse(res._body).installationId).toBe("67890");
+  });
+});
+
+describe("GET /api/queen/tick — happy path", () => {
+  it("returns 200 with runnerId + installationId + result", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    const body = JSON.parse(res._body);
+    expect(body.runnerId).toBeDefined();
+    expect(body.installationId).toBe("67890");
+    expect(body.result).toEqual(HAPPY_RESULT);
+  });
+
+  it("constructs App with appId + privateKey from getAppConfig", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(AppCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "12345",
+        privateKey: expect.stringContaining("BEGIN"),
+      }),
+    );
+  });
+
+  it("calls createSynthesizer with the installationId", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(createSynthesizerMock).toHaveBeenCalledWith({
+      installationId: 67890,
+    });
+  });
+
+  it("calls runQueenManagerLoop with all four DI dependencies", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
+    const args = runQueenManagerLoopMock.mock.calls[0][0];
+    expect(args.client).toBeDefined();
+    expect(args.synthesizer).toBeDefined();
+    expect(args.decisionPoster).toBeDefined();
+    expect(args.runnerId).toMatch(/^vercel-queen\.\d+\./);
+  });
+
+  it("uses HIVEMOOT_QUEEN_RUNNER_ID env when set", async () => {
+    process.env.HIVEMOOT_QUEEN_RUNNER_ID = "queen-prod-deploy-abc";
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    const args = runQueenManagerLoopMock.mock.calls[0][0];
+    expect(args.runnerId).toBe("queen-prod-deploy-abc");
+  });
+
+  it("forwards HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK as maxRoomsPerTick", async () => {
+    process.env.HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK = "25";
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    const args = runQueenManagerLoopMock.mock.calls[0][0];
+    expect(args.maxRoomsPerTick).toBe(25);
+  });
+
+  it("ignores invalid HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK", async () => {
+    process.env.HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK = "abc";
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    const args = runQueenManagerLoopMock.mock.calls[0][0];
+    expect(args.maxRoomsPerTick).toBeUndefined();
+  });
+});
+
+describe("GET /api/queen/tick — error paths", () => {
+  it("returns 500 when runQueenManagerLoop throws", async () => {
+    runQueenManagerLoopMock.mockRejectedValueOnce(new Error("upstream 502"));
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(500);
+    expect(JSON.parse(res._body)).toMatchObject({
+      code: "tick_failed",
+      message: "upstream 502",
+    });
+  });
+
+  it("returns 500 when getAppConfig throws", async () => {
+    getAppConfigMock.mockImplementationOnce(() => {
+      throw new Error("APP_ID environment variable is not set");
+    });
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(500);
+    expect(JSON.parse(res._body).code).toBe("tick_failed");
+  });
+});

--- a/bot/api/queen/tick.test.ts
+++ b/bot/api/queen/tick.test.ts
@@ -433,26 +433,42 @@ describe("GET /api/queen/tick — per-installation lock (R1 #542 builder)", () =
     expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
   });
 
-  it("acquires lock via SET NX EX when Redis configured", async () => {
+  it("acquires lock via SET NX EX with canonical key + body-form command", async () => {
+    // Closes #542 builder R2: previously used path-form
+    // /set/key/value?NX&EX=290 which has ambiguous query-arg handling
+    // per Upstash docs. Body-form keeps NX/EX as positional command
+    // args, semantics unambiguous + matches release path. Key namespace
+    // matches WAR_ROOM_DESIGN.md L999 + REDIS_KEY_CONVENTION.md
+    // (`hive:v1:lock:*` reserved for distributed locks).
     process.env.HIVEMOOT_REDIS_REST_URL = "https://fake-redis.upstash.io";
     process.env.HIVEMOOT_REDIS_REST_TOKEN = "fake-token";
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ result: "OK" }), { status: 200 }),
-      ) // acquire
+      )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ result: 1 }), { status: 200 }),
-      ); // release
+      );
     const res = makeResponse();
     await handler(
       makeRequest({ authorization: "Bearer test-secret" }),
       res,
     );
     expect(res._statusCode).toBe(200);
-    expect(fetchSpy.mock.calls[0][0]).toMatch(
-      /\/set\/queen%3Atick%3Alock%3Ainstallation%3A67890\/.*\?NX&EX=290/,
+    // Acquire is the first fetch — verify URL + body-form command.
+    const acquireCall = fetchSpy.mock.calls[0];
+    expect(acquireCall[0]).toBe("https://fake-redis.upstash.io");
+    const acquireBody = JSON.parse(
+      (acquireCall[1] as RequestInit).body as string,
     );
+    expect(acquireBody[0]).toBe("SET");
+    expect(acquireBody[1]).toBe("hive:v1:lock:queen-tick:67890");
+    // acquireBody[2] is the runnerId — generated, not asserted to a literal.
+    expect(typeof acquireBody[2]).toBe("string");
+    expect(acquireBody[3]).toBe("NX");
+    expect(acquireBody[4]).toBe("EX");
+    expect(acquireBody[5]).toBe("290");
     expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
     fetchSpy.mockRestore();
   });

--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -259,7 +259,12 @@ function emptyManagerLoopResult(): Awaited<
  * lock by TTL-expiry before the next 2-minute fire would block. */
 const TICK_LOCK_TTL_SECS = 290;
 
-const TICK_LOCK_KEY_PREFIX = "queen:tick:lock:installation:";
+/** Canonical lock key per WAR_ROOM_DESIGN.md L999 +
+ * REDIS_KEY_CONVENTION.md (the `hive:v1:lock:*` namespace is reserved
+ * for distributed locks). */
+function tickLockKey(installationId: string): string {
+  return `hive:v1:lock:queen-tick:${installationId}`;
+}
 
 /** Compare-and-DEL Lua: only DEL the lock key if it's still owned by
  * this runner. Prevents a tick whose work outlasted the TTL from
@@ -268,19 +273,39 @@ const TICK_LOCK_RELEASE_SCRIPT =
   'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
 
 /** Returns "ok" if the lock was acquired (or skipped because no
- * Redis configured), "contention" if another runner holds it. */
+ * Redis configured), "contention" if another runner holds it.
+ *
+ * Both acquire and release use Upstash REST's command-body form
+ * (`POST {url}` with JSON `["CMD", args...]`) rather than the path-
+ * segment form. Closes #542 builder R2: prior path-segment form
+ * `/set/key/value?NX&EX=290` had ambiguous query-arg handling per
+ * Upstash docs and risked degenerating into a plain `SET` (always
+ * returning `{ result: "OK" }`, breaking the serialization gate).
+ * Body-form keeps NX/EX as positional command args so semantics
+ * are unambiguous + match the release path.
+ */
 async function tryAcquireTickLock(
   installationId: string,
   runnerId: string,
 ): Promise<"ok" | "contention"> {
   const redis = getUpstashRedisConfig();
   if (!redis) return "ok"; // No Redis → run unlocked.
-  const key = TICK_LOCK_KEY_PREFIX + installationId;
+  const key = tickLockKey(installationId);
   try {
-    const url = `${redis.url}/set/${encodeURIComponent(key)}/${encodeURIComponent(runnerId)}?NX&EX=${TICK_LOCK_TTL_SECS}`;
-    const response = await fetch(url, {
+    const response = await fetch(redis.url, {
       method: "POST",
-      headers: { Authorization: `Bearer ${redis.token}` },
+      headers: {
+        Authorization: `Bearer ${redis.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        "SET",
+        key,
+        runnerId,
+        "NX",
+        "EX",
+        String(TICK_LOCK_TTL_SECS),
+      ]),
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
@@ -307,7 +332,7 @@ async function releaseTickLock(
 ): Promise<void> {
   const redis = getUpstashRedisConfig();
   if (!redis) return;
-  const key = TICK_LOCK_KEY_PREFIX + installationId;
+  const key = tickLockKey(installationId);
   try {
     const response = await fetch(redis.url, {
       method: "POST",

--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -1,0 +1,247 @@
+/**
+ * GET /api/queen/tick — Vercel Cron-driven queen manager loop.
+ *
+ * Final slice of Phase G' (queen module). Wires together everything
+ * G'.1-G'.4 built:
+ *
+ *   1. WarRoomClient (G'.1) — talks to hivemoot.dev /api/rooms/*
+ *   2. AiSdkSynthesizer / StubSynthesizer (G'.3) — produces decision
+ *      prose; stub fallback when LLM is not configured
+ *   3. GitHubDecisionPoster (G'.4) — posts decisions to PR threads
+ *   4. runQueenManagerLoop (G'.2) — orchestrates the
+ *      list → claim → synthesize → close → post cycle
+ *
+ * Auth: `Authorization: Bearer ${CRON_SECRET}` per Vercel's
+ * documented cron pattern. NOT V1 capability auth — this is a
+ * platform-level invocation. Missing or mismatched bearer → 401
+ * with empty body so an external probe can't differentiate
+ * "wrong bearer" from "no deployment". CRON_SECRET unset ALSO
+ * returns 401 (misconfig logged server-side via console.error,
+ * matches the watchdog at web/src/app/api/internal/queen/tick).
+ *
+ * Method: GET only (Vercel Cron sends GET, no body). POST returns
+ * 405. Keeps the surface narrow — no handcrafted-test backdoor
+ * to maintain.
+ *
+ * Installation selection (mirrors watchdog's #524 guard R2 N1):
+ *   1. `?installationId=X` query param wins (manual test override)
+ *   2. Otherwise read `HIVEMOOT_QUEEN_INSTALLATION_ID` env var
+ *   3. Neither set → 500 misconfig (the cron-bearer holder is
+ *      already authenticated, so fail-loud is acceptable)
+ *
+ * Required env (per deployment):
+ *   - CRON_SECRET — auth bearer
+ *   - APP_ID + (PRIVATE_KEY | APP_PRIVATE_KEY) — GitHub App credentials
+ *   - HIVEMOOT_BOT_AGENT_TOKEN — V1 capability bearer with
+ *     rooms.read_all + rooms.decide + rooms.close (queen preset)
+ *   - HIVEMOOT_QUEEN_INSTALLATION_ID — target installation
+ *   - LLM_PROVIDER + LLM_MODEL + provider API key (optional —
+ *     loop falls back to StubSynthesizer when missing)
+ *
+ * Optional:
+ *   - HIVEMOOT_API_BASE_URL (default: https://www.hivemoot.dev)
+ *   - HIVEMOOT_QUEEN_RUNNER_ID (default: derived from deployment)
+ *   - HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK (default: 100)
+ *
+ * Response: `{ runnerId, installationId, result }` where result is
+ * `QueenManagerLoopResult`. Operators alert on `result.errors > 0`
+ * or `result.postsFailed > 0`.
+ */
+
+import type { IncomingMessage, ServerResponse } from "http";
+import { App } from "octokit";
+
+import { getAppConfig } from "../lib/env-validation.js";
+import { logger } from "../lib/logger.js";
+import { runQueenManagerLoop } from "../lib/queen/manager-loop.js";
+import { createSynthesizer } from "../lib/queen/ai-sdk-synthesizer.js";
+import { GitHubDecisionPoster } from "../lib/queen/decision-poster.js";
+import { WarRoomClient } from "../lib/war-room-client.js";
+
+/** Numeric-only check — defense-in-depth even with an authenticated
+ * caller. Mirrors the watchdog's INSTALLATION_ID_REGEX. */
+const INSTALLATION_ID_REGEX = /^\d+$/;
+
+const DEFAULT_BASE_URL = "https://www.hivemoot.dev";
+
+function getCronSecret(): string | null {
+  const v = process.env.CRON_SECRET;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function makeRunnerId(): string {
+  const fromEnv = process.env.HIVEMOOT_QUEEN_RUNNER_ID;
+  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
+  return `vercel-queen.${Date.now()}.${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function parseMaxRoomsPerTick(): number | undefined {
+  const v = process.env.HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK;
+  if (typeof v !== "string" || v.length === 0) return undefined;
+  const n = Number(v);
+  if (!Number.isInteger(n) || n <= 0) return undefined;
+  return n;
+}
+
+/**
+ * Resolve `installationId` from query → env. Returns
+ *   - `{ ok: true, installationId }` on success
+ *   - `{ ok: false, status, body }` to short-circuit the response
+ */
+function resolveInstallationId(
+  url: URL,
+):
+  | { ok: true; installationId: string }
+  | { ok: false; status: number; body: Record<string, unknown> } {
+  const fromQuery = url.searchParams.get("installationId");
+  const fromEnv = process.env.HIVEMOOT_QUEEN_INSTALLATION_ID;
+  const installationId = fromQuery ?? fromEnv ?? null;
+
+  if (installationId === null || installationId.length === 0) {
+    logger.error(
+      "[queen-tick] no installationId — neither ?installationId query nor HIVEMOOT_QUEEN_INSTALLATION_ID env var is set",
+    );
+    return {
+      ok: false,
+      status: 500,
+      body: {
+        code: "no_installation_id",
+        message:
+          "No installationId resolved — neither ?installationId query nor HIVEMOOT_QUEEN_INSTALLATION_ID env var is set.",
+      },
+    };
+  }
+
+  if (!INSTALLATION_ID_REGEX.test(installationId)) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        code: "invalid_installation_id",
+        message:
+          "installationId must be a non-empty numeric string (GitHub installation IDs).",
+      },
+    };
+  }
+
+  return { ok: true, installationId };
+}
+
+function writeJson(
+  res: ServerResponse,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Run one queen tick for the resolved installation. Wraps the
+ * dependencies (WarRoomClient + Synthesizer + DecisionPoster) and
+ * delegates to runQueenManagerLoop.
+ *
+ * No per-installation lock: at V1 scale (one Hive, one
+ * installation) the cron interval (suggested every 2 minutes) is
+ * larger than a typical tick (≪ 30s). Overlapping ticks are
+ * already idempotent at the storage layer (claim_already_held +
+ * sequence_drift catch any collisions). If multi-installation
+ * scaling lands in V1.1, add the same compare-and-DEL Lua lock
+ * pattern the watchdog uses.
+ */
+async function runOneTick(installationId: string): Promise<{
+  runnerId: string;
+  result: Awaited<ReturnType<typeof runQueenManagerLoop>>;
+}> {
+  const appConfig = getAppConfig();
+  const app = new App({
+    appId: String(appConfig.appId),
+    privateKey: appConfig.privateKey,
+  });
+  const octokit = await app.getInstallationOctokit(Number(installationId));
+
+  const baseUrl = process.env.HIVEMOOT_API_BASE_URL ?? DEFAULT_BASE_URL;
+  const client = new WarRoomClient({ baseUrl });
+  const synthesizer = await createSynthesizer({
+    installationId: Number(installationId),
+  });
+  const poster = new GitHubDecisionPoster({ octokit });
+  const runnerId = makeRunnerId();
+
+  const result = await runQueenManagerLoop({
+    client,
+    synthesizer,
+    decisionPoster: poster,
+    runnerId,
+    maxRoomsPerTick: parseMaxRoomsPerTick(),
+    log: {
+      info: (msg) => logger.info(`[queen-tick] ${msg}`),
+      warn: (msg) => logger.warn(`[queen-tick] ${msg}`),
+      error: (msg) => logger.error(`[queen-tick] ${msg}`),
+    },
+  });
+
+  return { runnerId, result };
+}
+
+export default async function handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  // Auth: CRON_SECRET bearer. Misconfig (unset) and wrong-bearer
+  // both return 401 with empty body — no oracle.
+  const expected = getCronSecret();
+  if (expected === null) {
+    logger.error(
+      "[queen-tick] CRON_SECRET is not set in this deployment — refusing all requests. Add CRON_SECRET to the env (Vercel dashboard → Settings → Environment Variables).",
+    );
+    res.statusCode = 401;
+    res.end();
+    return;
+  }
+
+  const authHeader = req.headers["authorization"];
+  if (authHeader !== `Bearer ${expected}`) {
+    res.statusCode = 401;
+    res.end();
+    return;
+  }
+
+  // Method: GET only.
+  if (req.method !== "GET") {
+    writeJson(res, 405, {
+      code: "method_not_allowed",
+      message: "Only GET is accepted (Vercel Cron sends GET).",
+    });
+    return;
+  }
+
+  // Resolve installationId.
+  // url.parse via WHATWG URL; req.url is just the path so prepend a
+  // dummy origin to make WHATWG URL happy.
+  const url = new URL(req.url ?? "/", "http://placeholder.local");
+  const idResult = resolveInstallationId(url);
+  if (!idResult.ok) {
+    writeJson(res, idResult.status, idResult.body);
+    return;
+  }
+
+  // Run the tick.
+  try {
+    const { runnerId, result } = await runOneTick(idResult.installationId);
+    writeJson(res, 200, {
+      runnerId,
+      installationId: idResult.installationId,
+      result,
+    });
+  } catch (err) {
+    logger.error(
+      `[queen-tick] unhandled error installation=${idResult.installationId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    writeJson(res, 500, {
+      code: "tick_failed",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -138,51 +138,213 @@ function writeJson(
 }
 
 /**
+ * Build the log adapter passed to `runQueenManagerLoop`. Formats
+ * any structured `meta` argument into the message string so the
+ * bot's single-string Logger (which doesn't accept a meta object)
+ * preserves it for ops triage.
+ *
+ * Closes #542 guard B1: without this, every manager-loop log site
+ * (`list_rooms_failed`, `unexpected_error`, `synthesize_failed`,
+ * `contributions_read_failed`, `close_failed`, `post_failed`) would
+ * silently drop its roomId / error class — leaving operators
+ * staring at "[queen-tick] queen.manager_loop.unexpected_error" with
+ * no context when alerts fire.
+ */
+export function makeManagerLoopLogAdapter(): {
+  info: (message: string, meta?: Record<string, unknown>) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+  error: (message: string, meta?: Record<string, unknown>) => void;
+} {
+  const fmt = (msg: string, meta?: Record<string, unknown>): string => {
+    if (!meta || Object.keys(meta).length === 0) {
+      return `[queen-tick] ${msg}`;
+    }
+    return `[queen-tick] ${msg} ${JSON.stringify(meta)}`;
+  };
+  return {
+    info: (msg, meta) => logger.info(fmt(msg, meta)),
+    warn: (msg, meta) => logger.warn(fmt(msg, meta)),
+    error: (msg, meta) => logger.error(fmt(msg, meta)),
+  };
+}
+
+/**
  * Run one queen tick for the resolved installation. Wraps the
  * dependencies (WarRoomClient + Synthesizer + DecisionPoster) and
  * delegates to runQueenManagerLoop.
  *
- * No per-installation lock: at V1 scale (one Hive, one
- * installation) the cron interval (suggested every 2 minutes) is
- * larger than a typical tick (≪ 30s). Overlapping ticks are
- * already idempotent at the storage layer (claim_already_held +
- * sequence_drift catch any collisions). If multi-installation
- * scaling lands in V1.1, add the same compare-and-DEL Lua lock
- * pattern the watchdog uses.
+ * Per-installation lock: SET NX EX 290 + compare-and-DEL release.
+ * Closes #542 builder R1. Required by WAR_ROOM_DESIGN.md §971: at
+ * 2-minute schedule with 5-minute maxDuration, overlap between
+ * fires is real, and while storage-layer `claim_already_held`
+ * catches correctness collisions, we still want to avoid burning
+ * duplicate LLM credits on the same room. TTL of 290s leaves a
+ * 10s margin under the function timeout so a runaway tick that
+ * exceeds maxDuration still releases its lock before a follow-up
+ * fire would block.
+ *
+ * Lock is best-effort in two senses:
+ *   - When `HIVEMOOT_REDIS_REST_URL` / `TOKEN` env aren't configured,
+ *     run unlocked (V1 single-installation dev deployments).
+ *   - When Redis is unreachable mid-tick, log + run unlocked rather
+ *     than skipping the tick (availability over duplicate-work
+ *     prevention).
  */
 async function runOneTick(installationId: string): Promise<{
   runnerId: string;
   result: Awaited<ReturnType<typeof runQueenManagerLoop>>;
+  skipped?: boolean;
 }> {
-  const appConfig = getAppConfig();
-  const app = new App({
-    appId: String(appConfig.appId),
-    privateKey: appConfig.privateKey,
-  });
-  const octokit = await app.getInstallationOctokit(Number(installationId));
-
-  const baseUrl = process.env.HIVEMOOT_API_BASE_URL ?? DEFAULT_BASE_URL;
-  const client = new WarRoomClient({ baseUrl });
-  const synthesizer = await createSynthesizer({
-    installationId: Number(installationId),
-  });
-  const poster = new GitHubDecisionPoster({ octokit });
   const runnerId = makeRunnerId();
 
-  const result = await runQueenManagerLoop({
-    client,
-    synthesizer,
-    decisionPoster: poster,
-    runnerId,
-    maxRoomsPerTick: parseMaxRoomsPerTick(),
-    log: {
-      info: (msg) => logger.info(`[queen-tick] ${msg}`),
-      warn: (msg) => logger.warn(`[queen-tick] ${msg}`),
-      error: (msg) => logger.error(`[queen-tick] ${msg}`),
-    },
-  });
+  const acquired = await tryAcquireTickLock(installationId, runnerId);
+  if (acquired === "contention") {
+    logger.info(
+      `[queen-tick] lock contention installation=${installationId} — skip`,
+    );
+    // Return zeroed result so caller can serialize it consistently.
+    return { runnerId, result: emptyManagerLoopResult(), skipped: true };
+  }
 
-  return { runnerId, result };
+  try {
+    const appConfig = getAppConfig();
+    const app = new App({
+      appId: String(appConfig.appId),
+      privateKey: appConfig.privateKey,
+    });
+    const octokit = await app.getInstallationOctokit(Number(installationId));
+
+    const baseUrl = process.env.HIVEMOOT_API_BASE_URL ?? DEFAULT_BASE_URL;
+    const client = new WarRoomClient({ baseUrl });
+    const synthesizer = await createSynthesizer({
+      installationId: Number(installationId),
+    });
+    const poster = new GitHubDecisionPoster({ octokit });
+
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer,
+      decisionPoster: poster,
+      runnerId,
+      maxRoomsPerTick: parseMaxRoomsPerTick(),
+      log: makeManagerLoopLogAdapter(),
+    });
+
+    return { runnerId, result };
+  } finally {
+    await releaseTickLock(installationId, runnerId);
+  }
+}
+
+function emptyManagerLoopResult(): Awaited<
+  ReturnType<typeof runQueenManagerLoop>
+> {
+  return {
+    totalRoomsScanned: 0,
+    scannedAwaitingContributions: 0,
+    eligible: 0,
+    claimed: 0,
+    closed: 0,
+    conflicts: 0,
+    staleClaimsAbandoned: 0,
+    postsSucceeded: 0,
+    postsFailed: 0,
+    postsSkipped: 0,
+    errors: 0,
+  };
+}
+
+/** TTL on the per-installation tick lock. 290s = 10s margin under
+ * the function's `maxDuration: 300` so a runaway tick releases its
+ * lock by TTL-expiry before the next 2-minute fire would block. */
+const TICK_LOCK_TTL_SECS = 290;
+
+const TICK_LOCK_KEY_PREFIX = "queen:tick:lock:installation:";
+
+/** Compare-and-DEL Lua: only DEL the lock key if it's still owned by
+ * this runner. Prevents a tick whose work outlasted the TTL from
+ * releasing a follow-up runner's lock. */
+const TICK_LOCK_RELEASE_SCRIPT =
+  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
+
+/** Returns "ok" if the lock was acquired (or skipped because no
+ * Redis configured), "contention" if another runner holds it. */
+async function tryAcquireTickLock(
+  installationId: string,
+  runnerId: string,
+): Promise<"ok" | "contention"> {
+  const redis = getUpstashRedisConfig();
+  if (!redis) return "ok"; // No Redis → run unlocked.
+  const key = TICK_LOCK_KEY_PREFIX + installationId;
+  try {
+    const url = `${redis.url}/set/${encodeURIComponent(key)}/${encodeURIComponent(runnerId)}?NX&EX=${TICK_LOCK_TTL_SECS}`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${redis.token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      logger.warn(
+        `[queen-tick] lock acquire HTTP ${response.status} — running unlocked`,
+      );
+      return "ok";
+    }
+    const body = (await response.json()) as { result?: string | null };
+    // Upstash returns { result: "OK" } on success, { result: null }
+    // on NX conflict.
+    return body.result === "OK" ? "ok" : "contention";
+  } catch (err) {
+    logger.warn(
+      `[queen-tick] lock acquire error: ${err instanceof Error ? err.message : String(err)} — running unlocked`,
+    );
+    return "ok";
+  }
+}
+
+async function releaseTickLock(
+  installationId: string,
+  runnerId: string,
+): Promise<void> {
+  const redis = getUpstashRedisConfig();
+  if (!redis) return;
+  const key = TICK_LOCK_KEY_PREFIX + installationId;
+  try {
+    const response = await fetch(redis.url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${redis.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        "EVAL",
+        TICK_LOCK_RELEASE_SCRIPT,
+        "1",
+        key,
+        runnerId,
+      ]),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      logger.warn(`[queen-tick] lock release HTTP ${response.status}`);
+    }
+  } catch (err) {
+    logger.warn(
+      `[queen-tick] lock release error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+interface UpstashRedisConfig {
+  url: string;
+  token: string;
+}
+
+function getUpstashRedisConfig(): UpstashRedisConfig | null {
+  const url = process.env.HIVEMOOT_REDIS_REST_URL;
+  const token = process.env.HIVEMOOT_REDIS_REST_TOKEN;
+  if (typeof url !== "string" || url.length === 0) return null;
+  if (typeof token !== "string" || token.length === 0) return null;
+  return { url, token };
 }
 
 export default async function handler(
@@ -229,10 +391,14 @@ export default async function handler(
 
   // Run the tick.
   try {
-    const { runnerId, result } = await runOneTick(idResult.installationId);
+    const { runnerId, result, skipped } = await runOneTick(
+      idResult.installationId,
+    );
     writeJson(res, 200, {
       runnerId,
       installationId: idResult.installationId,
+      skipped: skipped ?? false,
+      ...(skipped ? { reason: "lock_contention" } : {}),
       result,
     });
   } catch (err) {

--- a/bot/vercel.json
+++ b/bot/vercel.json
@@ -6,8 +6,17 @@
   "functions": {
     "api/github/webhooks/index.ts": {
       "maxDuration": 120
+    },
+    "api/queen/tick.ts": {
+      "maxDuration": 300
     }
   },
+  "crons": [
+    {
+      "path": "/api/queen/tick",
+      "schedule": "*/2 * * * *"
+    }
+  ],
   "git": {
     "deploymentEnabled": false,
     "ignoreCommand": "exit 0"


### PR DESCRIPTION
Fixes #541

## Summary

Final slice of Phase G' (queen module). Wires together everything G'.1-G'.4 built into a Vercel-cron-driven `GET /api/queen/tick` endpoint. With this slice, the war-room V1 end-to-end flow is complete.

## What's new

```
bot/
├── api/queen/tick.ts        — Vercel function (GET handler)
├── api/queen/tick.test.ts   — 19 tests
└── vercel.json              — function decl + cron schedule
```

### End-to-end flow (now complete)

1. PR opened → bot creates war room (E.1)
2. PR synchronize/closed → bot emits subject_updated (E.2)
3. Workers RSVP (F.2) and submit contributions (F.1)
4. Watchdog reaps stale rooms (D.1.c)
5. **Queen manager-loop tick (G'.5):** lists → claims → synthesizes → closes → posts to PR

### Auth + safety

- `Authorization: Bearer ${CRON_SECRET}` per Vercel's documented cron pattern (matches the watchdog)
- Misconfig (env unset) AND wrong-bearer both 401 with empty body — no oracle for "wrong bearer" vs "no deployment"
- GET only (Vercel Cron sends GET, no body); POST/DELETE → 405
- InstallationId numeric format check (defense-in-depth)

### Installation resolution

```
?installationId=X  >  HIVEMOOT_QUEEN_INSTALLATION_ID env  >  500 misconfig
```

V1 single-installation. V1.1 multi-installation iteration would add the same compare-and-DEL Lua lock pattern the watchdog uses.

### Vercel cron schedule

```json
{
  "crons": [{ "path": "/api/queen/tick", "schedule": "*/2 * * * *" }],
  "functions": { "api/queen/tick.ts": { "maxDuration": 300 } }
}
```

Every 2 minutes, with a 5-minute budget per tick (Pro ceiling per WAR_ROOM_DESIGN.md).

## What it looks like

Successful tick response:

```json
{
  "runnerId": "vercel-queen.1730155847123.a4fd9c2x",
  "installationId": "67890",
  "result": {
    "totalRoomsScanned": 3,
    "scannedAwaitingContributions": 1,
    "eligible": 1,
    "claimed": 1,
    "closed": 1,
    "conflicts": 0,
    "staleClaimsAbandoned": 0,
    "postsSucceeded": 1,
    "postsFailed": 0,
    "postsSkipped": 0,
    "errors": 0
  }
}
```

Operators alert on `errors > 0` or `postsFailed > 0`.

## Required env (per deployment)

- `CRON_SECRET` — auth
- `APP_ID` + (`PRIVATE_KEY` | `APP_PRIVATE_KEY`) — GitHub App
- `HIVEMOOT_BOT_AGENT_TOKEN` — V1 capability bearer (queen preset: `rooms.read_all`, `rooms.decide`, `rooms.close`)
- `HIVEMOOT_QUEEN_INSTALLATION_ID` — target installation
- `LLM_PROVIDER` + `LLM_MODEL` + provider API key (optional — falls back to `StubSynthesizer`)

Optional:

- `HIVEMOOT_API_BASE_URL` (default: `https://www.hivemoot.dev`)
- `HIVEMOOT_QUEEN_RUNNER_ID` (default: derived from deployment timestamp)
- `HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK` (default: 100)

## NOT in scope (V1.1)

- Per-installation lock for multi-installation deployments
- Multiple-installation discovery (vs single env-var-driven)
- Post retry on transient failures
- mention_response + issue_triage subject types in the poster

## Test plan

- [x] `tsc --noEmit` clean
- [x] Tick tests: 19 (auth, method, installationId, happy path, env, errors)
- [x] Full bot suite: 1911 tests pass (was 1892, +19)
- [x] Lint clean
- [ ] Reviewer fleet sign-off