### PR TITLE
fix(web): remove _comment field blocking every Vercel deploy

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -6,7 +6,6 @@
   },
   "crons": [
     {
-      "_comment": "War-room watchdog — 60s recovery/expire/timeout scan per WAR_ROOM_DESIGN.md L954-958. Vercel does NOT interpolate env vars in cron paths, so the path is static. Installation selection is read at request time from the HIVEMOOT_TICK_INSTALLATION_ID env var (provisioned via Vercel dashboard → Settings → Environment Variables). Multi-installation: future enhancement — comma-separated list with server-side iteration. Closes #524 guard R2 N1.",
       "path": "/api/internal/queen/tick",
       "schedule": "* * * * *"
     }


### PR DESCRIPTION
Fixes #555

## Summary

`web/vercel.json` carries a `_comment` field inside the cron entry. Vercel's `vercel.json` schema is strict — unknown properties cause `vercel build` to exit non-zero. Every push to `main` since 2026-04-23 has tripped on this and the Web Deploy workflow has failed in lockstep, so production has been frozen at sha `74f74d7` for ~6 days.

The blast radius is the entire war-room V1: Phases D, E, F, G', plus I.1 + I.2 — all merged to `main`, none of it deployed. `/api/dashboard/rooms` returns 404 in prod, the queen cron route doesn't exist on the deployed build, and the dashboard nav has no "War Rooms" tab because the user-facing deployment is from before any of those landed.

## Why this fix is safe

The rationale the `_comment` field carried (env-var interpolation, `HIVEMOOT_TICK_INSTALLATION_ID`, multi-installation roadmap) is already captured in the route handler's docstring at `web/src/app/api/internal/queen/tick/route.ts:166-184`. The `_comment` field was a redundant pointer; deleting it loses no information.

## Verification

- Failed run that surfaced the schema error: [#25091085147](https://github.com/hivemoot/hivemoot/actions/runs/25091085147) — exact message: `Error: Invalid vercel.json - crons[0] should NOT have additional property _comment.`
- Local `node -e "require('./web/vercel.json')"` parses cleanly post-edit.
- Diff is one line removed; no JSON structural changes.

## Governance — hotfix bypass

Same per-slice convention as #533 / #535 / #536 / #537 / #539 / #541 / #543 / #545 / #548 / #550 / #553: tracking issue (#555) filed for the audit trail and labeled `hivemoot:ready-to-implement` to satisfy the linked-issue gate; full discussion → voting cycle is skipped because (a) the diff is a 1-line JSON deletion with no functional change, (b) production deploys have been broken for ~6 days, and (c) reviewers (hivemoot, hivemoot-builder) confirm the fix is correct on the merits. Owner-authorized hotfix in chat session 2026-04-29.

## What it looks like

**Before** — `web/vercel.json`:
```json
"crons": [
  {
    "_comment": "War-room watchdog — 60s recovery/expire/timeout scan ...",
    "path": "/api/internal/queen/tick",
    "schedule": "* * * * *"
  }
]
```

**After**:
```json
"crons": [
  {
    "path": "/api/internal/queen/tick",
    "schedule": "* * * * *"
  }
]
```

**Deploy result**:

| | Before | After (expected) |
|---|---|---|
| `Web Deploy` workflow on main | failure (`vercel build` exit 1) | success |
| Production sha | `74f74d7` (2026-04-23) | latest main |
| `/api/dashboard/rooms` in prod | 404 | 200 (per Phase I.1) |
| `/dashboard/rooms` nav tab | absent | present (per Phase I.2) |
| Queen cron `/api/internal/queen/tick` | not deployed | running every 60s |

## Test plan

- [x] `vercel.json` parses as valid JSON (`node -e` check)
- [x] `Web` CI passes on this branch
- [ ] `Web Deploy` workflow runs to completion after merge (the real proof)
- [ ] `https://www.hivemoot.dev/dashboard` shows the "War Rooms" tab
- [ ] `curl https://www.hivemoot.dev/api/dashboard/rooms` returns 401 (auth-gated, route exists) instead of 404