### PR TITLE
fix(agent): pipe Claude prompt over stdin to avoid Errno 7 E2BIG

### DIFF
--- a/agent/cli/hivemoot_agent/engine.py
+++ b/agent/cli/hivemoot_agent/engine.py
@@ -1393,6 +1393,7 @@ class Engine:
 
             exit_code, stdout = self._run_subprocess(
                 cmd, config, on_event=on_event, provider=provider,
+                prompt=effective_prompt,
             )
 
             # Retry once with a fresh session if resume failed.
@@ -1410,6 +1411,7 @@ class Engine:
                 )
                 exit_code, stdout = self._run_subprocess(
                     cmd, config, on_event=on_event, provider=provider,
+                    prompt=job.prompt,
                 )
 
             # Clean up MCP config and skill staging.  Wrapped because
@@ -1527,6 +1529,7 @@ class Engine:
         config: PluginConfig,
         on_event: Callable[[AgentEvent], None] | None = None,
         provider: Any = None,
+        prompt: str = "",
     ) -> tuple[int, str]:
         """Run an agent subprocess with streaming, returning (exit_code, stdout).
 
@@ -1534,12 +1537,24 @@ class Engine:
         passed to provider.parse_event(); if that returns an AgentEvent
         and on_event is set, the callback is invoked.  Stderr is
         collected in a separate thread to prevent pipe buffer deadlock.
+
+        Stdin routing: when ``provider.prompt_via_stdin`` is True the
+        engine pipes ``prompt`` over the subprocess's stdin in a
+        dedicated writer thread (mirroring the stdout/stderr reader
+        pattern below — necessary because PIPE_BUF on Linux is 4 KiB
+        and a synchronous write would deadlock for a prompt larger than
+        the kernel-side pipe buffer once the agent has filled stdout).
+        Providers that don't set the flag keep argv-only behavior.
         """
         timeout = int(config.get("AGENT_TIMEOUT_SECONDS", "1800"))
