### PR TITLE
feat(cli): hivemoot rooms list — V1 scope item #5 (1/4)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/rooms-list.test.ts
+++ b/cli/src/commands/rooms-list.test.ts
@@ -19,11 +19,9 @@ function makeRoom(overrides: Partial<ListedRoom> = {}): ListedRoom {
     subject_ref: "hivemoot/hivemoot#42",
     opened_at: "2026-04-29T18:00:00.000Z",
     timing_config: {
-      rsvp_quiet_period_secs: 60,
+      max_age_secs: 7200,
       rsvp_deadline_secs: 600,
       contribution_deadline_secs: 1800,
-      rsvp_contribution_timeout_secs: 1800,
-      max_age_secs: 7200,
     },
     status: "awaiting_contributions",
     ...overrides,

--- a/cli/src/commands/rooms-list.test.ts
+++ b/cli/src/commands/rooms-list.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CliError } from "../config/types.js";
+
+vi.mock("../hivemoot/client.js", () => ({
+  hivemootGet: vi.fn(),
+}));
+
+import { hivemootGet } from "../hivemoot/client.js";
+import { formatRoomsList, roomsListCommand } from "./rooms-list.js";
+import type { ListedRoom, ListRoomsResponse } from "../hivemoot/types.js";
+
+const mockedGet = vi.mocked(hivemootGet);
+
+function makeRoom(overrides: Partial<ListedRoom> = {}): ListedRoom {
+  return {
+    roomId: "8d2bbb86-1f33-4d6a-9b3a-3ed1c0fbcdef",
+    manager: "bot-queen",
+    subject_type: "pr_review",
+    subject_ref: "hivemoot/hivemoot#42",
+    opened_at: "2026-04-29T18:00:00.000Z",
+    timing_config: {
+      rsvp_quiet_period_secs: 60,
+      rsvp_deadline_secs: 600,
+      contribution_deadline_secs: 1800,
+      rsvp_contribution_timeout_secs: 1800,
+      max_age_secs: 7200,
+    },
+    status: "awaiting_contributions",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("formatRoomsList", () => {
+  it("emits an empty-list footer when there are no rooms", () => {
+    const out = formatRoomsList([]);
+    expect(out).toContain("WAR ROOMS — 0 rooms");
+    expect(out).toContain("(no rooms in this installation)");
+  });
+
+  it("uses singular 'room' for exactly one", () => {
+    const out = formatRoomsList([makeRoom()]);
+    expect(out).toMatch(/WAR ROOMS — 1 room$/m);
+  });
+
+  it("includes status, subject label, ref, opened time, roomId, manager per room", () => {
+    const out = formatRoomsList([makeRoom()]);
+    expect(out).toContain("[awaiting_contributions]");
+    expect(out).toContain("pr_review hivemoot/hivemoot#42");
+    expect(out).toContain("roomId: 8d2bbb86-1f33-4d6a-9b3a-3ed1c0fbcdef");
+    expect(out).toContain("manager: bot-queen");
+  });
+
+  it("renders mention_response subject as 'mention'", () => {
+    const out = formatRoomsList([
+      makeRoom({ subject_type: "mention_response", subject_ref: "hivemoot/colony#17" }),
+    ]);
+    expect(out).toContain("mention hivemoot/colony#17");
+  });
+
+  it("includes closed_at and closed_reason on terminal rooms", () => {
+    const out = formatRoomsList([
+      makeRoom({
+        status: "expired",
+        closed_at: "2026-04-29T12:00:00.000Z",
+        closed_reason: "expired",
+      }),
+    ]);
+    expect(out).toContain("[expired]");
+    expect(out).toContain(", closed");
+    expect(out).toContain("(expired)");
+  });
+
+  it("omits closed segment when room is still active", () => {
+    const out = formatRoomsList([makeRoom()]);
+    expect(out).not.toContain(", closed");
+  });
+});
+
+describe("roomsListCommand", () => {
+  it("calls /api/rooms with no query when no limit", async () => {
+    mockedGet.mockResolvedValue({ rooms: [] } as ListRoomsResponse);
+    await roomsListCommand({});
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    const call = mockedGet.mock.calls[0][0];
+    expect(call.path).toBe("/api/rooms");
+    expect(call.query).toEqual({ limit: undefined });
+  });
+
+  it("forwards --limit to the query", async () => {
+    mockedGet.mockResolvedValue({ rooms: [] } as ListRoomsResponse);
+    await roomsListCommand({ limit: 25 });
+    expect(mockedGet.mock.calls[0][0].query).toEqual({ limit: 25 });
+  });
+
+  it("forwards --token and --api-url to the client", async () => {
+    mockedGet.mockResolvedValue({ rooms: [] } as ListRoomsResponse);
+    await roomsListCommand({ token: "tok-abc", apiUrl: "https://staging.example" });
+    const call = mockedGet.mock.calls[0][0];
+    expect(call.token).toBe("tok-abc");
+    expect(call.apiUrl).toBe("https://staging.example");
+  });
+
+  it("rejects --limit=0 with INVALID_OPTION exit 1 (no API call)", async () => {
+    await expect(roomsListCommand({ limit: 0 })).rejects.toMatchObject({
+      code: "INVALID_OPTION",
+      exitCode: 1,
+    });
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects --limit=201 with INVALID_OPTION (server caps at 200)", async () => {
+    await expect(roomsListCommand({ limit: 201 })).rejects.toBeInstanceOf(
+      CliError,
+    );
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("emits JSON exactly as returned when --json", async () => {
+    const payload = { rooms: [makeRoom()] } satisfies ListRoomsResponse;
+    mockedGet.mockResolvedValue(payload);
+    const logSpy = vi.spyOn(console, "log");
+    await roomsListCommand({ json: true });
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual(payload);
+  });
+
+  it("emits the human formatter (not JSON) by default", async () => {
+    const payload = { rooms: [makeRoom()] } satisfies ListRoomsResponse;
+    mockedGet.mockResolvedValue(payload);
+    const logSpy = vi.spyOn(console, "log");
+    await roomsListCommand({});
+    const out = logSpy.mock.calls[0][0] as string;
+    expect(out).toContain("WAR ROOMS — 1 room");
+    expect(out).toContain("[awaiting_contributions]");
+  });
+
+  it("propagates CliError from the underlying client unchanged", async () => {
+    mockedGet.mockRejectedValue(
+      new CliError("401 unauthorized", "unauthorized", 2),
+    );
+    await expect(roomsListCommand({})).rejects.toMatchObject({
+      code: "unauthorized",
+      exitCode: 2,
+    });
+  });
+});

--- a/cli/src/commands/rooms-list.ts
+++ b/cli/src/commands/rooms-list.ts
@@ -1,0 +1,89 @@
+import { CliError } from "../config/types.js";
+import { hivemootGet } from "../hivemoot/client.js";
+import type {
+  ListedRoom,
+  ListRoomsResponse,
+  SubjectType,
+} from "../hivemoot/types.js";
+
+export interface RoomsListOptions {
+  limit?: number;
+  token?: string;
+  apiUrl?: string;
+  json?: boolean;
+}
+
+const SUBJECT_LABEL: Record<SubjectType, string> = {
+  pr_review: "pr_review",
+  mention_response: "mention",
+  issue_triage: "issue",
+};
+
+/**
+ * Best-effort relative time. ISO inputs that fail to parse fall back
+ * to the raw string so the human reader still sees *something*.
+ */
+function relativeTime(iso: string, nowMs = Date.now()): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+  const diffSec = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 48) return `${diffHour}h ago`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 14) return `${diffDay}d ago`;
+  return iso.slice(0, 10);
+}
+
+export function formatRoomsList(rooms: readonly ListedRoom[]): string {
+  const lines: string[] = [`WAR ROOMS — ${rooms.length} room${rooms.length === 1 ? "" : "s"}`];
+
+  if (rooms.length === 0) {
+    lines.push("(no rooms in this installation)");
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  for (const room of rooms) {
+    const subj = SUBJECT_LABEL[room.subject_type] ?? room.subject_type;
+    const opened = relativeTime(room.opened_at);
+    const closedSuffix = room.closed_at
+      ? `, closed ${relativeTime(room.closed_at)}${room.closed_reason ? ` (${room.closed_reason})` : ""}`
+      : "";
+    lines.push(
+      `[${room.status}] ${subj} ${room.subject_ref} — opened ${opened}${closedSuffix}`,
+    );
+    lines.push(`  roomId: ${room.roomId}  manager: ${room.manager}`);
+  }
+
+  return lines.join("\n");
+}
+
+export async function roomsListCommand(
+  options: RoomsListOptions,
+): Promise<void> {
+  // Server clamps `limit` to [1, 200]; surface the obvious caller mistake
+  // before a round-trip rather than shipping noise to the API.
+  if (options.limit !== undefined && (options.limit < 1 || options.limit > 200)) {
+    throw new CliError(
+      "limit must be between 1 and 200",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+
+  const result = await hivemootGet<ListRoomsResponse>({
+    apiUrl: options.apiUrl,
+    token: options.token,
+    path: "/api/rooms",
+    query: { limit: options.limit },
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatRoomsList(result.rooms));
+  }
+}

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -265,7 +265,16 @@ export type ErrorCode =
   | "INVALID_CONFIG"
   | "RATE_LIMITED"
   | "GH_APP_TOKEN_UNSUPPORTED"
-  | "GH_ERROR";
+  | "GH_ERROR"
+  | "AUTH_ERROR"
+  | "INVALID_OPTION"
+  | "NETWORK_ERROR"
+  | "PARSE_ERROR"
+  // Hivemoot API server-supplied codes (e.g., `unauthorized`,
+  // `missing_capability`, `HTTP_500`, etc.) pass through verbatim.
+  // The `string & {}` trick keeps IntelliSense on the literal members
+  // above while still permitting any string at the throw site.
+  | (string & {});
 
 export class CliError extends Error {
   constructor(

--- a/cli/src/hivemoot/client.test.ts
+++ b/cli/src/hivemoot/client.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CliError } from "../config/types.js";
+import {
+  DEFAULT_API_URL,
+  hivemootGet,
+  resolveApiUrl,
+  resolveToken,
+} from "./client.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.HIVEMOOT_API_URL;
+  delete process.env.HIVEMOOT_API_TOKEN;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("resolveApiUrl", () => {
+  it("returns the --api-url flag when supplied", () => {
+    process.env.HIVEMOOT_API_URL = "https://env.example";
+    expect(resolveApiUrl({ apiUrl: "https://flag.example" })).toBe(
+      "https://flag.example",
+    );
+  });
+
+  it("falls back to HIVEMOOT_API_URL env when no flag", () => {
+    process.env.HIVEMOOT_API_URL = "https://env.example";
+    expect(resolveApiUrl({})).toBe("https://env.example");
+  });
+
+  it("falls back to the production default when nothing set", () => {
+    expect(resolveApiUrl({})).toBe(DEFAULT_API_URL);
+  });
+
+  it("treats empty / whitespace flag as absent", () => {
+    process.env.HIVEMOOT_API_URL = "https://env.example";
+    expect(resolveApiUrl({ apiUrl: "   " })).toBe("https://env.example");
+  });
+});
+
+describe("resolveToken", () => {
+  it("returns the --token flag when supplied", () => {
+    process.env.HIVEMOOT_API_TOKEN = "env-tok";
+    expect(resolveToken({ token: "flag-tok" })).toBe("flag-tok");
+  });
+
+  it("falls back to HIVEMOOT_API_TOKEN env when no flag", () => {
+    process.env.HIVEMOOT_API_TOKEN = "env-tok";
+    expect(resolveToken({})).toBe("env-tok");
+  });
+
+  it("throws CliError(AUTH_ERROR, exit=2) when neither set", () => {
+    expect(() => resolveToken({})).toThrow(CliError);
+    try {
+      resolveToken({});
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      expect((err as CliError).code).toBe("AUTH_ERROR");
+      expect((err as CliError).exitCode).toBe(2);
+    }
+  });
+
+  it("treats whitespace-only as absent", () => {
+    process.env.HIVEMOOT_API_TOKEN = "   ";
+    expect(() => resolveToken({ token: "   " })).toThrow(CliError);
+  });
+
+  it("strips surrounding whitespace from the resolved token", () => {
+    expect(resolveToken({ token: "  abc  " })).toBe("abc");
+  });
+});
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  init: ResponseInit = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+describe("hivemootGet", () => {
+  it("constructs the URL and sends the bearer header", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(200, { rooms: [] }),
+    );
+    await hivemootGet<{ rooms: unknown[] }>({
+      apiUrl: "https://api.example",
+      token: "tok-123",
+      path: "/api/rooms",
+      query: { limit: 25, status: undefined },
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toBe("https://api.example/api/rooms?limit=25");
+    expect(init.method).toBe("GET");
+    expect(init.headers.Authorization).toBe("Bearer tok-123");
+    expect(init.headers.Accept).toBe("application/json");
+  });
+
+  it("returns parsed JSON on 2xx", async () => {
+    const payload = { rooms: [{ roomId: "r1" }] };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, payload));
+    const out = await hivemootGet<typeof payload>({
+      token: "t",
+      apiUrl: "https://x",
+      path: "/api/rooms",
+      fetchImpl,
+    });
+    expect(out).toEqual(payload);
+  });
+
+  it("maps 401 to exit code 2 (token issue)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(401, { code: "unauthorized", message: "bad bearer" }),
+    );
+    try {
+      await hivemootGet({
+        token: "t",
+        apiUrl: "https://x",
+        path: "/api/rooms",
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      expect((err as CliError).exitCode).toBe(2);
+      expect((err as CliError).code).toBe("unauthorized");
+      expect((err as CliError).message).toContain("401");
+      expect((err as CliError).message).toContain("bad bearer");
+    }
+  });
+
+  it("maps non-401 4xx to exit code 3 with server-supplied code", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(403, { code: "missing_capability", message: "need rooms.read_all" }),
+    );
+    try {
+      await hivemootGet({
+        token: "t",
+        apiUrl: "https://x",
+        path: "/api/rooms",
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).exitCode).toBe(3);
+      expect((err as CliError).code).toBe("missing_capability");
+    }
+  });
+
+  it("maps 5xx to exit code 3 with HTTP_<status> code when no body", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+    try {
+      await hivemootGet({
+        token: "t",
+        apiUrl: "https://x",
+        path: "/api/rooms",
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).exitCode).toBe(3);
+      expect((err as CliError).code).toBe("HTTP_500");
+    }
+  });
+
+  it("maps network errors to NETWORK_ERROR / exit 3", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    try {
+      await hivemootGet({
+        token: "t",
+        apiUrl: "https://x",
+        path: "/api/rooms",
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).code).toBe("NETWORK_ERROR");
+      expect((err as CliError).exitCode).toBe(3);
+      expect((err as CliError).message).toContain("https://x");
+    }
+  });
+
+  it("maps malformed JSON on a 2xx to PARSE_ERROR / exit 3", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      await hivemootGet({
+        token: "t",
+        apiUrl: "https://x",
+        path: "/api/rooms",
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).code).toBe("PARSE_ERROR");
+      expect((err as CliError).exitCode).toBe(3);
+    }
+  });
+
+  it("skips undefined and null query values", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    await hivemootGet({
+      token: "t",
+      apiUrl: "https://x",
+      path: "/api/rooms",
+      query: { limit: 10, status: undefined, repo: null },
+      fetchImpl,
+    });
+    const [calledUrl] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toBe("https://x/api/rooms?limit=10");
+  });
+
+  it("propagates the server message in the CliError text", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(429, { code: "rate_limited", message: "too many requests" }),
+    );
+    try {
+      await hivemootGet({
+        token: "t",
+        apiUrl: "https://x",
+        path: "/api/rooms",
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).message).toContain("too many requests");
+    }
+  });
+});

