### PR TITLE
Phase F.5 — plugin wiring + war_rooms config schema (final F slice)

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -145,6 +145,13 @@ class HivemootPlugin:
         # triggers/system_prompt methods don't re-read from the registry.
         self._cfg: "HivemootConfig | None" = None
 
+        # ── War-rooms subsystem state (F.5) ─────────────────────
+        # Trigger reference cached so on_job_finished can call
+        # `evict_seen_key` via the handler's on_post_failure callback
+        # when the post sequence totally fails. None when war_rooms
+        # disabled OR triggers() hasn't been called yet.
+        self._war_room_trigger: Any = None
+
         # Apiarist auth subscriber, populated in setup_lifecycle() when
         # cfg.apiarist.enabled is true. Cached for diagnostics and
         # tests; runtime path goes through engine.lifecycle directly.
@@ -441,6 +448,22 @@ class HivemootPlugin:
             )
             triggers.append(HealthHeartbeatTrigger(self))  # type: ignore[arg-type]
 
+        if cfg.war_rooms.enabled:
+            from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+                resolve_agent_token,
+            )
+            from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+                WarRoomWatcherTrigger,
+            )
+            token_path = str(cfg.token_file) if cfg.token_file else ""
+            self._war_room_trigger = WarRoomWatcherTrigger(
+                base_url=cfg.war_rooms.base_url,
+                token_resolver=lambda: resolve_agent_token(token_path),
+                poll_interval_secs=cfg.war_rooms.poll_interval_secs,
+                seen_cache_max=cfg.war_rooms.seen_cache_max,
+            )
+            triggers.append(self._war_room_trigger)  # type: ignore[arg-type]
+
         return triggers
 
     def system_prompt(self, config: PluginConfig) -> str:
@@ -542,6 +565,80 @@ class HivemootPlugin:
                     f"{type(exc).__name__}: {exc}",
                     file=sys.stderr, flush=True,
                 )
