### PR TITLE
Phase F.3 — war-room triage prompt + on_job_finished handler

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
@@ -25,6 +25,7 @@ from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api import (
 )
 from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler import (
     JOB_KIND_TRIAGE,
+    PostFailureCallback,
     handle_war_room_job_finished,
     is_war_room_job,
 )
@@ -57,4 +58,5 @@ __all__ = (
     "JOB_KIND_TRIAGE",
     "handle_war_room_job_finished",
     "is_war_room_job",
+    "PostFailureCallback",
 )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
@@ -26,8 +26,10 @@ from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api import (
 from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler import (
     JOB_KIND_TRIAGE,
     PostFailureCallback,
+    RAW_MD_CLIENT_CAP_BYTES,
     handle_war_room_job_finished,
     is_war_room_job,
+    truncate_raw_md,
 )
 from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.triage import (
     TRIAGE_OUTPUT_INSTRUCTIONS,
@@ -59,4 +61,6 @@ __all__ = (
     "handle_war_room_job_finished",
     "is_war_room_job",
     "PostFailureCallback",
+    "RAW_MD_CLIENT_CAP_BYTES",
+    "truncate_raw_md",
 )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/__init__.py
@@ -7,9 +7,10 @@ rooms eligible for their role, then RSVP and contribute.
 V1 layering:
   * `api` — HTTP client wrapping `/api/rooms/*` (F.1)
   * `trigger` — poll loop + dispatch + per-room state cache (F.2)
-  * `dispatch` — per-room triage + heavy contribution dispatch
-    (future F.3)
-  * plugin-manifest wiring (future F.4)
+  * `triage` — prompt template + structured-output parser (F.3)
+  * `handler` — on_job_finished dispatch to present/contribute/
+    withdraw based on parsed triage (F.3)
+  * plugin-manifest wiring + config schema (future F.5)
 
 The HTTP client uses the same shared transport (`..http`) and
 auth helper (`..auth`) as the existing tasks/health plugins.
@@ -21,6 +22,17 @@ from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api import (
     present_to_room,
     submit_contribution,
     withdraw_participant,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler import (
+    JOB_KIND_TRIAGE,
+    handle_war_room_job_finished,
+    is_war_room_job,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.triage import (
+    TRIAGE_OUTPUT_INSTRUCTIONS,
+    TriageDecision,
+    build_triage_prompt,
+    parse_triage_response,
 )
 from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.trigger import (
     DEFAULT_POLL_INTERVAL_SECS,
@@ -38,4 +50,11 @@ __all__ = (
     "WarRoomWatcherTrigger",
     "DEFAULT_POLL_INTERVAL_SECS",
     "DEFAULT_SEEN_CACHE_MAX",
+    "TriageDecision",
+    "TRIAGE_OUTPUT_INSTRUCTIONS",
+    "build_triage_prompt",
+    "parse_triage_response",
+    "JOB_KIND_TRIAGE",
+    "handle_war_room_job_finished",
+    "is_war_room_job",
 )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
@@ -1,0 +1,228 @@
+"""War-room job handler — runs in `on_job_finished` (F.3).
+
+After the engine finishes a triage Job, this handler:
+
+  1. Extracts the engine's markdown response from its log
+     (delegated to the existing `tasks.result_extractor` —
+     the same NDJSON-aware extractor the tasks plugin uses,
+     so behavior is consistent across providers).
+  2. Parses the structured triage block via `parse_triage_response`.
+  3. Calls the war-room API:
+     - PRESENT: `present_to_room` → `submit_contribution`
+     - WITHDRAW: `withdraw_participant` (with `reason` if given)
+
+# Failure isolation
+
+The handler swallows all exceptions and logs to stderr. The agent's
+exit code is NOT promoted to failure on a post error — the engine
+already finished successfully; a stuck post is a transient issue
+the next watching tick can re-attempt (the storage layer is
+idempotent on (room, role, sequence)).
+
+# Idempotency
+
+The trigger keys its dedupe cache by `{roomId}@{sequence}` so a
+re-tick with the same sequence won't re-dispatch. If the agent
+re-runs anyway (operator-forced re-dispatch, etc.), the API
+returns 409 `duplicate_present` / `duplicate_contribution` and the
+handler swallows + logs as a benign race.
+
+# Wire-cost guard
+
+A worker with a stuck/malformed triage output ALWAYS withdraws —
+never silently submits an empty contribution that the queen would
+read as data. The parse_error path produces a withdraw with
+reason `unparseable_triage_output:<class>` so operators can grep
+the worker logs and find the LLM that's producing garbage.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+
+from . import api as wr_api
+from .triage import TriageDecision, parse_triage_response
+
+
+__all__ = (
+    "JOB_KIND_TRIAGE",
+    "is_war_room_job",
+    "handle_war_room_job_finished",
+)
+
+
+# Marker the trigger writes into job.metadata so on_job_finished
+# can dispatch deterministically. Stable string — operators can
+# grep logs for it.
+JOB_KIND_TRIAGE = "war_room_triage"
+
+
+def is_war_room_job(job: Job) -> bool:
+    """Discriminator predicate. Mirrors `_is_task_job` in the
+    parent plugin's `__init__.py`. The `room_id` AND `kind` AND
+    `sequence` triple are all checked: a partial-marker Job is
+    treated as not-ours rather than risking a false-positive
+    dispatch."""
+    return (
+        job.metadata.get("job_kind") == JOB_KIND_TRIAGE
+        and bool(job.metadata.get("room_id"))
+        and isinstance(job.metadata.get("current_sequence"), int)
+    )
+
+
+def handle_war_room_job_finished(
+    job: Job,
+    result: AgentResult,
+    *,
+    base_url: str,
+    bearer: str,
+    extracted_markdown: str,
+) -> TriageDecision:
+    """Parse the agent's response and act on it.
+
+    Returns the parsed `TriageDecision` so callers (and tests) can
+    introspect what was decided. Side-effects: HTTP calls to the
+    war-room API. All API failures swallowed-and-logged; this
+    function never raises.
+    """
+    room_id = str(job.metadata.get("room_id") or "")
+    current_sequence = int(job.metadata.get("current_sequence") or 0)
+    subject_ref = str(job.metadata.get("subject_ref") or "")
+
+    decision = parse_triage_response(extracted_markdown)
+
+    if decision.kind == "present":
+        _do_present_and_contribute(
+            base_url=base_url,
+            bearer=bearer,
+            room_id=room_id,
+            current_sequence=current_sequence,
+            subject_ref=subject_ref,
+            decision=decision,
+            result=result,
+        )
+    else:
+        _do_withdraw(
+            base_url=base_url,
+            bearer=bearer,
+            room_id=room_id,
+            current_sequence=current_sequence,
+            subject_ref=subject_ref,
+            decision=decision,
+        )
+
+    return decision
+
+
+def _do_present_and_contribute(
+    *,
+    base_url: str,
+    bearer: str,
+    room_id: str,
+    current_sequence: int,
+    subject_ref: str,
+    decision: TriageDecision,
+    result: AgentResult,
+) -> None:
+    """RSVP via /present, then submit the contribution. If the
+    /present call benignly fails (already presented, room moved on,
+    etc.), still attempt the contribution — the storage layer
+    enforces ordering server-side."""
+
+    # 1. Present (RSVP). Best-effort: a benign 409 (already
+    #    presented at this sequence) is not fatal; we still want
+    #    to submit the contribution body.
+    try:
+        wr_api.present_to_room(
+            base_url=base_url,
+            room_id=room_id,
+            sequence_observed_by_client=current_sequence,
+            bearer=bearer,
+            intent_hint=decision.summary,
+        )
+    except Exception as exc:  # noqa: BLE001 — log + continue
+        _log(
+            f"present failed (continuing to contribute) "
+            f"room={room_id} subject={subject_ref} seq={current_sequence}: "
+            f"{type(exc).__name__}: {exc}",
+            level="warn",
+        )
+
+    # 2. Submit contribution. The structured body matches
+    #    WAR_ROOM_DESIGN.md §"Worker contribution body schema".
+    body: dict[str, Any] = {
+        "verdict": decision.verdict,
+        "summary": decision.summary,
+    }
+    raw_md = decision.body or ""
+
+    try:
+        seq = wr_api.submit_contribution(
+            base_url=base_url,
+            room_id=room_id,
+            sequence_observed_by_client=current_sequence,
+            contribution_body=body,
+            raw_md=raw_md,
+            bearer=bearer,
+        )
+        _log(
+            f"contributed room={room_id} subject={subject_ref} "
+            f"verdict={decision.verdict} body_bytes={len(raw_md.encode('utf-8'))} "
+            f"landed_seq={seq} agent_exit={result.exit_code}",
+            level="info",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log(
+            f"contribute failed room={room_id} subject={subject_ref} "
+            f"seq={current_sequence} verdict={decision.verdict}: "
+            f"{type(exc).__name__}: {exc}",
+            level="error",
+        )
+
+
+def _do_withdraw(
+    *,
+    base_url: str,
+    bearer: str,
+    room_id: str,
+    current_sequence: int,
+    subject_ref: str,
+    decision: TriageDecision,
+) -> None:
+    try:
+        seq = wr_api.withdraw_participant(
+            base_url=base_url,
+            room_id=room_id,
+            sequence_observed_by_client=current_sequence,
+            bearer=bearer,
+            reason=decision.reason,
+        )
+        level = "warn" if decision.parse_error else "info"
+        _log(
+            f"withdrew room={room_id} subject={subject_ref} "
+            f"seq={current_sequence} reason={decision.reason or 'unspecified'} "
+            f"landed_seq={seq} parse_error={decision.parse_error}",
+            level=level,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log(
+            f"withdraw failed room={room_id} subject={subject_ref} "
+            f"seq={current_sequence}: {type(exc).__name__}: {exc}",
+            level="error",
+        )
+
+
+def _log(message: str, *, level: str) -> None:
+    """Write to stderr with a stable prefix so operators can grep.
+    Mirrors the `[hivemoot-tasks]` / `[hivemoot-health]` pattern in
+    the parent plugin."""
+    prefix = "[hivemoot-war-rooms]"
+    if level == "error":
+        print(f"{prefix} ERROR {message}", file=sys.stderr, flush=True)
+    elif level == "warn":
+        print(f"{prefix} WARN {message}", file=sys.stderr, flush=True)
+    else:
+        print(f"{prefix} {message}", file=sys.stderr, flush=True)

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
@@ -62,9 +62,54 @@ from .triage import TriageDecision, parse_triage_response
 __all__ = (
     "JOB_KIND_TRIAGE",
     "PostFailureCallback",
+    "RAW_MD_CLIENT_CAP_BYTES",
     "is_war_room_job",
     "handle_war_room_job_finished",
+    "truncate_raw_md",
 )
+
+
+# Client-side cap on contribution `raw_md` payload size. Storage
+# layer enforces 32 KiB server-side; we trim under that to leave
+# headroom for the truncation marker + envelope overhead. Closes
+# #544 builder R2: an oversized raw_md from the agent would 400
+# server-side without firing the post-failure callback (since
+# /present succeeded), and each next-tick re-dispatch would call
+# /present again — `presentParticipant` rewrites `rsvp_at` on every
+# call (war-room.ts:2727), pushing out the watchdog timeout
+# indefinitely. Result: stuck-pending participant that never
+# resolves and never times out.
+RAW_MD_CLIENT_CAP_BYTES = 31 * 1024  # 31 KiB; storage cap is 32 KiB
+
+
+_TRUNCATION_MARKER = (
+    "\n\n_[truncated by worker — agent produced an oversized review]_"
+)
+
+
+def truncate_raw_md(text: str) -> str:
+    """Trim `text` to at most `RAW_MD_CLIENT_CAP_BYTES` UTF-8 bytes.
+
+    Cuts on the last newline before the cap so a fenced code block
+    or list item doesn't get split mid-line. Appends a clearly-
+    flagged marker so the queen's synthesizer (and human readers)
+    see the contribution was capped on the worker side.
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) <= RAW_MD_CLIENT_CAP_BYTES:
+        return text
+    marker_bytes = _TRUNCATION_MARKER.encode("utf-8")
+    budget = RAW_MD_CLIENT_CAP_BYTES - len(marker_bytes)
+    if budget <= 0:
+        # Pathological — should never trigger since the marker is
+        # ~70 bytes and the cap is 31 KiB, but defensive against a
+        # config tweak that lowers the cap absurdly.
+        return _TRUNCATION_MARKER.lstrip()
+    sliced = encoded[:budget]
+    decoded = sliced.decode("utf-8", errors="ignore")
+    last_newline = decoded.rfind("\n")
+    clean_cut = decoded[:last_newline] if last_newline > 0 else decoded
+    return clean_cut + _TRUNCATION_MARKER
 
 
 # Signature the trigger (F.5) will pass in to surface total-failure
@@ -194,7 +239,8 @@ def _do_present_and_contribute(
         "verdict": decision.verdict,
         "summary": decision.summary,
     }
-    raw_md = decision.body or ""
+    raw_md = truncate_raw_md(decision.body or "")
+    truncated = len(raw_md) < len(decision.body or "")
 
     try:
         seq = wr_api.submit_contribution(
@@ -208,7 +254,7 @@ def _do_present_and_contribute(
         _log(
             f"contributed room={room_id} subject={subject_ref} "
             f"verdict={decision.verdict} body_bytes={len(raw_md.encode('utf-8'))} "
-            f"landed_seq={seq} agent_exit={result.exit_code}",
+            f"truncated={truncated} landed_seq={seq} agent_exit={result.exit_code}",
             level="info",
         )
     except Exception as exc:  # noqa: BLE001

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
@@ -9,23 +9,35 @@ After the engine finishes a triage Job, this handler:
   2. Parses the structured triage block via `parse_triage_response`.
   3. Calls the war-room API:
      - PRESENT: `present_to_room` → `submit_contribution`
-     - WITHDRAW: `withdraw_participant` (with `reason` if given)
+     - WITHDRAW: `present_to_room` → `withdraw_participant`
+       (RSVP first because storage requires an existing
+       participant slot before withdrawal — closes #544 builder R1.1.
+       Two API calls is correct vs the alternative of relaxing the
+       storage contract to allow first-class opt-out.)
 
 # Failure isolation
 
 The handler swallows all exceptions and logs to stderr. The agent's
 exit code is NOT promoted to failure on a post error — the engine
 already finished successfully; a stuck post is a transient issue
-the next watching tick can re-attempt (the storage layer is
-idempotent on (room, role, sequence)).
+the next watching tick can re-attempt.
+
+# Recovery from total post failure
+
+Optional `on_post_failure` callback (closes #544 builder R1.2):
+when supplied (F.5 will wire it to the trigger's seen-cache),
+called with `(room_id, sequence, op_kind, exc)` on any API failure
+during the post sequence. Enables the trigger to evict the seen-key
+so the next watching tick re-dispatches — without this, a transient
+network failure during all post operations would silently drop the
+worker's participation.
 
 # Idempotency
 
-The trigger keys its dedupe cache by `{roomId}@{sequence}` so a
-re-tick with the same sequence won't re-dispatch. If the agent
-re-runs anyway (operator-forced re-dispatch, etc.), the API
-returns 409 `duplicate_present` / `duplicate_contribution` and the
-handler swallows + logs as a benign race.
+The trigger keys its dedupe cache by `{roomId}@{sequence}`. If the
+agent re-runs anyway (operator-forced re-dispatch, etc.), the API
+returns 409 / `duplicate_*` codes and the handler swallows + logs
+as benign races.
 
 # Wire-cost guard
 
@@ -39,7 +51,7 @@ the worker logs and find the LLM that's producing garbage.
 from __future__ import annotations
 
 import sys
-from typing import Any
+from typing import Any, Callable, Optional
 
 from hivemoot_agent.plugins.interfaces import AgentResult, Job
 
@@ -49,9 +61,21 @@ from .triage import TriageDecision, parse_triage_response
 
 __all__ = (
     "JOB_KIND_TRIAGE",
+    "PostFailureCallback",
     "is_war_room_job",
     "handle_war_room_job_finished",
 )
+
+
+# Signature the trigger (F.5) will pass in to surface total-failure
+# back to the watcher's seen-cache. Args:
+#   room_id: the room whose post sequence failed
+#   sequence: the sequence the worker was acting on (for re-dispatch
+#             keying — same key the trigger originally marked)
+#   op_kind: "present" | "contribute" | "withdraw" — which API call
+#            raised
+#   exc: the underlying exception
+PostFailureCallback = Callable[[str, int, str, Exception], None]
 
 
 # Marker the trigger writes into job.metadata so on_job_finished
@@ -80,6 +104,7 @@ def handle_war_room_job_finished(
     base_url: str,
     bearer: str,
     extracted_markdown: str,
+    on_post_failure: Optional[PostFailureCallback] = None,
 ) -> TriageDecision:
     """Parse the agent's response and act on it.
 
@@ -87,6 +112,13 @@ def handle_war_room_job_finished(
     introspect what was decided. Side-effects: HTTP calls to the
     war-room API. All API failures swallowed-and-logged; this
     function never raises.
+
+    `on_post_failure`, when supplied, is invoked exactly once per
+    call when the post sequence terminates without successfully
+    transitioning participant state — i.e. RSVP failed (and
+    therefore the follow-on contribute/withdraw was skipped).
+    F.5's plugin wiring threads this in to evict the trigger's
+    seen-cache so the next watching tick re-dispatches.
     """
     room_id = str(job.metadata.get("room_id") or "")
     current_sequence = int(job.metadata.get("current_sequence") or 0)
@@ -103,15 +135,17 @@ def handle_war_room_job_finished(
             subject_ref=subject_ref,
             decision=decision,
             result=result,
+            on_post_failure=on_post_failure,
         )
     else:
-        _do_withdraw(
+        _do_present_then_withdraw(
             base_url=base_url,
             bearer=bearer,
             room_id=room_id,
             current_sequence=current_sequence,
             subject_ref=subject_ref,
             decision=decision,
+            on_post_failure=on_post_failure,
         )
 
     return decision
@@ -126,15 +160,19 @@ def _do_present_and_contribute(
     subject_ref: str,
     decision: TriageDecision,
     result: AgentResult,
+    on_post_failure: Optional[PostFailureCallback],
 ) -> None:
-    """RSVP via /present, then submit the contribution. If the
-    /present call benignly fails (already presented, room moved on,
-    etc.), still attempt the contribution — the storage layer
-    enforces ordering server-side."""
+    """RSVP via /present, then submit the contribution.
 
-    # 1. Present (RSVP). Best-effort: a benign 409 (already
-    #    presented at this sequence) is not fatal; we still want
-    #    to submit the contribution body.
+    If /present raises, /contribute is still attempted (a benign
+    409 from /present — already presented at this seq — shouldn't
+    block contribute; the storage layer enforces ordering server-
+    side). Only when BOTH fail do we fire `on_post_failure` — at
+    that point no participant-state change has landed and the
+    worker dropped this room silently without re-dispatch.
+    """
+
+    present_failed_exc: Optional[Exception] = None
     try:
         wr_api.present_to_room(
             base_url=base_url,
@@ -144,6 +182,7 @@ def _do_present_and_contribute(
             intent_hint=decision.summary,
         )
     except Exception as exc:  # noqa: BLE001 — log + continue
+        present_failed_exc = exc
         _log(
             f"present failed (continuing to contribute) "
             f"room={room_id} subject={subject_ref} seq={current_sequence}: "
@@ -151,8 +190,6 @@ def _do_present_and_contribute(
             level="warn",
         )
 
-    # 2. Submit contribution. The structured body matches
-    #    WAR_ROOM_DESIGN.md §"Worker contribution body schema".
     body: dict[str, Any] = {
         "verdict": decision.verdict,
         "summary": decision.summary,
@@ -181,9 +218,15 @@ def _do_present_and_contribute(
             f"{type(exc).__name__}: {exc}",
             level="error",
         )
+        # Both legs failed → no state change landed. Surface to
+        # the trigger so the next tick re-dispatches.
+        if present_failed_exc is not None:
+            _safe_callback(
+                on_post_failure, room_id, current_sequence, "contribute", exc,
+            )
 
 
-def _do_withdraw(
+def _do_present_then_withdraw(
     *,
     base_url: str,
     bearer: str,
@@ -191,7 +234,41 @@ def _do_withdraw(
     current_sequence: int,
     subject_ref: str,
     decision: TriageDecision,
+    on_post_failure: Optional[PostFailureCallback],
 ) -> None:
+    """RSVP via /present, then withdraw via /withdraw.
+
+    Closes #544 builder R1.1: storage requires an existing
+    participant slot before withdrawal (war-room.ts:2776). A
+    first-pass opt-out from /watching that calls /withdraw
+    directly returns 409 `participant_not_found` and the withdraw
+    event never lands — the worker is silently re-listed by the
+    next /watching tick.
+
+    Two API calls vs one is the correct trade vs relaxing the
+    storage contract. The /present call here mirrors the
+    PRESENT-path's RSVP step exactly; the only difference is
+    leg 2 (/withdraw vs /contribute).
+    """
+
+    present_failed = False
+    try:
+        wr_api.present_to_room(
+            base_url=base_url,
+            room_id=room_id,
+            sequence_observed_by_client=current_sequence,
+            bearer=bearer,
+            intent_hint=decision.reason,
+        )
+    except Exception as exc:  # noqa: BLE001
+        present_failed = True
+        _log(
+            f"present (for withdraw) failed (continuing to withdraw) "
+            f"room={room_id} subject={subject_ref} seq={current_sequence}: "
+            f"{type(exc).__name__}: {exc}",
+            level="warn",
+        )
+
     try:
         seq = wr_api.withdraw_participant(
             base_url=base_url,
@@ -211,6 +288,33 @@ def _do_withdraw(
         _log(
             f"withdraw failed room={room_id} subject={subject_ref} "
             f"seq={current_sequence}: {type(exc).__name__}: {exc}",
+            level="error",
+        )
+        if present_failed:
+            _safe_callback(
+                on_post_failure, room_id, current_sequence, "withdraw", exc,
+            )
+
+
+def _safe_callback(
+    callback: Optional[PostFailureCallback],
+    room_id: str,
+    sequence: int,
+    op_kind: str,
+    exc: Exception,
+) -> None:
+    """Invoke the post-failure callback, swallowing any exception
+    it raises so a buggy trigger can't propagate into the engine's
+    job lifecycle."""
+    if callback is None:
+        return
+    try:
+        callback(room_id, sequence, op_kind, exc)
+    except Exception as cb_exc:  # noqa: BLE001
+        _log(
+            f"on_post_failure callback raised "
+            f"room={room_id} seq={sequence} op={op_kind}: "
+            f"{type(cb_exc).__name__}: {cb_exc}",
             level="error",
         )
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/triage.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/triage.py
@@ -1,0 +1,298 @@
+"""War-room triage prompt + response parser (F.3).
+
+The watcher trigger (F.2) dispatches one Job per visible room. The
+engine subprocess (claude / codex / etc.) runs the triage prompt
+returned here, then the on_job_finished handler parses the response
+to decide whether to PRESENT (RSVP + submit a contribution) or
+WITHDRAW.
+
+# Output contract
+
+The agent MUST produce markdown ending with two sections:
+
+```
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: REQUEST_CHANGES
+SUMMARY: <1-2 sentence summary>
+
+## Review
+
+<full markdown analysis>
+```
+
+Or for withdrawal:
+
+```
+## Triage decision
+
+DECISION: WITHDRAW
+REASON: <one-line explanation>
+```
+
+The line-prefix format is chosen over YAML/JSON blocks because:
+  - LLMs reliably produce simple "KEY: value" lines.
+  - Parsing is robust against incidental whitespace, fenced code
+    blocks elsewhere in the response, and trailing chatter.
+  - VERDICT enum matches WAR_ROOM_DESIGN.md §S2 exactly so the
+    queen's structural-floor aggregation reads it as-validated.
+
+# Failure modes (parser side)
+
+Any malformed response (missing/invalid DECISION, missing VERDICT
+when PRESENT, etc.) is treated as WITHDRAW with reason
+`unparseable_triage_output:<class>`. The handler chooses safety: a
+worker that produces garbage doesn't get to inject into the queen's
+synthesis input via raw_md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from . import api as wr_api
+
+
+__all__ = (
+    "TRIAGE_OUTPUT_INSTRUCTIONS",
+    "TriageDecision",
+    "build_triage_prompt",
+    "parse_triage_response",
+)
+
+
+VALID_VERDICTS: frozenset[str] = frozenset(
+    {"APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"}
+)
+
+
+# Embedded into the user prompt so every dispatched Job sees the
+# exact same output spec. Kept as a module constant so tests can
+# assert on its content without re-tokenizing the full prompt.
+TRIAGE_OUTPUT_INSTRUCTIONS = """\
+## Output format (MUST follow exactly)
+
+End your response with one of two structured blocks:
+
+**To contribute a review:**
+```
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: <APPROVE | COMMENT | CONCERNS | REQUEST_CHANGES>
+SUMMARY: <1-2 sentence summary, ≤500 chars>
+
+## Review
+
+<your full markdown analysis here>
+```
+
+**To skip this room (out of scope, no useful input, etc.):**
+```
+## Triage decision
+
+DECISION: WITHDRAW
+REASON: <one-line explanation>
+```
+
+Rules:
+- DECISION must be exactly `PRESENT` or `WITHDRAW`.
+- VERDICT (when PRESENT) must be one of the four enum values literal,
+  uppercase. The queen aggregates these structurally per
+  WAR_ROOM_DESIGN.md §S2 — APPROVE for clean, REQUEST_CHANGES for
+  blockers, CONCERNS for non-blocking issues that warrant pause,
+  COMMENT for FYI / unscoped observations.
+- SUMMARY is the one-line headline of your review; the queen
+  may surface this verbatim to the PR.
+- The Review section is your full prose analysis — anything you'd
+  normally include in a PR review comment (line refs, severities,
+  remediation suggestions). The queen treats this as untrusted PR-
+  derived content and isolates it inside `<untrusted-content>`
+  delimiters before passing to its own LLM, so don't bother with
+  prompt-injection probes — they won't reach the synthesis LLM
+  unfiltered."""
+
+
+@dataclass(frozen=True)
+class TriageDecision:
+    """Parsed structured output of the triage agent.
+
+    `kind`: "present" or "withdraw". When parsing fails, kind is
+    "withdraw" with `reason` set to a sentinel `"unparseable_…"`
+    string and `parse_error=True` so the handler can log distinctly.
+
+    For "present" decisions, `verdict` and `summary` are validated
+    populated. `body` is the markdown content of the Review section
+    (may be empty if the agent forgot to include one).
+    """
+
+    kind: str  # "present" | "withdraw"
+    # Present-only:
+    verdict: str | None = None  # one of VALID_VERDICTS when kind="present"
+    summary: str | None = None
+    body: str | None = None
+    # Withdraw-only:
+    reason: str | None = None
+    # Set when the parser failed and synthesized a withdraw.
+    parse_error: bool = False
+
+
+def build_triage_prompt(room: wr_api.WatchingRoom) -> str:
+    """Construct the user prompt the engine runs for this room.
+
+    Inputs the agent gets:
+      - Room identification (subject + ref + roomId)
+      - Status + sequence (so re-dispatched rooms see new state)
+      - Current participants (so the agent sees who else is in)
+      - The output-format spec
+
+    The agent's persistent system prompt — set by the role plugin
+    elsewhere — already instructs it on its review style, repo
+    paths, available tools, etc. The triage prompt purposefully
+    does NOT re-state that; it focuses on what's room-specific.
+    """
+    lines: list[str] = []
+    lines.append("# War-room triage")
+    lines.append("")
+    lines.append(
+        f"You've been surfaced into a war room for **{room.subject_type}** `{room.subject_ref}`. "
+        f"Decide whether to contribute a review or withdraw."
+    )
+    lines.append("")
+    lines.append(f"**Room ID:** `{room.room_id}`")
+    lines.append(f"**Status:** `{room.status}`")
+    lines.append(f"**Sequence (at dispatch):** {room.current_sequence}")
+    if room.manager:
+        lines.append(f"**Opened by:** `{room.manager}`")
+    lines.append("")
+
+    if room.participants:
+        lines.append("## Other participants in this room")
+        lines.append("")
+        for role, p in sorted(room.participants.items()):
+            status = (p or {}).get("status", "?")
+            lines.append(f"- **{role}**: `{status}`")
+        lines.append("")
+    else:
+        lines.append("_No other participants have RSVPd yet — you're early._")
+        lines.append("")
+
+    lines.append("## Your task")
+    lines.append("")
+    lines.append(
+        "Investigate the subject (use your normal review tools — gh CLI, "
+        "code search, etc.) and produce a structured triage decision per "
+        "the output format below. If the subject is genuinely outside "
+        "your role's purview, withdraw cleanly rather than contributing "
+        "a low-signal review."
+    )
+    lines.append("")
+    lines.append(TRIAGE_OUTPUT_INSTRUCTIONS)
+    return "\n".join(lines)
+
+
+# ── Parser ─────────────────────────────────────────────────────────
+
+
+_DECISION_RE = re.compile(r"^DECISION:\s*([A-Z_]+)\s*$", re.MULTILINE)
+_VERDICT_RE = re.compile(r"^VERDICT:\s*([A-Z_]+)\s*$", re.MULTILINE)
+_SUMMARY_RE = re.compile(r"^SUMMARY:\s*(.+)$", re.MULTILINE)
+_REASON_RE = re.compile(r"^REASON:\s*(.+)$", re.MULTILINE)
+# Body section: everything from `## Review` (case-insensitive) to end
+# of string. Captured non-greedily up to optional trailing whitespace.
+_BODY_RE = re.compile(
+    r"^##\s+Review\s*\n(.*?)\s*$", re.MULTILINE | re.DOTALL | re.IGNORECASE
+)
+# The triage block must come last; we look for the LAST occurrence
+# of a "## Triage decision" heading so the agent can think out loud
+# in earlier sections without confusing the parser.
+_TRIAGE_HEADER_RE = re.compile(
+    r"^##\s+Triage\s+decision\s*$", re.MULTILINE | re.IGNORECASE
+)
+
+
+def parse_triage_response(markdown: str) -> TriageDecision:
+    """Parse the agent's response into a structured `TriageDecision`.
+
+    Robust to:
+      - Trailing whitespace / extra blank lines
+      - Earlier sections containing the markers (we only look at
+        the LAST `## Triage decision` block)
+      - Missing optional fields (REASON on WITHDRAW)
+
+    Synthesizes a WITHDRAW with `parse_error=True` on:
+      - Empty / whitespace-only response
+      - No `## Triage decision` heading
+      - Missing or invalid DECISION
+      - DECISION=PRESENT with missing/invalid VERDICT
+      - DECISION=PRESENT with missing SUMMARY
+    """
+    if not markdown or not markdown.strip():
+        return _withdraw_parse_error("empty_response")
+
+    triage_block = _slice_last_triage_block(markdown)
+    if triage_block is None:
+        return _withdraw_parse_error("no_triage_heading")
+
+    decision_match = _DECISION_RE.search(triage_block)
+    if decision_match is None:
+        return _withdraw_parse_error("no_decision_marker")
+    decision = decision_match.group(1).strip()
+
+    if decision == "WITHDRAW":
+        reason_match = _REASON_RE.search(triage_block)
+        reason = reason_match.group(1).strip() if reason_match else None
+        return TriageDecision(kind="withdraw", reason=reason)
+
+    if decision != "PRESENT":
+        return _withdraw_parse_error(f"invalid_decision:{decision[:32]}")
+
+    # PRESENT path — verdict + summary required.
+    verdict_match = _VERDICT_RE.search(triage_block)
+    if verdict_match is None:
+        return _withdraw_parse_error("missing_verdict")
+    verdict = verdict_match.group(1).strip()
+    if verdict not in VALID_VERDICTS:
+        return _withdraw_parse_error(f"invalid_verdict:{verdict[:32]}")
+
+    summary_match = _SUMMARY_RE.search(triage_block)
+    if summary_match is None:
+        return _withdraw_parse_error("missing_summary")
+    summary = summary_match.group(1).strip()
+    if not summary:
+        return _withdraw_parse_error("empty_summary")
+    if len(summary) > 500:
+        # Server-side cap. Truncate cleanly rather than rejecting —
+        # an over-long summary is an ergonomics failure, not a safety
+        # one (the verdict is structural).
+        summary = summary[:497] + "…"
+
+    body_match = _BODY_RE.search(markdown)
+    body = body_match.group(1).strip() if body_match else ""
+
+    return TriageDecision(
+        kind="present",
+        verdict=verdict,
+        summary=summary,
+        body=body,
+    )
+
+
+def _slice_last_triage_block(markdown: str) -> str | None:
+    """Return the text from the LAST `## Triage decision` heading
+    onward, OR None if no such heading exists. Avoids false-positive
+    matches from earlier prose that mentions the marker."""
+    matches = list(_TRIAGE_HEADER_RE.finditer(markdown))
+    if not matches:
+        return None
+    return markdown[matches[-1].end():]
+
+
+def _withdraw_parse_error(reason: str) -> TriageDecision:
+    return TriageDecision(
+        kind="withdraw",
+        reason=f"unparseable_triage_output:{reason}",
+        parse_error=True,
+    )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/trigger.py
@@ -260,61 +260,48 @@ class WarRoomWatcherTrigger:
     def _build_job(self, room: wr_api.WatchingRoom) -> Any:
         """Construct the Job dispatched to the worker pipeline.
 
-        F.3 will replace the prompt body with the actual triage
-        prompt; this F.2 stub builds a minimal Job descriptor that
-        carries the room context in metadata. Returns a duck-typed
-        object so the test fixture doesn't need to import the real
-        `Job` dataclass (which lives in `hivemoot_agent.plugins.interfaces`).
+        Carries the room context in metadata so the on_job_finished
+        handler can post the engine's triage decision back to the
+        war-room API without re-reading the room's state. Returns a
+        duck-typed object so the test fixture doesn't need to
+        import the real `Job` dataclass (which lives in
+        `hivemoot_agent.plugins.interfaces`).
         """
+        from .handler import JOB_KIND_TRIAGE
+        from .triage import build_triage_prompt
+
+        metadata = {
+            # Job-kind discriminator so the parent plugin's
+            # on_job_finished can dispatch deterministically.
+            "job_kind": JOB_KIND_TRIAGE,
+            "room_id": room.room_id,
+            "current_sequence": room.current_sequence,
+            "subject_type": room.subject_type,
+            "subject_ref": room.subject_ref,
+            "manager": room.manager,
+            "status": room.status,
+            "participants": room.participants,
+        }
+        prompt = build_triage_prompt(room)
+        session_key = f"war-room:{room.room_id}@{room.current_sequence}"
+
         # Lazy import: the real Job dataclass requires pydantic +
         # the plugin-interface dependency graph. Tests inject a
-        # fake dispatcher, so the lazy import keeps F.2 testable
-        # in isolation.
+        # fake dispatcher, so the lazy import keeps the trigger
+        # testable in isolation.
         try:
             from hivemoot_agent.plugins.interfaces import Job  # type: ignore[import-not-found]
 
             return Job(
-                session_key=f"war-room:{room.room_id}@{room.current_sequence}",
-                prompt=_build_triage_prompt(room),
-                metadata={
-                    "room_id": room.room_id,
-                    "current_sequence": room.current_sequence,
-                    "subject_type": room.subject_type,
-                    "subject_ref": room.subject_ref,
-                    "manager": room.manager,
-                    "status": room.status,
-                    # F.3 will read this to decide whether to call
-                    # /present or /withdraw based on triage output.
-                    "participants": room.participants,
-                },
+                session_key=session_key,
+                prompt=prompt,
+                metadata=metadata,
             )
         except ImportError:
             # Fallback for tests that don't have the plugin interface
             # loaded — return a plain dict with the same shape.
             return {
-                "session_key": f"war-room:{room.room_id}@{room.current_sequence}",
-                "prompt": _build_triage_prompt(room),
-                "metadata": {
-                    "room_id": room.room_id,
-                    "current_sequence": room.current_sequence,
-                    "subject_type": room.subject_type,
-                    "subject_ref": room.subject_ref,
-                    "manager": room.manager,
-                    "status": room.status,
-                    "participants": room.participants,
-                },
+                "session_key": session_key,
+                "prompt": prompt,
+                "metadata": metadata,
             }
-
-
-def _build_triage_prompt(room: wr_api.WatchingRoom) -> str:
-    """Minimal F.2 stub. F.3 replaces with the actual triage prompt
-    template (cheap LLM call: should this role contribute?)."""
-    return (
-        f"# War-room triage\n\n"
-        f"Room: {room.room_id}\n"
-        f"Subject: {room.subject_type} {room.subject_ref}\n"
-        f"Status: {room.status}\n"
-        f"Sequence: {room.current_sequence}\n\n"
-        f"This is an F.2 stub prompt. F.3 will replace with the real "
-        f"triage prompt that drives the RSVP-vs-withdraw decision."
-    )

--- a/agent/cli/tests/test_hivemoot_war_rooms_handler.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_handler.py
@@ -1,0 +1,342 @@
+"""Tests for cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+    JOB_KIND_TRIAGE,
+    handle_war_room_job_finished,
+    is_war_room_job,
+)
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@dataclass
+class _CallRecord:
+    op: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+def _job(
+    *,
+    room_id: str = "01234567-89ab-4cde-9012-3456789abcde",
+    sequence: int = 5,
+    job_kind: str | None = JOB_KIND_TRIAGE,
+    extra_meta: dict[str, Any] | None = None,
+) -> Job:
+    metadata: dict[str, Any] = {
+        "room_id": room_id,
+        "current_sequence": sequence,
+        "subject_type": "pr_review",
+        "subject_ref": "owner/repo#42",
+        "manager": "bot-queen",
+        "status": "awaiting_contributions",
+        "participants": {},
+    }
+    if job_kind is not None:
+        metadata["job_kind"] = job_kind
+    if extra_meta:
+        metadata.update(extra_meta)
+    return Job(
+        session_key=f"war-room:{room_id}@{sequence}",
+        prompt="ignored in tests",
+        metadata=metadata,
+    )
+
+
+def _result(exit_code: int = 0, response: str = "") -> AgentResult:
+    return AgentResult(exit_code=exit_code, response=response)
+
+
+def _present_response() -> str:
+    return """\
+Investigation notes...
+
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: REQUEST_CHANGES
+SUMMARY: Found 2 SQL injection blockers.
+
+## Review
+
+The /login handler concatenates user input directly. Use a
+parameterized query.
+"""
+
+
+def _withdraw_response(reason: str = "Out of scope.") -> str:
+    return f"""\
+## Triage decision
+
+DECISION: WITHDRAW
+REASON: {reason}
+"""
+
+
+# ── is_war_room_job ───────────────────────────────────────────────
+
+
+class IsWarRoomJobTests(unittest.TestCase):
+
+    def test_recognizes_triage_job(self) -> None:
+        self.assertTrue(is_war_room_job(_job()))
+
+    def test_rejects_job_without_kind_marker(self) -> None:
+        self.assertFalse(is_war_room_job(_job(job_kind=None)))
+
+    def test_rejects_job_with_wrong_kind(self) -> None:
+        self.assertFalse(
+            is_war_room_job(_job(job_kind="some_other_kind"))
+        )
+
+    def test_rejects_job_with_empty_room_id(self) -> None:
+        self.assertFalse(is_war_room_job(_job(room_id="")))
+
+    def test_rejects_job_with_non_int_sequence(self) -> None:
+        # Defensive: metadata could be deserialized weirdly. The
+        # discriminator must reject a job that can't safely flow
+        # through the handler.
+        j = _job()
+        j.metadata["current_sequence"] = "5"
+        self.assertFalse(is_war_room_job(j))
+
+    def test_rejects_task_jobs_from_sibling_plugin(self) -> None:
+        j = Job(
+            session_key="task:abc",
+            prompt="x",
+            metadata={"task_id": "abc", "claim_token": "tk"},
+        )
+        self.assertFalse(is_war_room_job(j))
+
+
+# ── handle_war_room_job_finished ──────────────────────────────────
+
+
+def _patched_apis(record: list[_CallRecord]):
+    """Patch wr_api.* to record calls instead of making HTTP."""
+
+    def _present(**kwargs):
+        record.append(_CallRecord(op="present", kwargs=kwargs))
+        return 6  # landed sequence
+
+    def _contribute(**kwargs):
+        record.append(_CallRecord(op="contribute", kwargs=kwargs))
+        return 7
+
+    def _withdraw(**kwargs):
+        record.append(_CallRecord(op="withdraw", kwargs=kwargs))
+        return 6
+
+    return patch.multiple(
+        "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api",
+        present_to_room=_present,
+        submit_contribution=_contribute,
+        withdraw_participant=_withdraw,
+    )
+
+
+class HandlePresentPathTests(unittest.TestCase):
+
+    def test_present_path_calls_present_then_contribute(self) -> None:
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+            )
+        self.assertEqual(decision.kind, "present")
+        self.assertEqual(decision.verdict, "REQUEST_CHANGES")
+        ops = [r.op for r in record]
+        self.assertEqual(ops, ["present", "contribute"])
+
+    def test_contribute_body_carries_verdict_summary_and_raw_md(self) -> None:
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+            )
+        contribute = next(r for r in record if r.op == "contribute")
+        self.assertEqual(
+            contribute.kwargs["contribution_body"],
+            {
+                "verdict": "REQUEST_CHANGES",
+                "summary": "Found 2 SQL injection blockers.",
+            },
+        )
+        self.assertIn("/login handler", contribute.kwargs["raw_md"])
+        self.assertEqual(
+            contribute.kwargs["sequence_observed_by_client"], 5
+        )
+        self.assertEqual(contribute.kwargs["bearer"], "bearer")
+        self.assertEqual(contribute.kwargs["base_url"], "https://api")
+        self.assertEqual(
+            contribute.kwargs["room_id"],
+            "01234567-89ab-4cde-9012-3456789abcde",
+        )
+
+    def test_present_failure_still_attempts_contribute(self) -> None:
+        # Storage layer enforces ordering server-side, but a benign
+        # 409 on /present (already RSVPd at this seq, etc.) should
+        # not block /contributions.
+        record: list[_CallRecord] = []
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present returned status 409: race"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=lambda **k: record.append(_CallRecord("contribute", k)) or 7,
+        ):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+            )
+        self.assertEqual([r.op for r in record], ["contribute"])
+
+    def test_contribute_failure_swallowed_not_raised(self) -> None:
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            return_value=6,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=RuntimeError("contributions returned status 503"),
+        ):
+            # Must not raise — handler swallows + logs.
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+            )
+        # Decision is still parsed correctly.
+        self.assertEqual(decision.kind, "present")
+
+
+class HandleWithdrawPathTests(unittest.TestCase):
+
+    def test_explicit_withdraw_calls_api_with_reason(self) -> None:
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_withdraw_response("Out of scope."),
+            )
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertEqual(decision.reason, "Out of scope.")
+        self.assertFalse(decision.parse_error)
+        ops = [r.op for r in record]
+        self.assertEqual(ops, ["withdraw"])
+        withdraw = record[0]
+        self.assertEqual(withdraw.kwargs["reason"], "Out of scope.")
+        self.assertEqual(
+            withdraw.kwargs["sequence_observed_by_client"], 5
+        )
+
+    def test_unparseable_response_synthesizes_withdraw_with_parse_error_reason(self) -> None:
+        # Closes the safety invariant: a stuck/malformed agent
+        # response NEVER results in a contribution being silently
+        # submitted. Always withdraw.
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown="just some prose, no triage block",
+            )
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertTrue(decision.parse_error)
+        assert decision.reason is not None
+        self.assertIn("unparseable_triage_output", decision.reason)
+        ops = [r.op for r in record]
+        self.assertEqual(ops, ["withdraw"])
+        # The withdraw API MUST receive the parse-error reason so
+        # operators grepping logs can correlate failed worker LLMs
+        # with the rooms they couldn't process.
+        self.assertIn(
+            "unparseable_triage_output",
+            record[0].kwargs["reason"],
+        )
+
+    def test_withdraw_failure_swallowed_not_raised(self) -> None:
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.withdraw_participant",
+            side_effect=RuntimeError("withdraw returned status 503"),
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_withdraw_response(),
+            )
+        # Still doesn't raise; decision returned for caller introspection.
+        self.assertEqual(decision.kind, "withdraw")
+
+
+class HandlerSafetyInvariantTests(unittest.TestCase):
+
+    def test_empty_agent_response_withdraws_never_contributes(self) -> None:
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown="",
+            )
+        self.assertEqual([r.op for r in record], ["withdraw"])
+        self.assertTrue(decision.parse_error)
+
+    def test_present_with_invalid_verdict_withdraws(self) -> None:
+        record: list[_CallRecord] = []
+        bogus = """\
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: SHIP_IT_NOW
+SUMMARY: lol
+## Review
+go
+"""
+        with _patched_apis(record):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=bogus,
+            )
+        self.assertEqual([r.op for r in record], ["withdraw"])
+        self.assertTrue(decision.parse_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/cli/tests/test_hivemoot_war_rooms_handler.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_handler.py
@@ -236,7 +236,11 @@ class HandlePresentPathTests(unittest.TestCase):
 
 class HandleWithdrawPathTests(unittest.TestCase):
 
-    def test_explicit_withdraw_calls_api_with_reason(self) -> None:
+    def test_explicit_withdraw_rsvps_first_then_withdraws(self) -> None:
+        # Closes #544 builder R1.1: storage requires an existing
+        # participant slot before withdrawal — calling /withdraw
+        # without prior /present returns 409 participant_not_found
+        # and the event never lands. Handler always RSVPs first.
         record: list[_CallRecord] = []
         with _patched_apis(record):
             decision = handle_war_room_job_finished(
@@ -250,17 +254,41 @@ class HandleWithdrawPathTests(unittest.TestCase):
         self.assertEqual(decision.reason, "Out of scope.")
         self.assertFalse(decision.parse_error)
         ops = [r.op for r in record]
-        self.assertEqual(ops, ["withdraw"])
-        withdraw = record[0]
+        self.assertEqual(ops, ["present", "withdraw"])
+        present = record[0]
+        withdraw = record[1]
+        self.assertEqual(present.kwargs["intent_hint"], "Out of scope.")
         self.assertEqual(withdraw.kwargs["reason"], "Out of scope.")
         self.assertEqual(
             withdraw.kwargs["sequence_observed_by_client"], 5
         )
 
+    def test_present_failure_during_withdraw_path_continues_to_withdraw(self) -> None:
+        # Mirrors PRESENT path: a 409 on /present (already RSVPd at
+        # this seq) shouldn't block /withdraw — storage tolerates
+        # the duplicate present and the withdraw still lands.
+        record: list[_CallRecord] = []
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present returned status 409"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.withdraw_participant",
+            side_effect=lambda **k: record.append(_CallRecord("withdraw", k)) or 7,
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_withdraw_response(),
+            )
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertEqual([r.op for r in record], ["withdraw"])
+
     def test_unparseable_response_synthesizes_withdraw_with_parse_error_reason(self) -> None:
         # Closes the safety invariant: a stuck/malformed agent
         # response NEVER results in a contribution being silently
-        # submitted. Always withdraw.
+        # submitted. Always withdraw (via present + withdraw).
         record: list[_CallRecord] = []
         with _patched_apis(record):
             decision = handle_war_room_job_finished(
@@ -275,17 +303,20 @@ class HandleWithdrawPathTests(unittest.TestCase):
         assert decision.reason is not None
         self.assertIn("unparseable_triage_output", decision.reason)
         ops = [r.op for r in record]
-        self.assertEqual(ops, ["withdraw"])
-        # The withdraw API MUST receive the parse-error reason so
-        # operators grepping logs can correlate failed worker LLMs
-        # with the rooms they couldn't process.
+        self.assertEqual(ops, ["present", "withdraw"])
+        # Withdraw MUST receive the parse-error reason so operators
+        # grepping logs can correlate failed worker LLMs with the
+        # rooms they couldn't process.
         self.assertIn(
             "unparseable_triage_output",
-            record[0].kwargs["reason"],
+            record[1].kwargs["reason"],
         )
 
     def test_withdraw_failure_swallowed_not_raised(self) -> None:
         with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            return_value=6,
+        ), patch(
             "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.withdraw_participant",
             side_effect=RuntimeError("withdraw returned status 503"),
         ):
@@ -312,7 +343,7 @@ class HandlerSafetyInvariantTests(unittest.TestCase):
                 bearer="bearer",
                 extracted_markdown="",
             )
-        self.assertEqual([r.op for r in record], ["withdraw"])
+        self.assertEqual([r.op for r in record], ["present", "withdraw"])
         self.assertTrue(decision.parse_error)
 
     def test_present_with_invalid_verdict_withdraws(self) -> None:
@@ -334,8 +365,149 @@ go
                 bearer="bearer",
                 extracted_markdown=bogus,
             )
-        self.assertEqual([r.op for r in record], ["withdraw"])
+        self.assertEqual([r.op for r in record], ["present", "withdraw"])
         self.assertTrue(decision.parse_error)
+
+
+class PostFailureCallbackTests(unittest.TestCase):
+    """Closes #544 builder R1.2: post-failure callback so F.5 can
+    evict the trigger's seen-cache and re-dispatch on the next
+    watching tick when the post sequence drops participation."""
+
+    def test_callback_fires_when_both_legs_fail_present_path(self) -> None:
+        callback_calls: list[tuple] = []
+
+        def on_failure(room_id, seq, op_kind, exc):
+            callback_calls.append((room_id, seq, op_kind, type(exc).__name__))
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present 503"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=RuntimeError("contribute 503"),
+        ):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+                on_post_failure=on_failure,
+            )
+        self.assertEqual(len(callback_calls), 1)
+        room_id, seq, op_kind, exc_name = callback_calls[0]
+        self.assertEqual(
+            room_id, "01234567-89ab-4cde-9012-3456789abcde"
+        )
+        self.assertEqual(seq, 5)
+        self.assertEqual(op_kind, "contribute")
+        self.assertEqual(exc_name, "RuntimeError")
+
+    def test_callback_fires_when_both_legs_fail_withdraw_path(self) -> None:
+        callback_calls: list[tuple] = []
+
+        def on_failure(room_id, seq, op_kind, exc):
+            callback_calls.append((room_id, seq, op_kind, type(exc).__name__))
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present 503"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.withdraw_participant",
+            side_effect=RuntimeError("withdraw 503"),
+        ):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_withdraw_response(),
+                on_post_failure=on_failure,
+            )
+        self.assertEqual(len(callback_calls), 1)
+        self.assertEqual(callback_calls[0][2], "withdraw")
+
+    def test_callback_NOT_fired_when_only_present_fails_but_contribute_succeeds(
+        self,
+    ) -> None:
+        # Partial success: state DID change (contribute landed), so
+        # next /watching tick will naturally de-list the room. No
+        # need to evict seen-cache.
+        callback_calls: list[tuple] = []
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present 409"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            return_value=7,
+        ):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+                on_post_failure=lambda *a: callback_calls.append(a),
+            )
+        self.assertEqual(callback_calls, [])
+
+    def test_callback_NOT_fired_on_happy_path(self) -> None:
+        callback_calls: list[tuple] = []
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+                on_post_failure=lambda *a: callback_calls.append(a),
+            )
+        self.assertEqual(callback_calls, [])
+
+    def test_callback_exception_is_swallowed(self) -> None:
+        # A buggy trigger that raises in its callback shouldn't
+        # propagate into the engine's job lifecycle.
+        def buggy_callback(*args):
+            raise ValueError("buggy trigger")
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present 503"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=RuntimeError("contribute 503"),
+        ):
+            # Must not raise.
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+                on_post_failure=buggy_callback,
+            )
+
+    def test_callback_optional_omission_works(self) -> None:
+        # Default behavior (no callback): same as before, just no
+        # re-dispatch signal on total failure.
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present 503"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=RuntimeError("contribute 503"),
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+            )
+        # Still completes cleanly; decision is what was parsed.
+        self.assertEqual(decision.kind, "present")
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_war_rooms_handler.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_handler.py
@@ -13,8 +13,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
     JOB_KIND_TRIAGE,
