### PR TITLE
feat(web): dashboard UI for V1 capability token issuance (1/3)

### DIFF
--- a/web/src/app/api/dashboard/agent-tokens/[name]/rotate/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/[name]/rotate/route.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for POST /api/dashboard/agent-tokens/{name}/rotate.
+ * Mirrors the issuance test shape — auth gate, name validation,
+ * successful rotation (new bearer in response), TokenNotFoundError
+ * mapping for nonexistent names.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/require-installation", () => ({
+  requireInstallation: vi.fn(),
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    rotateAgentToken: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  rotateAgentToken,
+  TokenNotFoundError,
+} from "@/server/agent-token-v1";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedRequireInstallation = vi.mocked(requireInstallation);
+const mockedRotate = vi.mocked(rotateAgentToken);
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    "https://www.hivemoot.dev/api/dashboard/agent-tokens/queen/rotate",
+    { method: "POST", headers: { cookie: "session=mock" } },
+  );
+}
+
+function makeParams(name = "queen") {
+  return { params: Promise.resolve({ name }) };
+}
+
+function makeByokAuthOk() {
+  return {
+    ok: true as const,
+    session: {
+      userLogin: "operator-gh-login",
+      installationId: "12345",
+    } as never,
+    keyring: new Map<string, Buffer>([["v1", Buffer.alloc(32)]]),
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  };
+}
+
+function makeRotated() {
+  return {
+    token: "hmt_freshly_rotated_queen_bearer",
+    name: "queen",
+    agent_role: "queen",
+    capabilities: ["rooms.create", "rooms.read"],
+    fingerprint: "rotfp001",
+    expiresAt: null as string | null,
+  };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedRequireInstallation.mockReset();
+  mockedRotate.mockReset();
+});
+
+describe("POST /api/dashboard/agent-tokens/{name}/rotate — auth + path", () => {
+  it("byok auth failure → no rotate call", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "byok_session_invalid" }, { status: 401 }),
+    } as never);
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(401);
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+
+  it("requireInstallation failure → no rotate call", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ code: "installation_required" }, { status: 409 }),
+    } as never);
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(409);
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+
+  it("empty path name → 400 INVALID_NAME", async () => {
+    const res = await POST(makeRequest(), makeParams(""));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+
+  it("malformed path name (capitals) → 400 INVALID_NAME", async () => {
+    const res = await POST(makeRequest(), makeParams("Queen"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+    expect(mockedRotate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/dashboard/agent-tokens/{name}/rotate — success", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+  });
+
+  it("returns the new bearer + metadata + audit context uses dashboard convention", async () => {
+    mockedRotate.mockResolvedValue(makeRotated() as never);
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("hmt_freshly_rotated_queen_bearer");
+    expect(body.fingerprint).toBe("rotfp001");
+    expect(body.name).toBe("queen");
+    expect(body.capabilities).toEqual(["rooms.create", "rooms.read"]);
+    expect(body.message).toMatch(/store it in the target/i);
+
+    // Audit context is the cookie-auth convention
+    const call = mockedRotate.mock.calls[0][0];
+    expect(call.auditContext?.operator).toEqual({
+      fingerprint: "",
+      name: "dashboard",
+    });
+    expect(call.auditContext?.detailExtras).toEqual({
+      rotated_by: "operator-gh-login",
+    });
+  });
+});
+
+describe("POST /api/dashboard/agent-tokens/{name}/rotate — error mapping", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+  });
+
+  it("nonexistent name → TokenNotFoundError → 404", async () => {
+    mockedRotate.mockRejectedValue(new TokenNotFoundError("12345", "queen"));
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it("generic storage error → 500", async () => {
+    mockedRotate.mockRejectedValue(new Error("redis dropped"));
+    const res = await POST(makeRequest(), makeParams());
+    expect(res.status).toBe(500);
+  });
+});

--- a/web/src/app/api/dashboard/agent-tokens/[name]/rotate/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/[name]/rotate/route.ts
@@ -1,0 +1,110 @@
+/**
+ * POST /api/dashboard/agent-tokens/{name}/rotate — issue a fresh
+ * bearer for an existing token (cookie-auth dashboard surface).
+ *
+ * Rotation preserves the envelope's name + capabilities + agent_role
+ * + expiresAt; only the bearer (and its hash / fingerprint) change.
+ * The new bearer is shown ONCE in the response — operators must
+ * paste it into wherever the old bearer lived (queen agent config,
+ * apiarist secrets, etc.) immediately.
+ *
+ * See ../../route.ts for the rationale on cookie-auth wrappers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  rotateAgentToken,
+  type IssuedAgentTokenV1,
+} from "@/server/agent-token-v1";
+import {
+  validateName,
+  CapabilityValidationError,
+} from "@/server/agent-token-capabilities";
+import {
+  mapV1StorageErrorToResponse,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+} from "@/server/agent-token-v1-routes";
+
+interface PathParams {
+  params: Promise<{ name: string }>;
+}
+
+interface RotateResponse {
+  /** Raw bearer (`hmt_xxx...`). Shown ONCE — paste into target before
+   * leaving this view. */
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+  message: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: PathParams,
+): Promise<NextResponse> {
+  const { name: rawName } = await context.params;
+  if (typeof rawName !== "string" || rawName.length === 0) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+      "Token name is required in the URL path.",
+      400,
+    );
+  }
+  try {
+    validateName(rawName);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      return v1Error(AGENT_TOKENS_V1_ERROR.INVALID_NAME, err.message, 400, {
+        field: err.field,
+        value: err.value,
+      });
+    }
+    throw err;
+  }
+
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  let rotated: IssuedAgentTokenV1;
+  try {
+    rotated = await rotateAgentToken({
+      installationId,
+      name: rawName,
+      keyring: auth.keyring,
+      keyVersion: auth.activeKeyVersion,
+      redis: auth.redis,
+      auditContext: {
+        operator: { fingerprint: "", name: "dashboard" },
+        detailExtras: { rotated_by: auth.session.userLogin },
+      },
+    });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "POST /api/dashboard/agent-tokens/{name}/rotate",
+      installationId,
+      name: rawName,
+    });
+  }
+
+  const response: RotateResponse = {
+    token: rotated.token,
+    name: rotated.name,
+    agent_role: rotated.agent_role,
+    capabilities: [...rotated.capabilities],
+    fingerprint: rotated.fingerprint,
+    expiresAt: rotated.expiresAt,
+    message:
+      "New bearer — store it in the target (queen agent / apiarist secret / etc.) immediately. The previous bearer is now invalid.",
+  };
+  return NextResponse.json(response);
+}

