### PR TITLE
feat(web): per-runner agent_id split for war-room first-wins gate

### DIFF
--- a/web/src/app/api/rooms/[roomId]/contributions/route.ts
+++ b/web/src/app/api/rooms/[roomId]/contributions/route.ts
@@ -44,8 +44,52 @@ import {
   RoomParticipantNotFoundError,
   RoomParticipantStatePreconditionError,
   RoomContributionTooLargeError,
+  RoomRunnerFormatError,
   ContributionValidationError,
+  validateRunnerFormat,
 } from "@/server/war-room";
+
+/**
+ * Resolve the per-runner agentId for the war-room first-wins gate.
+ * Body-supplied (G5, #522): when present, validated via
+ * `validateRunnerFormat`. When absent, fall back to the bearer's
+ * `name` so single-runner-per-token deployments work unchanged.
+ *
+ * Returns either the resolved string or a `NextResponse` to short-
+ * circuit on validation failure.
+ */
+function resolveAgentId(
+  bodyAgentId: unknown,
+  bearerName: string,
+): { ok: true; agentId: string } | { ok: false; response: NextResponse } {
+  if (bodyAgentId === undefined) {
+    return { ok: true, agentId: bearerName };
+  }
+  if (typeof bodyAgentId !== "string") {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { code: "invalid_agent_id", message: "agentId must be a string." },
+        { status: 400 },
+      ),
+    };
+  }
+  try {
+    validateRunnerFormat(bodyAgentId);
+  } catch (err) {
+    if (err instanceof RoomRunnerFormatError) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { code: "invalid_agent_id", message: err.message },
+          { status: 400 },
+        ),
+      };
+    }
+    throw err;
+  }
+  return { ok: true, agentId: bodyAgentId };
+}
 
 // ---------------------------------------------------------------------------
 // GET — read contributions hash (D.1.b-i, scoped to rooms.read_all)
@@ -93,6 +137,8 @@ interface SubmitRequestBody {
   sequenceObservedByClient?: number;
   body?: ContributionBody;
   rawMd?: string;
+  /** Per-runner identity for the first-wins gate (G5, #522). */
+  agentId?: string;
 }
 
 export async function POST(
@@ -138,12 +184,16 @@ export async function POST(
     );
   }
 
