### PR TITLE
Phase I.1 — dashboard API for war rooms (session-scoped)

### DIFF
--- a/web/src/app/api/dashboard/rooms/[roomId]/route.test.ts
+++ b/web/src/app/api/dashboard/rooms/[roomId]/route.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", async () => {
+  const real = await vi.importActual<typeof import("@/server/war-room")>(
+    "@/server/war-room",
+  );
+  return {
+    ...real,
+    getRoomCore: vi.fn(),
+    getRoomParticipants: vi.fn(),
+    getRoomContributions: vi.fn(),
+    listRoomEvents: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import {
+  getRoomCore,
+  getRoomContributions,
+  getRoomParticipants,
+  listRoomEvents,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+import { GET } from "./route";
+
+const ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde";
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedGetCore = vi.mocked(getRoomCore);
+const mockedGetParticipants = vi.mocked(getRoomParticipants);
+const mockedGetContributions = vi.mocked(getRoomContributions);
+const mockedListEvents = vi.mocked(listRoomEvents);
+
+function makeRequest(url = `https://www.hivemoot.dev/api/dashboard/rooms/${ROOM_ID}`): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+function makeAuth(installationId: string | null) {
+  return {
+    ok: true as const,
+    session: {
+      installationId,
+      userId: 101,
+      userLogin: "queen",
+    },
+    redis: {} as never,
+    keyring: new Map(),
+    activeKeyVersion: "v1",
+  };
+}
+
+const FAKE_CORE = {
+  manager: "bot-queen",
+  subject_type: "pr_review" as const,
+  subject_ref: "owner/repo#42",
+  status: "deciding" as const,
+  opened_at: "2026-04-28T20:00:00Z",
+  timing_config: {
+    max_age_secs: 3600,
+    rsvp_deadline_secs: 600,
+    contribution_deadline_secs: 1200,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/dashboard/rooms/:roomId", () => {
+  it("returns 401 when session auth fails", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 401 }),
+    });
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    expect(res.status).toBe(401);
+    expect(mockedGetCore).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when session has no installationId (same shape as cross-install)", async () => {
+    // Important: we don't return a different shape for unscoped vs
+    // not-found, otherwise an unauthenticated probe could
+    // distinguish the two and discover roomIds.
+    mockedAuth.mockResolvedValue(makeAuth(null));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    expect((await res.json()).code).toBe("room_not_found");
+    expect(mockedGetCore).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 with code room_not_found when storage RoomNotFoundError", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockRejectedValue(new RoomNotFoundError("12345", ROOM_ID));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    expect(res.status).toBe(404);
+    expect((await res.json()).code).toBe("room_not_found");
+  });
+
+  it("returns 404 on RoomIdFormatError (malformed roomId)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockRejectedValue(new RoomIdFormatError("malformed"));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: "malformed" }),
+    });
+    expect(res.status).toBe(404);
+    expect((await res.json()).code).toBe("room_not_found");
+  });
+
+  it("happy path returns composite { roomId, core, participants, contributions, events, eventLimit }", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockResolvedValue(FAKE_CORE);
+    mockedGetParticipants.mockResolvedValue({
+      drone: {
+        agent_id: "drone-1",
+        role: "drone",
+        status: "resolved",
+        rsvp_at: "2026-04-28T20:01:00Z",
+      },
+    });
+    mockedGetContributions.mockResolvedValue({
+      drone: {
+        body: { verdict: "APPROVE", summary: "lgtm" },
+        raw_md: "LGTM",
+        contributed_at: "2026-04-28T20:05:00Z",
+      },
+    });
+    mockedListEvents.mockResolvedValue([
+      {
+        seq: 1,
+        timestamp: "2026-04-28T20:00:00Z",
+        event_type: "room_opened",
+        actor_role: "manager",
+        actor_id: "bot-queen",
+        body: {},
+      },
+    ]);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      roomId: ROOM_ID,
+      core: FAKE_CORE,
+      participants: expect.any(Object),
+      contributions: expect.any(Object),
+      events: expect.any(Array),
+      eventLimit: 100, // default
+    });
+    expect(body.participants.drone.role).toBe("drone");
+    expect(body.events).toHaveLength(1);
+  });
+
+  it("scopes core read to session installationId (cross-install isolation)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("99999"));
+    mockedGetCore.mockResolvedValue(FAKE_CORE);
+    mockedGetParticipants.mockResolvedValue({});
+    mockedGetContributions.mockResolvedValue({});
+    mockedListEvents.mockResolvedValue([]);
+    await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    expect(mockedGetCore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "99999",
+        roomId: ROOM_ID,
+      }),
+    );
+  });
+
+  it("respects ?eventLimit query param within bounds", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockResolvedValue(FAKE_CORE);
+    mockedGetParticipants.mockResolvedValue({});
+    mockedGetContributions.mockResolvedValue({});
+    mockedListEvents.mockResolvedValue([]);
+    await GET(
+      makeRequest(
+        `https://www.hivemoot.dev/api/dashboard/rooms/${ROOM_ID}?eventLimit=25`,
+      ),
+      { params: Promise.resolve({ roomId: ROOM_ID }) },
+    );
+    expect(mockedListEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25 }),
+    );
+  });
+
+  it("clamps ?eventLimit above MAX to 500", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockResolvedValue(FAKE_CORE);
+    mockedGetParticipants.mockResolvedValue({});
+    mockedGetContributions.mockResolvedValue({});
+    mockedListEvents.mockResolvedValue([]);
+    await GET(
+      makeRequest(
+        `https://www.hivemoot.dev/api/dashboard/rooms/${ROOM_ID}?eventLimit=9999`,
+      ),
+      { params: Promise.resolve({ roomId: ROOM_ID }) },
+    );
+    expect(mockedListEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 500 }),
+    );
+  });
+
+  it("returns 500 on unexpected storage error (not RoomNotFound)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockRejectedValue(new Error("Redis down"));
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe("load_room_failed");
+  });
+});