--- a/web/src/app/api/dashboard/agent-tokens/[name]/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/[name]/route.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the per-name dashboard cookie-auth wrappers (GET summary,
+ * DELETE revoke). The 404 branch on revoke is route-synthesized
+ * (storage returns `null` → route emits TOKEN_NOT_FOUND) — distinct
+ * from the `mapV1StorageErrorToResponse` path that handles thrown
+ * storage errors. Both branches are tested explicitly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/require-installation", () => ({
+  requireInstallation: vi.fn(),
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    getAgentTokenSummary: vi.fn(),
+    revokeAgentToken: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  getAgentTokenSummary,
+  revokeAgentToken,
+  TokenNotFoundError,
+} from "@/server/agent-token-v1";
+import { GET, DELETE } from "./route";
+
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedRequireInstallation = vi.mocked(requireInstallation);
+const mockedGetSummary = vi.mocked(getAgentTokenSummary);
+const mockedRevoke = vi.mocked(revokeAgentToken);
+
+function makeRequest(method: "GET" | "DELETE"): NextRequest {
+  return new NextRequest(
+    "https://www.hivemoot.dev/api/dashboard/agent-tokens/queen",
+    {
+      method,
+      headers: { cookie: "session=mock" },
+    },
+  );
+}
+
+function makeParams(name = "queen") {
+  return { params: Promise.resolve({ name }) };
+}
+
+function makeByokAuthOk() {
+  return {
+    ok: true as const,
+    session: {
+      userLogin: "operator-gh-login",
+      installationId: "12345",
+    } as never,
+    keyring: new Map<string, Buffer>([["v1", Buffer.alloc(32)]]),
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  };
+}
+
+function makeSummary() {
+  return {
+    name: "queen",
+    agent_role: "queen",
+    capabilities: ["rooms.create", "rooms.read"],
+    fingerprint: "queenfp1",
+    createdAt: "2026-04-30T07:00:00.000Z",
+    createdBy: "operator-gh-login",
+    expiresAt: null as string | null,
+  };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedRequireInstallation.mockReset();
+  mockedGetSummary.mockReset();
+  mockedRevoke.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Path validation (shared between GET/DELETE)
+// ---------------------------------------------------------------------------
+
+describe("path-name validation", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+  });
+
+  it("rejects empty name → 400 INVALID_NAME (no auth call needed for the empty case, but the handler runs auth first; either way 400 surfaces)", async () => {
+    const res = await GET(makeRequest("GET"), makeParams(""));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+  });
+
+  it("rejects malformed name (capital letters) → 400 INVALID_NAME", async () => {
+    const res = await GET(makeRequest("GET"), makeParams("QUEEN"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET — summary
+// ---------------------------------------------------------------------------
+
+describe("GET /api/dashboard/agent-tokens/{name}", () => {
+  it("byok auth failure → no summary call", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "byok_session_invalid" }, { status: 401 }),
+    } as never);
+    const res = await GET(makeRequest("GET"), makeParams());
+    expect(res.status).toBe(401);
+    expect(mockedGetSummary).not.toHaveBeenCalled();
+  });
+
+  it("requireInstallation failure → no summary call", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ code: "installation_required" }, { status: 409 }),
+    } as never);
+    const res = await GET(makeRequest("GET"), makeParams());
+    expect(res.status).toBe(409);
+    expect(mockedGetSummary).not.toHaveBeenCalled();
+  });
+
+  it("returns summary on success", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedGetSummary.mockResolvedValue(makeSummary() as never);
+    const res = await GET(makeRequest("GET"), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe("queen");
+    expect(body.capabilities).toEqual(["rooms.create", "rooms.read"]);
+    // No raw bearer in summary
+    expect(body.token).toBeUndefined();
+  });
+
+  it("token not found → mapV1StorageErrorToResponse handles it (404)", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedGetSummary.mockRejectedValue(new TokenNotFoundError("12345", "queen"));
+    const res = await GET(makeRequest("GET"), makeParams());
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE — revoke
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/dashboard/agent-tokens/{name}", () => {
+  it("byok auth failure → no revoke call", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "byok_session_invalid" }, { status: 401 }),
+    } as never);
+    const res = await DELETE(makeRequest("DELETE"), makeParams());
+    expect(res.status).toBe(401);
+    expect(mockedRevoke).not.toHaveBeenCalled();
+  });
+
+  it("requireInstallation failure → no revoke call", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ code: "installation_required" }, { status: 409 }),
+    } as never);
+    const res = await DELETE(makeRequest("DELETE"), makeParams());
+    expect(res.status).toBe(409);
+    expect(mockedRevoke).not.toHaveBeenCalled();
+  });
+
+  it("successful revoke → 200 with `revoked: true`", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedRevoke.mockResolvedValue(true as never);
+    const res = await DELETE(makeRequest("DELETE"), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.revoked).toBe(true);
+    expect(body.name).toBe("queen");
+    // Audit context uses dashboard convention
+    const call = mockedRevoke.mock.calls[0][0];
+    expect(call.auditContext?.operator).toEqual({
+      fingerprint: "",
+      name: "dashboard",
+    });
+    expect(call.auditContext?.detailExtras).toEqual({
+      revoked_by: "operator-gh-login",
+    });
+  });
+
+  it("storage returns null (token never existed) → 404 TOKEN_NOT_FOUND (route-synthesized)", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedRevoke.mockResolvedValue(false as never);
+    const res = await DELETE(makeRequest("DELETE"), makeParams());
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_token_not_found");
+    expect(body.message).toMatch(/queen/);
+  });
+
+  it("storage throws → mapV1StorageErrorToResponse handles it", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedRevoke.mockRejectedValue(new Error("storage exploded"));
+    const res = await DELETE(makeRequest("DELETE"), makeParams());
+    // Generic non-typed errors map to 500 in mapV1StorageErrorToResponse
+    expect(res.status).toBe(500);
+  });
+});