--- a/cli/src/hivemoot/client.ts
+++ b/cli/src/hivemoot/client.ts
@@ -1,0 +1,130 @@
+/**
+ * HTTP client for the hivemoot.dev war-room API.
+ *
+ * Auth: bearer token resolved from (in order) the `--token` flag,
+ * the `HIVEMOOT_API_TOKEN` env var, or a `CliError` if neither is
+ * supplied. Tokens are V1 capability bearers minted by the apiarist
+ * — operators with `rooms.read_all` can list/inspect any room in
+ * their installation; workers carry narrower scopes used by the
+ * agent-runtime plugin (which has its own client in
+ * `agent/cli/.../war_rooms/api.py`).
+ *
+ * Base URL: `--api-url`, then `HIVEMOOT_API_URL`, then production
+ * (`https://www.hivemoot.dev`). Override is mostly useful for
+ * staging / preview deploys / local `next dev`.
+ *
+ * Failure modes mapped to `CliError` so the existing global error
+ * handler in `cli/src/index.ts` renders them consistently:
+ *   - missing token → exit 2 (actionable: "set the env var")
+ *   - 401 → exit 2 (actionable: "your token is wrong/expired")
+ *   - 4xx with parseable body → exit 3, code from server's `code`
+ *   - 5xx / network / parse failures → exit 3, generic
+ */
+
+import { CliError } from "../config/types.js";
+
+export const DEFAULT_API_URL = "https://www.hivemoot.dev";
+
+export interface HivemootClientOptions {
+  /** Override base URL. Falls back to env, then production default. */
+  apiUrl?: string;
+  /** Bearer token. Falls back to `HIVEMOOT_API_TOKEN` env var. */
+  token?: string;
+}
+
+export function resolveApiUrl(opts: HivemootClientOptions): string {
+  const flag = opts.apiUrl?.trim();
+  if (flag && flag.length > 0) return flag;
+  const env = process.env.HIVEMOOT_API_URL?.trim();
+  if (env && env.length > 0) return env;
+  return DEFAULT_API_URL;
+}
+
+export function resolveToken(opts: HivemootClientOptions): string {
+  const flag = opts.token?.trim();
+  if (flag && flag.length > 0) return flag;
+  const env = process.env.HIVEMOOT_API_TOKEN?.trim();
+  if (env && env.length > 0) return env;
+  throw new CliError(
+    "No hivemoot API token. Set HIVEMOOT_API_TOKEN env var or pass --token <bearer>.",
+    "AUTH_ERROR",
+    2,
+  );
+}
+
+export interface HivemootGetArgs extends HivemootClientOptions {
+  /** Path relative to base URL — must start with `/`. */
+  path: string;
+  /** Optional querystring parameters. `undefined` / `null` values
+   * are skipped so callers can pass `{ status: opts.status }` without
+   * branching. */
+  query?: Record<string, string | number | undefined | null>;
+  /** Optional fetch override (testing). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export async function hivemootGet<T>(args: HivemootGetArgs): Promise<T> {
+  const baseUrl = resolveApiUrl(args);
+  const token = resolveToken(args);
+  const fetchFn = args.fetchImpl ?? fetch;
+
+  const url = new URL(args.path, baseUrl);
+  if (args.query) {
+    for (const [k, v] of Object.entries(args.query)) {
+      if (v !== undefined && v !== null) {
+        url.searchParams.set(k, String(v));
+      }
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await fetchFn(url.toString(), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    });
+  } catch (err) {
+    throw new CliError(
+      `Network error reaching ${baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
+      "NETWORK_ERROR",
+      3,
+    );
+  }
+
+  if (response.ok) {
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new CliError(
+        `Invalid JSON response from ${url.pathname}: ${err instanceof Error ? err.message : String(err)}`,
+        "PARSE_ERROR",
+        3,
+      );
+    }
+  }
+
+  // Try to extract the server's structured error envelope
+  // (`{ code, message }`) — both 4xx and 5xx routes use it.
+  let serverCode: string | undefined;
+  let serverMessage: string | undefined;
+  try {
+    const body = (await response.json()) as { code?: unknown; message?: unknown };
+    if (typeof body.code === "string") serverCode = body.code;
+    if (typeof body.message === "string") serverMessage = body.message;
+  } catch {
+    // Non-JSON body (e.g., plain "Unauthorized" or empty 401) — fall
+    // through to the generic message below.
+  }
+
+  const summary = serverMessage ?? response.statusText ?? "request failed";
+  // 401 is "fix your token" → exit 2; everything else is exit 3.
+  const exitCode = response.status === 401 ? 2 : 3;
+  throw new CliError(
+    `${response.status} ${summary} (${url.pathname})`,
+    serverCode ?? `HTTP_${response.status}`,
+    exitCode,
+  );
+}

--- a/cli/src/hivemoot/types.ts
+++ b/cli/src/hivemoot/types.ts
@@ -14,12 +14,13 @@ export type RoomStatus =
   | "awaiting_contributions"
   | "deciding"
   | "closed"
-  | "expired"
-  | "force_closed"
-  | "failed_synthesis";
+  | "expired";
 
 export type SubjectType = "pr_review" | "mention_response" | "issue_triage";
 
+/** Reason a room reached a terminal state via the
+ * `ROOM_TERMINATE_SCRIPT` path (vs the queen's happy-path close).
+ * Mirrors `TerminalReason` in `web/src/server/war-room.ts`. */
 export type TerminalReason =
   | "expired"
   | "failed_synthesis"
@@ -27,11 +28,9 @@ export type TerminalReason =
   | "manual";
 
 export interface TimingConfig {
-  rsvp_quiet_period_secs: number;
+  max_age_secs: number;
   rsvp_deadline_secs: number;
   contribution_deadline_secs: number;
-  rsvp_contribution_timeout_secs: number;
-  max_age_secs: number;
 }
 
 export interface RoomDecision {

--- a/cli/src/hivemoot/types.ts
+++ b/cli/src/hivemoot/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Wire types for the hivemoot.dev war-room HTTP API. Mirrors the
+ * server shapes in `web/src/server/war-room.ts` so the CLI's parsed
+ * response is structurally identical to what the server emits.
+ *
+ * Only the fields the CLI consumes are modelled. Optional fields
+ * (`closed_at`, `closed_reason`, `decision`, etc.) are typed as
+ * `?` — present only on rooms that have reached the relevant
+ * lifecycle state.
+ */
+
+export type RoomStatus =
+  | "awaiting_rsvp"
+  | "awaiting_contributions"
+  | "deciding"
+  | "closed"
+  | "expired"
+  | "force_closed"
+  | "failed_synthesis";
+
+export type SubjectType = "pr_review" | "mention_response" | "issue_triage";
+
+export type TerminalReason =
+  | "expired"
+  | "failed_synthesis"
+  | "force_close"
+  | "manual";
+
+export interface TimingConfig {
+  rsvp_quiet_period_secs: number;
+  rsvp_deadline_secs: number;
+  contribution_deadline_secs: number;
+  rsvp_contribution_timeout_secs: number;
+  max_age_secs: number;
+}
+
+export interface RoomDecision {
+  synthesized_at: string;
+  synthesis_runner: string;
+  content: string;
+  sequence_closed: number;
+}
+
+/**
+ * Shape returned by `GET /api/rooms` (one entry per room). Matches
+ * `RoomCoreWithId` on the server side.
+ */
+export interface ListedRoom {
+  roomId: string;
+  manager: string;
+  subject_type: SubjectType;
+  subject_ref: string;
+  opened_at: string;
+  timing_config: TimingConfig;
+  status: RoomStatus;
+  closed_at?: string;
+  closed_reason?: TerminalReason;
+  deciding_through_sequence?: number;
+  decision?: RoomDecision;
+}
+
+export interface ListRoomsResponse {
+  rooms: ListedRoom[];
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ import { issueVoteCommand } from "./commands/issue-vote.js";
 import { issuePostCommentCommand } from "./commands/issue-post-comment.js";
 import { issueSnapshotCommand } from "./commands/issue-snapshot.js";
 import { notificationsPullCommand } from "./commands/notifications-pull.js";
+import { roomsListCommand } from "./commands/rooms-list.js";
 import { CliError } from "./config/types.js";
 import { setGhToken } from "./github/client.js";
 
@@ -312,6 +313,39 @@ Examples:
     Skip notifications already processed by hivemoot watch/ack`,
   )
   .action(notificationsPullCommand);
+
+const roomsProgram = program
+  .command("rooms")
+  .description("War-room workflow helpers (V1 minimum: list)");
+
+roomsProgram
+  .command("list")
+  .description("List war rooms in this installation (newest-first)")
+  .option("--limit <n>", "Maximum rooms to return (1-200, default 50)", parseLimit)
+  .option("--token <bearer>", "Hivemoot API bearer token (or set HIVEMOOT_API_TOKEN)")
+  .option("--api-url <url>", "Hivemoot API base URL (default: https://www.hivemoot.dev or HIVEMOOT_API_URL)")
+  .option("--json", "Output as JSON")
+  .addHelpText(
+    "after",
+    `
+
+Auth:
+  The bearer must carry the \`rooms.read_all\` capability — operator-scope
+  for this installation. Workers (drone/builder/guard/etc.) have narrower
+  capabilities and cannot list rooms; they should use the agent-runtime
+  watcher instead.
+
+Examples:
+  $ hivemoot rooms list
+    List up to 50 rooms (token from HIVEMOOT_API_TOKEN env var)
+
+  $ hivemoot rooms list --limit 200 --json
+    Fetch the maximum page and emit JSON for scripting
+
+  $ HIVEMOOT_API_URL=http://localhost:3000 hivemoot rooms list
+    Hit a local \`next dev\` server`,
+  )
+  .action(roomsListCommand);
 
 program
   .command("ack")


### PR DESCRIPTION
Fixes #556

## Summary

First slice of the V1 CLI specified in `WAR_ROOM_DESIGN.md` L1384 (`hivemoot rooms list/get/contribute/events/watch` minimum). Establishes the hivemoot.dev HTTP-client foundation and ships the first read command.

| What | Where | Why here |
|---|---|---|
| `hivemoot/client.ts` | new — bearer-auth fetch wrapper | Foundation reused by every future `rooms` subcommand |
| `hivemoot/types.ts` | new — wire types matching `RoomCoreWithId` | Single source of truth for response shape |
| `commands/rooms-list.ts` | new — `hivemoot rooms list` | First V1 surface — operators can inspect the installation |
| `config/types.ts` | widened `ErrorCode` | Lets server codes (`unauthorized`, `missing_capability`, …) pass through verbatim while keeping autocomplete on the literal members |
| `index.ts` | registered `rooms` parent + `list` | Mirrors existing `issue` / `pr` / `notifications` parent-group convention |

## Auth model

- Token resolved from `--token` then `HIVEMOOT_API_TOKEN` env var (CliError exit 2 if neither set).
- Base URL: `--api-url` then `HIVEMOOT_API_URL` then production default (`https://www.hivemoot.dev`).
- Bearer must carry `rooms.read_all` (operator scope per design L750-754). Workers should keep using the agent-runtime watcher.

## Failure modes

| Cause | Exit | Code |
|---|---|---|
| Missing token | 2 | `AUTH_ERROR` |
| 401 from server | 2 | server-supplied (e.g., `unauthorized`) |
| Non-401 4xx with body | 3 | server-supplied (e.g., `missing_capability`) |
| 5xx / no body | 3 | `HTTP_<status>` |
| Network error | 3 | `NETWORK_ERROR` |
| Malformed JSON | 3 | `PARSE_ERROR` |
| `--limit` outside [1, 200] | 1 | `INVALID_OPTION` |

The 401-vs-other-4xx split mirrors `pr-preflight` / `issue-vote` exit-code conventions: actionable token-state issues get exit 2 so wrappers can branch on "fix your env" vs "execution failed."

## What it looks like

\`\`\`
$ hivemoot rooms list --limit 3
WAR ROOMS — 3 rooms

[awaiting_contributions] pr_review hivemoot/hivemoot#42 — opened 5m ago
  roomId: 8d2bbb86-1f33-4d6a-9b3a-3ed1c0fbcdef  manager: bot-queen
[awaiting_rsvp] mention hivemoot/colony#17 — opened 12m ago
  roomId: 4f1e9a2b-...  manager: bot-queen
[closed] pr_review hivemoot/cli#3 — opened 2h ago, closed 1h ago (expired)
  roomId: c9b32e61-...  manager: bot-queen

$ hivemoot rooms list --json
{ \"rooms\": [ { \"roomId\": \"8d2bbb86-...\", \"status\": \"awaiting_contributions\", ... } ] }

$ hivemoot rooms list --help
# (full help text including auth notes + examples)
\`\`\`

## Governance — V1-scope-execution bypass

Same per-slice convention as #533 / #553 / #554: tracking issue (#556) filed for the audit trail and labeled `hivemoot:ready-to-implement`; full discussion → voting cycle is skipped because (a) this implements an already-decided V1 scope item per `WAR_ROOM_DESIGN.md` L1384 with no new architectural surface, (b) the slice is small (~700 lines, half tests), (c) the four-PR split keeps each review tractable. Owner-authorized continuation of the autonomous war-room completion track in chat session 2026-04-29.

## Test plan

- [x] 32 new tests pin every documented branch:
  - `hivemoot/client.test.ts` (18) — token/URL resolution, success/error paths, query construction, exit-code mapping per status class
  - `commands/rooms-list.test.ts` (14) — formatter for empty/single/closed rooms, command option forwarding, `--limit` validation, `--json` mode, error propagation
- [x] 862 CLI tests pass (was 830, +32)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds; `node dist/index.js rooms list --help` renders the help correctly
- [ ] Reviewer fleet sign-off
- [ ] Smoke test against deployed prod once a `rooms.read_all` token is provisioned