--- a/web/src/app/api/dashboard/rooms/[roomId]/route.test.ts
+++ b/web/src/app/api/dashboard/rooms/[roomId]/route.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/server/war-room", async () => {
     getRoomCore: vi.fn(),
     getRoomParticipants: vi.fn(),
     getRoomContributions: vi.fn(),
-    listRoomEvents: vi.fn(),
+    listRecentRoomEvents: vi.fn(),
   };
 });
 
@@ -23,7 +23,7 @@ import {
   getRoomCore,
   getRoomContributions,
   getRoomParticipants,
-  listRoomEvents,
+  listRecentRoomEvents,
   RoomNotFoundError,
   RoomIdFormatError,
 } from "@/server/war-room";
@@ -34,7 +34,7 @@ const mockedAuth = vi.mocked(authenticateByokRequest);
 const mockedGetCore = vi.mocked(getRoomCore);
 const mockedGetParticipants = vi.mocked(getRoomParticipants);
 const mockedGetContributions = vi.mocked(getRoomContributions);
-const mockedListEvents = vi.mocked(listRoomEvents);
+const mockedListEvents = vi.mocked(listRecentRoomEvents);
 
 function makeRequest(url = `https://www.hivemoot.dev/api/dashboard/rooms/${ROOM_ID}`): NextRequest {
   return new NextRequest(url, { method: "GET" });
@@ -211,6 +211,46 @@ describe("GET /api/dashboard/rooms/:roomId", () => {
     expect(mockedListEvents).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 500 }),
     );