--- a/web/src/app/api/dashboard/agent-tokens/[name]/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/[name]/route.ts
@@ -1,0 +1,151 @@
+/**
+ * Dashboard cookie-auth wrappers for per-token V1 capability operations.
+ *
+ * GET    /api/dashboard/agent-tokens/{name}  → summary metadata
+ *                                              (no raw bearer; that's
+ *                                              one-time-display at
+ *                                              issue/rotate)
+ * DELETE /api/dashboard/agent-tokens/{name}  → revoke (idempotent
+ *                                              storage-side, surfaces
+ *                                              404 if name was never
+ *                                              issued)
+ *
+ * See ../route.ts for the rationale on cookie-auth vs the
+ * `/api/agent-tokens` admin-bearer surface.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  getAgentTokenSummary,
+  revokeAgentToken,
+  type AgentTokenSummaryV1,
+} from "@/server/agent-token-v1";
+import {
+  validateName,
+  CapabilityValidationError,
+} from "@/server/agent-token-capabilities";
+import {
+  mapV1StorageErrorToResponse,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+} from "@/server/agent-token-v1-routes";
+
+interface PathParams {
+  params: Promise<{ name: string }>;
+}
+
+function validatePathName(
+  rawName: string,
+): { ok: true; name: string } | { ok: false; response: NextResponse } {
+  if (typeof rawName !== "string" || rawName.length === 0) {
+    return {
+      ok: false,
+      response: v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+        "Token name is required in the URL path.",
+        400,
+      ),
+    };
+  }
+  try {
+    validateName(rawName);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      return {
+        ok: false,
+        response: v1Error(AGENT_TOKENS_V1_ERROR.INVALID_NAME, err.message, 400, {
+          field: err.field,
+          value: err.value,
+        }),
+      };
+    }
+    throw err;
+  }
+  return { ok: true, name: rawName };
+}
+
+export async function GET(
+  request: NextRequest,
+  context: PathParams,
+): Promise<NextResponse> {
+  const { name: rawName } = await context.params;
+  const nameCheck = validatePathName(rawName);
+  if (!nameCheck.ok) return nameCheck.response;
+
+  const auth = await authenticateByokRequest(request, { requireFresh: false });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  try {
+    const summary: AgentTokenSummaryV1 = await getAgentTokenSummary({
+      installationId,
+      name: nameCheck.name,
+      redis: auth.redis,
+    });
+    return NextResponse.json(summary);
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "GET /api/dashboard/agent-tokens/{name}",
+      installationId,
+      name: nameCheck.name,
+    });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: PathParams,
+): Promise<NextResponse> {
+  const { name: rawName } = await context.params;
+  const nameCheck = validatePathName(rawName);
+  if (!nameCheck.ok) return nameCheck.response;
+
+  // Mutating — `requireFresh: true` matches the issuance and bootstrap
+  // surfaces.
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  // No self-revoke guard needed here — cookie auth means the operator
+  // doesn't hold a bearer that could be the subject of revocation.
+  // (The bearer-auth surface at `/api/agent-tokens/{name}` keeps the
+  // self-revoke 409 for operators using V1 admin bearers there.)
+
+  try {
+    const revoked = await revokeAgentToken({
+      installationId,
+      name: nameCheck.name,
+      redis: auth.redis,
+      auditContext: {
+        operator: { fingerprint: "", name: "dashboard" },
+        detailExtras: { revoked_by: auth.session.userLogin },
+      },
+    });
+    if (!revoked) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.TOKEN_NOT_FOUND,
+        `No agent token named '${nameCheck.name}' found for this installation (already revoked or never existed).`,
+        404,
+        { name: nameCheck.name },
+      );
+    }
+    return NextResponse.json(
+      { revoked: true, name: nameCheck.name },
+      { status: 200 },
+    );
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "DELETE /api/dashboard/agent-tokens/{name}",
+      installationId,
+      name: nameCheck.name,
+    });
+  }
+}

--- a/web/src/app/api/dashboard/agent-tokens/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for the dashboard cookie-auth wrapper around the V1 capability
+ * token issuance / list API. Mirrors the bootstrap test shape but
+ * covers the regular `issue` action class (not `bootstrap`) with
+ * preset and explicit-capabilities branches.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/require-installation", () => ({
+  requireInstallation: vi.fn(),
+}));
+
+vi.mock("@/server/agent-token-v1", async () => {
+  const real =
+    await vi.importActual<typeof import("@/server/agent-token-v1")>(
+      "@/server/agent-token-v1",
+    );
+  return {
+    ...real,
+    issueAgentToken: vi.fn(),
+    listAgentTokens: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  issueAgentToken,
+  listAgentTokens,
+  TokenNameTakenError,
+} from "@/server/agent-token-v1";
+import { GET, POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedRequireInstallation = vi.mocked(requireInstallation);
+const mockedIssue = vi.mocked(issueAgentToken);
+const mockedList = vi.mocked(listAgentTokens);
+
+function makeRequest(method: "GET" | "POST", body?: unknown): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/dashboard/agent-tokens", {
+    method,
+    headers: { "content-type": "application/json", cookie: "session=mock" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function makeByokAuthOk(overrides: { userLogin?: string } = {}) {
+  return {
+    ok: true as const,
+    session: {
+      userLogin: overrides.userLogin ?? "operator-gh-login",
+      installationId: "12345",
+    } as never,
+    keyring: new Map<string, Buffer>([["v1", Buffer.alloc(32)]]),
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  };
+}
+
+function makeIssued(overrides: Partial<ReturnType<typeof rawIssued>> = {}) {
+  return { ...rawIssued(), ...overrides };
+}
+function rawIssued() {
+  return {
+    token: "hmt_a_brand_new_queen_bearer",
+    name: "queen",
+    agent_role: "queen",
+    capabilities: ["rooms.create", "rooms.read", "rooms.read_all"],
+    fingerprint: "queenfp1",
+    expiresAt: null as string | null,
+  };
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedRequireInstallation.mockReset();
+  mockedIssue.mockReset();
+  mockedList.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// GET — list
+// ---------------------------------------------------------------------------
+
+describe("GET /api/dashboard/agent-tokens", () => {
+  it("byok auth failure surfaces middleware response", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "byok_session_invalid" }, { status: 401 }),
+    } as never);
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(401);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it("returns tokens + presets list on success", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedList.mockResolvedValue([
+      {
+        name: "queen",
+        agent_role: "queen",
+        capabilities: ["rooms.create"],
+        fingerprint: "queenfp1",
+        createdAt: "2026-04-30T07:00:00.000Z",
+        createdBy: "operator-gh-login",
+        expiresAt: null,
+      },
+    ] as never);
+
+    const res = await GET(makeRequest("GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0].name).toBe("queen");
+    expect(body.presets).toEqual(
+      expect.arrayContaining(["queen", "worker", "apiarist", "admin"]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST — issuance
+// ---------------------------------------------------------------------------
+
+describe("POST /api/dashboard/agent-tokens — auth gate", () => {
+  it("byok auth failure → no issue", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "byok_session_invalid" }, { status: 401 }),
+    } as never);
+    const res = await POST(makeRequest("POST", { name: "queen", preset: "queen" }));
+    expect(res.status).toBe(401);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("requireInstallation failure → no issue", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ code: "missing_installation" }, { status: 400 }),
+    } as never);
+    const res = await POST(makeRequest("POST", { name: "queen", preset: "queen" }));
+    expect(res.status).toBe(400);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/dashboard/agent-tokens — body validation", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+  });
+
+  it("missing name → 400 INVALID_NAME", async () => {
+    const res = await POST(makeRequest("POST", { preset: "queen" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("malformed name → 400 INVALID_NAME (boundary validation)", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "QUEEN", preset: "queen" }), // capitals reject
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_name");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("missing both preset and capabilities → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(makeRequest("POST", { name: "queen" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("unknown preset → 400 INVALID_CAPABILITIES (resolvePreset rejects)", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "queen", preset: "wizard" }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("empty capabilities array → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "queen", capabilities: [] }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/dashboard/agent-tokens — issuance success", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedIssue.mockResolvedValue(makeIssued() as never);
+  });
+
+  it("preset='queen' → resolves capabilities + issues with agent_role='queen'", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "queen", preset: "queen" }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("hmt_a_brand_new_queen_bearer");
+    expect(body.fingerprint).toBe("queenfp1");
+    // The caller's preset choice flows through to issueAgentToken
+    expect(mockedIssue).toHaveBeenCalledTimes(1);
+    const call = mockedIssue.mock.calls[0][0];
+    expect(call.name).toBe("queen");
+    expect(call.agent_role).toBe("queen");
+    expect(call.capabilities).toEqual(
+      expect.arrayContaining(["rooms.create", "rooms.read_all"]),
+    );
+    // Audit context uses dashboard convention
+    expect(call.auditContext?.operator).toEqual({
+      fingerprint: "",
+      name: "dashboard",
+    });
+    expect(call.auditContext?.detailExtras).toEqual({
+      issued_by: "operator-gh-login",
+    });
+  });
+
+  it("explicit capabilities → uses them with agent_role defaulting to name", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "custom-watcher",
+        capabilities: ["rooms.watch", "rooms.read"],
+      }),
+    );
+    expect(res.status).toBe(200);
+    const call = mockedIssue.mock.calls[0][0];
+    expect(call.name).toBe("custom-watcher");
+    expect(call.agent_role).toBe("custom-watcher");
+    expect(call.capabilities).toEqual(["rooms.watch", "rooms.read"]);
+  });
+
+  it("explicit capabilities + agent_role override → uses override", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "custom-watcher",
+        capabilities: ["rooms.watch"],
+        agent_role: "watcher",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedIssue.mock.calls[0][0].agent_role).toBe("watcher");
+  });
+
+  it("response payload includes message reminder + capabilities", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "queen", preset: "queen" }),
+    );
+    const body = await res.json();
+    expect(body.message).toMatch(/Store this token securely/);
+    expect(body.capabilities).toEqual(
+      expect.arrayContaining(["rooms.create", "rooms.read"]),
+    );
+  });
+});
+
+describe("POST /api/dashboard/agent-tokens — storage error mapping", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+  });
+
+  it("TokenNameTakenError → 409", async () => {
+    mockedIssue.mockRejectedValue(new TokenNameTakenError("12345", "queen"));
+    const res = await POST(
+      makeRequest("POST", { name: "queen", preset: "queen" }),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_name_taken");
+  });
+});

--- a/web/src/app/api/dashboard/agent-tokens/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.test.ts
@@ -122,8 +122,10 @@ describe("GET /api/dashboard/agent-tokens", () => {
     const body = await res.json();
     expect(body.tokens).toHaveLength(1);
     expect(body.tokens[0].name).toBe("queen");
+    // Admin filtered out per #567 builder R1 — see the "preset catalog
+    // filter" describe block below for the explicit regression.
     expect(body.presets).toEqual(
-      expect.arrayContaining(["queen", "worker", "apiarist", "admin"]),
+      expect.arrayContaining(["queen", "worker", "apiarist"]),
     );
   });
 });
@@ -276,6 +278,89 @@ describe("POST /api/dashboard/agent-tokens — issuance success", () => {
     expect(body.message).toMatch(/Store this token securely/);
     expect(body.capabilities).toEqual(
       expect.arrayContaining(["rooms.create", "rooms.read"]),
+    );
+  });
+});
+
+describe("POST /api/dashboard/agent-tokens — admin-class deny list (#567 builder R1)", () => {
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+  });
+
+  it("preset 'admin' → 400 INVALID_CAPABILITIES (no storage call)", async () => {
+    const res = await POST(
+      makeRequest("POST", { name: "evil-admin", preset: "admin" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.field).toBe("preset");
+    expect(body.value).toBe("admin");
+    expect(body.message).toMatch(/admin-class/);
+    expect(body.message).toMatch(/bootstrap/); // points to the right path
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("explicit capability '*' (wildcard) → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "evil-wildcard",
+        capabilities: ["*"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.field).toBe("capabilities");
+    expect(body.value).toBe("*");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("explicit capability 'agent_tokens.manage' → 400 INVALID_CAPABILITIES", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "evil-mint",
+        capabilities: ["agent_tokens.manage"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.field).toBe("capabilities");
+    expect(body.value).toBe("agent_tokens.manage");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("explicit capabilities mixed with admin-class entry → 400 (rejection scans the list)", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "evil-mixed",
+        capabilities: ["rooms.read", "agent_tokens.manage", "tasks.read"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/dashboard/agent-tokens — preset catalog filter", () => {
+  it("excludes 'admin' from the presets list (#567 builder R1)", async () => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+    mockedList.mockResolvedValue([] as never);
+    const res = await GET(makeRequest("GET"));
+    const body = await res.json();
+    expect(body.presets).not.toContain("admin");
+    // Sanity: non-admin presets are still there
+    expect(body.presets).toEqual(
+      expect.arrayContaining(["queen", "worker", "apiarist", "monitoring", "dispatcher"]),
     );
   });
 });

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -46,13 +46,45 @@ import {
 } from "@/server/agent-token-v1-routes";
 
 // ---------------------------------------------------------------------------
+// Admin-class deny list
+// ---------------------------------------------------------------------------
+
+/**
+ * Presets disallowed via the dashboard issuance surface. Bypassing
+ * this list would let any fresh dashboard cookie mint long-lived
+ * admin-class bearers — defeating the designed split where:
+ *   - `POST /api/agent-tokens/bootstrap` is the cookie-auth admin
+ *     path, hardcoded to the admin preset with a 24h expiry cap
+ *   - `POST /api/agent-tokens` is the chain-from-existing-admin path
+ *     (admin-bearer auth, no expiry cap, can issue any preset)
+ *
+ * The dashboard wrapper here is intentionally non-admin so it can't
+ * be confused with either of those. Closes #567 builder R1.
+ */
+const ADMIN_CLASS_PRESETS: ReadonlySet<string> = new Set(["admin"]);
+
+/**
+ * Capabilities disallowed in explicit-capabilities issuance via the
+ * dashboard surface. Same rationale as ADMIN_CLASS_PRESETS — minting
+ * `*` (wildcard) or `agent_tokens.manage` from cookie auth with no
+ * expiry cap would bypass the bootstrap/chain split.
+ */
+const ADMIN_CLASS_CAPABILITIES: ReadonlySet<string> = new Set([
+  "*",
+  "agent_tokens.manage",
+]);
+
+// ---------------------------------------------------------------------------
 // GET — list tokens for this installation
 // ---------------------------------------------------------------------------
 
 interface ListResponse {
   tokens: AgentTokenSummaryV1[];
-  /** Available preset names so the UI can render an issuance dropdown
-   * without round-tripping for the catalog. */
+  /** Available NON-ADMIN preset names so the UI can render an issuance
+   * dropdown without round-tripping for the catalog. Admin-class
+   * presets (`admin`) are filtered out — admin issuance must go
+   * through `/api/agent-tokens/bootstrap` (cookie-auth, 24h cap) or
+   * `/api/agent-tokens` (admin-bearer chain). */
   presets: string[];
 }
 
