### PR TITLE
Phase E.3 — mention_response war rooms on @hivemoot comments

### DIFF
--- a/bot/api/github/webhooks/index.ts
+++ b/bot/api/github/webhooks/index.ts
@@ -31,7 +31,12 @@ import { parseCommand, executeCommand, retryQueuedSquash, autoGatherIfEligible }
 import { getLLMReadiness } from "../../lib/llm/provider.js";
 import { registerHandlerDispatcher } from "../../handlers/dispatcher.js";
 import { handlerEventMap } from "../../handlers/registry.js";
-import { maybeCreatePrReviewRoom, maybeEmitSubjectUpdated } from "../../lib/war-room-routing.js";
+import {
+  commentHasHivemootMention,
+  maybeCreateMentionRoom,
+  maybeCreatePrReviewRoom,
+  maybeEmitSubjectUpdated,
+} from "../../lib/war-room-routing.js";
 
 /**
  * Hivemoot Bot - Governance Automation
@@ -576,6 +581,23 @@ export function app(probotApp: Probot): void {
           log: context.log,
         });
         return;
+      }
+
+      // E.3: @hivemoot mention without /command → create a
+      // mention_response war room. Multiple mentions on the same
+      // issue/PR reuse the same roomId via the storage layer's
+      // subject-uniqueness gate. Non-fatal on error so this can't
+      // break the existing intake/governance flow.
+      if (commentHasHivemootMention(comment.body ?? "")) {
+        await maybeCreateMentionRoom({
+          owner,
+          repo,
+          issueOrPrNumber: issue.number,
+          commentAuthor: comment.user.login,
+          log: context.log,
+        });
+        // Don't return — let the existing PR intake / governance
+        // logic continue to run alongside the mention room.
       }
 
       // Non-command comments on issues: check auto-gather eligibility (discussion issues only)

--- a/bot/api/github/webhooks/index.ts
+++ b/bot/api/github/webhooks/index.ts
@@ -588,14 +588,29 @@ export function app(probotApp: Probot): void {
       // issue/PR reuse the same roomId via the storage layer's
       // subject-uniqueness gate. Non-fatal on error so this can't
       // break the existing intake/governance flow.
+      //
+      // Repo-config gate: mirror E.1/E.2's opt-in posture — only
+      // repos with `.hivemoot.yml` get war rooms. Without this,
+      // the handler would fire room creation API calls on every
+      // repo in every installation regardless of opt-in. Closes
+      // #549 drone B1.
       if (commentHasHivemootMention(comment.body ?? "")) {
-        await maybeCreateMentionRoom({
-          owner,
-          repo,
-          issueOrPrNumber: issue.number,
-          commentAuthor: comment.user.login,
-          log: context.log,
-        });
+        const mentionRepoConfig = await loadRepositoryConfig(
+          context.octokit, owner, repo,
+        );
+        if (mentionRepoConfig) {
+          await maybeCreateMentionRoom({
+            owner,
+            repo,
+            issueOrPrNumber: issue.number,
+            commentAuthor: comment.user.login,
+            log: context.log,
+          });
+        } else {
+          context.log.debug(
+            `No config in ${fullName}; skipping mention war-room creation`,
+          );
+        }
         // Don't return — let the existing PR intake / governance
         // logic continue to run alongside the mention room.
       }

--- a/bot/api/github/webhooks/index.ts
+++ b/bot/api/github/webhooks/index.ts
@@ -603,6 +603,7 @@ export function app(probotApp: Probot): void {
             owner,
             repo,
             issueOrPrNumber: issue.number,
+            commentId: comment.id,
             commentAuthor: comment.user.login,
             log: context.log,
           });

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -462,18 +462,40 @@ describe("commentHasHivemootMention", () => {
 });
 
 describe("deriveMentionRoomId", () => {
-  it("same identity → same roomId across calls (idempotent)", () => {
+  it("same identity (incl. commentId) → same roomId across calls (idempotent webhook redelivery)", () => {
     const a = deriveMentionRoomId({
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
     });
     const b = deriveMentionRoomId({
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
     });
     expect(a).toBe(b);
+  });
+
+  it("different commentId on same issue → different roomIds (post-close safety, #549 builder R1 #2)", () => {
+    // Storage retains room hashes for ~30 days after close. Without
+    // commentId in the derivation, a mention 31+ days after the
+    // previous mention's room closed would hit room_id_taken. Each
+    // mention now derives a fresh roomId.
+    const a = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentId: 1001,
+    });
+    const b = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentId: 1002,
+    });
+    expect(a).not.toBe(b);
   });
 
   it("different issue/PR → different roomIds", () => {
@@ -481,20 +503,21 @@ describe("deriveMentionRoomId", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
     });
     const b = deriveMentionRoomId({
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 43,
+      commentId: 1001,
     });
     expect(a).not.toBe(b);
   });
 
-  it("distinct namespace from derivePrRoomId (same owner/repo/num → different ids)", () => {
+  it("distinct namespace from derivePrRoomId", () => {
     // Critical invariant: a PR can have BOTH a pr_review room AND
     // a mention_response room simultaneously. The deterministic
-    // derivations MUST produce different ids for the same identity
-    // tuple, otherwise creating one would 409 on the other.
+    // derivations MUST produce different ids.
     const prId = derivePrRoomId({
       owner: "hivemoot",
       repo: "hivemoot",
@@ -504,6 +527,7 @@ describe("deriveMentionRoomId", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
     });
     expect(prId).not.toBe(mentionId);
   });
@@ -513,6 +537,7 @@ describe("deriveMentionRoomId", () => {
       owner: "x",
       repo: "y",
       issueOrPrNumber: 1,
+      commentId: 99,
     });
     expect(id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
@@ -534,6 +559,7 @@ describe("maybeCreateMentionRoom", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
       commentAuthor: "alice",
       log,
     });
@@ -541,15 +567,22 @@ describe("maybeCreateMentionRoom", () => {
     expect(mockedClientCtor).not.toHaveBeenCalled();
   });
 
-  function setupCreateRoomMock(createRoom: ReturnType<typeof vi.fn>): void {
+  function setupCreateRoomMock(
+    createRoom: ReturnType<typeof vi.fn>,
+    appendEvent?: ReturnType<typeof vi.fn>,
+  ): void {
     mockedClientCtor.mockImplementation(
-      function (this: { createRoom: typeof createRoom }) {
+      function (this: {
+        createRoom: typeof createRoom;
+        appendEvent?: typeof appendEvent;
+      }) {
         this.createRoom = createRoom;
+        if (appendEvent) this.appendEvent = appendEvent;
       } as unknown as typeof WarRoomClient,
     );
   }
 
-  it("happy path — calls createRoom with mention_response subject + deterministic roomId", async () => {
+  it("happy path — calls createRoom with mention_response subject + comment-stable roomId", async () => {
     process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
     const createRoom = vi.fn().mockResolvedValue({});
     setupCreateRoomMock(createRoom);
@@ -557,14 +590,17 @@ describe("maybeCreateMentionRoom", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
       commentAuthor: "alice",
       log,
     });
     expect(result.roomId).toMatch(/^[0-9a-f-]+$/);
+    expect(result.reusedExistingRoom).toBe(false);
     const expectedRoomId = deriveMentionRoomId({
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
     });
     expect(result.roomId).toBe(expectedRoomId);
     expect(createRoom).toHaveBeenCalledWith({
@@ -573,22 +609,70 @@ describe("maybeCreateMentionRoom", () => {
     });
   });
 
-  it("subject_already_open 409 → reuses existingRoomId (idempotent re-mention)", async () => {
+  it("subject_already_open 409 → emits subject_updated on existing room (re-mention safety, #549 builder R1 #2)", async () => {
+    // A prior @hivemoot's room is still open for this issue. The
+    // create attempt fails with subject_already_open (subject_ref
+    // is per-issue). The handler then emits subject_updated on the
+    // existing room so workers re-engage (per /watching contract,
+    // a new sequence past withdrew_at_sequence makes withdrawn
+    // workers re-eligible).
     process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
     const createRoom = vi.fn().mockRejectedValue(
       new WarRoomApiError(409, "subject_already_open", "open", {
         existingRoomId: ROOM_ID,
       }),
     );
-    setupCreateRoomMock(createRoom);
+    const appendEvent = vi.fn().mockResolvedValue({ sequence: 5 });
+    setupCreateRoomMock(createRoom, appendEvent);
     const result = await maybeCreateMentionRoom({
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
       commentAuthor: "alice",
       log,
     });
-    expect(result).toEqual({ roomId: ROOM_ID });
+    expect(result).toEqual({
+      roomId: ROOM_ID,
+      reusedExistingRoom: true,
+    });
+    expect(appendEvent).toHaveBeenCalledWith({
+      roomId: ROOM_ID,
+      eventType: "subject_updated",
+      body: {
+        change_kind: "mention",
+        comment_id: 1001,
+        comment_author: "alice",
+      },
+      // Idempotency key includes commentId so re-deliveries
+      // resolve to the same event (no double-emit on retry).
+      idempotencyKey: `bot.subject_updated.${ROOM_ID}.mention.1001`,
+    });
+  });
+
+  it("subject_already_open 409 → subject_updated emit fails → returns existing roomId with api_error (no throw)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const createRoom = vi.fn().mockRejectedValue(
+      new WarRoomApiError(409, "subject_already_open", "open", {
+        existingRoomId: ROOM_ID,
+      }),
+    );
+    const appendEvent = vi.fn().mockRejectedValue(
+      new WarRoomApiError(409, "status_precondition_failed", "room closing", {}),
+    );
+    setupCreateRoomMock(createRoom, appendEvent);
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentId: 1001,
+      commentAuthor: "alice",
+      log,
+    });
+    // Returns existing roomId (caller may want to log it) + api_error
+    // marker. Webhook handler shouldn't crash either way.
+    expect(result.roomId).toBe(ROOM_ID);
+    expect(result.skipped).toBe("api_error");
   });
 
   it("non-409 4xx → logs error + returns api_error", async () => {
@@ -601,6 +685,7 @@ describe("maybeCreateMentionRoom", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
       commentAuthor: "alice",
       log,
     });
@@ -616,6 +701,7 @@ describe("maybeCreateMentionRoom", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
       commentAuthor: "alice",
       log,
     });
@@ -632,6 +718,7 @@ describe("maybeCreateMentionRoom", () => {
       owner: "hivemoot",
       repo: "hivemoot",
       issueOrPrNumber: 42,
+      commentId: 1001,
       commentAuthor: "alice",
       log,
     });

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -4,9 +4,12 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  commentHasHivemootMention,
+  deriveMentionRoomId,
+  derivePrRoomId,
+  maybeCreateMentionRoom,
   maybeCreatePrReviewRoom,
   maybeEmitSubjectUpdated,
-  derivePrRoomId,
 } from "./war-room-routing.js";
 import { WarRoomApiError } from "./war-room-client.js";
 
@@ -406,5 +409,232 @@ describe("maybeEmitSubjectUpdated", () => {
         changeKind: "synchronize", log,
       }),
     ).resolves.toEqual({ sequence: null, skipped: "api_error" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E.3 — mention_response rooms
+// ---------------------------------------------------------------------------
+
+describe("commentHasHivemootMention", () => {
+  it.each([
+    ["@hivemoot can you take a look?", true],
+    ["Hi @hivemoot, please review.", true],
+    ["@hivemoot,", true], // comma is non-word/dash
+    ["@hivemoot.", true], // period
+    ["@hivemoot!", true], // bang
+    ["@hivemoot\nnewline after", true],
+    ["@HiveMoot mixed case", true], // case-insensitive
+    ["@hivemoot at end of comment @hivemoot", true],
+    ["text @hivemoot more text", true],
+  ])("matches %j → %s", (body, expected) => {
+    expect(commentHasHivemootMention(body)).toBe(expected);
+  });
+
+  it.each([
+    ["", false],
+    ["plain text with no mention", false],
+    ["@hivemoot-builder is a different identity", false],
+    ["@hivemoot-bot also distinct", false],
+    ["@hivemoot_test underscored", false],
+    ["@hivemoot42 alphanumeric continuation", false],
+    ["/gather followed by @hivemoot in body", false], // /command guard
+    [" /timeout some text with @hivemoot", false], // leading whitespace + /command
+  ])("non-match %j → %s", (body, expected) => {
+    expect(commentHasHivemootMention(body)).toBe(expected);
+  });
+
+  it("matches even when comment starts with @hivemoot at position 0", () => {
+    expect(commentHasHivemootMention("@hivemoot please")).toBe(true);
+  });
+
+  it("does NOT match when whole comment is a /command", () => {
+    expect(commentHasHivemootMention("/gather @hivemoot please")).toBe(false);
+  });
+
+  it("matches when /-prefix appears mid-comment but body doesn't start with /", () => {
+    // Defense check: only the /-prefix at start of comment skips,
+    // mid-comment / is allowed.
+    expect(
+      commentHasHivemootMention("hello @hivemoot use /timeout if needed"),
+    ).toBe(true);
+  });
+});
+
+describe("deriveMentionRoomId", () => {
+  it("same identity → same roomId across calls (idempotent)", () => {
+    const a = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+    });
+    const b = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+    });
+    expect(a).toBe(b);
+  });
+
+  it("different issue/PR → different roomIds", () => {
+    const a = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+    });
+    const b = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 43,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("distinct namespace from derivePrRoomId (same owner/repo/num → different ids)", () => {
+    // Critical invariant: a PR can have BOTH a pr_review room AND
+    // a mention_response room simultaneously. The deterministic
+    // derivations MUST produce different ids for the same identity
+    // tuple, otherwise creating one would 409 on the other.
+    const prId = derivePrRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+    });
+    const mentionId = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+    });
+    expect(prId).not.toBe(mentionId);
+  });
+
+  it("output matches storage's UUIDv4 regex", () => {
+    const id = deriveMentionRoomId({
+      owner: "x",
+      repo: "y",
+      issueOrPrNumber: 1,
+    });
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe("maybeCreateMentionRoom", () => {
+  beforeEach(() => {
+    delete process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+    log.info.mockReset();
+    log.warn.mockReset();
+    log.error.mockReset();
+    mockedClientCtor.mockReset();
+  });
+
+  it("skips with `no_token` reason when env var is unset", async () => {
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "no_token" });
+    expect(mockedClientCtor).not.toHaveBeenCalled();
+  });
+
+  function setupCreateRoomMock(createRoom: ReturnType<typeof vi.fn>): void {
+    mockedClientCtor.mockImplementation(
+      function (this: { createRoom: typeof createRoom }) {
+        this.createRoom = createRoom;
+      } as unknown as typeof WarRoomClient,
+    );
+  }
+
+  it("happy path — calls createRoom with mention_response subject + deterministic roomId", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const createRoom = vi.fn().mockResolvedValue({});
+    setupCreateRoomMock(createRoom);
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result.roomId).toMatch(/^[0-9a-f-]+$/);
+    const expectedRoomId = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+    });
+    expect(result.roomId).toBe(expectedRoomId);
+    expect(createRoom).toHaveBeenCalledWith({
+      subject: { type: "mention_response", ref: "hivemoot/hivemoot#42" },
+      roomId: expectedRoomId,
+    });
+  });
+
+  it("subject_already_open 409 → reuses existingRoomId (idempotent re-mention)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const createRoom = vi.fn().mockRejectedValue(
+      new WarRoomApiError(409, "subject_already_open", "open", {
+        existingRoomId: ROOM_ID,
+      }),
+    );
+    setupCreateRoomMock(createRoom);
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result).toEqual({ roomId: ROOM_ID });
+  });
+
+  it("non-409 4xx → logs error + returns api_error", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const createRoom = vi.fn().mockRejectedValue(
+      new WarRoomApiError(403, "forbidden", "missing rooms.create", {}),
+    );
+    setupCreateRoomMock(createRoom);
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "api_error" });
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("transient 5xx / network error → logs warn + returns api_error (no throw)", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const createRoom = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    setupCreateRoomMock(createRoom);
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "api_error" });
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  it("WarRoomClient construction throws → returns api_error without crashing", async () => {
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    mockedClientCtor.mockImplementation(() => {
+      throw new Error("invalid baseUrl");
+    });
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result).toEqual({ roomId: null, skipped: "api_error" });
   });
 });

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -637,4 +637,24 @@ describe("maybeCreateMentionRoom", () => {
     });
     expect(result).toEqual({ roomId: null, skipped: "api_error" });
   });
+
+  it("never throws — pin the non-throwing contract for webhook safety (drone #549 N1)", async () => {
+    // Webhook handler relies on this: a war-room failure must NOT
+    // bubble out and disrupt the existing intake / governance flow.
+    // Mirror maybeCreatePrReviewRoom's existing contract test.
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const createRoom = vi.fn().mockRejectedValue(
+      new Error("totally unexpected"),
+    );
+    setupCreateRoomMock(createRoom);
+    await expect(
+      maybeCreateMentionRoom({
+        owner: "hivemoot",
+        repo: "hivemoot",
+        issueOrPrNumber: 42,
+        commentAuthor: "alice",
+        log,
+      }),
+    ).resolves.toEqual({ roomId: null, skipped: "api_error" });
+  });
 });

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -650,6 +650,40 @@ describe("maybeCreateMentionRoom", () => {
     });
   });
 
+  it("same-comment webhook redelivery (existingRoomId === derived) → idempotent replay, NO subject_updated emit (#549 builder R2)", async () => {
+    // Same-comment webhook delivery hits subject_already_open
+    // because OUR previous delivery created the room. Without this
+    // guard, the redelivery would emit a spurious subject_updated
+    // and re-dispatch workers for a non-event.
+    process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
+    const ourDerivedRoomId = deriveMentionRoomId({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentId: 1001,
+    });
+    const createRoom = vi.fn().mockRejectedValue(
+      new WarRoomApiError(409, "subject_already_open", "open", {
+        existingRoomId: ourDerivedRoomId, // SAME as derived → replay
+      }),
+    );
+    const appendEvent = vi.fn(); // SHOULD NOT be called
+    setupCreateRoomMock(createRoom, appendEvent);
+    const result = await maybeCreateMentionRoom({
+      owner: "hivemoot",
+      repo: "hivemoot",
+      issueOrPrNumber: 42,
+      commentId: 1001,
+      commentAuthor: "alice",
+      log,
+    });
+    expect(result).toEqual({
+      roomId: ourDerivedRoomId,
+      reusedExistingRoom: false,
+    });
+    expect(appendEvent).not.toHaveBeenCalled();
+  });
+
   it("subject_already_open 409 → subject_updated emit fails → returns existing roomId with api_error (no throw)", async () => {
     process.env.HIVEMOOT_BOT_AGENT_TOKEN = "tk";
     const createRoom = vi.fn().mockRejectedValue(

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -58,24 +58,35 @@ export function derivePrRoomId(args: {
 }
 
 /**
- * Derive a deterministic UUIDv4-shaped roomId from an issue/PR's
- * mention-response identity. The same `(owner, repo, number)` always
- * maps to the same id, so multiple @hivemoot mentions on the same
- * issue/PR reuse the existing room (idempotent on `subject_already_open`).
+ * Derive a deterministic UUIDv4-shaped roomId for a mention-response.
  *
- * Distinct namespace from `derivePrRoomId` via the `mention:` prefix
- * — the same `owner/repo#N` produces a DIFFERENT roomId than its
- * pr_review counterpart, so a PR can simultaneously have one
- * pr_review room (review verdicts) AND one mention_response room
- * (free-form @hivemoot Q&A).
+ * Includes `commentId` in the derivation so:
+ *
+ *   1. **Post-close mention safety**: storage retains room hashes
+ *      for ~30 days after close. Without `commentId` in the
+ *      derivation, a mention 31+ days after the previous mention's
+ *      room closed would re-derive the SAME roomId and collide on
+ *      `room_id_taken`. With it, each mention gets a fresh
+ *      derivation. Closes #549 builder R1 #2 (post-close).
+ *
+ *   2. **Same-issue re-mention safety**: if a prior mention's room
+ *      is still open and a new mention arrives, the create attempt
+ *      uses a DIFFERENT roomId, so the create fails on
+ *      `subject_already_open` (subject_ref is per-issue, regardless
+ *      of comment). The caller then resolves the existing roomId
+ *      from the 409 response and emits a `subject_updated` event so
+ *      workers re-engage. Closes #549 builder R1 #2 (re-mention).
+ *
+ * Distinct namespace from `derivePrRoomId` via the `mention:` prefix.
  */
 export function deriveMentionRoomId(args: {
   owner: string;
   repo: string;
   issueOrPrNumber: number;
+  commentId: number;
 }): string {
   return derivedUuidV4(
-    `mention:${args.owner}/${args.repo}#${args.issueOrPrNumber}`,
+    `mention:${args.owner}/${args.repo}#${args.issueOrPrNumber}:${args.commentId}`,
   );
 }
 