+    RAW_MD_CLIENT_CAP_BYTES,
     handle_war_room_job_finished,
     is_war_room_job,
+    truncate_raw_md,
 )
 from hivemoot_agent.plugins.interfaces import AgentResult, Job
 
@@ -508,6 +510,82 @@ class PostFailureCallbackTests(unittest.TestCase):
             )
         # Still completes cleanly; decision is what was parsed.
         self.assertEqual(decision.kind, "present")
+
+
+class RawMdClientCapTests(unittest.TestCase):
+    """Closes #544 builder R2: oversized raw_md from the agent
+    must be capped client-side before /contributions, otherwise
+    the server returns 400 raw_md_too_large and the next-tick
+    re-dispatch loops indefinitely (presentParticipant rewrites
+    rsvp_at on each /present, pushing out the watchdog timeout)."""
+
+    def test_under_cap_passes_through_unchanged(self) -> None:
+        body = "## Review\n\n" + "small content"
+        self.assertEqual(truncate_raw_md(body), body)
+
+    def test_over_cap_truncates_to_under_storage_limit(self) -> None:
+        # Storage cap is 32 KiB; client cap is 31 KiB (1 KiB
+        # headroom for envelope overhead).
+        body = "x" * (RAW_MD_CLIENT_CAP_BYTES + 5_000) + "\nend"
+        result = truncate_raw_md(body)
+        self.assertLessEqual(len(result.encode("utf-8")), RAW_MD_CLIENT_CAP_BYTES)
+        self.assertIn("[truncated by worker", result)
+
+    def test_truncation_cuts_on_newline_boundary(self) -> None:
+        # Builds an oversized body where the cut point falls inside
+        # a long line; verify the truncation respects the last
+        # newline before the cap to avoid splitting fenced code or
+        # list items mid-line.
+        head = "x" * (RAW_MD_CLIENT_CAP_BYTES - 200)
+        body = head + "\n" + "y" * 500
+        result = truncate_raw_md(body)
+        # Last line should be the truncation marker, not chopped y's.
+        last_line = result.rsplit("\n", 1)[-1]
+        self.assertTrue(last_line.startswith("_[truncated"))
+
+    def test_handler_truncates_oversized_raw_md_before_contribute(self) -> None:
+        # End-to-end: agent produces an oversized review; handler
+        # caps it before submit_contribution. Storage 400 path is
+        # never triggered.
+        oversized_body = "x" * (RAW_MD_CLIENT_CAP_BYTES + 10_000)
+        oversized_response = (
+            "## Triage decision\n\n"
+            "DECISION: PRESENT\n"
+            "VERDICT: APPROVE\n"
+            "SUMMARY: ok\n\n"
+            "## Review\n\n" + oversized_body
+        )
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=oversized_response,
+            )
+        contribute = next(r for r in record if r.op == "contribute")
+        sent_raw_md = contribute.kwargs["raw_md"]
+        self.assertLessEqual(
+            len(sent_raw_md.encode("utf-8")),
+            RAW_MD_CLIENT_CAP_BYTES,
+        )
+        self.assertIn("[truncated by worker", sent_raw_md)
+
+    def test_handler_passes_through_under_cap_raw_md(self) -> None:
+        record: list[_CallRecord] = []
+        with _patched_apis(record):
+            handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+            )
+        contribute = next(r for r in record if r.op == "contribute")
+        # Sample _present_response is small; should not be truncated.
+        self.assertNotIn("[truncated by worker", contribute.kwargs["raw_md"])
+        self.assertIn("/login handler", contribute.kwargs["raw_md"])
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_war_rooms_triage.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_triage.py
@@ -1,0 +1,286 @@
+"""Tests for cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/triage.py."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+    WatchingRoom,
+    build_triage_prompt,
+    parse_triage_response,
+    TRIAGE_OUTPUT_INSTRUCTIONS,
+)
+
+
+def _room(
+    room_id: str = "01234567-89ab-4cde-9012-3456789abcde",
+    sequence: int = 5,
+    status: str = "awaiting_contributions",
+    subject_type: str = "pr_review",
+    subject_ref: str = "hivemoot/hivemoot#42",
+    manager: str = "bot-queen",
+    participants: dict | None = None,
+) -> WatchingRoom:
+    return WatchingRoom(
+        room_id=room_id,
+        status=status,
+        subject_type=subject_type,
+        subject_ref=subject_ref,
+        manager=manager,
+        opened_at="2026-04-28T20:00:00Z",
+        current_sequence=sequence,
+        participants=participants or {},
+    )
+
+
+class BuildTriagePromptTests(unittest.TestCase):
+
+    def test_includes_room_identification(self) -> None:
+        prompt = build_triage_prompt(_room())
+        self.assertIn("01234567-89ab-4cde-9012-3456789abcde", prompt)
+        self.assertIn("pr_review", prompt)
+        self.assertIn("hivemoot/hivemoot#42", prompt)
+        self.assertIn("Sequence (at dispatch):** 5", prompt)
+
+    def test_lists_other_participants_sorted(self) -> None:
+        prompt = build_triage_prompt(
+            _room(
+                participants={
+                    "guard": {"status": "resolved"},
+                    "builder": {"status": "pending"},
+                    "drone": {"status": "withdrew"},
+                }
+            )
+        )
+        self.assertIn("Other participants in this room", prompt)
+        # Sorted alphabetically.
+        builder_idx = prompt.index("**builder**")
+        drone_idx = prompt.index("**drone**")
+        guard_idx = prompt.index("**guard**")
+        self.assertLess(builder_idx, drone_idx)
+        self.assertLess(drone_idx, guard_idx)
+        self.assertIn("`pending`", prompt)
+        self.assertIn("`resolved`", prompt)
+
+    def test_marks_room_as_early_when_no_participants(self) -> None:
+        prompt = build_triage_prompt(_room(participants={}))
+        self.assertIn("you're early", prompt)
+
+    def test_appends_output_instructions_block(self) -> None:
+        prompt = build_triage_prompt(_room())
+        self.assertIn(TRIAGE_OUTPUT_INSTRUCTIONS, prompt)
+
+    def test_output_spec_lists_both_decisions(self) -> None:
+        # Spec must mention PRESENT and WITHDRAW so the LLM knows
+        # both are valid.
+        self.assertIn("DECISION: PRESENT", TRIAGE_OUTPUT_INSTRUCTIONS)
+        self.assertIn("DECISION: WITHDRAW", TRIAGE_OUTPUT_INSTRUCTIONS)
+
+    def test_output_spec_enumerates_all_four_verdicts(self) -> None:
+        for v in ("APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"):
+            self.assertIn(v, TRIAGE_OUTPUT_INSTRUCTIONS)
+
+
+class ParseTriageResponseTests(unittest.TestCase):
+
+    def test_parses_present_with_all_fields(self) -> None:
+        response = """\
+Some preamble.
+
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: REQUEST_CHANGES
+SUMMARY: Found 2 SQL injection blockers in auth flow.
+
+## Review
+
+The /login handler at line 42 concatenates user input directly
+into the SQL query. Use a parameterized query instead.
+"""
+        decision = parse_triage_response(response)
+        self.assertEqual(decision.kind, "present")
+        self.assertEqual(decision.verdict, "REQUEST_CHANGES")
+        self.assertEqual(
+            decision.summary,
+            "Found 2 SQL injection blockers in auth flow.",
+        )
+        assert decision.body is not None
+        self.assertIn("/login handler at line 42", decision.body)
+        self.assertFalse(decision.parse_error)
+
+    def test_parses_withdraw_with_reason(self) -> None:
+        response = """\
+## Triage decision
+
+DECISION: WITHDRAW
+REASON: Out of scope for guard role — docs-only PR.
+"""
+        decision = parse_triage_response(response)
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertEqual(
+            decision.reason, "Out of scope for guard role — docs-only PR."
+        )
+        self.assertFalse(decision.parse_error)
+
+    def test_parses_withdraw_without_reason(self) -> None:
+        response = """\
+## Triage decision
+
+DECISION: WITHDRAW
+"""
+        decision = parse_triage_response(response)
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertIsNone(decision.reason)
+        self.assertFalse(decision.parse_error)
+
+    def test_uses_last_triage_block_when_multiple(self) -> None:
+        # Agent might think out loud and include earlier "## Triage
+        # decision" mentions in prose. Parser must use the LAST one.
+        response = """\
+## Triage decision
+
+(Thinking out loud about what triage decisions look like...)
+
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: APPROVE
+SUMMARY: Looks clean.
+
+## Review
+
+LGTM.
+"""
+        decision = parse_triage_response(response)
+        self.assertEqual(decision.kind, "present")
+        self.assertEqual(decision.verdict, "APPROVE")
+
+    # Failure modes — all synthesize WITHDRAW with parse_error=True.
+
+    def test_empty_response_synthesizes_withdraw_parse_error(self) -> None:
+        d = parse_triage_response("")
+        self.assertEqual(d.kind, "withdraw")
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("empty_response", d.reason)
+
+    def test_whitespace_only_response_synthesizes_withdraw_parse_error(self) -> None:
+        d = parse_triage_response("  \n\n   \t  \n")
+        self.assertEqual(d.kind, "withdraw")
+        self.assertTrue(d.parse_error)
+
+    def test_no_triage_heading_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response("Just some prose. No structured block.")
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("no_triage_heading", d.reason)
+
+    def test_no_decision_marker_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response("## Triage decision\n\nVERDICT: APPROVE\n")
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("no_decision_marker", d.reason)
+
+    def test_invalid_decision_value_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response(
+            "## Triage decision\n\nDECISION: MERGE_NOW\n"
+        )
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("invalid_decision", d.reason)
+        self.assertIn("MERGE_NOW", d.reason)
+
+    def test_present_without_verdict_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response(
+            "## Triage decision\n\nDECISION: PRESENT\nSUMMARY: x\n"
+        )
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("missing_verdict", d.reason)
+
+    def test_present_with_invalid_verdict_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response(
+            "## Triage decision\n\nDECISION: PRESENT\nVERDICT: APPROVE_PLUS\nSUMMARY: x\n"
+        )
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("invalid_verdict", d.reason)
+
+    def test_present_without_summary_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response(
+            "## Triage decision\n\nDECISION: PRESENT\nVERDICT: APPROVE\n"
+        )
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("missing_summary", d.reason)
+
+    def test_present_with_empty_summary_synthesizes_withdraw(self) -> None:
+        d = parse_triage_response(
+            "## Triage decision\n\nDECISION: PRESENT\nVERDICT: APPROVE\nSUMMARY:    \n"
+        )
+        self.assertTrue(d.parse_error)
+        assert d.reason is not None
+        self.assertIn("empty_summary", d.reason)
+
+    def test_long_summary_truncates_under_500_chars(self) -> None:
+        long_sum = "x" * 1000
+        d = parse_triage_response(
+            f"## Triage decision\n\nDECISION: PRESENT\nVERDICT: APPROVE\nSUMMARY: {long_sum}\n"
+        )
+        self.assertEqual(d.kind, "present")
+        assert d.summary is not None
+        # Truncated body + ellipsis must fit under the server-side
+        # 500-char cap to land cleanly via /contributions.
+        self.assertLessEqual(len(d.summary), 500)
+        self.assertTrue(d.summary.endswith("…"))
+
+    def test_present_without_review_section_uses_empty_body(self) -> None:
+        # The review body is optional in the parser (defensive); the
+        # contribution will land with empty raw_md.
+        d = parse_triage_response(
+            "## Triage decision\n\nDECISION: PRESENT\nVERDICT: COMMENT\nSUMMARY: noted\n"
+        )
+        self.assertEqual(d.kind, "present")
+        self.assertEqual(d.body, "")
+
+    def test_handles_extra_whitespace_around_markers(self) -> None:
+        response = """\
+## Triage decision
+
+DECISION:    PRESENT
+VERDICT:    APPROVE
+SUMMARY:     trimmed.
+
+## Review
+
+ok.
+"""
+        d = parse_triage_response(response)
+        self.assertEqual(d.kind, "present")
+        self.assertEqual(d.verdict, "APPROVE")
+        self.assertEqual(d.summary, "trimmed.")
+
+    def test_review_heading_case_insensitive(self) -> None:
+        response = """\
+## Triage decision
+
+DECISION: PRESENT
+VERDICT: APPROVE
+SUMMARY: ok
+
+## review
+
+body
+"""
+        d = parse_triage_response(response)
+        assert d.body is not None
+        self.assertIn("body", d.body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #543

## Summary

Closes the worker side of the war-room flow. The watcher trigger (F.2) already dispatches Jobs; this slice gives the engine a real triage prompt and parses the structured response back into present-and-contribute or withdraw API calls.

Without F.3, rooms sit in `awaiting_contributions` until they expire — workers can't actually participate. With F.3 + F.5 wiring (next slice), the worker LLM produces a structured triage decision per the WAR_ROOM_DESIGN.md §S2 contract, and the on_job_finished handler routes it to the war-room API.

## What's new

```
agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/
├── triage.py     — build_triage_prompt + parse_triage_response + spec
├── handler.py    — is_war_room_job + handle_war_room_job_finished
└── trigger.py    — replaces stub prompt; tags job_kind=war_room_triage

agent/cli/tests/
├── test_hivemoot_war_rooms_triage.py     (23 tests)
└── test_hivemoot_war_rooms_handler.py    (18 tests)
```

### Output contract

The worker's LLM produces markdown ending with two structured sections:

```
## Triage decision

DECISION: PRESENT
VERDICT: REQUEST_CHANGES
SUMMARY: Found 2 SQL injection blockers in auth flow.

## Review

The /login handler at line 42 concatenates user input directly...
```

Or for withdrawal:

```
## Triage decision

DECISION: WITHDRAW
REASON: Out of scope for guard role — docs-only PR.
```

Line-prefix format chosen over YAML/JSON because LLMs reliably produce simple "KEY: value" lines. VERDICT enum matches WAR_ROOM_DESIGN.md §S2 exactly so the queen's structural-floor aggregation reads it as-validated.

### Safety invariant

A stuck/malformed agent response **always withdraws** — never silently submits an empty contribution that would land in the queen's synthesis input. Unparseable responses synthesize WITHDRAW with `reason="unparseable_triage_output:<class>"` so operators can grep worker logs and find the LLM that's producing garbage.

### PRESENT path

The handler:
1. Calls `present_to_room` (RSVP). Benign 409 (already presented at this seq) doesn't block step 2.
2. Calls `submit_contribution` with structured body (`verdict`, `summary`) + `raw_md` (the full review).
3. Logs the landed sequence + contribution byte count for ops correlation.

All API failures are swallowed-and-logged via `[hivemoot-war-rooms]` stderr prefix; the handler never raises into the engine's job lifecycle.

## What's NOT in this slice (F.5)

| Slice | Scope |
|---|---|
| F.5 | Plugin manifest wiring (HivemootPlugin instantiates trigger + hooks handler into on_job_finished) + config schema (HivemootWarRoomsConfig) |

After F.5 lands, the end-to-end worker→queen flow is operational:

1. Bot creates war room (E.1)
2. Watcher trigger discovers the room (F.2)
3. Triage Job dispatched to engine
4. Engine produces structured response
5. **on_job_finished parses → present + contribute (F.3)**
6. Queen synthesizes (G'.3)
7. Queen posts decision (G'.4)

## Test plan

- [x] 41 new tests across triage + handler
- [x] Full agent suite: 574 tests pass (was 533, +41)
- [ ] Reviewer fleet sign-off