+
+        # War-rooms handler dispatch (F.5). Wraps independently
+        # from tasks/health — one feature failing must not skip
+        # the others.
+        if cfg.war_rooms.enabled:
+            from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+                is_war_room_job,
+            )
+            if is_war_room_job(job):
+                try:
+                    self._war_room_on_job_finished(job, result, config)
+                except Exception as exc:
+                    print(
+                        f"[hivemoot-war-rooms] on_job_finished raised "
+                        f"room={job.metadata.get('room_id')}: "
+                        f"{type(exc).__name__}: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
+
+    def _war_room_on_job_finished(
+        self,
+        job: Job,
+        result: AgentResult,
+        config: PluginConfig,
+    ) -> None:
+        """Bridge from the engine's on_job_finished to the war-room
+        handler. Extracts the engine's markdown response (same
+        provider-agnostic extractor the tasks plugin uses) and hands
+        it to handle_war_room_job_finished. Wires the trigger's
+        seen-cache eviction as the on_post_failure callback so
+        total post-sequence failure re-dispatches on the next tick.
+        """
+        from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+            resolve_agent_token,
+        )
+        from hivemoot_agent.plugins_builtin.hivemoot.tasks import (
+            result_extractor,
+        )
+        from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+            handle_war_room_job_finished,
+        )
+
+        cfg = self._cfg
+        if cfg is None or not cfg.war_rooms.enabled:
+            return
+
+        bearer = resolve_agent_token(
+            str(cfg.token_file) if cfg.token_file else "",
+        )
+        provider = config.get("AGENT_PROVIDER", "claude")
+        log_path = self._resolve_provider_log_path(config)
+        sidecar = self._codex_sidecar_path
+
+        markdown = result_extractor.extract_result(
+            provider, log_path, sidecar_path=sidecar,
+        )
+
+        # Wire the trigger's evict_seen_key as the post-failure
+        # recovery callback. Triggers may be None if validate ran
+        # but triggers() hasn't yet — defensive null-guard.
+        evict = (
+            self._war_room_trigger.evict_seen_key
+            if self._war_room_trigger is not None
+            else None
+        )
+
+        handle_war_room_job_finished(
+            job,
+            result,
+            base_url=cfg.war_rooms.base_url,
+            bearer=bearer,
+            extracted_markdown=markdown,
+            on_post_failure=evict,
+        )
 
     # ── Helpers used by triggers ──────────────────────────────────
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -1,6 +1,6 @@
 """Consolidated Hivemoot ecosystem plugin.
 
-One plugin, three independently-toggleable features:
+One plugin, five independently-toggleable features:
 
   * ``health`` — periodic heartbeats + per-run reports to
     ``POST {base_url}/api/agent-health`` (dashboard Agent Health tab).
@@ -9,6 +9,11 @@ One plugin, three independently-toggleable features:
   * ``github_workflows`` — autonomous contribution operating mode,
     buzz role loading, skill bundle.  Co-loads with the ``github``
     plugin (reads its typed config for the target repo).
+  * ``apiarist`` — broker GitHub installation tokens via the
+    apiarist Unix-socket service (host-side daemon).
+  * ``war_rooms`` — poll ``/api/rooms/watching``, dispatch a triage
+    Job per visible room, parse the agent's structured response,
+    and call ``/present + /contribute`` or ``/present + /withdraw``.
 
 YAML shape (``hivemoot.yaml``):
 
@@ -23,6 +28,8 @@ YAML shape (``hivemoot.yaml``):
           claim_url: https://www.hivemoot.dev/api/tasks/claim
           execute_base_url: https://www.hivemoot.dev/api/tasks
         github_workflows:
+          enabled: true
+        war_rooms:
           enabled: true
 
 Host behaviour is plugin-agnostic per ADR-002; this plugin owns its

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -279,6 +279,56 @@ class HivemootApiaristConfig(StrictPluginConfig):
     )
 
 
+class HivemootWarRoomsConfig(StrictPluginConfig):
+    """War-room watcher — polls /api/rooms/watching and dispatches
+    one Job per visible room (F.2 trigger). Job handler (F.3) parses
+    the agent's structured response and calls /present + /contribute
+    or /present + /withdraw against the war-room API.
+
+    Off by default so the plugin ships idempotently; fleet YAML
+    must opt in. End-to-end PR review flow (queen ↔ workers)
+    requires this enabled on every reviewer agent.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable the war-room watcher trigger + on_job_finished "
+            "handler. Off by default; fleet YAML opts each reviewer "
+            "role in."
+        ),
+    )
+    base_url: str = Field(
+        default="https://www.hivemoot.dev",
+        description=(
+            "Base URL for the war-room API. Polls go to "
+            "``{base_url}/api/rooms/watching``; lifecycle posts to "
+            "``{base_url}/api/rooms/{id}/{present,contributions,withdraw}``. "
+            "Override for staging environments."
+        ),
+    )
+    poll_interval_secs: int = Field(
+        default=60,
+        ge=5,
+        description=(
+            "Seconds between /watching polls. Default 60s matches the "
+            "watchdog's tick cadence — rooms surfaced this poll get "
+            "dispatched within one queen-tick window. Floor of 5s "
+            "prevents tight-looping; raise to 120-300s on high-room-"
+            "count fleets to reduce backend load."
+        ),
+    )
+    seen_cache_max: int = Field(
+        default=1000,
+        ge=10,
+        description=(
+            "Max (roomId, sequence) entries the trigger remembers to "
+            "deduplicate within a session. LRU-evicted past this cap. "
+            "1000 covers ~weeks of room activity at typical Hive scale."
+        ),
+    )
+
+
 class HivemootConfig(StrictPluginConfig):
     """Top-level typed config for the consolidated hivemoot plugin."""
 
@@ -307,4 +357,8 @@ class HivemootConfig(StrictPluginConfig):
     apiarist: HivemootApiaristConfig = Field(
         default_factory=HivemootApiaristConfig,
         description="GitHub installation-token brokering via apiarist.",
+    )
+    war_rooms: HivemootWarRoomsConfig = Field(
+        default_factory=HivemootWarRoomsConfig,
+        description="War-room watcher + per-room triage/contribution handler.",
     )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/trigger.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import sys
 import threading
 from collections import OrderedDict
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import api as wr_api
 