@@ -433,6 +444,12 @@ interface MaybeCreateMentionRoomArgs {
    * distinguish; the room's downstream consumers can read
    * `pull_request` on the original webhook payload if they need to. */
   issueOrPrNumber: number;
+  /** GitHub comment.id of the @hivemoot mention. Folded into the
+   * deterministic roomId so each mention gets a fresh room (post-
+   * close safety) AND used as the `subject_updated` event's
+   * idempotency key when the issue already has an open mention room
+   * (re-mention safety). */
+  commentId: number;
   /** GitHub login of the comment author. Logged for ops triage —
    * NOT used for any access decision (the bot's own bearer is
    * what authorizes the room creation). */
@@ -441,10 +458,17 @@ interface MaybeCreateMentionRoomArgs {
 }
 
 interface MaybeCreateMentionRoomResult {
-  /** The war-room roomId (newly created OR reused via the
-   * idempotent 409 path). `null` when the bot has no agent token
-   * configured OR when the API call hit a 5xx / network error. */
+  /** The war-room roomId. May be:
+   *   - The newly-created room (this comment opened a fresh mention room)
+   *   - The pre-existing open room for this issue (re-mention path —
+   *     a `subject_updated` event was emitted to advance its seq)
+   *   - `null` when no token configured / API error / etc.
+   */
   roomId: string | null;
+  /** Whether the room already existed and we emitted subject_updated
+   * instead of creating fresh. False when newly created. False
+   * when roomId is null. */
+  reusedExistingRoom?: boolean;
   /** Why the room wasn't created when `roomId === null`. */
   skipped?: "no_token" | "api_error";
 }
@@ -509,6 +533,7 @@ export async function maybeCreateMentionRoom(
     owner: args.owner,
     repo: args.repo,
     issueOrPrNumber: args.issueOrPrNumber,
+    commentId: args.commentId,
   });
 
   try {
@@ -518,27 +543,32 @@ export async function maybeCreateMentionRoom(
         owner: args.owner,
         repo: args.repo,
         issueOrPrNumber: args.issueOrPrNumber,
+        commentId: args.commentId,
         commentAuthor: args.commentAuthor,
         roomId,
       },
       "[war-room] created mention_response room",
     );