+  });
+
+  it("calls listRecentRoomEvents (tail) NOT listRoomEvents (since=0) — closes #551 builder R1 #2", async () => {
+    // Pin the contract: events response is the TAIL of the log
+    // (most-recent up to limit, chronological), not the head. This
+    // matters for rooms with > eventLimit events where the dashboard
+    // detail page needs to show recent close/recovery/subject_updated
+    // activity, not just the room_opened event from N days ago.
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedGetCore.mockResolvedValue(FAKE_CORE);
+    mockedGetParticipants.mockResolvedValue({});
+    mockedGetContributions.mockResolvedValue({});
+    // Storage returns recent events in chronological order.
+    mockedListEvents.mockResolvedValue([
+      {
+        seq: 999,
+        timestamp: "2026-04-28T20:30:00Z",
+        event_type: "room_decided",
+        actor_role: "manager",
+        actor_id: "queen",
+        body: {},
+      },
+    ]);
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ roomId: ROOM_ID }),
+    });
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].seq).toBe(999); // recent event surfaced
+    // Verify the tail-reading function was called, NOT the
+    // head-reading listRoomEvents.
+    expect(mockedListEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: ROOM_ID,
+        limit: 100,
+      }),
+    );
+    // Make sure no `since` arg was passed (would imply head-read).
+    const args = mockedListEvents.mock.calls[0][0];
+    expect("since" in args).toBe(false);
   });
 
   it("returns 500 on unexpected storage error (not RoomNotFound)", async () => {

--- a/web/src/app/api/dashboard/rooms/[roomId]/route.ts
+++ b/web/src/app/api/dashboard/rooms/[roomId]/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/dashboard/rooms/:roomId — composite room detail for the
+ * dashboard (Phase I). Returns core + participants + contributions
+ * + recent events in a single response so the detail page can
+ * render without a fan-out of round-trips.
+ *
+ * Distinct from `/api/rooms/:roomId` (capability-bearer agent route)
+ * which returns only the bare core. The composite shape is dashboard-
+ * specific.
+ *
+ * Auth: BYOK browser session. Cross-installation isolation: the
+ * room is read from the session's installation only — a roomId
+ * belonging to another installation returns 404.
+ *
+ * Response shape:
+ * ```
+ * {
+ *   roomId: string,
+ *   core: RoomCore,
+ *   participants: Record<role, RoomParticipant>,
+ *   contributions: Record<role, RoomContribution>,
+ *   events: RoomEvent[],            // most recent up to limit
+ *   eventLimit: number,             // requested limit
+ * }
+ * ```
+ *
+ * Errors:
+ *   - 401 — missing / invalid session
+ *   - 404 — room not found OR cross-installation OR malformed roomId
+ *           (same response shape — no oracle for unauthorized
+ *           discovery)
+ *   - 500 — Redis / storage failure
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import {
+  getRoomCore,
+  getRoomContributions,
+  getRoomParticipants,
+  listRoomEvents,
+  RoomNotFoundError,
+  RoomIdFormatError,
+} from "@/server/war-room";
+
+const DEFAULT_EVENT_LIMIT = 100;
+const MAX_EVENT_LIMIT = 500;
+
+function parseEventLimit(value: string | null): number {
+  if (!value) return DEFAULT_EVENT_LIMIT;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    return DEFAULT_EVENT_LIMIT;
+  }
+  if (parsed < 1) return 1;
+  if (parsed > MAX_EVENT_LIMIT) return MAX_EVENT_LIMIT;
+  return parsed;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const installationId = auth.session.installationId;
+  if (installationId === null) {
+    // Same response as cross-installation read — no oracle for
+    // "unscoped session vs nonexistent room".
+    return NextResponse.json(
+      { code: "room_not_found", message: "Room not found." },
+      { status: 404 },
+    );
+  }
+
+  const { roomId } = await params;
+  const installationIdStr = String(installationId);
+  const eventLimit = parseEventLimit(
+    new URL(request.url).searchParams.get("eventLimit"),
+  );
+
+  try {
+    // Fetch core first — if it's not in this installation, 404
+    // before paying for the parallel sub-reads.
+    const core = await getRoomCore({
+      installationId: installationIdStr,
+      roomId,
+      redis: auth.redis,
+    });
+    // Parallel fan-out for the auxiliary reads — they're
+    // independent of each other.
+    const [participants, contributions, events] = await Promise.all([
+      getRoomParticipants({ roomId, redis: auth.redis }),
+      getRoomContributions({ roomId, redis: auth.redis }),
+      listRoomEvents({ roomId, since: 0, limit: eventLimit, redis: auth.redis }),
+    ]);
+    return NextResponse.json({
+      roomId,
+      core,
+      participants,
+      contributions,
+      events,
+      eventLimit,
+    });
+  } catch (err) {
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: "Room not found." },
+        { status: 404 },
+      );
+    }
+    console.error("[dashboard.rooms] Failed to load room detail", {
+      installationId,
+      roomId,
+      err,
+    });
+    return NextResponse.json(
+      { code: "load_room_failed", message: "Failed to load room." },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/dashboard/rooms/[roomId]/route.ts
+++ b/web/src/app/api/dashboard/rooms/[roomId]/route.ts
@@ -19,9 +19,15 @@
  *   core: RoomCore,
  *   participants: Record<role, RoomParticipant>,
  *   contributions: Record<role, RoomContribution>,
- *   events: RoomEvent[],            // most recent up to limit
+ *   events: RoomEvent[],            // most recent up to limit, chronological
  *   eventLimit: number,             // requested limit
  * }