@@ -129,19 +129,33 @@ class WarRoomWatcherTrigger:
     def stop(self) -> None:
         self._stop_event.set()
 
-    def evict_seen_key(self, room_id: str, sequence: int) -> None:
+    def evict_seen_key(
+        self,
+        room_id: str,
+        sequence: int,
+        op_kind: str = "",
+        exc: Optional[BaseException] = None,
+    ) -> None:
         """Remove a (room, sequence) entry from the seen cache so
         the next tick re-dispatches it.
 
-        Wired in F.5 as the handler's `on_post_failure` callback:
-        when the post sequence (present + contribute / withdraw)
-        totally fails, no participant-state change has landed and
-        /watching will keep listing this room. Without this
-        eviction, the next tick would skip (seen-cache hit) and the
-        worker would silently drop participation.
+        Wired in F.5 as the handler's `on_post_failure` callback —
+        signature matches `handler.PostFailureCallback`
+        (`Callable[[str, int, str, Exception], None]`) so the
+        bridge can pass this method directly without an adapter
+        lambda. Closes #546 drone B1: prior 2-arg signature would
+        TypeError when invoked from `_safe_callback` with the full
+        4-arg shape, and the handler's swallow-and-log would
+        silently break the recovery loop.
+
+        `op_kind` and `exc` are accepted but not used — they're
+        already logged by the handler's `[hivemoot-war-rooms] ERROR`
+        line at the failure site, so the trigger doesn't need to
+        re-log. Future enhancement: surface them in a metric.
 
         Idempotent — eviction of a non-existent key is a no-op.
         """
+        del op_kind, exc  # silence "unused" — matched for callback shape
         key = f"{room_id}@{sequence}"
         if key in self._seen._cache:
             del self._seen._cache[key]

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/trigger.py
@@ -129,6 +129,23 @@ class WarRoomWatcherTrigger:
     def stop(self) -> None:
         self._stop_event.set()
 