+        pipe_stdin = bool(prompt) and bool(
+            getattr(provider, "prompt_via_stdin", False),
+        )
 
         try:
             proc = subprocess.Popen(
                 cmd,
+                stdin=subprocess.PIPE if pipe_stdin else subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -1601,6 +1616,37 @@ class Engine:
         t_out.start()
         t_err.start()
 
+        # Feed prompt over stdin in a dedicated thread when the provider
+        # opts in (see Popen above + provider.prompt_via_stdin). The
+        # writer must run concurrently with the stdout reader because
+        # PIPE_BUF on Linux is 4 KiB; a synchronous write of a large
+        # prompt would deadlock once the agent's stdout buffer fills.
+        # BrokenPipeError is swallowed: it means the agent exited
+        # before reading the full prompt (e.g., it produced a result
+        # from a partial prefix), which is not a writer-side failure.
+        t_stdin: threading.Thread | None = None
+        if pipe_stdin and proc.stdin is not None:
+            stdin_pipe = proc.stdin
+
+            def _feed_stdin() -> None:
+                try:
+                    stdin_pipe.write(prompt)
+                except BrokenPipeError:
+                    pass
+                except Exception as exc:
+                    print(
+                        f"[engine] stdin write error: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
+                finally:
+                    try:
+                        stdin_pipe.close()
+                    except Exception:
+                        pass
+
+            t_stdin = threading.Thread(target=_feed_stdin, daemon=True)
+            t_stdin.start()
+
         try:
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
@@ -1609,6 +1655,8 @@ class Engine:
             proc.wait()
             t_out.join()
             t_err.join()
+            if t_stdin is not None:
+                t_stdin.join(timeout=5)
             if event_queue is not None:
                 event_queue.put(event_sentinel)
             if event_thread is not None:
@@ -1617,6 +1665,8 @@ class Engine:
 
         t_out.join()
         t_err.join()
+        if t_stdin is not None:
+            t_stdin.join(timeout=5)
         if event_queue is not None:
             event_queue.put(event_sentinel)
         if event_thread is not None:

--- a/agent/cli/hivemoot_agent/providers/__init__.py
+++ b/agent/cli/hivemoot_agent/providers/__init__.py
@@ -33,6 +33,18 @@ class Provider(Protocol):
     # must be concatenated with the user prompt.
     supports_system_prompt_flag: bool
 
+    # OPTIONAL — defaults to False if a provider module doesn't define it.
+    # When True, the provider's `build_cmd` returns argv WITHOUT the user
+    # prompt (it gets piped over stdin by the engine instead). Used to
+    # avoid `[Errno 7] Argument list too long` for large prompts (full PR
+    # diffs, multi-file context, etc.) — the kernel's argv ceiling is
+    # ~128 KiB on most Linux configs.
+    #
+    # The engine reads this attribute via `getattr(provider,
+    # "prompt_via_stdin", False)`, so a provider that doesn't define it
+    # silently keeps the legacy argv-only behavior.
+    prompt_via_stdin: bool
+
     def build_cmd(
         self,
         prompt: str,

--- a/agent/cli/hivemoot_agent/providers/claude.py
+++ b/agent/cli/hivemoot_agent/providers/claude.py
@@ -10,6 +10,15 @@ name = "claude"
 supports_system_prompt_flag = True
 native_skill_backend = "claude_plugin_dir"
 
+# Claude Code's headless mode (`-p`) reads the user prompt from stdin
+# when no positional `<prompt>` is supplied. Routing the prompt through
+# stdin instead of argv avoids `[Errno 7] Argument list too long` on
+# real PR-review jobs where the prompt carries a full diff. Empirically
+# any agent run on a non-trivial PR can blow past the kernel's
+# `MAX_ARG_PAGES` ceiling (~128 KiB on most Linux configs); the engine
+# reads this flag and pipes the prompt over stdin.
+prompt_via_stdin = True
+
 # Deny rules block naive single-command exfiltration from prompt injection.
 # Enforced even with --dangerously-skip-permissions.  Container isolation
 # is the primary defense; these are defense-in-depth.  See issue #94.
@@ -42,6 +51,19 @@ def build_cmd(
     *,
     plugin_dir: str = "",
 ) -> list[str]:
+    """Build claude argv WITHOUT the user prompt.
+
+    The `prompt` parameter is intentionally NOT placed in argv — the
+    engine pipes it over stdin when `prompt_via_stdin = True` (see the
+    module-level note above). This keeps the kernel's argv-size ceiling
+    out of the failure surface for large PR-review prompts.
+
+    `prompt` is still in the signature because the Provider Protocol
+    requires the same shape across providers (codex / gemini / kilo /
+    opencode all consume it via argv). For claude it's accepted and
+    discarded here.
+    """
+    del prompt  # routed via stdin by the engine — see prompt_via_stdin
     if session_id:
         cmd = [
             "claude", "--resume", session_id, "-p",
@@ -66,7 +88,6 @@ def build_cmd(
         cmd += ["--plugin-dir", plugin_dir]
     if model:
         cmd += ["--model", model]
-    cmd += ["--", prompt]
     return cmd
 
 

--- a/agent/cli/tests/test_engine.py
+++ b/agent/cli/tests/test_engine.py
@@ -592,6 +592,142 @@ def test_response_extracted_for_claude():
     assert response == "Final Claude answer"
 
 
+# ── prompt-via-stdin tests (E2BIG fix) ─────────────────────────────
+
+
+def test_run_subprocess_pipes_prompt_via_stdin_for_claude():
+    """Claude provider opts into prompt_via_stdin — engine writes prompt to subprocess stdin."""
+    import hivemoot_agent.providers.claude as claude_provider
+
+    mock_proc = _make_mock_popen(['{"type":"result","result":"ok"}\n'])
+    big_prompt = "Review this PR\n" + ("X" * 200_000)  # > kernel argv ceiling
+
+    with patch("subprocess.Popen", return_value=mock_proc) as popen_mock:
+        engine = Engine()
+        config = PluginConfig(name="test", settings={"AGENT_TIMEOUT_SECONDS": "60"})
+        engine._run_subprocess(
+            ["claude", "-p"], config,
+            provider=claude_provider,
+            prompt=big_prompt,
+        )
+
+    # Popen received stdin=PIPE (not DEVNULL) because claude opted in
+    popen_kwargs = popen_mock.call_args.kwargs
+    assert popen_kwargs["stdin"] == subprocess.PIPE
+    # The prompt was written to stdin and stdin was closed
+    assert mock_proc.stdin.write.called
+    written_prompt = mock_proc.stdin.write.call_args.args[0]
+    assert written_prompt == big_prompt
+    assert mock_proc.stdin.close.called
+
+
+def test_run_subprocess_no_stdin_when_no_prompt():
+    """Empty prompt → engine uses DEVNULL even with claude provider (no point piping nothing)."""
+    import hivemoot_agent.providers.claude as claude_provider
+
+    mock_proc = _make_mock_popen(['{"type":"result","result":"ok"}\n'])
+
+    with patch("subprocess.Popen", return_value=mock_proc) as popen_mock:
+        engine = Engine()
+        config = PluginConfig(name="test", settings={"AGENT_TIMEOUT_SECONDS": "60"})
+        engine._run_subprocess(
+            ["claude", "-p"], config,
+            provider=claude_provider,
+            prompt="",
+        )
+
+    popen_kwargs = popen_mock.call_args.kwargs
+    assert popen_kwargs["stdin"] == subprocess.DEVNULL
+
+
+def test_run_subprocess_no_stdin_for_provider_without_flag():
+    """Codex doesn't set prompt_via_stdin — engine uses DEVNULL even with non-empty prompt."""
+    import hivemoot_agent.providers.codex as codex_provider
+
+    mock_proc = _make_mock_popen([])
+
+    with patch("subprocess.Popen", return_value=mock_proc) as popen_mock:
+        engine = Engine()
+        config = PluginConfig(name="test", settings={"AGENT_TIMEOUT_SECONDS": "60"})
+        engine._run_subprocess(
+            ["codex", "exec"], config,
+            provider=codex_provider,
+            prompt="some prompt that's already in argv via codex.build_cmd",
+        )
+
+    popen_kwargs = popen_mock.call_args.kwargs
+    assert popen_kwargs["stdin"] == subprocess.DEVNULL
+
+
+def test_run_subprocess_swallows_broken_pipe_on_stdin():
+    """If claude exits before reading the full prompt, BrokenPipeError must not crash the writer."""
+    import hivemoot_agent.providers.claude as claude_provider
+
+    mock_proc = _make_mock_popen(['{"type":"result","result":"ok"}\n'])
+    mock_proc.stdin.write.side_effect = BrokenPipeError("agent closed stdin early")
+
+    with patch("subprocess.Popen", return_value=mock_proc):
+        engine = Engine()
+        config = PluginConfig(name="test", settings={"AGENT_TIMEOUT_SECONDS": "60"})
+        # Should not raise — BrokenPipeError is swallowed in the writer thread
+        exit_code, stdout = engine._run_subprocess(
+            ["claude", "-p"], config,
+            provider=claude_provider,
+            prompt="anything",
+        )
+
+    # The write was attempted but failed; the read path still works
+    assert exit_code == 0
+    assert mock_proc.stdin.close.called  # finally-block always closes
+
+
+def test_claude_build_cmd_omits_user_prompt_from_argv():
+    """Regression for [Errno 7] Argument list too long: the user prompt
+    must NOT appear in argv (it's piped via stdin instead). The
+    --append-system-prompt is still inline because system_prompt is
+    typically much smaller than the user prompt for PR-review jobs."""
+    import hivemoot_agent.providers.claude as claude_provider
+
+    huge_prompt = "X" * 500_000
+    cmd = claude_provider.build_cmd(
+        prompt=huge_prompt,
+        system_prompt="you are a reviewer",
+        model="",
+        mcp_config="",
+        session_id="",
+    )
+
+    # Iron-clad: NO argv element contains the huge prompt
+    for arg in cmd:
+        assert huge_prompt not in arg, (
+            f"prompt leaked into argv element of length {len(arg)}: "
+            f"{arg[:80]!r}..."
+        )
+    # The system_prompt is still inline (--append-system-prompt expects a string)
+    assert "you are a reviewer" in cmd
+    # And the engine reads this flag to decide stdin routing
+    assert claude_provider.prompt_via_stdin is True
+
+
+def test_claude_build_cmd_omits_user_prompt_with_resume():
+    """Same regression covering the --resume code path."""
+    import hivemoot_agent.providers.claude as claude_provider
+
+    huge_prompt = "Y" * 500_000
+    cmd = claude_provider.build_cmd(
+        prompt=huge_prompt,
+        system_prompt="ctx",
+        model="",
+        mcp_config="",
+        session_id="abc-123",
+    )
+
+    for arg in cmd:
+        assert huge_prompt not in arg
+    assert "--resume" in cmd
+    assert "abc-123" in cmd
+
+
 if __name__ == "__main__":
     import inspect
     import tempfile


### PR DESCRIPTION
Fixes #560

## Summary

Guard agent (and any engine running provider=claude) was crashing on every PR event with `[Errno 7] Argument list too long: 'claude'`. The user prompt for a PR review carries the full diff — easily hundreds of KiB — and \`providers/claude.py\` was appending it to argv via `["--", prompt]`. Combined with envp this exceeded the kernel's `MAX_ARG_PAGES` ceiling, so `execve()` returned `E2BIG` and the agent never started.

Found while diagnosing why guard hadn't reviewed any of PR #554 / #557 / #559 (per the new memory rule about SSH'ing the hive when reviewers are slow). Hive logs:

```
$ ssh agent@192.168.50.202 'tail -3 /opt/apiary/logs/hivemoot/guard.log'
[engine] running agent (plugin=github, provider=claude, mcp=yes)
[engine] agent failed: [Errno 7] Argument list too long: 'claude'
[github-new-pr] agent failed (exit=1); skipping ack
```

## Fix

Route the prompt over stdin instead of argv:

| Component | Change |
|---|---|
| `providers/claude.py` | Drop `["--", prompt]` from `build_cmd`. Add module-level `prompt_via_stdin = True` so the engine knows to pipe the prompt. Claude's `-p` headless mode reads stdin when no positional prompt is supplied. |
| `providers/__init__.py` | Declare optional `prompt_via_stdin: bool` on the Provider Protocol. Other providers (codex/gemini/kilo/opencode) don't set it and keep argv-only behavior — backward compatible via `getattr(provider, "prompt_via_stdin", False)`. |
| `engine.py _run_subprocess` | Accept `prompt: str` parameter. When provider opts in, open `stdin=subprocess.PIPE` and spawn a writer thread that feeds the prompt and closes stdin. Concurrency is required because Linux `PIPE_BUF` is 4 KiB — a synchronous write would deadlock for prompts larger than the pipe buffer once the agent's stdout fills. `BrokenPipeError` swallowed (agent-exits-early is not a writer-side failure); finally-block always closes. |
| `engine.py _run_agent_inner` | Thread `effective_prompt` (and the retry's `job.prompt`) through to `_run_subprocess` at both call sites. |

## Why stdin and not a temp file

Stdin is what Claude Code's CLI natively supports for headless mode. A temp file would require a CLI flag the binary doesn't expose (`--prompt-file` or similar). Stdin keeps the change zero-disk-footprint, atomic with the subprocess lifetime, and avoids cleanup races on agent crashes.

## What it looks like

**Before** (today's hive logs):

```
[engine] agent failed: [Errno 7] Argument list too long: 'claude'
[github-new-pr] agent failed (exit=1); skipping ack
```

**After**:

```
[engine] running agent (plugin=github, provider=claude, mcp=yes)
[engine] agent exit=0 stdout=N stderr=M
[github-new-pr] event #559 by @hivemoot
[engine] session saved: ...
```

## Test plan

- [x] 6 new tests in `test_engine.py` (34 pass total, was 28):
  - `pipes_prompt_via_stdin_for_claude` — 200_000-byte prompt round-trips
  - `no_stdin_when_no_prompt` — empty prompt → DEVNULL
  - `no_stdin_for_provider_without_flag` — codex stays argv-only
  - `swallows_broken_pipe_on_stdin` — agent-exits-early doesn't crash
  - `claude_build_cmd_omits_user_prompt_from_argv` — 500_000-char prompt assertion that NO argv element contains it
  - `claude_build_cmd_omits_user_prompt_with_resume` — same for `--resume` code path
- [x] All other engine tests still green (`test_engine.py` 34/34, `test_engine_lifecycle.py` 3/3, `test_lifecycle.py` 14/14)
- [x] `test_streaming_progress.py` has 7 unrelated failures that exist on `main` without this PR (Telegram messaging plugin tests — `'NoneType' object has no attribute 'allowed_chat_ids'`); not regressions.
- [ ] Reviewer fleet sign-off
- [ ] Real-world test: redeploy the agent image to the hive and observe guard's next PR event lands cleanly (will follow up on this PR with the log snippet once it ships)

## Governance — emergency hot-fix bypass

Same per-slice convention as #554 / #557 / #559: tracking issue (#560) labeled `hivemoot:ready-to-implement`; full discussion → voting cycle skipped because (a) this is a fix to live agent runtime that's blocking guard from doing ANY review work, (b) the diff is small and tightly scoped (one provider + one Popen call site, +220 LOC mostly tests), (c) found via active diagnosis during the autonomous war-room track. Owner-authorized in chat session 2026-04-29.