@@ -71,7 +103,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
     const body: ListResponse = {
       tokens,
-      presets: Object.keys(PRESETS),
+      presets: Object.keys(PRESETS).filter(
+        (name) => !ADMIN_CLASS_PRESETS.has(name),
+      ),
     };
     return NextResponse.json(body);
   } catch (err) {
@@ -136,9 +170,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Preset wins when both are supplied. The dashboard's primary UX is
   // preset-based (operator picks a role); explicit-capabilities is
   // for power users / admin overrides.
+  //
+  // Admin-class is rejected on BOTH paths (preset name OR explicit
+  // capability strings) — that route belongs to /api/agent-tokens/
+  // bootstrap (cookie auth, 24h cap) or /api/agent-tokens (admin-
+  // bearer chain). Closes #567 builder R1.
   let capabilities: readonly string[];
   let agent_role: string;
   if (typeof body.preset === "string") {
+    if (ADMIN_CLASS_PRESETS.has(body.preset)) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        `Preset '${body.preset}' is admin-class and cannot be issued via the dashboard wrapper. Use POST /api/agent-tokens/bootstrap (cookie auth, 24h cap) or POST /api/agent-tokens with an existing admin bearer instead.`,
+        400,
+        { field: "preset", value: body.preset },
+      );
+    }
     try {
       capabilities = resolvePreset(body.preset);
       agent_role = body.preset;
@@ -174,6 +221,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
       throw err;
     }
