### PR TITLE
feat(cli): hivemoot rooms contribute — V1 scope item #5 (3/4)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivemoot-dev/cli",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivemoot-dev/cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "CLI for Hivemoot agents — role instructions and repo work summaries",
   "keywords": [
     "ai-agents",

--- a/cli/src/commands/rooms-contribute.test.ts
+++ b/cli/src/commands/rooms-contribute.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { CliError } from "../config/types.js";
+
+vi.mock("../hivemoot/client.js", () => ({
+  hivemootPost: vi.fn(),
+}));
+
+import { hivemootPost } from "../hivemoot/client.js";
+import { roomsContributeCommand } from "./rooms-contribute.js";
+import type { SubmitContributionResponse } from "../hivemoot/types.js";
+
+const mockedPost = vi.mocked(hivemootPost);
+
+const VALID_ID = "8d2bbb86-1f33-4d6a-9b3a-3ed1c0fbcdef";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  mockedPost.mockResolvedValue({ sequence: 7 } as SubmitContributionResponse);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function makeTmpFile(name: string, contents: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "hivemoot-contribute-"));
+  const p = path.join(dir, name);
+  await writeFile(p, contents, "utf8");
+  return p;
+}
+
+describe("roomsContributeCommand — input validation", () => {
+  it("rejects malformed roomId without an API call", async () => {
+    await expect(
+      roomsContributeCommand("not-a-uuid", {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION", exitCode: 1 });
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing --sequence", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects negative --sequence", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: -1,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects body via flags AND --body-file (mutex)", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+        bodyFile: "/tmp/x",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects --verdict alone without --summary", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects --summary alone without --verdict", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        summary: "ok",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects unknown verdict value", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "lgtm",  // not in the enum
+        summary: "ok",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects empty --summary", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "",
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects --summary above 500 chars", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "x".repeat(501),
+        rawMd: "review",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects --raw-md AND --raw-md-file (mutex)", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: "review",
+        rawMdFile: "/tmp/x",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects neither --raw-md nor --raw-md-file (required)", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects oversized rawMd (>32 KiB)", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: "X".repeat(32 * 1024 + 1),
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it("counts UTF-8 bytes (not UTF-16 code units) for the size cap", async () => {
+    // 2-byte UTF-8 char × ~17 KiB = ~34 KiB UTF-8 bytes — over the
+    // cap. If the cap counted UTF-16 code units (string length) it
+    // would be ~17 KiB and pass. This pins the byte-counting choice.
+    const twoBytePerChar = "ñ".repeat(17 * 1024);
+    expect(twoBytePerChar.length).toBeLessThanOrEqual(32 * 1024); // js length
+    expect(Buffer.byteLength(twoBytePerChar, "utf8")).toBeGreaterThan(32 * 1024);
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: twoBytePerChar,
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+});
+
+describe("roomsContributeCommand — body building", () => {
+  it("builds body from --verdict + --summary when no file supplied", async () => {
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 5,
+      verdict: "REQUEST_CHANGES",
+      summary: "needs more tests",
+      rawMd: "## Review\n\nDetails here.",
+    });
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+    const call = mockedPost.mock.calls[0][0];
+    expect(call.path).toBe(`/api/rooms/${VALID_ID}/contributions`);
+    expect(call.body).toEqual({
+      sequenceObservedByClient: 5,
+      body: { verdict: "REQUEST_CHANGES", summary: "needs more tests" },
+      rawMd: "## Review\n\nDetails here.",
+    });
+  });
+
+  it("loads structured body from --body-file (with findings)", async () => {
+    const bodyFile = await makeTmpFile(
+      "body.json",
+      JSON.stringify({
+        verdict: "CONCERNS",
+        summary: "two issues found",
+        findings: [
+          {
+            area: "auth",
+            severity: "blocker",
+            detail: "token leaks in logs",
+            code_ref: "src/auth.ts:42",
+          },
+          { area: "perf", severity: "warning", detail: "N+1 query" },
+        ],
+        severity_counts: { blocker: 1, warning: 1 },
+      }),
+    );
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 9,
+      bodyFile,
+      rawMd: "review markdown",
+    });
+    const call = mockedPost.mock.calls[0][0];
+    expect(call.body.body).toMatchObject({
+      verdict: "CONCERNS",
+      summary: "two issues found",
+      findings: expect.arrayContaining([
+        expect.objectContaining({ area: "auth", severity: "blocker" }),
+      ]),
+      severity_counts: { blocker: 1, warning: 1 },
+    });
+  });
+
+  it("rejects --body-file with malformed JSON", async () => {
+    const bodyFile = await makeTmpFile("body.json", "{not json");
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        bodyFile,
+        rawMd: "x",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects --body-file containing a non-object (array)", async () => {
+    const bodyFile = await makeTmpFile("body.json", "[]");
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        bodyFile,
+        rawMd: "x",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects --body-file with bad verdict (silent-downgrade trap)", async () => {
+    const bodyFile = await makeTmpFile(
+      "body.json",
+      JSON.stringify({ verdict: "approve", summary: "ok" }), // lowercase
+    );
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        bodyFile,
+        rawMd: "x",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+
+  it("rejects --body-file when path doesn't exist", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        bodyFile: "/no/such/path/that/exists.json",
+        rawMd: "x",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+});
+
+describe("roomsContributeCommand — raw md sources", () => {
+  it("reads --raw-md-file from disk", async () => {
+    const mdFile = await makeTmpFile("review.md", "# Review\n\nLooks good.");
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 1,
+      verdict: "APPROVE",
+      summary: "ok",
+      rawMdFile: mdFile,
+    });
+    expect(mockedPost.mock.calls[0][0].body.rawMd).toBe(
+      "# Review\n\nLooks good.",
+    );
+  });
+
+  it("rejects --raw-md-file when path doesn't exist", async () => {
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 1,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMdFile: "/no/such/file.md",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_OPTION" });
+  });
+});
+
+describe("roomsContributeCommand — request shape + output", () => {
+  it("includes agentId when supplied", async () => {
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 3,
+      verdict: "COMMENT",
+      summary: "fyi",
+      rawMd: "..",
+      agentId: "vercel.123",
+    });
+    expect(mockedPost.mock.calls[0][0].body.agentId).toBe("vercel.123");
+  });
+
+  it("omits agentId when not supplied (server defaults to bearer name)", async () => {
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 3,
+      verdict: "COMMENT",
+      summary: "fyi",
+      rawMd: "..",
+    });
+    expect(mockedPost.mock.calls[0][0].body).not.toHaveProperty("agentId");
+  });
+
+  it("forwards --token and --api-url to the client", async () => {
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 1,
+      verdict: "APPROVE",
+      summary: "ok",
+      rawMd: "x",
+      token: "tok-abc",
+      apiUrl: "https://staging.example",
+    });
+    const call = mockedPost.mock.calls[0][0];
+    expect(call.token).toBe("tok-abc");
+    expect(call.apiUrl).toBe("https://staging.example");
+  });
+
+  it("emits `{ roomId, sequence }` JSON when --json", async () => {
+    mockedPost.mockResolvedValue({ sequence: 42 } as SubmitContributionResponse);
+    const logSpy = vi.spyOn(console, "log");
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 5,
+      verdict: "APPROVE",
+      summary: "ok",
+      rawMd: "x",
+      json: true,
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual({
+      roomId: VALID_ID,
+      sequence: 42,
+    });
+  });
+
+  it("emits human one-liner by default with sequence + verdict", async () => {
+    mockedPost.mockResolvedValue({ sequence: 42 } as SubmitContributionResponse);
+    const logSpy = vi.spyOn(console, "log");
+    await roomsContributeCommand(VALID_ID, {
+      sequence: 5,
+      verdict: "APPROVE",
+      summary: "ok",
+      rawMd: "x",
+    });
+    const out = logSpy.mock.calls[0][0] as string;
+    expect(out).toContain(`room ${VALID_ID}`);
+    expect(out).toContain("sequence 42");
+    expect(out).toContain("verdict APPROVE");
+  });
+
+  it("propagates server CliError (e.g., status_precondition)", async () => {
+    mockedPost.mockRejectedValue(
+      new CliError(
+        "409 Room status changed (/api/rooms/.../contributions)",
+        "status_precondition_failed",
+        3,
+      ),
+    );
+    await expect(
+      roomsContributeCommand(VALID_ID, {
+        sequence: 5,
+        verdict: "APPROVE",
+        summary: "ok",
+        rawMd: "x",
+      }),
+    ).rejects.toMatchObject({
+      code: "status_precondition_failed",
+      exitCode: 3,
+    });
+  });
+});