+ *
+ * `events` is the tail of the room's event log — for a room with N
+ * events, the response includes the last `min(N, eventLimit)`
+ * entries in chronological order. Most-recent activity (close,
+ * recovery, subject_updated) is always visible, regardless of how
+ * deep the log is.
  * ```
  *
  * Errors:
@@ -38,7 +44,7 @@ import {
   getRoomCore,
   getRoomContributions,
   getRoomParticipants,
-  listRoomEvents,
+  listRecentRoomEvents,
   RoomNotFoundError,
   RoomIdFormatError,
 } from "@/server/war-room";
@@ -93,7 +99,12 @@ export async function GET(
     const [participants, contributions, events] = await Promise.all([
       getRoomParticipants({ roomId, redis: auth.redis }),
       getRoomContributions({ roomId, redis: auth.redis }),
-      listRoomEvents({ roomId, since: 0, limit: eventLimit, redis: auth.redis }),
+      // Tail read — newest `eventLimit` events (chronological in
+      // returned slice). Closes #551 builder R1 #2: prior code used
+      // listRoomEvents with since=0 which returns the OLDEST events,
+      // hiding the most recent close/recovery/subject_updated activity
+      // from the dashboard detail view.
+      listRecentRoomEvents({ roomId, limit: eventLimit, redis: auth.redis }),
     ]);
     return NextResponse.json({
       roomId,

--- a/web/src/app/api/dashboard/rooms/route.test.ts
+++ b/web/src/app/api/dashboard/rooms/route.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/war-room", () => ({
+  listRooms: vi.fn(),
+}));
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { listRooms } from "@/server/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedList = vi.mocked(listRooms);
+
+function makeRequest(url = "https://www.hivemoot.dev/api/dashboard/rooms"): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+function makeAuth(installationId: string | null) {
+  return {
+    ok: true as const,
+    session: {
+      installationId,
+      userId: 101,
+      userLogin: "queen",
+    },
+    redis: {} as never,
+    keyring: new Map(),
+    activeKeyVersion: "v1",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/dashboard/rooms", () => {
+  it("returns 401 when session auth fails", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 401 }),
+    });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it("returns empty list when session has no installationId", async () => {
+    mockedAuth.mockResolvedValue(makeAuth(null));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ rooms: [] });
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it("returns rooms scoped to session installationId", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedList.mockResolvedValue([
+      {
+        roomId: "01234567-89ab-4cde-9012-3456789abcde",
+        manager: "bot-queen",
+        subject_type: "pr_review",
+        subject_ref: "owner/repo#42",
+        status: "awaiting_contributions",
+        opened_at: "2026-04-28T20:00:00Z",
+        timing_config: {
+          max_age_secs: 3600,
+          rsvp_deadline_secs: 600,
+          contribution_deadline_secs: 1200,
+        },
+      },
+    ]);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rooms).toHaveLength(1);
+    expect(body.rooms[0].roomId).toBe("01234567-89ab-4cde-9012-3456789abcde");
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "12345",
+        limit: 50, // default
+      }),
+    );
+  });
+
+  it("respects ?limit query param within bounds", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedList.mockResolvedValue([]);
+    await GET(
+      makeRequest("https://www.hivemoot.dev/api/dashboard/rooms?limit=25"),
+    );
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25 }),
+    );
+  });
+
+  it("clamps ?limit above MAX_LIMIT to 200", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedList.mockResolvedValue([]);
+    await GET(
+      makeRequest("https://www.hivemoot.dev/api/dashboard/rooms?limit=9999"),
+    );
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 200 }),
+    );
+  });
+
+  it("clamps ?limit below 1 to 1", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedList.mockResolvedValue([]);
+    await GET(
+      makeRequest("https://www.hivemoot.dev/api/dashboard/rooms?limit=0"),
+    );
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 1 }),
+    );
+  });
+
+  it("ignores non-numeric ?limit and uses default", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedList.mockResolvedValue([]);
+    await GET(
+      makeRequest("https://www.hivemoot.dev/api/dashboard/rooms?limit=abc"),
+    );
+    expect(mockedList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+
+  it("returns 500 when storage throws", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("12345"));
+    mockedList.mockRejectedValue(new Error("Redis down"));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe("list_rooms_failed");
+  });
+});

--- a/web/src/app/api/dashboard/rooms/route.ts
+++ b/web/src/app/api/dashboard/rooms/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET /api/dashboard/rooms — list war rooms for the operator's
+ * installation (Phase I dashboard).
+ *
+ * Distinct from `/api/rooms` which uses the V1 capability bearer
+ * (agent-facing). This route uses BYOK session auth (browser
+ * dashboard) and scopes by `session.installationId`.
+ *
+ * Response: `{ rooms: RoomCoreWithId[] }`. Empty list when:
+ *   - Session has no installationId (unscoped browser session)
+ *   - The installation has no rooms yet
+ *
+ * Errors:
+ *   - 401 — missing / invalid session
+ *   - 500 — Redis / storage failure
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { listRooms } from "@/server/war-room";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parseLimit(value: string | null): number {
+  if (!value) return DEFAULT_LIMIT;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) return DEFAULT_LIMIT;
+  if (parsed < 1) return 1;
+  if (parsed > MAX_LIMIT) return MAX_LIMIT;
+  return parsed;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const installationId = auth.session.installationId;
+  // Null-installation sessions (browser without a linked GitHub
+  // installation) never own rooms — return empty so the dashboard
+  // renders its empty state instead of an error.
+  if (installationId === null) {
+    return NextResponse.json({ rooms: [] });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const limit = parseLimit(searchParams.get("limit"));
+
+  try {
+    const rooms = await listRooms({
+      installationId: String(installationId),
+      redis: auth.redis,
+      limit,
+    });
+    return NextResponse.json({ rooms });
+  } catch (error) {
+    console.error("[dashboard.rooms] Failed to list rooms", {
+      installationId,
+      error,
+    });
+    return NextResponse.json(
+      { code: "list_rooms_failed", message: "Failed to load rooms." },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/server/war-room.ts
+++ b/web/src/server/war-room.ts
@@ -3594,6 +3594,41 @@ export async function listRoomEvents(args: {
   return raw.map((s) => JSON.parse(s) as RoomEvent);
 }
 
+/**
+ * Read the N most-recent events for a room, returned in chronological
+ * order (oldest-first within the returned slice).
+ *
+ * For dashboards / detail views that want to surface recent activity
+ * (close, recovery, subject_updated, latest contributions). Distinct
+ * from `listRoomEvents` which reads forward from `since` and would
+ * return the OLDEST events for a room with more than `limit` events.
+ *
+ * Uses ZRANGE BYSCORE with `rev: true` to fetch the highest-scored
+ * `limit` entries (newest seq), then reverses client-side to deliver
+ * chronological order so callers can render top-down naturally.
+ */
+export async function listRecentRoomEvents(args: {
+  roomId: string;
+  limit?: number;
+  redis: Redis;
+}): Promise<RoomEvent[]> {
+  const limit = args.limit ?? 200;
+  const raw = await args.redis.zrange<string[]>(
+    eventsKey(args.roomId),
+    "+inf",
+    0,
+    {
+      byScore: true,
+      rev: true,
+      offset: 0,
+      count: limit,
+    },
+  );
+  // ZREVRANGE returns newest-first; reverse for chronological
+  // delivery so callers don't need to know about the rev: detail.
+  return raw.map((s) => JSON.parse(s) as RoomEvent).reverse();
+}
+
 /** Read all participants for a room, keyed by role. Returns `{}`
  * for rooms with no participants yet (or rooms that don't exist —
  * caller should `getRoomCore` separately if existence is meaningful). */


### PR DESCRIPTION
Fixes #550

## Summary

First slice of Phase I (war-rooms dashboard). Adds session-authed API endpoints the upcoming UI pages will fetch. Distinct from `/api/rooms/*` (V1 capability bearer, agent-facing) — these are scoped by browser `session.installationId` for operator views.

## Routes

- **`GET /api/dashboard/rooms`** — list rooms for the session's installation. Optional `?limit` (default 50, max 200, clamped 1-200). Empty list when session has no installationId. 500 on storage error.

- **`GET /api/dashboard/rooms/:roomId`** — composite room detail in one response so the detail page renders without a fan-out of round-trips:
```json
{
  "roomId": "01234567-89ab-4cde-9012-3456789abcde",
  "core": { "manager": "bot-queen", "subject_type": "pr_review", ... },
  "participants": { "drone": { "agent_id": "drone-1", "status": "resolved", ... } },
  "contributions": { "drone": { "body": {...}, "raw_md": "LGTM", ... } },
  "events": [ { "seq": 1, "event_type": "room_opened", ... } ],
  "eventLimit": 100
}
```
Cross-installation isolation: roomId belonging to another installation returns 404 (same response shape as not-found, no oracle for unauthorized discovery). Optional `?eventLimit` (default 100, max 500).

## Test plan

- [x] 17 new tests covering 401 / no-installation / installation-scoping / limit clamping / 404 on RoomNotFound + RoomIdFormatError / 500 on unexpected / composite happy path
- [x] Web suite: 1360 (was 1343, +17)
- [x] Typecheck + lint clean
- [ ] Reviewer fleet sign-off

## NOT in scope

- **I.2** — UI pages (list view at `/dashboard/rooms`, detail view at `/dashboard/rooms/[roomId]`)
- **I.3** — DashboardNav tab + auto-refresh + status filtering