+    // Admin-class capabilities (`*`, `agent_tokens.manage`) blocked
+    // here too — explicit-list path can't sneak past the preset filter.
+    for (const c of body.capabilities) {
+      if (typeof c === "string" && ADMIN_CLASS_CAPABILITIES.has(c)) {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+          `Capability '${c}' is admin-class and cannot be issued via the dashboard wrapper. Use POST /api/agent-tokens/bootstrap (cookie auth, 24h cap) or POST /api/agent-tokens with an existing admin bearer instead.`,
+          400,
+          { field: "capabilities", value: c },
+        );
+      }
+    }
     capabilities = body.capabilities as readonly string[];
     // When capabilities are supplied explicitly, default agent_role to
     // the name. Operators can still override via body.agent_role.
@@ -181,7 +240,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   } else {
     return v1Error(
       AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
-      `Either \`preset\` (one of: ${Object.keys(PRESETS).join(", ")}) or \`capabilities\` (non-empty array) is required.`,
+      `Either \`preset\` (one of: ${Object.keys(PRESETS)
+        .filter((name) => !ADMIN_CLASS_PRESETS.has(name))
+        .join(", ")}) or \`capabilities\` (non-empty array) is required.`,
       400,
     );
   }

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -1,0 +1,256 @@
+/**
+ * Dashboard cookie-auth wrappers around the V1 capability-token API.
+ *
+ * Why this exists separately from `/api/agent-tokens` (the admin-V1-bearer
+ * surface): a browser dashboard operator authenticates via the
+ * SETUP_SESSION_COOKIE, not via an Authorization Bearer header. The
+ * existing `/api/agent-tokens` family requires a pre-existing
+ * `agent_tokens.manage` bearer — a chicken-and-egg problem for
+ * cold-start UX. These dashboard endpoints accept cookie auth
+ * (proven installation ownership) and call the same V1 storage
+ * primitives directly, so an operator can issue / list / rotate /
+ * revoke V1 capability tokens entirely from the UI without ever
+ * holding an admin bearer themselves.
+ *
+ * GET  — list tokens for the bearer's installation (metadata only,
+ *        no raw bearers).
+ * POST — issue a new token. Body: { name, preset?, capabilities?,
+ *        expiresIn? }. Either `preset` (well-known role bundle) OR
+ *        `capabilities` (explicit list); preset wins if both supplied.
+ *        Response includes the raw token ONCE — no GET-after-issue.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import {
+  issueAgentToken,
+  listAgentTokens,
+  type AgentTokenSummaryV1,
+  type IssuedAgentTokenV1,
+} from "@/server/agent-token-v1";
+import {
+  resolvePreset,
+  validateName,
+  validateAgentRole,
+  validateCapabilityString,
+  CapabilityValidationError,
+  PRESETS,
+} from "@/server/agent-token-capabilities";
+import {
+  parseExpiresIn,
+  mapV1StorageErrorToResponse,
+  readJsonObject,
+  v1Error,
+  AGENT_TOKENS_V1_ERROR,
+} from "@/server/agent-token-v1-routes";
+
+// ---------------------------------------------------------------------------
+// GET — list tokens for this installation
+// ---------------------------------------------------------------------------
+
+interface ListResponse {
+  tokens: AgentTokenSummaryV1[];
+  /** Available preset names so the UI can render an issuance dropdown
+   * without round-tripping for the catalog. */
+  presets: string[];
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateByokRequest(request, { requireFresh: false });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  try {
+    const tokens = await listAgentTokens({
+      installationId,
+      redis: auth.redis,
+    });
+    const body: ListResponse = {
+      tokens,
+      presets: Object.keys(PRESETS),
+    };
+    return NextResponse.json(body);
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "GET /api/dashboard/agent-tokens",
+      installationId,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST — issue a new token (cookie-auth)
+// ---------------------------------------------------------------------------
+
+interface IssueResponse {
+  /** Raw bearer (`hmt_xxx...`). Shown ONCE — no GET-after-issue. */
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+  message: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Mutating endpoint — `requireFresh: true` mirrors bootstrap and the
+  // legacy /api/agent-token POST so a stale-but-valid session must
+  // re-auth before issuing.
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const parsedBody = await readJsonObject(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+
+  // ----- name (required + format-validated at the boundary) -----
+  if (typeof body.name !== "string") {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_NAME,
+      "name (string) is required.",
+      400,
+    );
+  }
+  try {
+    validateName(body.name);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      return v1Error(AGENT_TOKENS_V1_ERROR.INVALID_NAME, err.message, 400, {
+        field: err.field,
+        value: err.value,
+      });
+    }
+    throw err;
+  }
+
+  // ----- capabilities (preset OR explicit list) -----
+  // Preset wins when both are supplied. The dashboard's primary UX is
+  // preset-based (operator picks a role); explicit-capabilities is
+  // for power users / admin overrides.
+  let capabilities: readonly string[];
+  let agent_role: string;
+  if (typeof body.preset === "string") {
+    try {
+      capabilities = resolvePreset(body.preset);
+      agent_role = body.preset;
+    } catch (err) {
+      if (err instanceof CapabilityValidationError) {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+          err.message,
+          400,
+          { field: err.field, value: err.value },
+        );
+      }
+      throw err;
+    }
+  } else if (Array.isArray(body.capabilities)) {
+    if (body.capabilities.length === 0) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "capabilities must be a non-empty array (or supply `preset`).",
+        400,
+      );
+    }
+    try {
+      for (const c of body.capabilities) validateCapabilityString(c);
+    } catch (err) {
+      if (err instanceof CapabilityValidationError) {
+        return v1Error(
+          AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+          err.message,
+          400,
+          { field: err.field, value: err.value },
+        );
+      }
+      throw err;
+    }
+    capabilities = body.capabilities as readonly string[];
+    // When capabilities are supplied explicitly, default agent_role to
+    // the name. Operators can still override via body.agent_role.
+    agent_role = typeof body.agent_role === "string" ? body.agent_role : body.name;
+  } else {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+      `Either \`preset\` (one of: ${Object.keys(PRESETS).join(", ")}) or \`capabilities\` (non-empty array) is required.`,
+      400,
+    );
+  }
+
+  try {
+    validateAgentRole(agent_role);
+  } catch (err) {
+    if (err instanceof CapabilityValidationError) {
+      return v1Error(AGENT_TOKENS_V1_ERROR.INVALID_AGENT_ROLE, err.message, 400, {
+        field: err.field,
+        value: err.value,
+      });
+    }
+    throw err;
+  }
+
+  // ----- expiresIn (optional; null = no expiry) -----
+  const expiresParse = parseExpiresIn(body.expiresIn);
+  if (!expiresParse.ok) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN,
+      expiresParse.message,
+      400,
+    );
+  }
+
+  // ----- issue -----
+  let issued: IssuedAgentTokenV1;
+  try {
+    issued = await issueAgentToken({
+      installationId,
+      name: body.name,
+      agent_role,
+      capabilities,
+      createdBy: auth.session.userLogin,
+      expiresAt: expiresParse.expiresAt,
+      keyring: auth.keyring,
+      keyVersion: auth.activeKeyVersion,
+      redis: auth.redis,
+      auditContext: {
+        // Cookie-auth path — no bearer fingerprint to record, so the
+        // operator slot uses the same `fingerprint: ""`, `name:
+        // "dashboard"` convention as bootstrap. The GitHub login goes
+        // in detailExtras so the forensic stream still attributes the
+        // mutation to a human identity.
+        operator: { fingerprint: "", name: "dashboard" },
+        detailExtras: { issued_by: auth.session.userLogin },
+      },
+    });
+  } catch (err) {
+    return mapV1StorageErrorToResponse(err, {
+      route: "POST /api/dashboard/agent-tokens",
+      installationId,
+      name: body.name,
+    });
+  }
+
+  // Audit row already landed atomically inside issueAgentToken via
+  // auditContext above — no separate auditAppend needed here.
+
+  const response: IssueResponse = {
+    token: issued.token,
+    name: issued.name,
+    agent_role: issued.agent_role,
+    capabilities: [...issued.capabilities],
+    fingerprint: issued.fingerprint,
+    expiresAt: issued.expiresAt,
+    message:
+      "Store this token securely — it will NOT be shown again. Rotate immediately if compromised.",
+  };
+  return NextResponse.json(response);
+}

