### PR TITLE
Phase I.2 — war-rooms dashboard UI pages + nav tab

### DIFF
--- a/web/src/app/dashboard/DashboardNav.tsx
+++ b/web/src/app/dashboard/DashboardNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const TABS = [
   { href: "/dashboard", label: "Agent Health" },
   { href: "/dashboard/tasks", label: "Tasks" },
+  { href: "/dashboard/rooms", label: "War Rooms" },
   { href: "/dashboard/credentials", label: "Credentials" },
 ] as const;
 

--- a/web/src/app/dashboard/rooms/RoomsList.tsx
+++ b/web/src/app/dashboard/rooms/RoomsList.tsx
@@ -3,7 +3,9 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import {
+  isRoomStuck,
   relativeTime,
+  sortRoomsByStuckness,
   statusLabel,
   statusPillClass,
   subjectLabel,
@@ -97,8 +99,12 @@ export default function RoomsList() {
       )}
 
       {state.status === "ready" && state.rooms.length > 0 && (
+        // Sort by stuck-ness DESC (most-stuck active rooms at top)
+        // then terminal rooms by opened_at DESC. Per
+        // WAR_ROOM_DESIGN.md L1247 — operators see rooms that
+        // need attention without filtering. Closes #553 builder R1.
         <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/5 bg-zinc-900/50">
-          {state.rooms.map((room) => (
+          {sortRoomsByStuckness(state.rooms).map((room) => (
             <RoomRow key={room.roomId} room={room} />
           ))}
         </ul>
@@ -108,8 +114,15 @@ export default function RoomsList() {
 }
 
 function RoomRow({ room }: { room: RoomCoreWithId }) {
+  // Red highlight when past 80% of the relevant deadline
+  // (rsvp_deadline_secs for awaiting_rsvp, contribution_deadline_secs
+  // for awaiting_contributions/deciding). Per WAR_ROOM_DESIGN.md L1248.
+  const stuck = isRoomStuck(room.opened_at, room.status, room.timing_config);
+  const stuckHighlight = stuck
+    ? "border-l-2 border-red-500/60 bg-red-500/5"
+    : "";
   return (
-    <li>
+    <li className={stuckHighlight}>
       <Link
         href={`/dashboard/rooms/${room.roomId}`}
         className="block px-4 py-3 transition-colors hover:bg-white/5"
@@ -121,6 +134,11 @@ function RoomRow({ room }: { room: RoomCoreWithId }) {
             >
               {statusLabel(room.status)}
             </span>
+            {stuck && (
+              <span className="rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-medium text-red-300 ring-1 ring-red-500/30">
+                near deadline
+              </span>
+            )}
             <span className="text-xs uppercase tracking-wide text-zinc-500">
               {subjectLabel(room.subject_type)}
             </span>

--- a/web/src/app/dashboard/rooms/RoomsList.tsx
+++ b/web/src/app/dashboard/rooms/RoomsList.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  relativeTime,
+  statusLabel,
+  statusPillClass,
+  subjectLabel,
+} from "./room-helpers";
+import type { RoomCoreWithId } from "./types";
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "ready"; rooms: RoomCoreWithId[] }
+  | { status: "error"; message: string };
+
+export default function RoomsList() {
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  const fetchRooms = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dashboard/rooms?limit=50", {
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        setState({
+          status: "error",
+          message: `Failed to load rooms (HTTP ${res.status}): ${text.slice(0, 200)}`,
+        });
+        return;
+      }
+      const body = (await res.json()) as { rooms?: RoomCoreWithId[] };
+      setState({ status: "ready", rooms: body.rooms ?? [] });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial fetch + 30s polling. The async fetch triggers a
+    // cascading setState (loading → ready) which the React 19
+    // strict rule flags; for polling-fetch UX this cascade is
+    // intentional (the initial loading state is useful for users
+    // waiting on the first response). Mirrors TasksDashboard's
+    // existing polling pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchRooms();
+    const interval = setInterval(() => {
+      void fetchRooms();
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchRooms]);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-zinc-100">
+          War Rooms
+        </h1>
+        <p className="mt-1 text-sm text-zinc-500">
+          Active and recently-closed governance synthesis rooms for this
+          installation. Refreshes every 30 seconds.
+        </p>
+      </header>
+
+      {state.status === "loading" && (
+        <p className="text-sm text-zinc-500">Loading rooms…</p>
+      )}
+
+      {state.status === "error" && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
+          <p className="text-sm text-red-300">{state.message}</p>
+          <button
+            type="button"
+            onClick={fetchRooms}
+            className="mt-2 text-xs text-red-300 underline hover:text-red-200"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {state.status === "ready" && state.rooms.length === 0 && (
+        <div className="rounded-lg border border-white/5 bg-zinc-900/50 p-6 text-center">
+          <p className="text-sm text-zinc-400">
+            No war rooms yet. Rooms appear when the bot creates one for a
+            PR review or @hivemoot mention.
+          </p>
+        </div>
+      )}
+
+      {state.status === "ready" && state.rooms.length > 0 && (
+        <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/5 bg-zinc-900/50">
+          {state.rooms.map((room) => (
+            <RoomRow key={room.roomId} room={room} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function RoomRow({ room }: { room: RoomCoreWithId }) {
+  return (
+    <li>
+      <Link
+        href={`/dashboard/rooms/${room.roomId}`}
+        className="block px-4 py-3 transition-colors hover:bg-white/5"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <span
+              className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusPillClass(room.status)}`}
+            >
+              {statusLabel(room.status)}
+            </span>
+            <span className="text-xs uppercase tracking-wide text-zinc-500">
+              {subjectLabel(room.subject_type)}
+            </span>
+            <span className="font-mono text-sm text-zinc-300">
+              {room.subject_ref}
+            </span>
+          </div>
+          <span className="text-xs text-zinc-500">
+            opened {relativeTime(room.opened_at)}
+            {room.closed_at && ` · closed ${relativeTime(room.closed_at)}`}
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
+++ b/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  participantStatusCounts,
+  relativeTime,
+  statusLabel,
+  statusPillClass,
+  subjectGithubUrl,
+  subjectLabel,
+} from "../room-helpers";
+import type {
+  RoomContribution,
+  RoomDetailResponse,
+  RoomEvent,
+  RoomParticipant,
+} from "../types";
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "ready"; data: RoomDetailResponse }
+  | { status: "not_found" }
+  | { status: "error"; message: string };
+
+export default function RoomDetail({ roomId }: { roomId: string }) {
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  const fetchDetail = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/dashboard/rooms/${encodeURIComponent(roomId)}`,
+        { cache: "no-store" },
+      );
+      if (res.status === 404) {
+        setState({ status: "not_found" });
+        return;
+      }
+      if (!res.ok) {
+        const text = await res.text();
+        setState({
+          status: "error",
+          message: `HTTP ${res.status}: ${text.slice(0, 200)}`,
+        });
+        return;
+      }
+      const body = (await res.json()) as RoomDetailResponse;
+      setState({ status: "ready", data: body });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [roomId]);
+
+  useEffect(() => {
+    // See RoomsList for the rationale on the cascading-render
+    // exemption — same polling-fetch UX pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchDetail();
+    const interval = setInterval(() => {
+      void fetchDetail();
+    }, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchDetail]);
+
+  return (
+    <div className="space-y-6">
+      <nav className="text-xs text-zinc-500">
+        <Link href="/dashboard/rooms" className="hover:text-zinc-300">
+          ← Back to all war rooms
+        </Link>
+      </nav>
+
+      {state.status === "loading" && (
+        <p className="text-sm text-zinc-500">Loading room…</p>
+      )}
+
+      {state.status === "not_found" && (
+        <div className="rounded-lg border border-white/5 bg-zinc-900/50 p-6">
+          <p className="text-sm text-zinc-300">
+            Room <span className="font-mono">{roomId}</span> not found.
+          </p>
+          <p className="mt-1 text-xs text-zinc-500">
+            It may have expired (30-day retention after close), or it
+            belongs to a different installation.
+          </p>
+        </div>
+      )}
+
+      {state.status === "error" && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
+          <p className="text-sm text-red-300">{state.message}</p>
+          <button
+            type="button"
+            onClick={fetchDetail}
+            className="mt-2 text-xs text-red-300 underline hover:text-red-200"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {state.status === "ready" && (
+        <RoomDetailContent roomId={roomId} data={state.data} />
+      )}
+    </div>
+  );
+}
+
+function RoomDetailContent({
+  roomId,
+  data,
+}: {
+  roomId: string;
+  data: RoomDetailResponse;
+}) {
+  const { core, participants, contributions, events } = data;
+  const partCounts = participantStatusCounts(participants);
+  const githubUrl = subjectGithubUrl(core.subject_ref);
+
+  return (
+    <>
+      <header className="space-y-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <span
+            className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusPillClass(core.status)}`}
+          >
+            {statusLabel(core.status)}
+          </span>
+          <span className="text-xs uppercase tracking-wide text-zinc-500">
+            {subjectLabel(core.subject_type)}
+          </span>
+        </div>
+        <h1 className="text-xl font-semibold text-zinc-100">
+          {githubUrl ? (
+            <a
+              href={githubUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="font-mono hover:text-honey-400"
+            >
+              {core.subject_ref} ↗
+            </a>
+          ) : (
+            <span className="font-mono">{core.subject_ref}</span>
+          )}
+        </h1>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-500">
+          <dt>Room ID</dt>
+          <dd className="font-mono text-zinc-400">{roomId}</dd>
+          <dt>Manager</dt>
+          <dd className="font-mono text-zinc-400">{core.manager}</dd>
+          <dt>Opened</dt>
+          <dd className="text-zinc-400">{relativeTime(core.opened_at)}</dd>
+          {core.closed_at && (
+            <>
+              <dt>Closed</dt>
+              <dd className="text-zinc-400">
+                {relativeTime(core.closed_at)}
+                {core.closed_reason && ` · ${core.closed_reason}`}
+              </dd>
+            </>
+          )}
+        </dl>
+      </header>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-zinc-300">
+          Participants ({partCounts.total})
+        </h2>
+        {partCounts.total === 0 ? (
+          <p className="text-sm text-zinc-500">
+            No participants have RSVP&apos;d yet.
+          </p>
+        ) : (
+          <p className="mb-3 text-xs text-zinc-500">
+            {partCounts.resolved} resolved · {partCounts.pending} pending ·{" "}
+            {partCounts.withdrew} withdrew · {partCounts.timed_out} timed out
+          </p>
+        )}
+        {partCounts.total > 0 && <ParticipantsTable participants={participants} />}
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-zinc-300">
+          Contributions ({Object.keys(contributions).length})
+        </h2>
+        {Object.keys(contributions).length === 0 ? (
+          <p className="text-sm text-zinc-500">No contributions submitted.</p>
+        ) : (
+          <ContributionsList contributions={contributions} />
+        )}
+      </section>
+
+      {core.decision && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold text-zinc-300">Decision</h2>
+          <DecisionBlock decision={core.decision} />
+        </section>
+      )}
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-zinc-300">
+          Recent events ({events.length})
+        </h2>
+        {events.length === 0 ? (
+          <p className="text-sm text-zinc-500">No events yet.</p>
+        ) : (
+          <EventsList events={events} />
+        )}
+      </section>
+    </>
+  );
+}
+
+function ParticipantsTable({
+  participants,
+}: {
+  participants: Record<string, RoomParticipant>;
+}) {
+  const rows = Object.entries(participants).sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+  return (
+    <table className="w-full text-left text-sm">
+      <thead className="text-xs uppercase text-zinc-500">
+        <tr>
+          <th className="py-1 pr-4">Role</th>
+          <th className="py-1 pr-4">Agent</th>
+          <th className="py-1 pr-4">Status</th>
+          <th className="py-1">RSVP&apos;d</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-white/5">
+        {rows.map(([role, p]) => (
+          <tr key={role}>
+            <td className="py-1.5 pr-4 font-medium text-zinc-200">{role}</td>
+            <td className="py-1.5 pr-4 font-mono text-xs text-zinc-400">
+              {p.agent_id}
+            </td>
+            <td className="py-1.5 pr-4 text-zinc-300">{p.status}</td>
+            <td className="py-1.5 text-xs text-zinc-500">
+              {relativeTime(p.rsvp_at)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ContributionsList({
+  contributions,
+}: {
+  contributions: Record<string, RoomContribution>;
+}) {
+  return (
+    <ul className="space-y-3">
+      {Object.entries(contributions)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([role, c]) => (
+          <li
+            key={role}
+            className="rounded-lg border border-white/5 bg-zinc-900/50 p-3"
+          >
+            <div className="mb-1 flex items-center gap-2 text-xs">
+              <span className="font-medium text-zinc-200">{role}</span>
+              {c.withdrawn ? (
+                <span className="rounded-full bg-zinc-700/30 px-2 py-0.5 text-zinc-400">
+                  withdrawn
+                </span>
+              ) : (
+                c.body?.verdict !== undefined && (
+                  <span className="rounded-full bg-honey-500/10 px-2 py-0.5 text-honey-400">
+                    {String(c.body.verdict)}
+                  </span>
+                )
+              )}
+              {c.contributed_at && (
+                <span className="text-zinc-500">
+                  · {relativeTime(c.contributed_at)}
+                </span>
+              )}
+            </div>
+            {!c.withdrawn && c.body?.summary !== undefined && (
+              <p className="text-sm text-zinc-300">
+                {String(c.body.summary)}
+              </p>
+            )}
+            {!c.withdrawn && c.raw_md && (
+              <details className="mt-2">
+                <summary className="cursor-pointer text-xs text-zinc-500 hover:text-zinc-400">
+                  Show review body ({c.raw_md.length} chars)
+                </summary>
+                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-2 text-xs text-zinc-300">
+                  {c.raw_md}
+                </pre>
+              </details>
+            )}
+          </li>
+        ))}
+    </ul>
+  );
+}
+
+function DecisionBlock({
+  decision,
+}: {
+  decision: NonNullable<RoomDetailResponse["core"]["decision"]>;
+}) {
+  return (
+    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+      <div className="mb-2 flex items-center gap-3 text-xs text-zinc-500">
+        <span>synthesized {relativeTime(decision.synthesized_at)}</span>
+        <span>·</span>
+        <span className="font-mono">{decision.synthesis_runner}</span>
+        <span>·</span>
+        <span>through seq {decision.sequence_closed}</span>
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-3 text-sm text-zinc-200">
+        {decision.content}
+      </pre>
+    </div>
+  );
+}
+
+function EventsList({ events }: { events: RoomEvent[] }) {
+  return (
+    <ol className="space-y-1 text-xs">
+      {events.map((e) => (
+        <li
+          key={e.seq}
+          className="flex items-baseline gap-3 rounded border border-white/5 bg-zinc-900/30 px-2 py-1"
+        >
+          <span className="font-mono text-zinc-600">#{e.seq}</span>
+          <span className="font-medium text-zinc-300">{e.event_type}</span>
+          <span className="text-zinc-500">
+            by{" "}
+            <span className="font-mono">
+              {e.actor_role}/{e.actor_id}
+            </span>
+          </span>
+          <span className="ml-auto text-zinc-600">
+            {relativeTime(e.timestamp)}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/src/app/dashboard/rooms/[roomId]/page.tsx
+++ b/web/src/app/dashboard/rooms/[roomId]/page.tsx
@@ -1,0 +1,10 @@
+import RoomDetail from "./RoomDetail";
+
+export default async function RoomDetailPage({
+  params,
+}: {
+  params: Promise<{ roomId: string }>;
+}) {
+  const { roomId } = await params;
+  return <RoomDetail roomId={roomId} />;
+}

--- a/web/src/app/dashboard/rooms/page.tsx
+++ b/web/src/app/dashboard/rooms/page.tsx
@@ -1,0 +1,5 @@
+import RoomsList from "./RoomsList";
+
+export default function RoomsPage() {
+  return <RoomsList />;
+}

--- a/web/src/app/dashboard/rooms/room-helpers.test.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
+  ACTIVE_STATUSES,
+  isActiveStatus,
+  isRoomStuck,
   participantStatusCounts,
   relativeTime,
+  relevantDeadlineSecs,
+  sortRoomsByStuckness,
   statusLabel,
   statusPillClass,
+  STUCK_THRESHOLD,
+  stucknessRatio,
   subjectGithubUrl,
   subjectLabel,
 } from "./room-helpers";
-import type { RoomParticipant } from "./types";
+import type { RoomCoreWithId, RoomParticipant } from "./types";
 
 describe("statusLabel", () => {
   it.each([
@@ -125,5 +132,275 @@ describe("relativeTime", () => {
 
   it("clamps negative deltas (future timestamp) to 'just now'", () => {
     expect(relativeTime("2026-04-28T13:00:00Z", NOW)).toBe("just now");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stuckness — closes #553 builder R1 (WAR_ROOM_DESIGN.md L1247-1248)
+// ---------------------------------------------------------------------------
+
+describe("isActiveStatus + ACTIVE_STATUSES", () => {
+  it.each(["awaiting_rsvp", "awaiting_contributions", "deciding"] as const)(
+    "%s is active",
+    (s) => {
+      expect(isActiveStatus(s)).toBe(true);
+      expect(ACTIVE_STATUSES.has(s)).toBe(true);
+    },
+  );
+  it.each(["closed", "expired"] as const)("%s is NOT active", (s) => {
+    expect(isActiveStatus(s)).toBe(false);
+    expect(ACTIVE_STATUSES.has(s)).toBe(false);
+  });
+});
+
+describe("relevantDeadlineSecs", () => {
+  it("awaiting_rsvp uses rsvp_deadline_secs", () => {
+    expect(
+      relevantDeadlineSecs("awaiting_rsvp", {
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      }),
+    ).toBe(600);
+  });
+
+  it("awaiting_contributions uses contribution_deadline_secs", () => {
+    expect(
+      relevantDeadlineSecs("awaiting_contributions", {
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      }),
+    ).toBe(1200);
+  });
+
+  it("deciding uses contribution_deadline_secs", () => {
+    expect(
+      relevantDeadlineSecs("deciding", {
+        rsvp_deadline_secs: 600,
+        contribution_deadline_secs: 1200,
+      }),
+    ).toBe(1200);
+  });
+
+  it("returns null for terminal statuses", () => {
+    expect(
+      relevantDeadlineSecs("closed", { rsvp_deadline_secs: 600 }),
+    ).toBeNull();
+    expect(
+      relevantDeadlineSecs("expired", { rsvp_deadline_secs: 600 }),
+    ).toBeNull();
+  });
+
+  it("returns null when timing_config is undefined", () => {
+    expect(relevantDeadlineSecs("awaiting_rsvp", undefined)).toBeNull();
+  });
+});
+
+describe("stucknessRatio", () => {
+  const NOW = Date.parse("2026-04-28T12:00:00Z");
+
+  it("0 for terminal rooms", () => {
+    expect(
+      stucknessRatio(
+        "2026-04-28T11:00:00Z",
+        "closed",
+        { contribution_deadline_secs: 1200 },
+        NOW,
+      ),
+    ).toBe(0);
+  });
+
+  it("0 when timing_config missing", () => {
+    expect(
+      stucknessRatio("2026-04-28T11:00:00Z", "awaiting_rsvp", undefined, NOW),
+    ).toBe(0);
+  });
+
+  it("0 when relevant deadline is 0 or negative (defensive)", () => {
+    expect(
+      stucknessRatio(
+        "2026-04-28T11:00:00Z",
+        "awaiting_rsvp",
+        { rsvp_deadline_secs: 0 },
+        NOW,
+      ),
+    ).toBe(0);
+  });
+
+  it("computes ratio as (now - opened) / deadline_secs", () => {
+    // 30 minutes elapsed, deadline=3600s (1h) → ratio=0.5
+    expect(
+      stucknessRatio(
+        "2026-04-28T11:30:00Z",
+        "awaiting_contributions",
+        { contribution_deadline_secs: 3600 },
+        NOW,
+      ),
+    ).toBeCloseTo(0.5);
+  });
+
+  it("returns >1 when past deadline", () => {
+    expect(
+      stucknessRatio(
+        "2026-04-28T10:00:00Z",
+        "awaiting_rsvp",
+        { rsvp_deadline_secs: 600 }, // 10m deadline, 2h elapsed
+        NOW,
+      ),
+    ).toBeCloseTo(12);
+  });
+
+  it("0 on unparseable opened_at (defensive)", () => {
+    expect(
+      stucknessRatio(
+        "not-a-date",
+        "awaiting_rsvp",
+        { rsvp_deadline_secs: 600 },
+        NOW,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("isRoomStuck", () => {
+  const NOW = Date.parse("2026-04-28T12:00:00Z");
+
+  it("STUCK_THRESHOLD is 0.8 per WAR_ROOM_DESIGN.md L1248", () => {
+    expect(STUCK_THRESHOLD).toBe(0.8);
+  });
+
+  it("true when ratio >= 0.8", () => {
+    // 8m elapsed of 10m deadline = 0.8
+    expect(
+      isRoomStuck(
+        "2026-04-28T11:52:00Z",
+        "awaiting_rsvp",
+        { rsvp_deadline_secs: 600 },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("false when ratio < 0.8", () => {
+    // 7m elapsed of 10m deadline = 0.7
+    expect(
+      isRoomStuck(
+        "2026-04-28T11:53:00Z",
+        "awaiting_rsvp",
+        { rsvp_deadline_secs: 600 },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("false for terminal rooms regardless of age", () => {
+    expect(
+      isRoomStuck(
+        "2026-01-01T00:00:00Z", // ancient
+        "closed",
+        { contribution_deadline_secs: 600 },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("sortRoomsByStuckness", () => {
+  const NOW = Date.parse("2026-04-28T12:00:00Z");
+
+  function r(
+    id: string,
+    status:
+      | "awaiting_rsvp"
+      | "awaiting_contributions"
+      | "deciding"
+      | "closed"
+      | "expired",
+    opened_at: string,
+    rsvpDeadline = 600,
+    contribDeadline = 1200,
+  ): RoomCoreWithId {
+    return {
+      roomId: id,
+      manager: "x",
+      subject_type: "pr_review",
+      subject_ref: `o/r#${id.length}`,
+      status,
+      opened_at,
+      timing_config: {
+        rsvp_deadline_secs: rsvpDeadline,
+        contribution_deadline_secs: contribDeadline,
+      },
+    };
+  }
+
+  it("active rooms before terminal rooms", () => {
+    const sorted = sortRoomsByStuckness(
+      [
+        r("a", "closed", "2026-04-28T11:59:00Z"),
+        r("b", "awaiting_rsvp", "2026-04-28T11:55:00Z"),
+        r("c", "expired", "2026-04-28T11:50:00Z"),
+        r("d", "deciding", "2026-04-28T11:30:00Z"),
+      ],
+      NOW,
+    );
+    // First two should be the active rooms.
+    expect(sorted.slice(0, 2).map((r) => r.roomId).sort()).toEqual(["b", "d"]);
+    // Last two terminal.
+    expect(sorted.slice(2).map((r) => r.roomId).sort()).toEqual(["a", "c"]);
+  });
+
+  it("active rooms sorted by stuckness DESC (most-stuck first)", () => {
+    const sorted = sortRoomsByStuckness(
+      [
+        r("low", "awaiting_rsvp", "2026-04-28T11:58:00Z"), // 2m / 10m = 0.2
+        r("high", "awaiting_rsvp", "2026-04-28T11:51:00Z"), // 9m / 10m = 0.9
+        r("mid", "awaiting_rsvp", "2026-04-28T11:54:00Z"), // 6m / 10m = 0.6
+      ],
+      NOW,
+    );
+    expect(sorted.map((r) => r.roomId)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("terminal rooms sorted by opened_at DESC (most-recent first)", () => {
+    const sorted = sortRoomsByStuckness(
+      [
+        r("old", "closed", "2026-04-28T10:00:00Z"),
+        r("new", "closed", "2026-04-28T11:30:00Z"),
+        r("mid", "expired", "2026-04-28T11:00:00Z"),
+      ],
+      NOW,
+    );
+    expect(sorted.map((r) => r.roomId)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("ties between active rooms with no deadline configured fall back to opened_at ASC", () => {
+    const noTimingA: RoomCoreWithId = {
+      roomId: "a",
+      manager: "x",
+      subject_type: "pr_review",
+      subject_ref: "o/r#1",
+      status: "awaiting_rsvp",
+      opened_at: "2026-04-28T11:00:00Z",
+      // no timing_config
+    };
+    const noTimingB: RoomCoreWithId = {
+      ...noTimingA,
+      roomId: "b",
+      opened_at: "2026-04-28T11:30:00Z",
+    };
+    const sorted = sortRoomsByStuckness([noTimingB, noTimingA], NOW);
+    // Without deadline both have stuckness 0; sorted by opened_at ASC
+    // (oldest first) so 'a' comes before 'b'.
+    expect(sorted.map((r) => r.roomId)).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const original = [
+      r("a", "closed", "2026-04-28T11:59:00Z"),
+      r("b", "awaiting_rsvp", "2026-04-28T11:55:00Z"),
+    ];
+    const beforeIds = original.map((r) => r.roomId);
+    sortRoomsByStuckness(original, NOW);
+    expect(original.map((r) => r.roomId)).toEqual(beforeIds);
   });
 });

--- a/web/src/app/dashboard/rooms/room-helpers.test.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  participantStatusCounts,
+  relativeTime,
+  statusLabel,
+  statusPillClass,
+  subjectGithubUrl,
+  subjectLabel,
+} from "./room-helpers";
+import type { RoomParticipant } from "./types";
+
+describe("statusLabel", () => {
+  it.each([
+    ["awaiting_rsvp", "Awaiting RSVPs"],
+    ["awaiting_contributions", "Awaiting contributions"],
+    ["deciding", "Synthesizing"],
+    ["closed", "Closed"],
+    ["expired", "Expired"],
+  ] as const)("%s → %s", (status, expected) => {
+    expect(statusLabel(status)).toBe(expected);
+  });
+});
+
+describe("statusPillClass", () => {
+  it("returns class strings for every known status", () => {
+    for (const s of [
+      "awaiting_rsvp",
+      "awaiting_contributions",
+      "deciding",
+      "closed",
+      "expired",
+    ] as const) {
+      expect(statusPillClass(s).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("subjectLabel", () => {
+  it.each([
+    ["pr_review", "PR review"],
+    ["mention_response", "Mention"],
+    ["issue_triage", "Issue triage"],
+  ] as const)("%s → %s", (type, expected) => {
+    expect(subjectLabel(type)).toBe(expected);
+  });
+});
+
+describe("subjectGithubUrl", () => {
+  it("builds a URL from owner/repo#N", () => {
+    expect(subjectGithubUrl("hivemoot/hivemoot#42")).toBe(
+      "https://github.com/hivemoot/hivemoot/issues/42",
+    );
+  });
+
+  it("supports owner/repo with hyphens + dots + underscores", () => {
+    expect(subjectGithubUrl("my-org/my.repo_test#1")).toBe(
+      "https://github.com/my-org/my.repo_test/issues/1",
+    );
+  });
+
+  it("returns null for malformed refs", () => {
+    expect(subjectGithubUrl("not-a-ref")).toBeNull();
+    expect(subjectGithubUrl("owner/repo")).toBeNull();
+    expect(subjectGithubUrl("owner/repo#")).toBeNull();
+    expect(subjectGithubUrl("owner/repo#0")).toBeNull(); // no leading zero / zero
+  });
+});
+
+describe("participantStatusCounts", () => {
+  function p(status: RoomParticipant["status"]): RoomParticipant {
+    return {
+      agent_id: "x",
+      role: "x",
+      status,
+      rsvp_at: "2026-04-28T20:00:00Z",
+    };
+  }
+
+  it("returns all-zeros for empty hash", () => {
+    expect(participantStatusCounts({})).toEqual({
+      pending: 0,
+      resolved: 0,
+      withdrew: 0,
+      timed_out: 0,
+      total: 0,
+    });
+  });
+
+  it("counts by status", () => {
+    expect(
+      participantStatusCounts({
+        guard: p("resolved"),
+        builder: p("pending"),
+        drone: p("withdrew"),
+        scout: p("timed_out"),
+        nurse: p("resolved"),
+      }),
+    ).toEqual({
+      pending: 1,
+      resolved: 2,
+      withdrew: 1,
+      timed_out: 1,
+      total: 5,
+    });
+  });
+});
+
+describe("relativeTime", () => {
+  const NOW = Date.parse("2026-04-28T12:00:00Z");
+
+  it.each([
+    ["just now (< 5s)", "2026-04-28T11:59:58Z", "just now"],
+    ["seconds (5-59)", "2026-04-28T11:59:30Z", "30s ago"],
+    ["minutes (1-59)", "2026-04-28T11:30:00Z", "30m ago"],
+    ["hours (1-23)", "2026-04-28T08:00:00Z", "4h ago"],
+    ["days (1-6)", "2026-04-26T12:00:00Z", "2d ago"],
+    ["7+ days → absolute date", "2026-04-15T12:00:00Z", "2026-04-15"],
+  ])("%s", (_label, iso, expected) => {
+    expect(relativeTime(iso, NOW)).toBe(expected);
+  });
+
+  it("returns input unchanged on unparseable timestamp", () => {
+    expect(relativeTime("not-a-date", NOW)).toBe("not-a-date");
+  });
+
+  it("clamps negative deltas (future timestamp) to 'just now'", () => {
+    expect(relativeTime("2026-04-28T13:00:00Z", NOW)).toBe("just now");
+  });
+});

--- a/web/src/app/dashboard/rooms/room-helpers.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.ts
@@ -74,6 +74,120 @@ export function participantStatusCounts(
   return { ...counts, total: Object.keys(participants).length };
 }
 
+// ---------------------------------------------------------------------------
+// Stuckness — closes #553 builder R1 (WAR_ROOM_DESIGN.md L1247)
+// ---------------------------------------------------------------------------
+
+/** Active rooms — workers / queen are still expected to act. The
+ * dashboard prioritizes these above terminal rooms because they're
+ * the ones that may need operator attention. */
+export const ACTIVE_STATUSES: ReadonlySet<RoomStatus> = new Set([
+  "awaiting_rsvp",
+  "awaiting_contributions",
+  "deciding",
+]);
+
+export function isActiveStatus(status: RoomStatus): boolean {
+  return ACTIVE_STATUSES.has(status);
+}
+
+/**
+ * Pick the relevant deadline for a room based on its current status.
+ * - awaiting_rsvp → rsvp_deadline_secs
+ * - awaiting_contributions / deciding → contribution_deadline_secs
+ * - terminal statuses → null (no deadline applies)
+ *
+ * Falls back to undefined when the room has no timing_config (older
+ * rooms or test fixtures).
+ */
+export function relevantDeadlineSecs(
+  status: RoomStatus,
+  timingConfig?: { rsvp_deadline_secs?: number; contribution_deadline_secs?: number },
+): number | null {
+  if (!isActiveStatus(status)) return null;
+  if (!timingConfig) return null;
+  if (status === "awaiting_rsvp") {
+    return timingConfig.rsvp_deadline_secs ?? null;
+  }
+  return timingConfig.contribution_deadline_secs ?? null;
+}
+
+/**
+ * `(now - opened_at) / deadline` ratio in [0, ∞). Used for sorting
+ * (highest first = most stuck) AND highlighting (>= 0.8 → red row
+ * per WAR_ROOM_DESIGN.md L1248).
+ *
+ * Returns 0 for terminal rooms or rooms with no relevant deadline
+ * — terminal rooms aren't "stuck" and unconfigured rooms can't be
+ * scored.
+ */
+export function stucknessRatio(
+  openedAtIso: string,
+  status: RoomStatus,
+  timingConfig?: { rsvp_deadline_secs?: number; contribution_deadline_secs?: number },
+  nowMs: number = Date.now(),
+): number {
+  const deadline = relevantDeadlineSecs(status, timingConfig);
+  if (deadline === null || deadline <= 0) return 0;
+  const openedMs = Date.parse(openedAtIso);
+  if (!Number.isFinite(openedMs)) return 0;
+  const ageSecs = Math.max(0, (nowMs - openedMs) / 1000);
+  return ageSecs / deadline;
+}
+
+/** Per WAR_ROOM_DESIGN.md L1248: red highlight when past 80% of
+ * the relevant deadline. */
+export const STUCK_THRESHOLD = 0.8;
+
+export function isRoomStuck(
+  openedAtIso: string,
+  status: RoomStatus,
+  timingConfig?: { rsvp_deadline_secs?: number; contribution_deadline_secs?: number },
+  nowMs: number = Date.now(),
+): boolean {
+  return (
+    stucknessRatio(openedAtIso, status, timingConfig, nowMs) >= STUCK_THRESHOLD
+  );
+}
+
+/**
+ * Sort rooms for the default dashboard view per WAR_ROOM_DESIGN.md
+ * L1247 — active rooms by stuck-ness DESC (most-stuck first), then
+ * terminal rooms by opened_at DESC (most-recent first). Operators
+ * see the rooms that need attention without filtering.
+ *
+ * Pure function on `(rooms, nowMs)` — no Date.now coupling so the
+ * sort can be tested deterministically.
+ */
+export function sortRoomsByStuckness<
+  T extends {
+    status: RoomStatus;
+    opened_at: string;
+    timing_config?: {
+      rsvp_deadline_secs?: number;
+      contribution_deadline_secs?: number;
+    };
+  },
+>(rooms: T[], nowMs: number = Date.now()): T[] {
+  return [...rooms].sort((a, b) => {
+    const aActive = isActiveStatus(a.status);
+    const bActive = isActiveStatus(b.status);
+    // Active rooms always come before terminal.
+    if (aActive && !bActive) return -1;
+    if (!aActive && bActive) return 1;
+    if (aActive && bActive) {
+      // Within active: most-stuck (highest ratio) first. Falls back
+      // to opened_at ASC (oldest first) when ratios tie at 0.
+      const aRatio = stucknessRatio(a.opened_at, a.status, a.timing_config, nowMs);
+      const bRatio = stucknessRatio(b.opened_at, b.status, b.timing_config, nowMs);
+      if (aRatio !== bRatio) return bRatio - aRatio;
+      return Date.parse(a.opened_at) - Date.parse(b.opened_at);
+    }
+    // Within terminal: most-recent opened_at first.
+    return Date.parse(b.opened_at) - Date.parse(a.opened_at);
+  });
+}
+
 /**
  * Format an ISO 8601 timestamp as a human-readable relative time
  * ("3m ago", "2h ago"). Returns absolute date for >7d ago.

--- a/web/src/app/dashboard/rooms/room-helpers.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.ts
@@ -1,0 +1,94 @@
+// Pure helpers for war-room dashboard views. Extracted so they can
+// be unit-tested without a DOM environment.
+import type { RoomParticipant, RoomStatus, SubjectType } from "./types";
+
+const STATUS_LABELS: Record<RoomStatus, string> = {
+  awaiting_rsvp: "Awaiting RSVPs",
+  awaiting_contributions: "Awaiting contributions",
+  deciding: "Synthesizing",
+  closed: "Closed",
+  expired: "Expired",
+};
+
+export function statusLabel(status: RoomStatus): string {
+  return STATUS_LABELS[status] ?? status;
+}
+
+/**
+ * Tailwind class fragment for the colored status pill. Matches the
+ * dashboard's existing color vocabulary.
+ */
+export function statusPillClass(status: RoomStatus): string {
+  switch (status) {
+    case "awaiting_rsvp":
+    case "awaiting_contributions":
+      return "bg-honey-500/10 text-honey-400 ring-1 ring-honey-500/20";
+    case "deciding":
+      return "bg-blue-500/10 text-blue-300 ring-1 ring-blue-500/20";
+    case "closed":
+      return "bg-emerald-500/10 text-emerald-300 ring-1 ring-emerald-500/20";
+    case "expired":
+      return "bg-red-500/10 text-red-300 ring-1 ring-red-500/20";
+    default:
+      return "bg-zinc-700/30 text-zinc-300 ring-1 ring-zinc-700/40";
+  }
+}
+
+const SUBJECT_LABELS: Record<SubjectType, string> = {
+  pr_review: "PR review",
+  mention_response: "Mention",
+  issue_triage: "Issue triage",
+};
+
+export function subjectLabel(type: SubjectType): string {
+  return SUBJECT_LABELS[type] ?? type;
+}
+
+/** Build a GitHub URL from a subject_ref of the form `owner/repo#N`.
+ * Returns null when the ref doesn't match. */
+export function subjectGithubUrl(subjectRef: string): string | null {
+  const match = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)#([1-9][0-9]*)$/.exec(
+    subjectRef,
+  );
+  if (!match) return null;
+  const [, owner, repo, num] = match;
+  return `https://github.com/${owner}/${repo}/issues/${num}`;
+}
+
+/**
+ * Counts of participants by status. Empty hash → all-zero counts.
+ */
+export function participantStatusCounts(
+  participants: Record<string, RoomParticipant>,
+): {
+  pending: number;
+  resolved: number;
+  withdrew: number;
+  timed_out: number;
+  total: number;
+} {
+  const counts = { pending: 0, resolved: 0, withdrew: 0, timed_out: 0 };
+  for (const p of Object.values(participants)) {
+    counts[p.status] += 1;
+  }
+  return { ...counts, total: Object.keys(participants).length };
+}
+
+/**
+ * Format an ISO 8601 timestamp as a human-readable relative time
+ * ("3m ago", "2h ago"). Returns absolute date for >7d ago.
+ */
+export function relativeTime(iso: string, nowMs: number = Date.now()): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso;
+  const deltaSecs = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (deltaSecs < 5) return "just now";
+  if (deltaSecs < 60) return `${deltaSecs}s ago`;
+  const mins = Math.floor(deltaSecs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(t).toISOString().slice(0, 10);
+}

--- a/web/src/app/dashboard/rooms/types.ts
+++ b/web/src/app/dashboard/rooms/types.ts
@@ -1,0 +1,72 @@
+// Shared client-side war-room models used by the dashboard list +
+// detail views. Kept aligned with the storage layer's wire shape
+// (see web/src/server/war-room.ts for the canonical types).
+
+export type RoomStatus =
+  | "awaiting_rsvp"
+  | "awaiting_contributions"
+  | "deciding"
+  | "closed"
+  | "expired";
+
+export type SubjectType = "pr_review" | "mention_response" | "issue_triage";
+
+export interface RoomCore {
+  manager: string;
+  subject_type: SubjectType;
+  subject_ref: string;
+  status: RoomStatus;
+  opened_at: string;
+  timing_config?: {
+    max_age_secs?: number;
+    rsvp_deadline_secs?: number;
+    contribution_deadline_secs?: number;
+  };
+  closed_at?: string;
+  closed_reason?: "expired" | "failed_synthesis" | "force_close" | "manual";
+  deciding_through_sequence?: number;
+  decision?: {
+    synthesized_at: string;
+    synthesis_runner: string;
+    content: string;
+    sequence_closed: number;
+  };
+}
+
+export interface RoomCoreWithId extends RoomCore {
+  roomId: string;
+}
+
+export interface RoomParticipant {
+  agent_id: string;
+  role: string;
+  status: "pending" | "resolved" | "withdrew" | "timed_out";
+  rsvp_at: string;
+  resolved_at?: string;
+  withdrew_at_sequence?: number;
+}
+
+export interface RoomContribution {
+  body?: Record<string, unknown>;
+  raw_md?: string;
+  contributed_at?: string;
+  withdrawn?: boolean;
+}
+
+export interface RoomEvent {
+  seq: number;
+  timestamp: string;
+  event_type: string;
+  actor_role: string;
+  actor_id: string;
+  body: Record<string, unknown>;
+}
+
+export interface RoomDetailResponse {
+  roomId: string;
+  core: RoomCore;
+  participants: Record<string, RoomParticipant>;
+  contributions: Record<string, RoomContribution>;
+  events: RoomEvent[];
+  eventLimit: number;
+}


### PR DESCRIPTION
Fixes #552

## Summary

Builds on I.1 (#551 dashboard API). Adds the user-facing pages operators visit to see active rooms and dive into specific room state.

## What's new

```
web/src/app/dashboard/rooms/
├── page.tsx                — list entry
├── RoomsList.tsx           — client component, polls /api/dashboard/rooms (30s)
├── [roomId]/
│   ├── page.tsx            — detail entry
│   └── RoomDetail.tsx      — client component, polls detail (30s)
├── types.ts                — shared client types matching wire shape
├── room-helpers.ts         — pure helpers
└── room-helpers.test.ts    — 22 unit tests

web/src/app/dashboard/DashboardNav.tsx
└── added "War Rooms" tab between Tasks and Credentials
```

## What it looks like

**List view** (`/dashboard/rooms`):

```
War Rooms
Active and recently-closed governance synthesis rooms for this
installation. Refreshes every 30 seconds.

┌──────────────────────────────────────────────────────────────────┐
│ [Synthesizing] PR review  hivemoot/hivemoot#42  opened 5m ago    │
│ [Awaiting]     Mention    hivemoot/colony#17    opened 12m ago   │
│ [Closed]       PR review  hivemoot/cli#3        opened 2h ago ·  │
│                                                  closed 1h ago    │
└──────────────────────────────────────────────────────────────────┘
```

**Detail view** (`/dashboard/rooms/[roomId]`):

- Status pill + subject type + GitHub link (if pr_review/issue ref)
- Room ID, manager, opened/closed timestamps
- Participants table: role, agent, status, RSVP'd
- Contributions list: per-role with verdict pill, summary, collapsible review body
- Decision block (when closed) with synthesized markdown
- Recent events list (chronological tail of last 100)

## Helper coverage

22 tests on `room-helpers`:
- `statusLabel` for all 5 statuses
- `statusPillClass` returns class strings
- `subjectLabel` for all 3 subject types
- `subjectGithubUrl` happy path + edge cases (hyphens, dots, underscores) + null on malformed
- `participantStatusCounts` empty + populated
- `relativeTime` 7 cases (just-now, seconds, minutes, hours, days, >7d absolute, unparseable)

## Test plan

- [x] 1383 tests pass (was 1361, +22)
- [x] Typecheck clean
- [x] Lint clean (0 errors; the react-hooks/set-state-in-effect rule silenced via inline disable comments on the polling-fetch useEffect — matches TasksDashboard's existing pattern; the cascading initial-load → ready render is intentional UX)
- [ ] Reviewer fleet sign-off

## NOT in scope

- I.3 — Status filtering, subject-type filtering, search across rooms. Can land as a follow-up if operators want them after using V1.