-    return { roomId };
+    return { roomId, reusedExistingRoom: false };
   } catch (err) {
     if (err instanceof WarRoomApiError) {
       if (err.code === "subject_already_open") {
         const existingRoomId = err.response.existingRoomId;
         if (typeof existingRoomId === "string") {
-          args.log.info(
-            {
-              owner: args.owner,
-              repo: args.repo,
-              issueOrPrNumber: args.issueOrPrNumber,
-              existingRoomId,
-            },
-            "[war-room] subject_already_open — reusing existing mention room",
-          );
-          return { roomId: existingRoomId };
+          // A prior mention's room is still open for this issue.
+          // Emit a subject_updated event so workers re-engage if they
+          // already withdrew/resolved on the prior mention. Closes
+          // #549 builder R1 #2.
+          return await emitMentionSubjectUpdated({
+            client,
+            owner: args.owner,
+            repo: args.repo,
+            issueOrPrNumber: args.issueOrPrNumber,
+            commentId: args.commentId,
+            commentAuthor: args.commentAuthor,
+            existingRoomId,
+            log: args.log,
+          });
         }
       }
       args.log.error(
@@ -549,6 +579,7 @@ export async function maybeCreateMentionRoom(
           owner: args.owner,
           repo: args.repo,
           issueOrPrNumber: args.issueOrPrNumber,
+          commentId: args.commentId,
         },
         "[war-room] API rejected mention_response create — skipping (config / programmer error; see code).",
       );
@@ -560,9 +591,84 @@ export async function maybeCreateMentionRoom(
         owner: args.owner,
         repo: args.repo,
         issueOrPrNumber: args.issueOrPrNumber,
+        commentId: args.commentId,
       },
       "[war-room] mention_response create transient error — skipping (no auto-retry; see file docstring)",
     );
     return { roomId: null, skipped: "api_error" };
+  }
+}
+
+/**
+ * Emit a `subject_updated` event on an existing mention room when a
+ * fresh @hivemoot comment lands on the same issue. The event's
+ * idempotency key is keyed by `commentId` so re-deliveries of the
+ * same webhook resolve to the same event (not duplicated). Workers
+ * see the bumped sequence via /watching and re-engage if they had
+ * withdrawn/resolved on the prior mention.
+ */
+async function emitMentionSubjectUpdated(args: {
+  client: WarRoomClient;
+  owner: string;
+  repo: string;
+  issueOrPrNumber: number;
+  commentId: number;
+  commentAuthor: string;
+  existingRoomId: string;
+  log: Pick<Logger, "info" | "warn" | "error">;
+}): Promise<MaybeCreateMentionRoomResult> {
+  const idempotencyKey = `bot.subject_updated.${args.existingRoomId}.mention.${args.commentId}`;
+  try {
+    await args.client.appendEvent({
+      roomId: args.existingRoomId,
+      eventType: "subject_updated",
+      body: {
+        change_kind: "mention",
+        comment_id: args.commentId,
+        comment_author: args.commentAuthor,
+      },
+      idempotencyKey,
+    });
+    args.log.info(
+      {
+        owner: args.owner,
+        repo: args.repo,
+        issueOrPrNumber: args.issueOrPrNumber,
+        commentId: args.commentId,
+        commentAuthor: args.commentAuthor,
+        existingRoomId: args.existingRoomId,
+      },
+      "[war-room] re-mention on existing room — emitted subject_updated to re-engage workers",
+    );
+    return { roomId: args.existingRoomId, reusedExistingRoom: true };
+  } catch (err) {
+    if (err instanceof WarRoomApiError) {
+      args.log.warn(
+        {
+          err,
+          status: err.status,
+          code: err.code,
+          owner: args.owner,
+          repo: args.repo,
+          issueOrPrNumber: args.issueOrPrNumber,
+          commentId: args.commentId,
+          existingRoomId: args.existingRoomId,
+        },
+        "[war-room] re-mention subject_updated rejected (room may have just closed) — skipping",
+      );
+      return { roomId: args.existingRoomId, skipped: "api_error" };
+    }
+    args.log.warn(
+      {
+        err,
+        owner: args.owner,
+        repo: args.repo,
+        issueOrPrNumber: args.issueOrPrNumber,
+        commentId: args.commentId,
+        existingRoomId: args.existingRoomId,
+      },
+      "[war-room] re-mention subject_updated transient error — skipping",
+    );
+    return { roomId: args.existingRoomId, skipped: "api_error" };
   }
 }

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -555,10 +555,34 @@ export async function maybeCreateMentionRoom(
       if (err.code === "subject_already_open") {
         const existingRoomId = err.response.existingRoomId;
         if (typeof existingRoomId === "string") {
-          // A prior mention's room is still open for this issue.
-          // Emit a subject_updated event so workers re-engage if they
-          // already withdrew/resolved on the prior mention. Closes
-          // #549 builder R1 #2.
+          // Two cases collapse into subject_already_open and we MUST
+          // distinguish them — closes #549 builder R2:
+          //
+          //   (a) Same-comment webhook redelivery: the room WE
+          //       created on the first delivery still exists, so
+          //       existingRoomId === our derived roomId. This is an
+          //       idempotent replay; emitting subject_updated would
+          //       falsely advance the sequence and re-dispatch
+          //       workers for a non-event.
+          //
+          //   (b) Different-comment re-mention: a prior comment's
+          //       room is still open and a NEW @hivemoot landed.
+          //       existingRoomId !== our derived roomId (different
+          //       commentId in the derivation). Emit subject_updated
+          //       so workers re-engage.
+          if (existingRoomId === roomId) {
+            args.log.info(
+              {
+                owner: args.owner,
+                repo: args.repo,
+                issueOrPrNumber: args.issueOrPrNumber,
+                commentId: args.commentId,
+                roomId,
+              },
+              "[war-room] same-comment webhook redelivery — idempotent replay, no subject_updated emit",
+            );
+            return { roomId, reusedExistingRoom: false };
+          }
           return await emitMentionSubjectUpdated({
             client,
             owner: args.owner,

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -54,19 +54,79 @@ export function derivePrRoomId(args: {
   repo: string;
   prNumber: number;
 }): string {
-  const subject = `${args.owner}/${args.repo}#${args.prNumber}`;
-  const hash = createHash("sha256").update(subject).digest("hex");
-  // Format hex chars as UUID: 8-4-4-4-12.
-  // Then patch the version nibble (13th hex char → "4") and the
-  // variant nibble (17th hex char → 8/9/a/b) to satisfy UUIDv4.
+  return derivedUuidV4(`${args.owner}/${args.repo}#${args.prNumber}`);
+}
+
+/**
+ * Derive a deterministic UUIDv4-shaped roomId from an issue/PR's
+ * mention-response identity. The same `(owner, repo, number)` always
+ * maps to the same id, so multiple @hivemoot mentions on the same
+ * issue/PR reuse the existing room (idempotent on `subject_already_open`).
+ *
+ * Distinct namespace from `derivePrRoomId` via the `mention:` prefix
+ * — the same `owner/repo#N` produces a DIFFERENT roomId than its
+ * pr_review counterpart, so a PR can simultaneously have one
+ * pr_review room (review verdicts) AND one mention_response room
+ * (free-form @hivemoot Q&A).
+ */
+export function deriveMentionRoomId(args: {
+  owner: string;
+  repo: string;
+  issueOrPrNumber: number;
+}): string {
+  return derivedUuidV4(
+    `mention:${args.owner}/${args.repo}#${args.issueOrPrNumber}`,
+  );
+}
+
+/**
+ * Internal: hash the input string into a UUIDv4-formatted id (32 hex
+ * chars + version + variant nibble fixups, 8-4-4-4-12 layout).
+ * Storage's regex
+ * `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`
+ * enforces UUIDv4 format; this helper produces a string that
+ * matches while remaining stable per input.
+ */
+function derivedUuidV4(input: string): string {
+  const hash = createHash("sha256").update(input).digest("hex");
   const chars = hash.slice(0, 32).split("");
   chars[12] = "4"; // version 4
-  // Variant bits: top two bits of byte 8 must be 10. Mask the high
-  // nibble: 0b10xx → "8" | "9" | "a" | "b".
   const variantNibble = (parseInt(chars[16], 16) & 0x3) | 0x8;
   chars[16] = variantNibble.toString(16);
   const joined = chars.join("");
   return `${joined.slice(0, 8)}-${joined.slice(8, 12)}-${joined.slice(12, 16)}-${joined.slice(16, 20)}-${joined.slice(20, 32)}`;
+}
+
+/**
+ * Match the literal `@hivemoot` mention NOT followed by a word
+ * character or hyphen. Excludes `@hivemoot-builder`, `@hivemoot_test`,
+ * etc., which are distinct GitHub identities. Anchors:
+ *   - Start of string OR non-word boundary before `@hivemoot`
+ *   - End of string OR non-`[\w-]` char after the `t`
+ *
+ * Case-insensitive (`hello @Hivemoot` works).
+ */
+const HIVEMOOT_MENTION_REGEX = /(?:^|\W)@hivemoot(?![\w-])/i;
+
+/**
+ * Detect a `@hivemoot` mention in a comment body. Skips zero-length
+ * bodies and bodies starting with `/` (which are command comments
+ * routed elsewhere).
+ *
+ * The intent is conservative: a comment that's primarily a /command
+ * shouldn't ALSO trigger mention-room creation — operators clicking
+ * `/gather` etc. don't expect a war room to spawn. Mid-comment
+ * mentions inside a /command body are a real edge case but rare;
+ * they fall through to the command path only.
+ */
+export function commentHasHivemootMention(commentBody: string): boolean {
+  if (typeof commentBody !== "string" || commentBody.length === 0) {
+    return false;
+  }
+  if (commentBody.trimStart().startsWith("/")) {
+    return false; // command comment — don't double-route
+  }
+  return HIVEMOOT_MENTION_REGEX.test(commentBody);
 }
 
 interface MaybeCreatePrReviewRoomArgs {
@@ -361,3 +421,148 @@ export async function maybeEmitSubjectUpdated(
   }
 }
 
+// ---------------------------------------------------------------------------
+// E.3 — mention_response rooms on @hivemoot comments
+// ---------------------------------------------------------------------------
+
+interface MaybeCreateMentionRoomArgs {
+  owner: string;
+  repo: string;
+  /** The issue OR PR number — same field on the GitHub `issue` payload
+   * for both. The mention_response subject_ref shape doesn't
+   * distinguish; the room's downstream consumers can read
+   * `pull_request` on the original webhook payload if they need to. */
+  issueOrPrNumber: number;
+  /** GitHub login of the comment author. Logged for ops triage —
+   * NOT used for any access decision (the bot's own bearer is
+   * what authorizes the room creation). */
+  commentAuthor: string;
+  log: Pick<Logger, "info" | "warn" | "error">;
+}
+
+interface MaybeCreateMentionRoomResult {
+  /** The war-room roomId (newly created OR reused via the
+   * idempotent 409 path). `null` when the bot has no agent token
+   * configured OR when the API call hit a 5xx / network error. */
+  roomId: string | null;
+  /** Why the room wasn't created when `roomId === null`. */
+  skipped?: "no_token" | "api_error";
+}
+
+/**
+ * Create a `mention_response` war room for an @hivemoot comment on
+ * an issue or PR. Multiple mentions on the same issue/PR get the
+ * SAME roomId (deterministic per `(owner, repo, issueOrPrNumber)`)
+ * — so subsequent mentions reuse the existing room via the
+ * `subject_already_open` 409 path. Once that room closes, a new
+ * mention will create a fresh room (storage frees the subject).
+ *
+ * Same auth-gated, non-fatal-on-error policy as `maybeCreatePrReviewRoom`:
+ *   - `HIVEMOOT_BOT_AGENT_TOKEN` unset → log + return null
+ *   - 5xx / network → log + return null
+ *   - 409 `subject_already_open` → reuse existing roomId
+ *   - other 4xx → log + return null
+ *
+ * The webhook handler invokes this helper AFTER the /command parser
+ * has rejected the comment (a comment that's primarily a /command
+ * should NOT also spawn a mention room — see
+ * `commentHasHivemootMention`'s `/`-prefix guard).
+ */
+export async function maybeCreateMentionRoom(
+  args: MaybeCreateMentionRoomArgs,
+): Promise<MaybeCreateMentionRoomResult> {
+  const token = process.env.HIVEMOOT_BOT_AGENT_TOKEN;
+  if (!token) {
+    args.log.info(
+      {
+        owner: args.owner,
+        repo: args.repo,
+        issueOrPrNumber: args.issueOrPrNumber,
+        commentAuthor: args.commentAuthor,
+      },
+      "[war-room] HIVEMOOT_BOT_AGENT_TOKEN unset — skipping mention room creation. Set the env var to enable mention war-rooms.",
+    );
+    return { roomId: null, skipped: "no_token" };
+  }
+
+  let client: WarRoomClient;
+  try {
+    client = new WarRoomClient({ log: args.log });
+  } catch (err) {
+    args.log.error(
+      {
+        err,
+        owner: args.owner,
+        repo: args.repo,
+        issueOrPrNumber: args.issueOrPrNumber,
+      },
+      "[war-room] failed to construct WarRoomClient — skipping mention room creation.",
+    );
+    return { roomId: null, skipped: "api_error" };
+  }
+
+  const subject = {
+    type: "mention_response" as const,
+    ref: `${args.owner}/${args.repo}#${args.issueOrPrNumber}`,
+  };
+  const roomId = deriveMentionRoomId({
+    owner: args.owner,
+    repo: args.repo,
+    issueOrPrNumber: args.issueOrPrNumber,
+  });
+
+  try {
+    await client.createRoom({ subject, roomId });
+    args.log.info(
+      {
+        owner: args.owner,
+        repo: args.repo,
+        issueOrPrNumber: args.issueOrPrNumber,
+        commentAuthor: args.commentAuthor,
+        roomId,
+      },
+      "[war-room] created mention_response room",
+    );
+    return { roomId };
+  } catch (err) {
+    if (err instanceof WarRoomApiError) {
+      if (err.code === "subject_already_open") {
+        const existingRoomId = err.response.existingRoomId;
+        if (typeof existingRoomId === "string") {
+          args.log.info(
+            {
+              owner: args.owner,
+              repo: args.repo,
+              issueOrPrNumber: args.issueOrPrNumber,
+              existingRoomId,
+            },
+            "[war-room] subject_already_open — reusing existing mention room",
+          );
+          return { roomId: existingRoomId };
+        }
+      }
+      args.log.error(
+        {
+          err,
+          status: err.status,
+          code: err.code,
+          owner: args.owner,
+          repo: args.repo,
+          issueOrPrNumber: args.issueOrPrNumber,
+        },
+        "[war-room] API rejected mention_response create — skipping (config / programmer error; see code).",
+      );
+      return { roomId: null, skipped: "api_error" };
+    }
+    args.log.warn(
+      {
+        err,
+        owner: args.owner,
+        repo: args.repo,
+        issueOrPrNumber: args.issueOrPrNumber,
+      },
+      "[war-room] mention_response create transient error — skipping (no auto-retry; see file docstring)",
+    );
+    return { roomId: null, skipped: "api_error" };
+  }
+}


### PR DESCRIPTION
Fixes #548

## Summary

Closes the deferred E.3 from Phase E. When a user comments on an issue or PR with `@hivemoot` (and the comment isn't a /command), the bot creates a `mention_response` war room. Multiple mentions on the same issue/PR reuse the same room (idempotent via storage's subject-uniqueness gate).

## What's new

```
bot/api/lib/war-room-routing.ts
├── HIVEMOOT_MENTION_REGEX + commentHasHivemootMention(body)
│   — detection helper. Excludes @hivemoot-builder, @hivemoot_test,
│     @hivemoot42 via negative lookahead. Skips comments starting
│     with / (command path).
├── deriveMentionRoomId({owner, repo, issueOrPrNumber})
│   — namespaced UUIDv4 deterministic derivation with `mention:`
│     prefix so a PR can have BOTH a pr_review room AND a
│     mention_response room simultaneously (different ids).
├── derivedUuidV4(input) — internal helper extracted from
│   derivePrRoomId; deriveMentionRoomId reuses it.
└── maybeCreateMentionRoom(args)
    — auth-gated, idempotent, non-fatal-on-error. Same policy as
      maybeCreatePrReviewRoom.

bot/api/github/webhooks/index.ts
└── In issue_comment.created, after parseCommand returns null:
    fire-and-forget maybeCreateMentionRoom; existing intake/governance
    flow continues alongside.
```

## What it looks like

Before E.3:

```
User: @hivemoot can you take a look?
Bot:  *silence — only /commands handled*
```

After E.3:

```
User: @hivemoot can you take a look?
Bot:  *creates mention_response room, workers RSVP via /watching,
      queen synthesizes once contributions land (reuses Phase F + G' wiring)*
```

## Detection table

| Comment | Match? | Reason |
|---|---|---|
| `@hivemoot please review` | ✅ | space after |
| `@hivemoot,` | ✅ | comma is non-word/dash |
| `@HiveMoot mixed case` | ✅ | case-insensitive |
| `text @hivemoot more text` | ✅ | mid-comment |
| `@hivemoot-builder` | ❌ | dash continuation = different identity |
| `@hivemoot_test` | ❌ | underscore = different identity |
| `@hivemoot42` | ❌ | alphanumeric continuation |
| `/gather @hivemoot` | ❌ | /-prefix → command path |

## Test plan

- [x] 30 new tests covering detection, derivation, room creation
- [x] Full bot suite: 1950 tests pass (was 1920, +30)
- [x] Typecheck clean, lint clean
- [ ] Reviewer fleet sign-off

## NOT in scope

- Updating workers to dispatch `mention_response`-specific triage Jobs (handler currently only knows about `pr_review`). The /watching trigger contract surfaces ALL eligible rooms regardless of subject_type, and the existing triage prompt is generic enough to handle mentions today. F.6 may add subject-type-aware prompt variants.