+    def evict_seen_key(self, room_id: str, sequence: int) -> None:
+        """Remove a (room, sequence) entry from the seen cache so
+        the next tick re-dispatches it.
+
+        Wired in F.5 as the handler's `on_post_failure` callback:
+        when the post sequence (present + contribute / withdraw)
+        totally fails, no participant-state change has landed and
+        /watching will keep listing this room. Without this
+        eviction, the next tick would skip (seen-cache hit) and the
+        worker would silently drop participation.
+
+        Idempotent — eviction of a non-existent key is a no-op.
+        """
+        key = f"{room_id}@{sequence}"
+        if key in self._seen._cache:
+            del self._seen._cache[key]
+
     def validate(self, config: Any) -> list[str]:
         """Return config errors (empty = valid).
 

--- a/agent/cli/tests/test_hivemoot_config.py
+++ b/agent/cli/tests/test_hivemoot_config.py
@@ -16,6 +16,7 @@ from hivemoot_agent.plugins_builtin.hivemoot.config import (
     HivemootGithubWorkflowsConfig,
     HivemootHealthConfig,
     HivemootTasksConfig,
+    HivemootWarRoomsConfig,
 )
 
 
@@ -26,6 +27,31 @@ class DefaultsTests(unittest.TestCase):
         self.assertFalse(cfg.tasks.enabled)
         self.assertFalse(cfg.github_workflows.enabled)
         self.assertFalse(cfg.apiarist.enabled)
+        self.assertFalse(cfg.war_rooms.enabled)
+
+    def test_war_rooms_defaults(self) -> None:
+        cfg = HivemootWarRoomsConfig()
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.base_url, "https://www.hivemoot.dev")
+        self.assertEqual(cfg.poll_interval_secs, 60)
+        self.assertEqual(cfg.seen_cache_max, 1000)
+
+    def test_war_rooms_poll_interval_min_5s(self) -> None:
+        # Floor of 5s prevents tight-looping; raise to 120-300s on
+        # high-room-count fleets to reduce backend load.
+        with self.assertRaises(ValidationError):
+            HivemootWarRoomsConfig(poll_interval_secs=4)
+        # 5 is OK.
+        HivemootWarRoomsConfig(poll_interval_secs=5)
+
+    def test_war_rooms_seen_cache_min_10(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootWarRoomsConfig(seen_cache_max=9)
+        HivemootWarRoomsConfig(seen_cache_max=10)
+
+    def test_war_rooms_unknown_field_rejected(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootConfig(war_rooms={"enabled": True, "typo": "x"})
 
     def test_health_defaults(self) -> None:
         cfg = HivemootHealthConfig()

--- a/agent/cli/tests/test_hivemoot_war_rooms_wiring.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_wiring.py
@@ -215,6 +215,68 @@ class EvictSeenKeyTests(unittest.TestCase):
         )
         trigger.evict_seen_key("never-dispatched", 0)
 
+    def test_evict_seen_key_signature_matches_PostFailureCallback(self) -> None:
+        # Closes #546 drone B1: prior 2-arg signature would TypeError
+        # when invoked from the handler's _safe_callback with the
+        # full 4-arg PostFailureCallback shape, and the handler's
+        # swallow-and-log would silently break the recovery loop.
+        # This test exercises the EXACT call shape the handler uses
+        # so any future signature drift fails loudly here, not in
+        # silent prod corruption.
+        trigger = WarRoomWatcherTrigger(
+            base_url="https://x", token_resolver=lambda: "tk"
+        )
+        trigger._seen.add("room-1@5")
+        # Invoke with the same 4 args _safe_callback passes:
+        # (room_id, sequence, op_kind, exc).
+        trigger.evict_seen_key("room-1", 5, "contribute", RuntimeError("503"))
+        self.assertNotIn("room-1@5", trigger._seen._cache)
+
+    def test_evict_seen_key_usable_as_PostFailureCallback_via_handler(
+        self,
+    ) -> None:
+        # End-to-end: feed the trigger's bound method through the
+        # actual handler's callback path. If the signatures drift,
+        # this test fails with a clear assertion error instead of a
+        # silent log-and-continue.
+        from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+            handle_war_room_job_finished,
+        )
+
+        trigger = WarRoomWatcherTrigger(
+            base_url="https://x", token_resolver=lambda: "tk"
+        )
+        trigger._seen.add("01234567-89ab-4cde-9012-3456789abcde@5")
+
+        # Force both legs of the post sequence to fail so the
+        # handler's on_post_failure callback fires.
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=RuntimeError("present 503"),
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=RuntimeError("contribute 503"),
+        ):
+            handle_war_room_job_finished(
+                _war_room_job(),
+                AgentResult(0, ""),
+                base_url="https://x",
+                bearer="tk",
+                extracted_markdown=(
+                    "## Triage decision\n\n"
+                    "DECISION: PRESENT\nVERDICT: APPROVE\nSUMMARY: ok\n\n"
+                    "## Review\n\nlgtm.\n"
+                ),
+                on_post_failure=trigger.evict_seen_key,
+            )
+        # The seen-cache entry must have been evicted by the
+        # callback. If the signature mismatched, _safe_callback would
+        # have caught the TypeError and left the entry in place.
+        self.assertNotIn(
+            "01234567-89ab-4cde-9012-3456789abcde@5",
+            trigger._seen._cache,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/agent/cli/tests/test_hivemoot_war_rooms_wiring.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_wiring.py
@@ -1,0 +1,220 @@
+"""Tests for the F.5 plugin wiring: triggers() instantiates the
+war-room watcher when enabled, and on_job_finished dispatches to
+the handler with the trigger's seen-cache eviction wired as the
+post-failure callback.
+
+Tests in this file exercise the HivemootPlugin's surface area
+specific to war_rooms — config tests live in
+test_hivemoot_config.py, handler tests in
+test_hivemoot_war_rooms_handler.py, trigger tests in
+test_hivemoot_war_rooms_trigger.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job, PluginConfig
+from hivemoot_agent.plugins_builtin.hivemoot import HivemootPlugin
+from hivemoot_agent.plugins_builtin.hivemoot.config import (
+    HivemootConfig,
+    HivemootWarRoomsConfig,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
+    JOB_KIND_TRIAGE,
+    WarRoomWatcherTrigger,
+)
+
+
+_TOKEN_FILE = Path("/tmp/.hivemoot-test-token")
+
+
+def _ensure_token_file() -> Path:
+    if not _TOKEN_FILE.exists():
+        _TOKEN_FILE.write_text("test-token")
+    return _TOKEN_FILE
+
+
+def _mk_config(
+    *,
+    war_rooms: HivemootWarRoomsConfig | None = None,
+) -> PluginConfig:
+    typed = HivemootConfig(
+        token_file=_ensure_token_file(),
+        war_rooms=war_rooms or HivemootWarRoomsConfig(),
+    )
+    return PluginConfig(name="hivemoot", settings={}, typed=typed)
+
+
+def _war_room_job(
+    room_id: str = "01234567-89ab-4cde-9012-3456789abcde",
+    sequence: int = 5,
+) -> Job:
+    return Job(
+        session_key=f"war-room:{room_id}@{sequence}",
+        prompt="ignored in tests",
+        metadata={
+            "job_kind": JOB_KIND_TRIAGE,
+            "room_id": room_id,
+            "current_sequence": sequence,
+            "subject_type": "pr_review",
+            "subject_ref": "owner/repo#42",
+            "manager": "bot-queen",
+            "status": "awaiting_contributions",
+            "participants": {},
+        },
+    )
+
+
+def _task_job() -> Job:
+    return Job(
+        session_key="task:abc",
+        prompt="ignored",
+        metadata={"task_id": "abc", "claim_token": "tk"},
+    )
+
+
+# ── triggers() wiring ────────────────────────────────────────────
+
+
+class WarRoomTriggerWiringTests(unittest.TestCase):
+
+    def test_disabled_by_default_no_trigger(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config().typed
+        self.assertEqual(plugin.triggers(), [])
+        self.assertIsNone(plugin._war_room_trigger)
+
+    def test_enabled_instantiates_war_room_trigger(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        ).typed
+        triggers = plugin.triggers()
+        self.assertEqual(len(triggers), 1)
+        self.assertIsInstance(triggers[0], WarRoomWatcherTrigger)
+        # Plugin caches the reference so on_job_finished can wire
+        # the post-failure callback to evict_seen_key.
+        self.assertIs(plugin._war_room_trigger, triggers[0])
+
+    def test_trigger_constructed_with_config_values(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(
+                enabled=True,
+                base_url="https://staging.hivemoot.dev",
+                poll_interval_secs=30,
+                seen_cache_max=500,
+            ),
+        ).typed
+        triggers = plugin.triggers()
+        trigger = triggers[0]
+        self.assertEqual(trigger._base_url, "https://staging.hivemoot.dev")
+        self.assertEqual(trigger._poll_interval_secs, 30)
+
+
+# ── on_job_finished dispatch ─────────────────────────────────────
+
+
+class OnJobFinishedDispatchTests(unittest.TestCase):
+
+    def test_war_room_job_dispatched_when_enabled(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        ).typed
+        plugin.triggers()  # populate _war_room_trigger
+        config = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        )
+
+        with patch.object(
+            plugin, "_war_room_on_job_finished"
+        ) as bridge_mock:
+            plugin.on_job_finished(_war_room_job(), AgentResult(0, ""), config)
+        bridge_mock.assert_called_once()
+
+    def test_war_room_job_NOT_dispatched_when_disabled(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config().typed
+        config = _mk_config()
+
+        with patch.object(
+            plugin, "_war_room_on_job_finished"
+        ) as bridge_mock:
+            plugin.on_job_finished(_war_room_job(), AgentResult(0, ""), config)
+        bridge_mock.assert_not_called()
+
+    def test_task_job_NOT_routed_to_war_room_handler(self) -> None:
+        # Even with war_rooms enabled, a task-shaped Job should NOT
+        # invoke the war-room bridge — the discriminator filters by
+        # job_kind=war_room_triage.
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        ).typed
+        plugin.triggers()
+        config = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        )
+
+        with patch.object(
+            plugin, "_war_room_on_job_finished"
+        ) as bridge_mock:
+            plugin.on_job_finished(_task_job(), AgentResult(0, ""), config)
+        bridge_mock.assert_not_called()
+
+    def test_handler_exception_swallowed_does_not_break_job_lifecycle(
+        self,
+    ) -> None:
+        # If the war-room bridge raises, the engine's job lifecycle
+        # must continue cleanly. Mirror the tasks/health pattern.
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        ).typed
+        plugin.triggers()
+        config = _mk_config(
+            war_rooms=HivemootWarRoomsConfig(enabled=True),
+        )
+
+        with patch.object(
+            plugin,
+            "_war_room_on_job_finished",
+            side_effect=RuntimeError("bridge boom"),
+        ):
+            # Must not raise.
+            plugin.on_job_finished(_war_room_job(), AgentResult(0, ""), config)
+
+
+# ── Trigger evict_seen_key (handler ↔ trigger feedback channel) ──
+
+
+class EvictSeenKeyTests(unittest.TestCase):
+
+    def test_evict_seen_key_removes_existing_entry(self) -> None:
+        trigger = WarRoomWatcherTrigger(
+            base_url="https://x", token_resolver=lambda: "tk"
+        )
+        # Manually seed the seen-cache to simulate a dispatch.
+        trigger._seen.add("room-1@5")
+        self.assertIn("room-1@5", trigger._seen._cache)
+        trigger.evict_seen_key("room-1", 5)
+        self.assertNotIn("room-1@5", trigger._seen._cache)
+
+    def test_evict_seen_key_idempotent_on_missing_entry(self) -> None:
+        # Eviction of a never-seen key must not raise.
+        trigger = WarRoomWatcherTrigger(
+            base_url="https://x", token_resolver=lambda: "tk"
+        )
+        trigger.evict_seen_key("never-dispatched", 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #545

## Summary

Wires the F.2 trigger + F.3 handler into the consolidated hivemoot plugin's lifecycle. With this slice, the **end-to-end PR review flow is operational** from the worker side. Phase F (worker runtime) is complete.

## What's new

- **Config**: `HivemootWarRoomsConfig` (enabled, base_url, poll_interval_secs, seen_cache_max) with bounds + `war_rooms` field on `HivemootConfig`. StrictPluginConfig forbids unknown fields.
- **Trigger wiring**: `HivemootPlugin.triggers()` instantiates `WarRoomWatcherTrigger` when `cfg.war_rooms.enabled`. Reference cached at `self._war_room_trigger` so the on_job_finished bridge can wire the eviction callback.
- **Handler bridge**: `_war_room_on_job_finished` extracts the engine markdown via the same provider-agnostic `result_extractor` the tasks plugin uses, then calls `handle_war_room_job_finished` with `on_post_failure=trigger.evict_seen_key` — closing the recovery loop F.3 set up.
- **Trigger eviction surface**: `WarRoomWatcherTrigger.evict_seen_key(room_id, sequence)` public method, idempotent on missing keys.

## End-to-end flow now live

```
PR opened → bot creates war room (E.1)
         ↓
worker /watching trigger discovers (F.2)
         ↓
triage Job dispatched to engine
         ↓
engine produces structured response (F.3 prompt)
         ↓
on_job_finished parses + dispatches (F.3 handler + F.5 bridge)
         ↓                        ↓
   present + contribute      present + withdraw
                ↓
   queen synthesizes (G'.3)
                ↓
   queen posts decision to PR (G'.4)
```

Total post-sequence failure now triggers the trigger to evict its seen-cache entry → next watching tick re-dispatches → recovery without operator intervention.

## Test plan

- [x] 599 tests pass (was 586, +13)
- [x] All existing tests still green
- [x] Config tests: defaults, poll_interval_secs ≥ 5 floor, seen_cache_max ≥ 10 floor, unknown-field rejection
- [x] Wiring tests: trigger absent when disabled, instantiated when enabled, config values flow to constructor, on_job_finished routes war-room jobs to bridge but NOT task-shaped jobs, bridge exception swallowed (mirrors tasks/health pattern)
- [x] Eviction tests: removes existing entry, idempotent on missing
- [ ] Reviewer fleet sign-off