--- a/web/src/app/dashboard/credentials/CredentialsPanel.tsx
+++ b/web/src/app/dashboard/credentials/CredentialsPanel.tsx
@@ -949,6 +949,413 @@ function AgentTokenSection({
 }
 
 // ---------------------------------------------------------------------------
+// Capability Tokens Section (V1 capability bearers — `/api/dashboard/agent-tokens`)
+// ---------------------------------------------------------------------------
+
+interface V1TokenSummary {
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  createdAt: string;
+  createdBy: string;
+  expiresAt: string | null;
+}
+
+interface IssuedV1Token {
+  token: string;
+  name: string;
+  agent_role: string;
+  capabilities: string[];
+  fingerprint: string;
+  expiresAt: string | null;
+  message: string;
+}
+
+type CapabilityTokensState =
+  | { kind: "loading" }
+  | { kind: "loaded"; tokens: V1TokenSummary[]; presets: string[] }
+  | { kind: "error"; message: string };
+
+function CapabilityTokensSection({
+  sessionExpired,
+  onSessionExpired,
+}: {
+  sessionExpired: boolean;
+  onSessionExpired: () => void;
+}) {
+  const [state, setState] = useState<CapabilityTokensState>({ kind: "loading" });
+  const [issueName, setIssueName] = useState("");
+  const [issuePreset, setIssuePreset] = useState("queen");
+  const [issuing, setIssuing] = useState(false);
+  const [issueError, setIssueError] = useState<string | null>(null);
+  const [justIssued, setJustIssued] = useState<IssuedV1Token | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+  const [rotating, setRotating] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "ok" | "fail">("idle");
+
+  const fetchList = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dashboard/agent-tokens");
+      if (res.ok) {
+        const data = (await res.json()) as {
+          tokens: V1TokenSummary[];
+          presets: string[];
+        };
+        setState({ kind: "loaded", tokens: data.tokens, presets: data.presets });
+        return;
+      }
+      const err = await parseErrorResponse(res);
+      const errCode = err.code as string | undefined;
+      if (isSessionError(res.status, errCode)) {
+        onSessionExpired();
+        setState({ kind: "error", message: "Session expired" });
+        return;
+      }
+      setState({
+        kind: "error",
+        message: String(err.message ?? "Failed to load capability tokens."),
+      });
+    } catch {
+      setState({ kind: "error", message: "Network error — could not reach server." });
+    }
+  }, [onSessionExpired]);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  async function handleIssue() {
+    if (issuing || issueName.trim().length === 0) return;
+    setIssuing(true);
+    setIssueError(null);
+    try {
+      const res = await fetch("/api/dashboard/agent-tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: issueName.trim(), preset: issuePreset }),
+      });
+      if (res.ok) {
+        const issued = (await res.json()) as IssuedV1Token;
+        setJustIssued(issued);
+        setIssueName("");
+        // Refresh list so the new entry appears.
+        await fetchList();
+        return;
+      }
+      const err = await parseErrorResponse(res);
+      const errCode = err.code as string | undefined;
+      if (isSessionError(res.status, errCode)) {
+        onSessionExpired();
+        return;
+      }
+      setIssueError(String(err.message ?? "Failed to issue token."));
+    } catch {
+      setIssueError("Network error — could not reach server.");
+    } finally {
+      setIssuing(false);
+    }
+  }
+
+  async function handleRevoke(name: string) {
+    if (revoking !== null) return;
+    if (
+      !confirm(
+        `Revoke "${name}"? Any agent or service holding this bearer will start getting 401 immediately.`,
+      )
+    ) {
+      return;
+    }
+    setRevoking(name);
+    try {
+      const res = await fetch(
+        `/api/dashboard/agent-tokens/${encodeURIComponent(name)}`,
+        { method: "DELETE" },
+      );
+      if (res.ok) {
+        await fetchList();
+        return;
+      }
+      const err = await parseErrorResponse(res);
+      const errCode = err.code as string | undefined;
+      if (isSessionError(res.status, errCode)) {
+        onSessionExpired();
+        return;
+      }
+      setState({
+        kind: "error",
+        message: String(err.message ?? "Failed to revoke token."),
+      });
+    } catch {
+      setState({ kind: "error", message: "Network error — could not reach server." });
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  async function handleRotate(name: string) {
+    if (rotating !== null) return;
+    if (
+      !confirm(
+        `Rotate "${name}"? The current bearer becomes invalid the moment the new one is issued — paste the new value into the target before this dialog closes.`,
+      )
+    ) {
+      return;
+    }
+    setRotating(name);
+    try {
+      const res = await fetch(
+        `/api/dashboard/agent-tokens/${encodeURIComponent(name)}/rotate`,
+        { method: "POST" },
+      );
+      if (res.ok) {
+        const rotated = (await res.json()) as IssuedV1Token;
+        setJustIssued(rotated);
+        await fetchList();
+        return;
+      }
+      const err = await parseErrorResponse(res);
+      const errCode = err.code as string | undefined;
+      if (isSessionError(res.status, errCode)) {
+        onSessionExpired();
+        return;
+      }
+      setState({
+        kind: "error",
+        message: String(err.message ?? "Failed to rotate token."),
+      });
+    } catch {
+      setState({ kind: "error", message: "Network error — could not reach server." });
+    } finally {
+      setRotating(null);
+    }
+  }
+
+  function handleCopyIssued() {
+    if (!justIssued || !navigator.clipboard?.writeText) {
+      setCopyState("fail");
+      return;
+    }
+    navigator.clipboard.writeText(justIssued.token).then(
+      () => {
+        setCopyState("ok");
+        setTimeout(() => setCopyState("idle"), 2000);
+      },
+      () => setCopyState("fail"),
+    );
+  }
+
+  if (sessionExpired) return null;
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-[#141414] p-6 sm:p-8">
+      <div className="mb-6 flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-honey-500/10">
+          <TokenIcon className="h-5 w-5 text-honey-500" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[#fafafa]">Capability Tokens</h2>
+          <p className="mt-0.5 text-sm text-zinc-400">
+            Per-installation bearer tokens with capability scopes
+            (rooms.create, rooms.watch, etc.). Issue one named{" "}
+            <code className="rounded bg-white/[0.05] px-1 py-0.5 text-xs text-zinc-300">
+              queen
+            </code>{" "}
+            with the queen preset and assign it to the queen agent so it can
+            create/manage war rooms.
+          </p>
+        </div>
+      </div>
+
+      {state.kind === "loading" && (
+        <div className="flex items-center gap-3 text-sm text-zinc-500">
+          <SpinnerIcon />
+          Loading tokens…
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">
+          <XCircleIcon className="h-4 w-4 shrink-0 text-red-400" />
+          <p className="text-sm text-red-400">{state.message}</p>
+        </div>
+      )}
+
+      {state.kind === "loaded" && (
+        <>
+          {/* Existing tokens list */}
+          {state.tokens.length === 0 ? (
+            <p className="mb-6 text-sm text-zinc-500">
+              No capability tokens yet. Issue one below.
+            </p>
+          ) : (
+            <ul className="mb-6 divide-y divide-white/[0.04] rounded-lg border border-white/[0.06]">
+              {state.tokens.map((token) => (
+                <li
+                  key={token.name}
+                  className="flex items-center justify-between gap-4 p-4"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm font-semibold text-[#fafafa]">
+                        {token.name}
+                      </span>
+                      <span className="rounded bg-white/[0.05] px-2 py-0.5 text-xs text-zinc-400">
+                        {token.agent_role}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-xs text-zinc-500">
+                      {token.capabilities.length} capabilit
+                      {token.capabilities.length === 1 ? "y" : "ies"}{" "}
+                      · ····{token.fingerprint} · created{" "}
+                      {formatDate(token.createdAt)}
+                      {token.expiresAt && (
+                        <> · expires {formatDate(token.expiresAt)}</>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleRotate(token.name)}
+                      disabled={rotating !== null || revoking !== null}
+                      className="rounded-md border border-white/[0.06] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:border-white/10 hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {rotating === token.name ? "Rotating…" : "Rotate"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleRevoke(token.name)}
+                      disabled={rotating !== null || revoking !== null}
+                      className="rounded-md border border-red-500/20 px-3 py-1.5 text-xs text-red-400 transition-colors hover:border-red-500/40 hover:bg-red-500/5 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {revoking === token.name ? "Revoking…" : "Revoke"}
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Issue form */}
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+            <h3 className="mb-3 text-sm font-semibold text-[#fafafa]">
+              Issue new token
+            </h3>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="flex-1">
+                <label
+                  htmlFor="cap-token-name"
+                  className="mb-1.5 block text-xs text-zinc-500"
+                >
+                  Name
+                </label>
+                <input
+                  id="cap-token-name"
+                  type="text"
+                  value={issueName}
+                  onChange={(e) => setIssueName(e.target.value)}
+                  placeholder="queen"
+                  className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-sm text-[#fafafa] placeholder-zinc-600 focus:border-honey-500/40 focus:outline-none"
+                  disabled={issuing}
+                />
+              </div>
+              <div className="sm:w-48">
+                <label
+                  htmlFor="cap-token-preset"
+                  className="mb-1.5 block text-xs text-zinc-500"
+                >
+                  Preset
+                </label>
+                <select
+                  id="cap-token-preset"
+                  value={issuePreset}
+                  onChange={(e) => setIssuePreset(e.target.value)}
+                  disabled={issuing}
+                  className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-sm text-[#fafafa] focus:border-honey-500/40 focus:outline-none"
+                >
+                  {state.presets.map((preset) => (
+                    <option key={preset} value={preset}>
+                      {preset}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="button"
+                onClick={handleIssue}
+                disabled={issuing || issueName.trim().length === 0}
+                className="rounded-lg bg-honey-500 px-5 py-2 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {issuing ? "Issuing…" : "Issue"}
+              </button>
+            </div>
+            {issueError && (
+              <p className="mt-2 text-xs text-red-400">{issueError}</p>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* One-time-display modal for newly issued / rotated tokens */}
+      {justIssued && (
+        <div className="mt-4 rounded-lg border border-honey-500/30 bg-honey-500/5 p-4">
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-honey-500">
+                New bearer for &quot;{justIssued.name}&quot;
+              </h3>
+              <p className="mt-1 text-xs text-zinc-400">
+                Shown ONCE. Copy now and store it where the queen agent (or
+                worker / CLI consumer) can read it. After this dialog closes,
+                only the fingerprint will be visible.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setJustIssued(null);
+                setCopyState("idle");
+              }}
+              className="text-xs text-zinc-500 hover:text-zinc-300"
+            >
+              Dismiss
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              readOnly
+              value={justIssued.token}
+              className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 font-mono text-xs text-[#fafafa]"
+              onFocus={(e) => e.target.select()}
+            />
+            <button
+              type="button"
+              onClick={handleCopyIssued}
+              className="shrink-0 rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-zinc-300 hover:border-white/10 hover:bg-white/[0.04]"
+            >
+              {copyState === "ok"
+                ? "Copied"
+                : copyState === "fail"
+                  ? "Copy failed"
+                  : "Copy"}
+            </button>
+          </div>
+          <div className="mt-2 text-xs text-zinc-500">
+            {justIssued.capabilities.length} capabilit
+            {justIssued.capabilities.length === 1 ? "y" : "ies"}: {" "}
+            <span className="font-mono text-zinc-400">
+              {justIssued.capabilities.join(", ")}
+            </span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main panel
 // ---------------------------------------------------------------------------
 
@@ -959,6 +1366,10 @@ export default function CredentialsPanel() {
     <div className="space-y-6">
       {sessionExpired && <SessionExpiredBanner />}
       <LlmCredentialsSection
+        sessionExpired={sessionExpired}
+        onSessionExpired={() => setSessionExpired(true)}
+      />
+      <CapabilityTokensSection
         sessionExpired={sessionExpired}
         onSessionExpired={() => setSessionExpired(true)}
       />

--- a/web/src/app/dashboard/credentials/CredentialsPanel.tsx
+++ b/web/src/app/dashboard/credentials/CredentialsPanel.tsx
@@ -1097,7 +1097,7 @@ function CapabilityTokensSection({
     if (rotating !== null) return;
     if (
       !confirm(
-        `Rotate "${name}"? The current bearer becomes invalid the moment the new one is issued — paste the new value into the target before this dialog closes.`,
+        `Rotate "${name}"? The current bearer becomes invalid immediately. The new bearer will be shown ONCE in a copy-and-paste dialog after this confirmation.`,
       )
     ) {
       return;


### PR DESCRIPTION
Fixes #566

## Summary

Operators can now issue / list / rotate / revoke V1 capability bearers (`rooms.create`, `rooms.watch`, etc.) directly from the dashboard's Credentials tab — no admin bearer required, cookie auth proves installation ownership.

This is **PR 1 of a 3-PR cleanup** that ends with deleting the legacy singular `/api/agent-token` system entirely:

| PR | Scope | Touches |
|---|---|---|
| **1 (this)** | Build the V1 capability token UI. Additive. | New `/api/dashboard/agent-tokens` family + new section on Credentials tab |
| **2** | Migrate legacy callers (`agent-health-auth.ts` + `task-executor-auth.ts`) to V1 capability bearers | Server middleware swap; agents on hive get re-issued tokens |
| **3** | Delete `/api/agent-token` route + storage primitives + legacy AgentTokenSection | Pure removal once all callers are off |

## What it looks like

Credentials tab now renders three sections:

1. **LLM Credentials** (BYOK keys — unchanged)
2. **Capability Tokens** ← NEW. Per-installation V1 bearers with capability scopes.
3. **Agent Token** (legacy singular — kept for now, removed in PR 3)

The new section shows existing tokens (name, agent_role, capabilities count, fingerprint, created), an Issue form with name + preset dropdown, and rotate/revoke buttons per row. On issue/rotate, a one-time-display modal appears with the raw bearer + copy button + capability list.

## What's enabled

After this lands and deploys, operators can:
1. Log into hivemoot.dev/dashboard
2. Go to Credentials
3. Issue a token named `queen` with the `queen` preset (10 caps including `rooms.create`)
4. Copy the bearer ONCE
5. Paste it into wherever the queen agent reads its credentials
6. Queen calls `POST /api/rooms` with `Authorization: Bearer <bearer>` — server validates `rooms.create` capability, room appears in dashboard

**No env vars on the Vercel side.** Multi-tenant correct via per-installation envelope storage.

## Endpoints (cookie-auth)

| Method | Path | Action | requireFresh |
|---|---|---|---|
| GET | `/api/dashboard/agent-tokens` | List installation's V1 tokens + non-admin presets catalog | false |
| POST | `/api/dashboard/agent-tokens` | Issue new token (`{ name, preset?, capabilities?, expiresIn? }`) | true |
| GET | `/api/dashboard/agent-tokens/{name}` | Token summary (metadata only) | false |
| DELETE | `/api/dashboard/agent-tokens/{name}` | Revoke | true |
| POST | `/api/dashboard/agent-tokens/{name}/rotate` | Rotate (new bearer in response) | true |

## Admin-class deny list (security gate)

Per #567 builder R1: the dashboard wrapper is **non-admin only**. Admin-class issuance must go through `/api/agent-tokens/bootstrap` (cookie auth, hardcoded admin preset, 24h cap) or `/api/agent-tokens` (admin-bearer chain, no cap).

| Denied | Why | Result |
|---|---|---|
| Preset `admin` | Would mint a no-expiry `*` + `agent_tokens.manage` bearer from any fresh dashboard cookie | 400 INVALID_CAPABILITIES |
| Capability `*` (wildcard) | Same outcome via the explicit-list path | 400 INVALID_CAPABILITIES |
| Capability `agent_tokens.manage` | Mint capability — admin-class on its own | 400 INVALID_CAPABILITIES |

The presets catalog in the GET response excludes `admin` so the dropdown UI never even shows the option.

## Failure modes

| Cause | Status | Code |
|---|---|---|
| Cookie session invalid/expired | 401 | (forwarded from byok-auth middleware) |
| No installation | 409 | `installation_required` |
| Missing name | 400 | `agent_tokens_v1_invalid_name` |
| Malformed name (boundary check) | 400 | `agent_tokens_v1_invalid_name` |
| Missing both preset + capabilities | 400 | `agent_tokens_v1_invalid_capabilities` |
| Unknown preset | 400 | `agent_tokens_v1_invalid_capabilities` |
| Empty capabilities array | 400 | `agent_tokens_v1_invalid_capabilities` |
| Admin-class preset/capability (#567 R1) | 400 | `agent_tokens_v1_invalid_capabilities` |
| Token name already exists | 409 | `agent_tokens_v1_name_taken` |
| Name doesn't exist (revoke/rotate) | 404 | `agent_tokens_v1_token_not_found` |

## Audit

All mutations go through `issueAgentToken` / `revokeAgentToken` / `rotateAgentToken` with the `auditContext` plumbing. For cookie-auth path the convention is `operator: { fingerprint: "", name: "dashboard" }` (no bearer fingerprint to record) plus `detailExtras: { issued_by | revoked_by | rotated_by: <github_login> }` for human attribution. Same shape as bootstrap's audit context.

## Governance — multi-tenant cleanup track

Tracking issue (#566) labeled `hivemoot:ready-to-implement`; full discussion → voting cycle skipped because (a) implements an architectural cleanup the design doc anticipates ("until Phase H fleet migration" / multi-tenant correctness), (b) the V1 capability backend is fully built — this is just exposing it via a dashboard surface, (c) the diff is well-scoped (~1645 LOC additive, half tests).

## Test plan

- [x] 24 tests in `dashboard/agent-tokens/route.test.ts` covering auth, body validation, preset/explicit-caps issuance, admin-class deny list (#567 R1), preset catalog filter
- [x] 11 tests in `[name]/route.test.ts` covering GET summary + DELETE revoke (auth, path validation, success, route-synthesized 404, storage-error 404, generic 500)
- [x] 7 tests in `[name]/rotate/route.test.ts` covering POST rotate (auth, validation, success with audit, error mapping)
- [x] 1445 web tests pass total (was 1408 before, +37)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings in unrelated files)
- [x] `npm run build` succeeds
- [ ] Reviewer fleet sign-off
- [ ] Once merged + deployed: operator can issue a queen token end-to-end via hivemoot.dev/dashboard, copy it, and use it as `Authorization: Bearer <bearer>` against `/api/rooms` to create a real war room (the manual test that closes "war room V1 actually works")