+  const agentIdResult = resolveAgentId(reqBody.agentId, auth.name);
+  if (!agentIdResult.ok) return agentIdResult.response;
+
   try {
     const sequence = await submitContribution({
       installationId: auth.installationId,
       roomId,
       role: auth.agent_role,
-      agentId: auth.name,
+      agentId: agentIdResult.agentId,
+      actorId: auth.name,
       sequenceObservedByClient: reqBody.sequenceObservedByClient,
       body: reqBody.body,
       rawMd: reqBody.rawMd,
@@ -162,6 +212,8 @@ export async function POST(
 interface WithdrawContributionBody {
   sequenceObservedByClient?: number;
   reason?: string;
+  /** Per-runner identity for the first-wins gate (G5, #522). */
+  agentId?: string;
 }
 
 export async function DELETE(
@@ -201,12 +253,16 @@ export async function DELETE(
     );
   }
 
+  const agentIdResult = resolveAgentId(reqBody.agentId, auth.name);
+  if (!agentIdResult.ok) return agentIdResult.response;
+
   try {
     const sequence = await withdrawContribution({
       installationId: auth.installationId,
       roomId,
       role: auth.agent_role,
-      agentId: auth.name,
+      agentId: agentIdResult.agentId,
+      actorId: auth.name,
       sequenceObservedByClient: reqBody.sequenceObservedByClient,
       reason: reqBody.reason,
       redis: auth.redis,

--- a/web/src/app/api/rooms/[roomId]/present/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/present/route.test.ts
@@ -82,7 +82,7 @@ describe("POST /api/rooms/:roomId/present", () => {
     );
   });
 
-  it("happy path → returns sequence; role + agentId server-derived", async () => {
+  it("happy path → returns sequence; role server-derived; agentId defaults to auth.name", async () => {
     mockedAuth.mockResolvedValue(makeWorkerAuth());
     mockedPresent.mockResolvedValue(3);
     const res = await POST(
@@ -96,11 +96,59 @@ describe("POST /api/rooms/:roomId/present", () => {
         installationId: "12345",
         roomId: VALID_ROOM_ID,
         role: "drone", // server-derived from envelope, not body
-        agentId: "drone-1", // server-derived from envelope
+        agentId: "drone-1", // back-compat: defaults to auth.name when body omits
+        actorId: "drone-1", // always bearer-derived for audit trail
         sequenceObservedByClient: 1,
         intentHint: "review",
       }),
     );
+  });
+
+  it("body-supplied agentId flows through to storage; actorId stays bearer-derived (#522)", async () => {
+    // Subscriber-mode: a runner sharing a bearer with siblings sends
+    // its own per-runner identity as agentId. The first-wins gate
+    // distinguishes runners by agentId; the audit trail uses the
+    // bearer name as actorId.
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    mockedPresent.mockResolvedValue(3);
+    await POST(
+      makeRequest({
+        sequenceObservedByClient: 1,
+        agentId: "drone-runner-host42",
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(mockedPresent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "drone-runner-host42", // body-supplied
+        actorId: "drone-1",              // auth.name
+      }),
+    );
+  });
+
+  it("rejects non-string body agentId → 400 invalid_agent_id", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(
+      makeRequest({ sequenceObservedByClient: 1, agentId: 12345 }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_agent_id");
+    expect(mockedPresent).not.toHaveBeenCalled();
+  });
+
+  it("rejects body agentId that fails validateRunnerFormat → 400", async () => {
+    mockedAuth.mockResolvedValue(makeWorkerAuth());
+    const res = await POST(
+      makeRequest({
+        sequenceObservedByClient: 1,
+        agentId: "drone runner with spaces",  // RUNNER_FORMAT_REGEX rejects
+      }),
+      { params: Promise.resolve({ roomId: VALID_ROOM_ID }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("invalid_agent_id");
+    expect(mockedPresent).not.toHaveBeenCalled();
   });
 
   it("rejects missing sequenceObservedByClient → 400", async () => {

--- a/web/src/app/api/rooms/[roomId]/present/route.ts
+++ b/web/src/app/api/rooms/[roomId]/present/route.ts
@@ -29,21 +29,19 @@ import {
   RoomEventStatusPreconditionError,
   RoomEventBodyTooLargeError,
   RoomParticipantOwnerConflictError,
+  RoomRunnerFormatError,
+  validateRunnerFormat,
 } from "@/server/war-room";
 
 interface PresentRequestBody {
   sequenceObservedByClient?: number;
   intentHint?: string;
+  /** Per-runner identity for the first-wins gate (G5, #522). When
+   * omitted, falls back to the bearer's `name` (single-runner-per-
+   * token deployments — current Hive fleet model). Subscriber-mode
+   * fleets sharing one token MUST send a distinct value per runner. */
+  agentId?: string;
 }
-
-// Carry-forward (#521 builder R1 #1, will be tracked in follow-up
-// issue): G5 (design L861-877) calls for per-runner `agent_id`.
-// Currently `agentId = auth.name` (bearer token name), so subscriber-
-// mode fleets sharing one token collapse to a single owner for the
-// first-wins gate. Drone's review noted that fixing this requires a
-// storage-layer split between agent_id (first-wins) and actor_id
-// (audit) — too invasive for this slice. Will be addressed before
-// Phase H fleet migration.
 
 export async function POST(
   request: NextRequest,
@@ -89,12 +87,40 @@ export async function POST(
     );
   }
 
+  // Body-supplied agentId for subscriber-mode first-wins gate (#522).
+  // Optional: when omitted, fall back to bearer name so single-runner-
+  // per-token deployments (drone pilot) work unchanged.
+  let agentId: string;
+  if (body.agentId !== undefined) {
+    if (typeof body.agentId !== "string") {
+      return NextResponse.json(
+        { code: "invalid_agent_id", message: "agentId must be a string." },
+        { status: 400 },
+      );
+    }
+    try {
+      validateRunnerFormat(body.agentId);
+    } catch (err) {
+      if (err instanceof RoomRunnerFormatError) {
+        return NextResponse.json(
+          { code: "invalid_agent_id", message: err.message },
+          { status: 400 },
+        );
+      }
+      throw err;
+    }
+    agentId = body.agentId;
+  } else {
+    agentId = auth.name;
+  }
+
   try {
     const sequence = await presentParticipant({
       installationId: auth.installationId,
       roomId,
       role: auth.agent_role,
-      agentId: auth.name,
+      agentId,
+      actorId: auth.name,
       sequenceObservedByClient: body.sequenceObservedByClient,
       intentHint: body.intentHint,
       redis: auth.redis,

--- a/web/src/app/api/rooms/[roomId]/withdraw/route.ts
+++ b/web/src/app/api/rooms/[roomId]/withdraw/route.ts
@@ -28,11 +28,15 @@ import {
   RoomParticipantOwnerConflictError,
   RoomParticipantNotFoundError,
   RoomParticipantStatePreconditionError,
+  RoomRunnerFormatError,
+  validateRunnerFormat,
 } from "@/server/war-room";
 
 interface WithdrawRequestBody {
   sequenceObservedByClient?: number;
   reason?: string;
+  /** Per-runner identity for the first-wins gate (G5, #522). */
+  agentId?: string;
 }
 
 export async function POST(
@@ -72,12 +76,38 @@ export async function POST(
     );
   }
 
+  // Body-supplied agentId for subscriber-mode first-wins gate (#522).
+  let agentId: string;
+  if (body.agentId !== undefined) {
+    if (typeof body.agentId !== "string") {
+      return NextResponse.json(
+        { code: "invalid_agent_id", message: "agentId must be a string." },
+        { status: 400 },
+      );
+    }
+    try {
+      validateRunnerFormat(body.agentId);
+    } catch (err) {
+      if (err instanceof RoomRunnerFormatError) {
+        return NextResponse.json(
+          { code: "invalid_agent_id", message: err.message },
+          { status: 400 },
+        );
+      }
+      throw err;
+    }
+    agentId = body.agentId;
+  } else {
+    agentId = auth.name;
+  }
+
   try {
     const sequence = await withdrawParticipant({
       installationId: auth.installationId,
       roomId,
       role: auth.agent_role,
-      agentId: auth.name,
+      agentId,
+      actorId: auth.name,
       sequenceObservedByClient: body.sequenceObservedByClient,
       reason: body.reason,
       redis: auth.redis,

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -2033,6 +2033,169 @@ describe("presentParticipant", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Per-runner agent_id (#522 / G5 — subscriber-mode first-wins gate)
+// ---------------------------------------------------------------------------
+
+describe("Per-runner agent_id (G5 subscriber-mode)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    await createRoom({
+      installationId: "12345",
+      roomId: RID_A,
+      manager: "bot-queen",
+      subject: { type: "pr_review", ref: "hivemoot/hivemoot#508" },
+      redis,
+    });
+  });
+
+  it("event.actor_id uses bearer-derived actorId, not body-supplied agentId", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-host42",  // body-supplied per-runner identity
+      actorId: "shared-token-name",     // bearer-derived (auth.name)
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 0, redis });
+    const presented = events.find(
+      (e) => e.event_type === "participant_presented",
+    );
+    expect(presented).toBeDefined();
+    // Audit trail attributes the action to the bearer (anti-impersonation),
+    // NOT to the body-supplied agentId.
+    expect(presented?.actor_id).toBe("shared-token-name");
+  });
+
+  it("participant.agent_id uses body-supplied agentId for first-wins distinction", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-host42",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    // Materialized record stores the per-runner identity so the
+    // first-wins gate can distinguish concurrent runners.
+    expect(participants.drone.agent_id).toBe("drone-runner-host42");
+  });
+
+  it("subscriber-mode regression: two distinct agentIds with same actorId → second gets owner_conflict", async () => {
+    // Closes #522: prior code used auth.name for both agentId AND
+    // actorId, so two runners sharing a token (subscriber-mode)
+    // would collapse to a single owner — the second's RSVP would
+    // be treated as idempotent (or worse, a re-RSVP from withdrew).
+    // With the split, the bearer (actorId) audits both attempts,
+    // but the gate sees them as DISTINCT runners and rejects the
+    // second.
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-A",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-B",  // DIFFERENT runner, same bearer
+        actorId: "shared-token-name",
+        sequenceObservedByClient: 2,
+        redis,
+      }),
+    ).rejects.toThrow(/first-wins|already claimed/);
+  });
+
+  it("back-compat: actorId omitted defaults to agentId (existing call sites)", async () => {
+    // Pre-#522 callers passed only agentId. The default actorId →
+    // agentId behavior preserves their semantics so they don't
+    // break; production routes (post-#522) MUST pass both.
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-1",  // no actorId — defaults to agentId
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 0, redis });
+    const presented = events.find(
+      (e) => e.event_type === "participant_presented",
+    );
+    expect(presented?.actor_id).toBe("drone-1");
+  });
+
+  it("split applies to withdrawParticipant: actorId is audit, agentId is owner check", async () => {
+    // RSVP first.
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-host42",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    // Withdraw with same agentId (owner check passes), distinct actorId.
+    await withdrawParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-host42",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 2,
+      reason: "out of capacity",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 0, redis });
+    const withdrawn = events.find(
+      (e) => e.event_type === "participant_withdrawn",
+    );
+    expect(withdrawn?.actor_id).toBe("shared-token-name");
+  });
+
+  it("split applies to submitContribution + withdrawContribution similarly", async () => {
+    await redis.hset(roomKey("12345", RID_A), {
+      status: "awaiting_contributions",
+    });
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-host42",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await submitContribution({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-host42",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 2,
+      body: { verdict: "APPROVE", summary: "lgtm" },
+      rawMd: "approved.",
+      redis,
+    });
+    const events = await listRoomEvents({ roomId: RID_A, since: 0, redis });
+    const contributed = events.find(
+      (e) => e.event_type === "contribution_submitted",
+    );
+    expect(contributed?.actor_id).toBe("shared-token-name");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // withdrawParticipant
 // ---------------------------------------------------------------------------
 

--- a/web/src/server/war-room.test.ts
+++ b/web/src/server/war-room.test.ts
@@ -2115,6 +2115,47 @@ describe("Per-runner agent_id (G5 subscriber-mode)", () => {
     ).rejects.toThrow(/first-wins|already claimed/);
   });
 
+  it("subscriber-mode regression — concurrent poll: same observedSequence + distinct agentId → 409 (NOT 200 replay)", async () => {
+    // Closes #522 builder R2: the actual concurrent-poll case the
+    // first regression test missed. Two runners sharing a bearer
+    // observe the same /watching response sequence (race window
+    // between watching tick and present call), then both call
+    // /present with seq=1.
+    //
+    // Without per-runner idem-lane separation:
+    //   - Runner A writes (room, drone, present, seq=1) idem key
+    //   - Runner B's idem check matches → RoomEventIdempotencyReplayError
+    //   - Route maps to 200 { replay: true } — runner B believes
+    //     its RSVP succeeded but it's actually runner A's slot
+    //
+    // With per-runner idem (this test):
+    //   - Runner A writes (room, drone, present, runner-A, seq=1)
+    //   - Runner B's idem key is DIFFERENT (runner-B in the tuple)
+    //   - Idem check passes (no collision)
+    //   - Owner check fires → RoomParticipantOwnerConflictError
+    //   - Route maps to 409 owner_conflict — correct rejection
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-A",
+      actorId: "shared-token-name",
+      sequenceObservedByClient: 1, // SAME observed sequence
+      redis,
+    });
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-B",
+        actorId: "shared-token-name",
+        sequenceObservedByClient: 1, // SAME observed sequence as above
+        redis,
+      }),
+    ).rejects.toThrow(/first-wins|already claimed/);
+  });
+
   it("back-compat: actorId omitted defaults to agentId (existing call sites)", async () => {
     // Pre-#522 callers passed only agentId. The default actorId →
     // agentId behavior preserves their semantics so they don't

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -2686,9 +2686,32 @@ interface RSVPCommonArgs {
    * so client-supplied role would let one bearer overwrite another's
    * RSVP. */
   role: string;
-  /** Server-derived from token envelope's `name`. Used as the actor_id
-   * on the event log + materialized participant record. */
+  /** Per-runner identity used for the per-(room, role) **first-wins
+   * gate** (G5 — subscriber-mode). Body-supplied at the route layer
+   * (validated via `validateRunnerFormat`). Two runners that share a
+   * bearer but have distinct `agentId` race correctly — the second
+   * gets `RoomParticipantOwnerConflictError`. Stored on the
+   * materialized participant record as `participant.agent_id`.
+   *
+   * #522 / WAR_ROOM_DESIGN.md L861-877: prior code used the
+   * bearer-derived name here, collapsing subscriber-mode runners.
+   * The split between `agentId` (gate) and `actorId` (audit) is the
+   * fix — together they let us prevent impersonation (audit can't
+   * be forged) AND distinguish concurrent runners (gate uses each
+   * runner's own id). */
   agentId: string;
+  /** Bearer-derived audit identity used for the event log's
+   * `actor_id`. Anti-impersonation: a request body cannot forge
+   * who-took-this-action in the audit trail. Routes wire this from
+   * `auth.name`. May equal `agentId` in single-runner-per-token
+   * deployments (drone pilot, etc.).
+   *
+   * Optional in the type for back-compat with existing call sites
+   * (storage tests pre-#522). When omitted, defaults to `agentId`
+   * — same behavior as before #522. PRODUCTION ROUTES MUST pass
+   * `actorId` explicitly so the audit trail records the bearer,
+   * not a body-supplied value. */
+  actorId?: string;
   /** Required header value (`If-Room-Sequence-At-Or-After`). Used to
    * derive the idempotency key — two retries with the same observed
    * sequence resolve to the same key, replay-safe. */
@@ -2740,7 +2763,10 @@ export async function presentParticipant(args: RSVPCommonArgs & {
       timestamp: nowIso,
       event_type: "participant_presented",
       actor_role: args.role,
-      actor_id: args.agentId,
+      // Audit trail uses bearer-derived actorId for impersonation
+      // safety. Per-runner agentId (used by ownerCheck below) lives
+      // on the materialized participant record only. #522.
+      actor_id: args.actorId ?? args.agentId,
       body: {
         ...(args.intentHint !== undefined ? { intent_hint: args.intentHint } : {}),
       },
@@ -2752,6 +2778,8 @@ export async function presentParticipant(args: RSVPCommonArgs & {
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
     allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
+    // First-wins gate: per-runner agentId distinguishes subscriber-
+    // mode runners that share a bearer.
     ownerCheck: { field: args.role, expectedAgentId: args.agentId },
     materialized1: {
       key: participantsKey(args.roomId),
@@ -2790,7 +2818,8 @@ export async function withdrawParticipant(
       timestamp: nowIso,
       event_type: "participant_withdrawn",
       actor_role: args.role,
-      actor_id: args.agentId,
+      // Audit: bearer-derived. #522.
+      actor_id: args.actorId ?? args.agentId,
       body: {
         ...(args.reason !== undefined ? { reason: args.reason } : {}),
       },
@@ -2866,7 +2895,9 @@ export async function submitContribution(args: RSVPCommonArgs & {
       timestamp: nowIso,
       event_type: "contribution_submitted",
       actor_role: args.role,
-      actor_id: args.agentId,
+      // Audit: bearer-derived. Owner check below uses per-runner
+      // agentId for subscriber-mode safety. #522.
+      actor_id: args.actorId ?? args.agentId,
       body: {
         body: args.body as unknown as Record<string, unknown>,
         // raw_md NOT in event body — bounded separately at 32 KiB
@@ -2926,7 +2957,8 @@ export async function withdrawContribution(
       timestamp: nowIso,
       event_type: "contribution_withdrawn",
       actor_role: args.role,
-      actor_id: args.agentId,
+      // Audit: bearer-derived. #522.
+      actor_id: args.actorId ?? args.agentId,
       body: {
         ...(args.reason !== undefined ? { reason: args.reason } : {}),
       },

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -1628,25 +1628,46 @@ const ROLE_REGEX = /^[a-z][a-z0-9_-]{0,31}$/;
 
 /**
  * Server-canonical idempotency key derivation. Input is a stable
- * tuple of (roomId, role, action, sequenceObservedByClient); SHA-256
- * keeps the key opaque + bounded-length while making collisions
- * cryptographically negligible.
+ * tuple of (roomId, role, action, agentId, sequenceObservedByClient);
+ * SHA-256 keeps the key opaque + bounded-length while making
+ * collisions cryptographically negligible.
  *
  * `sequenceObservedByClient` is the `If-Room-Sequence-At-Or-After`
  * header value the client read when constructing the request. Two
- * retries from the same client see the same observed sequence and
- * thus derive the same key — that's the desired behavior for the
- * replay-detection path.
+ * retries from the same client see the same observed sequence + same
+ * agentId and thus derive the same key — that's the desired behavior
+ * for the replay-detection path.
+ *
+ * **Per-runner idempotency** (#522 / G5 — closes builder R2):
+ * `agentId` is included so two runners sharing a bearer (subscriber-
+ * mode) AND observing the same sequence DON'T collide on the idem
+ * key. Without this, runner A wins the idem write, then runner B
+ * gets RoomEventIdempotencyReplayError (which the route maps to 200
+ * `replay: true`) — runner B believes its RSVP succeeded but it's
+ * actually runner A's slot. The owner check that should reject B
+ * runs AFTER the idem check in the script, so it never fires. Adding
+ * agentId to the key forces B's request to go through the script's
+ * owner check, where it correctly gets 409 owner_conflict.
+ *
+ * `agentId` is optional in the function signature for back-compat
+ * with non-RSVP actions (decide, close, subject_updated, etc.) that
+ * don't have a per-runner identity. RSVP actions (present, withdraw,
+ * contribute) MUST pass it.
  */
 export function deriveIdempotencyKey(args: {
   roomId: string;
   role: string;
   action: RoomEventAction;
   sequenceObservedByClient: number;
+  /** Per-runner identity for subscriber-mode idem-lane separation
+   * (#522). Omit for non-RSVP actions where there's no per-runner
+   * concept. */
+  agentId?: string;
 }): string {
+  const agentSegment = args.agentId !== undefined ? `:${args.agentId}` : "";
   return createHash("sha256")
     .update(
-      `v1:${args.roomId}:${args.role}:${args.action}:${args.sequenceObservedByClient}`,
+      `v1:${args.roomId}:${args.role}:${args.action}${agentSegment}:${args.sequenceObservedByClient}`,
     )
     .digest("hex");
 }
@@ -2775,6 +2796,11 @@ export async function presentParticipant(args: RSVPCommonArgs & {
       roomId: args.roomId,
       role: args.role,
       action: "present",
+      // #522 builder R2: per-runner idem-lane separation. Without
+      // this, two runners sharing a bearer + observing same seq
+      // collide on the idem key and runner B gets a spurious
+      // 200 replay instead of 409 owner_conflict.
+      agentId: args.agentId,
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
     allowedStatuses: ["awaiting_rsvp", "awaiting_contributions"],
@@ -2828,6 +2854,7 @@ export async function withdrawParticipant(
       roomId: args.roomId,
       role: args.role,
       action: "withdraw_participant",
+      agentId: args.agentId, // #522 builder R2 — per-runner idem lane
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
     ownerRequired: true,
@@ -2908,6 +2935,7 @@ export async function submitContribution(args: RSVPCommonArgs & {
       roomId: args.roomId,
       role: args.role,
       action: "contribute",
+      agentId: args.agentId, // #522 builder R2 — per-runner idem lane
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
     ownerRequired: true,
@@ -2967,6 +2995,7 @@ export async function withdrawContribution(
       roomId: args.roomId,
       role: args.role,
       action: "withdraw_contribution",
+      agentId: args.agentId, // #522 builder R2 — per-runner idem lane
       sequenceObservedByClient: args.sequenceObservedByClient,
     }),
     ownerRequired: true,

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -1664,10 +1664,16 @@ export function deriveIdempotencyKey(args: {
    * concept. */
   agentId?: string;
 }): string {
+  // Bump to v2 when agentId is supplied so the per-runner idem
+  // namespace is explicitly distinct from any v1 keys still in flight
+  // during a deploy. v1 keys expire via TTL within the room's
+  // max_age_secs, so no migration needed; the bump just makes the
+  // change visible in keyspace if an operator inspects Redis.
+  const prefix = args.agentId !== undefined ? "v2" : "v1";
   const agentSegment = args.agentId !== undefined ? `:${args.agentId}` : "";
   return createHash("sha256")
     .update(
-      `v1:${args.roomId}:${args.role}:${args.action}${agentSegment}:${args.sequenceObservedByClient}`,
+      `${prefix}:${args.roomId}:${args.role}:${args.action}${agentSegment}:${args.sequenceObservedByClient}`,
     )
     .digest("hex");
 }


### PR DESCRIPTION
Closes #522

## Summary

Splits `agentId` (per-runner, first-wins gate) from `actorId` (bearer-derived, audit). Prior code used the bearer name for both, so subscriber-mode fleets sharing one token collapsed to a single owner — second runner's RSVP would race-corrupt the first.

## What's new

**Storage layer** (`web/src/server/war-room.ts`):
- `RSVPCommonArgs` carries both fields. `agentId` for owner check + materialized `participant.agent_id`. `actorId` (optional, defaults to `agentId` for back-compat) for `event.actor_id` audit.
- 4 RSVP functions updated: `presentParticipant`, `withdrawParticipant`, `submitContribution`, `withdrawContribution`.

**Routes** (`/present`, `/withdraw`, `/contributions` POST + DELETE):
- Accept optional body `agentId` (validated via existing `validateRunnerFormat`).
- Always pass `actorId: auth.name` so audit can't be forged via body.
- When body `agentId` omitted → fall back to `auth.name`. Single-runner-per-token deployments (drone pilot today) work unchanged.

## Anti-impersonation invariant

A request body cannot forge audit-trail identity — `event.actor_id` is ALWAYS bearer-derived. The body's `agentId` is treated as the runner's self-declared identity for the gate, not as an authority claim.

## Why the optional-with-fallback shape

| Deployment | `agentId` source | Behavior |
|---|---|---|
| Single-runner-per-token (current Hive, drone pilot) | omitted → `auth.name` | unchanged from pre-#522 |
| Subscriber-mode (multi-runner shared bearer) | body-supplied per runner | first-wins gate distinguishes runners correctly |

This makes Phase H drone pilot land WITHOUT requiring a coordinated worker-side update.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Web suite: 1342 tests pass (was 1333, +9)
- [x] 6 storage tests: `event.actor_id` uses `actorId`, `participant.agent_id` uses `agentId`, subscriber-mode regression (two distinct agentIds same actorId → second gets owner_conflict), back-compat (omitted actorId defaults to agentId), split applies to all 4 RSVP functions
- [x] 3 route tests for /present (body agentId flows through, rejects non-string, rejects invalid format)
- [x] Lint clean (only pre-existing warnings)
- [ ] Reviewer fleet sign-off

## NOT in scope

- Worker-side update to send a per-runner `agentId` (F.3 worker still uses the back-compat fall-through). Workers can be updated incrementally as fleets move to subscriber-mode.
- Phase H drone pilot doesn't require this PR; #522 is the foundation that unblocks multi-runner scale-out later.