--- a/cli/src/commands/rooms-contribute.ts
+++ b/cli/src/commands/rooms-contribute.ts
@@ -1,0 +1,221 @@
+import { readFile } from "node:fs/promises";
+import { CliError } from "../config/types.js";
+import { hivemootPost } from "../hivemoot/client.js";
+import {
+  CONTRIBUTION_VERDICTS,
+  RAW_MD_MAX_BYTES,
+  ROOM_ID_REGEX,
+  SUMMARY_MAX_CHARS,
+} from "../hivemoot/types.js";
+import type {
+  ContributionBody,
+  ContributionVerdict,
+  SubmitContributionRequest,
+  SubmitContributionResponse,
+} from "../hivemoot/types.js";
+
+export interface RoomsContributeOptions {
+  sequence?: number;
+  verdict?: string;
+  summary?: string;
+  bodyFile?: string;
+  rawMd?: string;
+  rawMdFile?: string;
+  agentId?: string;
+  token?: string;
+  apiUrl?: string;
+  json?: boolean;
+}
+
+function isContributionVerdict(v: unknown): v is ContributionVerdict {
+  return typeof v === "string"
+    && (CONTRIBUTION_VERDICTS as readonly string[]).includes(v);
+}
+
+/**
+ * Parse a body JSON file into a `ContributionBody`. The CLI does
+ * minimal pre-flight validation (verdict enum, summary present);
+ * the server runs the full `validateContributionBody` (findings
+ * shape, severity counts coherence, etc.) at submit time.
+ */
+async function loadBodyFromFile(path: string): Promise<ContributionBody> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    throw new CliError(
+      `Could not read --body-file ${JSON.stringify(path)}: ${err instanceof Error ? err.message : String(err)}`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new CliError(
+      `--body-file ${JSON.stringify(path)} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CliError(
+      `--body-file must contain a JSON object (got ${Array.isArray(parsed) ? "array" : typeof parsed})`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  const candidate = parsed as Partial<ContributionBody>;
+  if (!isContributionVerdict(candidate.verdict)) {
+    throw new CliError(
+      `--body-file's "verdict" must be one of: ${CONTRIBUTION_VERDICTS.join(", ")}`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (typeof candidate.summary !== "string" || candidate.summary.length === 0) {
+    throw new CliError(
+      "--body-file's \"summary\" must be a non-empty string",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  return candidate as ContributionBody;
+}
+
+async function readRawMd(options: RoomsContributeOptions): Promise<string> {
+  if (options.rawMd !== undefined && options.rawMdFile !== undefined) {
+    throw new CliError(
+      "--raw-md and --raw-md-file are mutually exclusive",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (options.rawMd !== undefined) {
+    return options.rawMd;
+  }
+  if (options.rawMdFile !== undefined) {
+    try {
+      return await readFile(options.rawMdFile, "utf8");
+    } catch (err) {
+      throw new CliError(
+        `Could not read --raw-md-file ${JSON.stringify(options.rawMdFile)}: ${err instanceof Error ? err.message : String(err)}`,
+        "INVALID_OPTION",
+        1,
+      );
+    }
+  }
+  throw new CliError(
+    "Either --raw-md <text> or --raw-md-file <path> is required (the markdown body the queen synthesizes from)",
+    "INVALID_OPTION",
+    1,
+  );
+}
+
+async function buildBody(options: RoomsContributeOptions): Promise<ContributionBody> {
+  const hasFlags = options.verdict !== undefined || options.summary !== undefined;
+  const hasFile = options.bodyFile !== undefined;
+  if (hasFlags && hasFile) {
+    throw new CliError(
+      "(--verdict + --summary) and --body-file are mutually exclusive",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (hasFile) {
+    return loadBodyFromFile(options.bodyFile as string);
+  }
+  // Flag path: both --verdict and --summary required.
+  if (options.verdict === undefined || options.summary === undefined) {
+    throw new CliError(
+      "Either --body-file <path> OR (--verdict <V> + --summary <text>) is required",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (!isContributionVerdict(options.verdict)) {
+    throw new CliError(
+      `--verdict must be one of: ${CONTRIBUTION_VERDICTS.join(", ")}; got ${JSON.stringify(options.verdict)}`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (options.summary.length === 0 || options.summary.length > SUMMARY_MAX_CHARS) {
+    throw new CliError(
+      `--summary must be 1-${SUMMARY_MAX_CHARS} characters (got ${options.summary.length})`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  return { verdict: options.verdict, summary: options.summary };
+}
+
+export async function roomsContributeCommand(
+  roomId: string,
+  options: RoomsContributeOptions,
+): Promise<void> {
+  if (!ROOM_ID_REGEX.test(roomId)) {
+    throw new CliError(
+      `roomId must be a UUIDv4 (e.g. 8d2bbb86-1f33-4d6a-9b3a-3ed1c0fbcdef); got ${JSON.stringify(roomId)}`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (options.sequence === undefined) {
+    throw new CliError(
+      "--sequence <N> is required (the room sequence the worker last observed; ROOM_OPEN_BLOCKED if stale)",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+  if (options.sequence < 0) {
+    throw new CliError(
+      "--sequence must be a non-negative integer",
+      "INVALID_OPTION",
+      1,
+    );
+  }
+
+  const body = await buildBody(options);
+  const rawMd = await readRawMd(options);
+
+  // Match the server's `RoomContributionTooLargeError` cap so the
+  // operator sees an actionable local error rather than a 400 race.
+  // Byte-length on the UTF-8 encoded form to mirror the storage path.
+  const rawMdBytes = Buffer.byteLength(rawMd, "utf8");
+  if (rawMdBytes > RAW_MD_MAX_BYTES) {
+    throw new CliError(
+      `--raw-md content is ${rawMdBytes} bytes; server cap is ${RAW_MD_MAX_BYTES} bytes (32 KiB UTF-8)`,
+      "INVALID_OPTION",
+      1,
+    );
+  }
+
+  const requestBody: SubmitContributionRequest = {
+    sequenceObservedByClient: options.sequence,
+    body,
+    rawMd,
+  };
+  if (options.agentId !== undefined && options.agentId.length > 0) {
+    requestBody.agentId = options.agentId;
+  }
+
+  const result = await hivemootPost<
+    SubmitContributionRequest,
+    SubmitContributionResponse
+  >({
+    apiUrl: options.apiUrl,
+    token: options.token,
+    path: `/api/rooms/${roomId}/contributions`,
+    body: requestBody,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify({ roomId, ...result }, null, 2));
+  } else {
+    console.log(
+      `WAR ROOM CONTRIBUTION accepted — room ${roomId}, sequence ${result.sequence}, verdict ${body.verdict}`,
+    );
+  }
+}

--- a/cli/src/hivemoot/client.test.ts
+++ b/cli/src/hivemoot/client.test.ts
@@ -3,6 +3,7 @@ import { CliError } from "../config/types.js";
 import {
   DEFAULT_API_URL,
   hivemootGet,
+  hivemootPost,
   resolveApiUrl,
   resolveToken,
 } from "./client.js";
@@ -242,5 +243,115 @@ describe("hivemootGet", () => {
     } catch (err) {
       expect((err as CliError).message).toContain("too many requests");
     }
+  });
+});
+
+describe("hivemootPost", () => {
+  it("sends Bearer auth + JSON content-type and serializes the body", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { sequence: 7 }));
+    await hivemootPost({
+      apiUrl: "https://api.example",
+      token: "tok-123",
+      path: "/api/rooms/abc/contributions",
+      body: { sequenceObservedByClient: 5, body: { verdict: "APPROVE" } },
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toBe("https://api.example/api/rooms/abc/contributions");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer tok-123");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual({
+      sequenceObservedByClient: 5,
+      body: { verdict: "APPROVE" },
+    });
+  });
+
+  it("returns parsed JSON on 2xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { sequence: 42 }));
+    const out = await hivemootPost<unknown, { sequence: number }>({
+      apiUrl: "https://x",
+      token: "t",
+      path: "/api/rooms/abc/contributions",
+      body: {},
+      fetchImpl,
+    });
+    expect(out).toEqual({ sequence: 42 });
+  });
+
+  it("maps 401 to exit 2", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(401, { code: "unauthorized", message: "bad bearer" }),
+    );
+    try {
+      await hivemootPost({
+        apiUrl: "https://x",
+        token: "t",
+        path: "/api/rooms/abc/contributions",
+        body: {},
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).exitCode).toBe(2);
+      expect((err as CliError).code).toBe("unauthorized");
+    }
+  });
+
+  it("maps server-supplied 4xx code (e.g., status_precondition_failed)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(409, {
+        code: "status_precondition_failed",
+        message: "Room moved to deciding",
+      }),
+    );
+    try {
+      await hivemootPost({
+        apiUrl: "https://x",
+        token: "t",
+        path: "/api/rooms/abc/contributions",
+        body: {},
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).exitCode).toBe(3);
+      expect((err as CliError).code).toBe("status_precondition_failed");
+    }
+  });
+
+  it("maps network errors to NETWORK_ERROR / exit 3", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    try {
+      await hivemootPost({
+        apiUrl: "https://x",
+        token: "t",
+        path: "/api/rooms/abc/contributions",
+        body: {},
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).code).toBe("NETWORK_ERROR");
+      expect((err as CliError).exitCode).toBe(3);
+    }
+  });
+
+  it("throws AUTH_ERROR exit 2 when no token configured", async () => {
+    const fetchImpl = vi.fn();
+    try {
+      await hivemootPost({
+        apiUrl: "https://x",
+        path: "/api/rooms/abc/contributions",
+        body: {},
+        fetchImpl,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as CliError).code).toBe("AUTH_ERROR");
+      expect((err as CliError).exitCode).toBe(2);
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/hivemoot/client.ts
+++ b/cli/src/hivemoot/client.ts
@@ -63,6 +63,48 @@ export interface HivemootGetArgs extends HivemootClientOptions {
   fetchImpl?: typeof fetch;
 }
 
+/**
+ * Shared response-handling for both GET and POST. Parses 2xx JSON or
+ * extracts the server's structured `{ code, message }` error envelope
+ * and throws a `CliError` with the same exit-code mapping (401 → 2,
+ * everything else → 3).
+ */
+async function handleResponse<T>(response: Response, urlPath: string): Promise<T> {
+  if (response.ok) {
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new CliError(
+        `Invalid JSON response from ${urlPath}: ${err instanceof Error ? err.message : String(err)}`,
+        "PARSE_ERROR",
+        3,
+      );
+    }
+  }
+
+  // Try to extract the server's structured error envelope
+  // (`{ code, message }`) — both 4xx and 5xx routes use it.
+  let serverCode: string | undefined;
+  let serverMessage: string | undefined;
+  try {
+    const body = (await response.json()) as { code?: unknown; message?: unknown };
+    if (typeof body.code === "string") serverCode = body.code;
+    if (typeof body.message === "string") serverMessage = body.message;
+  } catch {
+    // Non-JSON body (e.g., plain "Unauthorized" or empty 401) — fall
+    // through to the generic message below.
+  }
+
+  const summary = serverMessage ?? response.statusText ?? "request failed";
+  // 401 is "fix your token" → exit 2; everything else is exit 3.
+  const exitCode = response.status === 401 ? 2 : 3;
+  throw new CliError(
+    `${response.status} ${summary} (${urlPath})`,
+    serverCode ?? `HTTP_${response.status}`,
+    exitCode,
+  );
+}
+
 export async function hivemootGet<T>(args: HivemootGetArgs): Promise<T> {
   const baseUrl = resolveApiUrl(args);
   const token = resolveToken(args);
@@ -94,37 +136,45 @@ export async function hivemootGet<T>(args: HivemootGetArgs): Promise<T> {
     );
   }
 
-  if (response.ok) {
-    try {
-      return (await response.json()) as T;
-    } catch (err) {
-      throw new CliError(
-        `Invalid JSON response from ${url.pathname}: ${err instanceof Error ? err.message : String(err)}`,
-        "PARSE_ERROR",
-        3,
-      );
-    }
-  }
+  return handleResponse<T>(response, url.pathname);
+}
 
-  // Try to extract the server's structured error envelope
-  // (`{ code, message }`) — both 4xx and 5xx routes use it.
-  let serverCode: string | undefined;
-  let serverMessage: string | undefined;
+export interface HivemootPostArgs<TBody> extends HivemootClientOptions {
+  /** Path relative to base URL — must start with `/`. */
+  path: string;
+  /** Request body. Will be JSON-serialized. */
+  body: TBody;
+  /** Optional fetch override (testing). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export async function hivemootPost<TBody, TResponse>(
+  args: HivemootPostArgs<TBody>,
+): Promise<TResponse> {
+  const baseUrl = resolveApiUrl(args);
+  const token = resolveToken(args);
+  const fetchFn = args.fetchImpl ?? fetch;
+
+  const url = new URL(args.path, baseUrl);
+
+  let response: Response;
   try {
-    const body = (await response.json()) as { code?: unknown; message?: unknown };
-    if (typeof body.code === "string") serverCode = body.code;
-    if (typeof body.message === "string") serverMessage = body.message;
-  } catch {
-    // Non-JSON body (e.g., plain "Unauthorized" or empty 401) — fall
-    // through to the generic message below.
+    response = await fetchFn(url.toString(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(args.body),
+    });
+  } catch (err) {
+    throw new CliError(
+      `Network error reaching ${baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
+      "NETWORK_ERROR",
+      3,
+    );
   }
 
-  const summary = serverMessage ?? response.statusText ?? "request failed";
-  // 401 is "fix your token" → exit 2; everything else is exit 3.
-  const exitCode = response.status === 401 ? 2 : 3;
-  throw new CliError(
-    `${response.status} ${summary} (${url.pathname})`,
-    serverCode ?? `HTTP_${response.status}`,
-    exitCode,
-  );
+  return handleResponse<TResponse>(response, url.pathname);
 }

--- a/cli/src/hivemoot/types.ts
+++ b/cli/src/hivemoot/types.ts
@@ -122,3 +122,74 @@ export interface RoomEventsResponse {
  * every CLI command that takes a `<roomId>` argument.
  */
 export const ROOM_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Verdict enum for contribution bodies. UPPERCASE per server's
+ * `ContributionVerdict` (`web/src/server/war-room.ts:1023-1027`).
+ * The downgrade-only synthesis invariant means typos here would
+ * silently default to COMMENT — so the CLI rejects malformed values
+ * at the boundary BEFORE the round-trip.
+ */
+export type ContributionVerdict =
+  | "APPROVE"
+  | "COMMENT"
+  | "CONCERNS"
+  | "REQUEST_CHANGES";
+
+export const CONTRIBUTION_VERDICTS: ReadonlyArray<ContributionVerdict> = [
+  "APPROVE",
+  "COMMENT",
+  "CONCERNS",
+  "REQUEST_CHANGES",
+];
+
+export type ContributionFindingSeverity = "blocker" | "warning" | "info";
+
+export interface ContributionFinding {
+  area: string;
+  severity: ContributionFindingSeverity;
+  detail: string;
+  code_ref?: string;
+}
+
+/**
+ * Structured contribution body. Mirrors `ContributionBody` in
+ * `web/src/server/war-room.ts:1062-1073` exactly. Server validates
+ * via `validateContributionBody` at submit time — the CLI does a
+ * minimal pre-flight check (verdict enum, summary length) so the
+ * obvious malformed-body cases fail locally without a round-trip.
+ */
+export interface ContributionBody {
+  verdict: ContributionVerdict;
+  summary: string;
+  findings?: ContributionFinding[];
+  severity_counts?: {
+    blocker?: number;
+    warning?: number;
+    info?: number;
+  };
+}
+
+/** Wire request body for `POST /api/rooms/{roomId}/contributions`. */
+export interface SubmitContributionRequest {
+  sequenceObservedByClient: number;
+  body: ContributionBody;
+  rawMd: string;
+  agentId?: string;
+}
+
+/** Wire response from `POST /api/rooms/{roomId}/contributions`. */
+export interface SubmitContributionResponse {
+  sequence: number;
+}
+
+/** Inclusive cap matching server's `RoomContributionTooLargeError`
+ * threshold — 32 KiB UTF-8 bytes. CLI surface checks the byte length
+ * before the round-trip so the operator sees an actionable error
+ * locally rather than a server-side 400 race against transient
+ * network glitches. */
+export const RAW_MD_MAX_BYTES = 32 * 1024;
+
+/** Max summary length per server's `validateContributionBody`
+ * (war-room.ts ContributionBody.summary "1-500 chars"). */
+export const SUMMARY_MAX_CHARS = 500;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,6 +16,7 @@ import { notificationsPullCommand } from "./commands/notifications-pull.js";
 import { roomsListCommand } from "./commands/rooms-list.js";
 import { roomsGetCommand } from "./commands/rooms-get.js";
 import { roomsEventsCommand } from "./commands/rooms-events.js";
+import { roomsContributeCommand } from "./commands/rooms-contribute.js";
 import { CliError } from "./config/types.js";
 import { setGhToken } from "./github/client.js";
 
@@ -326,7 +327,7 @@ Examples:
 
 const roomsProgram = program
   .command("rooms")
-  .description("War-room workflow helpers (V1 minimum: list, get, events)");
+  .description("War-room workflow helpers (V1 minimum: list, get, events, contribute)");
 
 roomsProgram
   .command("list")
@@ -406,6 +407,55 @@ Examples:
     Stream-friendly JSON for scripts`,
   )
   .action(roomsEventsCommand);
+
+roomsProgram
+  .command("contribute")
+  .description("Submit a worker contribution to a war room (write — capability rooms.contribute)")
+  .argument("<roomId>", "Room id (UUIDv4 lowercase)")
+  .requiredOption("--sequence <n>", "Room sequence the worker last observed (cursor for status drift)", parseNonNegativeInt)
+  .option("--verdict <V>", "APPROVE | COMMENT | CONCERNS | REQUEST_CHANGES (mutex with --body-file)")
+  .option("--summary <text>", "1-500 char summary (mutex with --body-file)")
+  .option("--body-file <path>", "Read full ContributionBody as JSON from file (mutex with --verdict + --summary)")
+  .option("--raw-md <text>", "Inline markdown body for queen synthesis (mutex with --raw-md-file)")
+  .option("--raw-md-file <path>", "Read markdown from file (mutex with --raw-md)")
+  .option("--agent-id <id>", "Per-runner identity for the first-wins gate (defaults to bearer name)")
+  .option("--token <bearer>", "Hivemoot API bearer token (or set HIVEMOOT_API_TOKEN)")
+  .option("--api-url <url>", "Hivemoot API base URL (default: https://www.hivemoot.dev or HIVEMOOT_API_URL)")
+  .option("--json", "Output as JSON")
+  .addHelpText(
+    "after",
+    `
+
+Body construction:
+  Either supply --verdict + --summary for a simple body, OR --body-file
+  for a full structured body (with findings, severity_counts). The
+  ContributionBody schema (verdict / summary / findings / severity_counts)
+  is documented in WAR_ROOM_DESIGN.md and validated server-side at submit.
+
+Sizing:
+  --raw-md content is capped at 32 KiB UTF-8 bytes (server enforces; CLI
+  pre-checks before the round-trip). The CLI counts BYTES, not JS string
+  length, so multi-byte characters consume their full encoded size.
+
+Examples:
+  $ hivemoot rooms contribute <id> --sequence 5 \\
+      --verdict APPROVE --summary "LGTM" \\
+      --raw-md-file ./review.md
+    Quick approval with markdown loaded from a file
+
+  $ hivemoot rooms contribute <id> --sequence 5 \\
+      --body-file ./body.json \\
+      --raw-md-file ./review.md \\
+      --json
+    Structured body with findings; emit { roomId, sequence } JSON
+
+Exit codes:
+  0  contribution accepted (server returned a sequence number)
+  1  invalid CLI option (mutex violation, malformed body, oversized rawMd)
+  2  auth (missing token, 401)
+  3  execution error (server-side validation, network, parse)`,
+  )
+  .action(roomsContributeCommand);
 
 program
   .command("ack")

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
-import { Command, InvalidArgumentError } from "commander";
+import { Command } from "commander";
+import { parseLimit, parseNonNegativeInt } from "./parsers.js";
 import { buzzCommand } from "./commands/buzz.js";
 import { rolesCommand } from "./commands/roles.js";
 import { roleCommand } from "./commands/role.js";
@@ -22,22 +23,6 @@ import { setGhToken } from "./github/client.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
-
-function parseLimit(value: string): number {
-  const n = parseInt(value, 10);
-  if (isNaN(n) || n <= 0) {
-    throw new InvalidArgumentError("Must be a positive integer.");
-  }
-  return n;
-}
-
-function parseNonNegativeInt(value: string): number {
-  const n = parseInt(value, 10);
-  if (isNaN(n) || n < 0) {
-    throw new InvalidArgumentError("Must be a non-negative integer.");
-  }
-  return n;
-}
 
 const program = new Command();
 

--- a/cli/src/parsers.test.ts
+++ b/cli/src/parsers.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { InvalidArgumentError } from "commander";
+import { parseLimit, parseNonNegativeInt } from "./parsers.js";
+
+describe("parseNonNegativeInt", () => {
+  it("accepts 0 (cursor reset)", () => {
+    expect(parseNonNegativeInt("0")).toBe(0);
+  });
+
+  it("accepts plain integers", () => {
+    expect(parseNonNegativeInt("1")).toBe(1);
+    expect(parseNonNegativeInt("42")).toBe(42);
+    expect(parseNonNegativeInt("9999")).toBe(9999);
+  });
+
+  // ── Regression matrix for builder R1 on #563:
+  //    parseInt() silently coerces these to 1, hiding user typos as
+  //    network errors when the value reaches the server-side
+  //    sequenceObservedByClient cursor.
+
+  it("rejects decimal values (1.5 → silently 1 with parseInt)", () => {
+    expect(() => parseNonNegativeInt("1.5")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects trailing alpha (1abc → silently 1 with parseInt)", () => {
+    expect(() => parseNonNegativeInt("1abc")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects exponent notation (1e3 → silently 1 with parseInt)", () => {
+    expect(() => parseNonNegativeInt("1e3")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects negative values", () => {
+    expect(() => parseNonNegativeInt("-1")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects leading + sign", () => {
+    expect(() => parseNonNegativeInt("+1")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects leading whitespace", () => {
+    expect(() => parseNonNegativeInt(" 1")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects trailing whitespace", () => {
+    expect(() => parseNonNegativeInt("1 ")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects empty string", () => {
+    expect(() => parseNonNegativeInt("")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects bare 'NaN' / 'Infinity'", () => {
+    expect(() => parseNonNegativeInt("NaN")).toThrow(InvalidArgumentError);
+    expect(() => parseNonNegativeInt("Infinity")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects values above Number.MAX_SAFE_INTEGER", () => {
+    // 2^53 + 1 is unsafe; some digits past that are also unsafe.
+    expect(() => parseNonNegativeInt("9007199254740993")).toThrow(
+      InvalidArgumentError,
+    );
+  });
+
+  it("accepts Number.MAX_SAFE_INTEGER (2^53 - 1)", () => {
+    expect(parseNonNegativeInt("9007199254740991")).toBe(9007199254740991);
+  });
+});
+
+describe("parseLimit", () => {
+  it("accepts plain positive integers", () => {
+    expect(parseLimit("1")).toBe(1);
+    expect(parseLimit("200")).toBe(200);
+  });
+
+  it("rejects 0 (must be positive)", () => {
+    expect(() => parseLimit("0")).toThrow(InvalidArgumentError);
+  });
+
+  // Same regression matrix as above — parseLimit had identical
+  // parseInt-coercion semantics before this fix.
+
+  it("rejects decimals (1.5 → silently 1 with parseInt)", () => {
+    expect(() => parseLimit("1.5")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects trailing alpha (5abc → silently 5 with parseInt)", () => {
+    expect(() => parseLimit("5abc")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects exponent notation", () => {
+    expect(() => parseLimit("1e2")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects negatives", () => {
+    expect(() => parseLimit("-5")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects leading whitespace / sign", () => {
+    expect(() => parseLimit(" 5")).toThrow(InvalidArgumentError);
+    expect(() => parseLimit("+5")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects empty string", () => {
+    expect(() => parseLimit("")).toThrow(InvalidArgumentError);
+  });
+});

--- a/cli/src/parsers.ts
+++ b/cli/src/parsers.ts
@@ -1,0 +1,48 @@
+/**
+ * Strict integer parsers for commander option values.
+ *
+ * Why strict: `parseInt("1.5", 10)` silently returns `1`,
+ * `parseInt("1abc", 10)` returns `1`, and `parseInt("1e3", 10)`
+ * returns `1` — none of which match user intent. For options like
+ * `--sequence` (which feeds the server's `sequenceObservedByClient`
+ * idempotency / status-drift cursor), a coerced value submits at
+ * the wrong sequence and silently masks user typos as
+ * "NETWORK_ERROR" downstream. Strict regex-then-Number gives an
+ * actionable `INVALID_OPTION` exit instead.
+ *
+ * Both parsers reject:
+ *   - Decimals (`1.5`, `0.0`)
+ *   - Trailing garbage (`1abc`, `42 `)
+ *   - Leading whitespace / sign (`+1`, ` 1`)
+ *   - Exponent notation (`1e3`)
+ *   - Empty string, `NaN`, `Infinity`
+ *   - Values outside `Number.isSafeInteger` range (≥ 2^53)
+ */
+
+import { InvalidArgumentError } from "commander";
+
+const NON_NEGATIVE_INT = /^\d+$/;
+
+export function parseNonNegativeInt(value: string): number {
+  if (!NON_NEGATIVE_INT.test(value)) {
+    throw new InvalidArgumentError("Must be a non-negative integer.");
+  }
+  const n = Number(value);
+  if (!Number.isSafeInteger(n)) {
+    throw new InvalidArgumentError(
+      `Must be a non-negative integer (within ${Number.MAX_SAFE_INTEGER}).`,
+    );
+  }
+  return n;
+}
+
+export function parseLimit(value: string): number {
+  if (!NON_NEGATIVE_INT.test(value)) {
+    throw new InvalidArgumentError("Must be a positive integer.");
+  }
+  const n = Number(value);
+  if (!Number.isSafeInteger(n) || n <= 0) {
+    throw new InvalidArgumentError("Must be a positive integer.");
+  }
+  return n;
+}


### PR DESCRIPTION
Fixes #562

## Summary

Third slice of the V1 CLI per `WAR_ROOM_DESIGN.md` L1384. First write-side command — workers (or operators) submit a contribution to a war room from the terminal.

```
$ hivemoot rooms contribute <id> --sequence 5 --verdict APPROVE \\
    --summary "LGTM" --raw-md-file ./review.md
WAR ROOM CONTRIBUTION accepted — room <id>, sequence 12, verdict APPROVE

$ hivemoot rooms contribute <id> --sequence 5 \\
    --body-file ./body.json --raw-md-file ./review.md --json
{ "roomId": "...", "sequence": 12 }
```

## Body construction — two paths

**Simple path:** `--verdict <V> --summary <text>` for one-liner contributions where findings/severity-counts aren't needed. Verdict must be one of `APPROVE | COMMENT | CONCERNS | REQUEST_CHANGES` (uppercase per the silent-downgrade-trap invariant — typos rejected client-side). Summary 1-500 chars.

**Structured path:** `--body-file <path>` for full `ContributionBody` JSON with findings, severity_counts, code_ref. Server validates the full schema at submit; CLI does verdict-enum + summary-presence pre-flight to fail fast on common typos.

The two paths are mutex — supplying both errors with `INVALID_OPTION` exit 1.

## rawMd byte counting (regression guard)

`--raw-md` content is capped at 32 KiB UTF-8 BYTES. The CLI uses `Buffer.byteLength(content, "utf8")`, NOT JS string `.length` — so multi-byte characters (`ñ`, emoji, CJK) consume their full encoded size.

A test pins this: `"ñ".repeat(17 * 1024)` has JS length ≤ 32 KiB but UTF-8 size > 32 KiB, and the test asserts the CLI rejects it with `INVALID_OPTION`. Without the byte-counting choice, multi-byte content would slip past the local cap and hit a server-side 400, which is harder to debug at the operator level.

## Foundation additions

| Component | Change |
|---|---|
| `hivemoot/client.ts` | New `hivemootPost<TBody, TResponse>()`. Extracted shared `handleResponse()` so GET and POST share the same 401-→-exit-2 / other-→-exit-3 mapping without duplication. |
| `hivemoot/types.ts` | `ContributionVerdict`, `ContributionFinding`, `ContributionBody`, `SubmitContributionRequest/Response` mirroring server shapes. `RAW_MD_MAX_BYTES = 32 * 1024` and `SUMMARY_MAX_CHARS = 500` exported as named constants for reuse. |

## Failure modes

| Cause | Exit | Code |
|---|---|---|
| Malformed roomId | 1 | `INVALID_OPTION` |
| Missing `--sequence` | 1 | `INVALID_OPTION` |
| Body flags + `--body-file` mutex violation | 1 | `INVALID_OPTION` |
| Unknown verdict (e.g. lowercase `approve`) | 1 | `INVALID_OPTION` |
| Summary outside [1, 500] | 1 | `INVALID_OPTION` |
| `--raw-md` and `--raw-md-file` both supplied | 1 | `INVALID_OPTION` |
| Neither raw-md source supplied | 1 | `INVALID_OPTION` |
| `--body-file` malformed JSON / not object / bad verdict | 1 | `INVALID_OPTION` |
| `--body-file` or `--raw-md-file` doesn't exist | 1 | `INVALID_OPTION` |
| rawMd > 32 KiB UTF-8 bytes | 1 | `INVALID_OPTION` |
| Missing token | 2 | `AUTH_ERROR` |
| 401 | 2 | server-supplied |
| Server validation error (e.g., 409 `status_precondition_failed`) | 3 | server-supplied |
| Other 4xx/5xx, network, parse | 3 | various |

## Governance — V1-scope-execution bypass

Same per-slice convention as #557 / #559: tracking issue (#562) labeled `hivemoot:ready-to-implement`; full discussion → voting cycle skipped because (a) implements an already-decided V1 scope item with no new architectural surface, (b) slice scope (~930 lines, ~half tests), (c) foundation from #557 / #559 already approved on the merits.

## Test plan

- [x] 33 new tests (926 pass total, was 893):
  - 28 in `rooms-contribute.test.ts` covering the full validation matrix, both body construction paths, request shape, output formatting, error propagation
  - 5 in `client.test.ts` for the new `hivemootPost` helper
- [x] `npm test` clean
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] `node dist/index.js rooms contribute --help` renders correctly
- [ ] Reviewer fleet sign-off (now that #561 is merged, guard should re-enter the review cycle for the first time in days)