### PR TITLE
Dashboard: custom capability selection for token issuance

### DIFF
--- a/web/src/app/api/dashboard/agent-tokens/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.test.ts
@@ -347,21 +347,56 @@ describe("POST /api/dashboard/agent-tokens — admin-class deny list (#567 build
   });
 });
 
-describe("GET /api/dashboard/agent-tokens — preset catalog filter", () => {
-  it("excludes 'admin' from the presets list (#567 builder R1)", async () => {
+describe("GET /api/dashboard/agent-tokens — catalogs (presets + capabilities)", () => {
+  beforeEach(() => {
     mockedAuth.mockResolvedValue(makeByokAuthOk());
     mockedRequireInstallation.mockReturnValue({
       ok: true,
       installationId: "12345",
     } as never);
     mockedList.mockResolvedValue([] as never);
+  });
+
+  it("excludes 'admin' from the presets list (#567 builder R1)", async () => {
     const res = await GET(makeRequest("GET"));
     const body = await res.json();
     expect(body.presets).not.toContain("admin");
-    // Sanity: non-admin presets are still there
     expect(body.presets).toEqual(
       expect.arrayContaining(["queen", "worker", "apiarist", "monitoring", "dispatcher"]),
     );
+  });
+
+  it("returns the capability vocabulary filtered to non-admin entries", async () => {
+    const res = await GET(makeRequest("GET"));
+    const body = await res.json();
+    // Admin-class capabilities are filtered (matches the deny list
+    // applied to the POST issuance path).
+    expect(body.capabilities).not.toContain("agent_tokens.manage");
+    expect(body.capabilities).not.toContain("*");
+    // Sanity: every preset's capabilities ARE in the catalog so the
+    // UI can faithfully render preset → custom transitions.
+    expect(body.capabilities).toEqual(
+      expect.arrayContaining([
+        "installation_token.mint",
+        "agent_health.report",
+        "tasks.claim",
+        "rooms.create",
+        "rooms.read_all",
+        "rooms.force_close",
+      ]),
+    );
+  });
+
+  it("preserves subsystem-grouping order (installation_token → agent_health → tasks → rooms)", async () => {
+    const res = await GET(makeRequest("GET"));
+    const body = await res.json();
+    const caps = body.capabilities as string[];
+    const idxOf = (cap: string) => caps.indexOf(cap);
+    // Each subsystem boundary stays ordered relative to the next so
+    // the UI can group by prefix without re-sorting.
+    expect(idxOf("installation_token.mint")).toBeLessThan(idxOf("agent_health.report"));
+    expect(idxOf("agent_health.read")).toBeLessThan(idxOf("tasks.claim"));
+    expect(idxOf("tasks.cancel")).toBeLessThan(idxOf("rooms.watch"));
   });
 });
 

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -36,6 +36,7 @@ import {
   validateCapabilityString,
   CapabilityValidationError,
   PRESETS,
+  KNOWN_CAPABILITIES,
 } from "@/server/agent-token-capabilities";
 import {
   parseExpiresIn,
@@ -86,6 +87,15 @@ interface ListResponse {
    * through `/api/agent-tokens/bootstrap` (cookie-auth, 24h cap) or
    * `/api/agent-tokens` (admin-bearer chain). */
   presets: string[];
+  /** Capability vocabulary filtered to non-admin entries so the UI
+   * can render a custom-selection mode (checkboxes per capability)
+   * without the operator having to consult the source. The wire
+   * order matches `KNOWN_CAPABILITIES` (subsystem-grouped:
+   * `installation_token` → `agent_health` → `tasks` → `rooms`),
+   * which is also the rendering order the UI uses for grouping
+   * headers. Admin-class capabilities (`agent_tokens.manage`) are
+   * excluded — same rationale as the preset filter. */
+  capabilities: string[];
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -105,6 +115,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       tokens,
       presets: Object.keys(PRESETS).filter(
         (name) => !ADMIN_CLASS_PRESETS.has(name),
+      ),
+      capabilities: KNOWN_CAPABILITIES.filter(
+        (cap) => !ADMIN_CLASS_CAPABILITIES.has(cap),
       ),
     };
     return NextResponse.json(body);

--- a/web/src/app/dashboard/credentials/CredentialsPanel.tsx
+++ b/web/src/app/dashboard/credentials/CredentialsPanel.tsx
@@ -664,8 +664,36 @@ interface IssuedV1Token {
 
 type CapabilityTokensState =
   | { kind: "loading" }
-  | { kind: "loaded"; tokens: V1TokenSummary[]; presets: string[] }
+  | {
+      kind: "loaded";
+      tokens: V1TokenSummary[];
+      presets: string[];
+      capabilities: string[];
+    }
   | { kind: "error"; message: string };
+
+type IssueMode = "preset" | "custom";
+
+/** Subsystem prefix used to group capability checkboxes. The order
+ * here matches the order capabilities appear in the API response
+ * (subsystem-grouped at the source) so the rendering is stable. */
+const CAPABILITY_GROUP_LABELS: Record<string, string> = {
+  installation_token: "Installation token",
+  agent_health: "Agent health",
+  tasks: "Tasks",
+  rooms: "War rooms",
+};
+
+function capabilityGroupOrder(capabilities: string[]): string[] {
+  // Preserve first-seen order to keep the group order stable across
+  // renders even though presets / KNOWN_CAPABILITIES order can shift.
+  const seen: string[] = [];
+  for (const cap of capabilities) {
+    const prefix = cap.split(".")[0];
+    if (!seen.includes(prefix)) seen.push(prefix);
+  }
+  return seen;
+}
 
 function CapabilityTokensSection({
   sessionExpired,
@@ -676,13 +704,26 @@ function CapabilityTokensSection({
 }) {
   const [state, setState] = useState<CapabilityTokensState>({ kind: "loading" });
   const [issueName, setIssueName] = useState("");
+  const [issueMode, setIssueMode] = useState<IssueMode>("preset");
   const [issuePreset, setIssuePreset] = useState("queen");
+  const [issueCustomCaps, setIssueCustomCaps] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [issuing, setIssuing] = useState(false);
   const [issueError, setIssueError] = useState<string | null>(null);
   const [justIssued, setJustIssued] = useState<IssuedV1Token | null>(null);
   const [revoking, setRevoking] = useState<string | null>(null);
   const [rotating, setRotating] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<"idle" | "ok" | "fail">("idle");
+
+  function toggleCustomCap(cap: string): void {
+    setIssueCustomCaps((prev) => {
+      const next = new Set(prev);
+      if (next.has(cap)) next.delete(cap);
+      else next.add(cap);
+      return next;
+    });
+  }
 
   const fetchList = useCallback(async () => {
     try {
@@ -691,8 +732,14 @@ function CapabilityTokensSection({
         const data = (await res.json()) as {
           tokens: V1TokenSummary[];
           presets: string[];
+          capabilities: string[];
         };
-        setState({ kind: "loaded", tokens: data.tokens, presets: data.presets });
+        setState({
+          kind: "loaded",
+          tokens: data.tokens,
+          presets: data.presets,
+          capabilities: data.capabilities ?? [],
+        });
         return;
       }
       const err = await parseErrorResponse(res);
@@ -717,18 +764,43 @@ function CapabilityTokensSection({
 
   async function handleIssue() {
     if (issuing || issueName.trim().length === 0) return;
+
+    // Body shape depends on the mode the operator is in. The server
+    // accepts either `preset` (well-known role bundle) OR
+    // `capabilities` (explicit list); UI sends whichever the operator
+    // actually configured. In custom mode, reject zero-cap selections
+    // locally so the round-trip surfaces the right error message
+    // (server would also reject with INVALID_CAPABILITIES, but local
+    // surface is faster and clearer).
+    let body: { name: string; preset?: string; capabilities?: string[] };
+    if (issueMode === "preset") {
+      body = { name: issueName.trim(), preset: issuePreset };
+    } else {
+      if (issueCustomCaps.size === 0) {
+        setIssueError(
+          "Custom mode requires at least one capability checked.",
+        );
+        return;
+      }
+      body = {
+        name: issueName.trim(),
+        capabilities: Array.from(issueCustomCaps).sort(),
+      };
+    }
+
     setIssuing(true);
     setIssueError(null);
     try {
       const res = await fetch("/api/dashboard/agent-tokens", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: issueName.trim(), preset: issuePreset }),
+        body: JSON.stringify(body),
       });
       if (res.ok) {
         const issued = (await res.json()) as IssuedV1Token;
         setJustIssued(issued);
         setIssueName("");
+        setIssueCustomCaps(new Set());
         // Refresh list so the new entry appears.
         await fetchList();
         return;
@@ -932,6 +1004,36 @@ function CapabilityTokensSection({
             <h3 className="mb-3 text-sm font-semibold text-[#fafafa]">
               Issue new token
             </h3>
+
+            {/* Mode toggle */}
+            <div className="mb-3 inline-flex rounded-lg border border-white/[0.06] p-0.5">
+              <button
+                type="button"
+                onClick={() => setIssueMode("preset")}
+                disabled={issuing}
+                className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                  issueMode === "preset"
+                    ? "bg-honey-500/15 text-honey-500"
+                    : "text-zinc-400 hover:text-zinc-300"
+                }`}
+              >
+                Preset
+              </button>
+              <button
+                type="button"
+                onClick={() => setIssueMode("custom")}
+                disabled={issuing}
+                className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                  issueMode === "custom"
+                    ? "bg-honey-500/15 text-honey-500"
+                    : "text-zinc-400 hover:text-zinc-300"
+                }`}
+              >
+                Custom
+              </button>
+            </div>
+
+            {/* Name + (preset OR issue button) row */}
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
               <div className="flex-1">
                 <label
@@ -950,36 +1052,91 @@ function CapabilityTokensSection({
                   disabled={issuing}
                 />
               </div>
-              <div className="sm:w-48">
-                <label
-                  htmlFor="cap-token-preset"
-                  className="mb-1.5 block text-xs text-zinc-500"
-                >
-                  Preset
-                </label>
-                <select
-                  id="cap-token-preset"
-                  value={issuePreset}
-                  onChange={(e) => setIssuePreset(e.target.value)}
-                  disabled={issuing}
-                  className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-sm text-[#fafafa] focus:border-honey-500/40 focus:outline-none"
-                >
-                  {state.presets.map((preset) => (
-                    <option key={preset} value={preset}>
-                      {preset}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              {issueMode === "preset" && (
+                <div className="sm:w-48">
+                  <label
+                    htmlFor="cap-token-preset"
+                    className="mb-1.5 block text-xs text-zinc-500"
+                  >
+                    Preset
+                  </label>
+                  <select
+                    id="cap-token-preset"
+                    value={issuePreset}
+                    onChange={(e) => setIssuePreset(e.target.value)}
+                    disabled={issuing}
+                    className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-sm text-[#fafafa] focus:border-honey-500/40 focus:outline-none"
+                  >
+                    {state.presets.map((preset) => (
+                      <option key={preset} value={preset}>
+                        {preset}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <button
                 type="button"
                 onClick={handleIssue}
-                disabled={issuing || issueName.trim().length === 0}
+                disabled={
+                  issuing
+                  || issueName.trim().length === 0
+                  || (issueMode === "custom" && issueCustomCaps.size === 0)
+                }
                 className="rounded-lg bg-honey-500 px-5 py-2 text-sm font-semibold text-[#0a0a0a] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {issuing ? "Issuing…" : "Issue"}
               </button>
             </div>
+
+            {/* Custom-mode capability checkboxes, grouped by subsystem */}
+            {issueMode === "custom" && (
+              <div className="mt-4 rounded-md border border-white/[0.04] bg-white/[0.02] p-3">
+                <div className="mb-2 flex items-center justify-between text-xs text-zinc-500">
+                  <span>
+                    Selected: {issueCustomCaps.size} of {state.capabilities.length}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setIssueCustomCaps(new Set())}
+                    disabled={issuing || issueCustomCaps.size === 0}
+                    className="text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Clear
+                  </button>
+                </div>
+                {capabilityGroupOrder(state.capabilities).map((prefix) => {
+                  const groupCaps = state.capabilities.filter(
+                    (c) => c.split(".")[0] === prefix,
+                  );
+                  return (
+                    <div key={prefix} className="mb-2 last:mb-0">
+                      <div className="mb-1 text-xs font-semibold text-zinc-400">
+                        {CAPABILITY_GROUP_LABELS[prefix] ?? prefix}
+                      </div>
+                      <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                        {groupCaps.map((cap) => (
+                          <label
+                            key={cap}
+                            className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-xs text-zinc-300 hover:bg-white/[0.03]"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={issueCustomCaps.has(cap)}
+                              onChange={() => toggleCustomCap(cap)}
+                              disabled={issuing}
+                              className="h-3.5 w-3.5 cursor-pointer"
+                            />
+                            <span className="font-mono">{cap}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
             {issueError && (
               <p className="mt-2 text-xs text-red-400">{issueError}</p>
             )}


### PR DESCRIPTION
Resolves #570.

## Why

The Capability Tokens panel only supported presets, so operators
who wanted a non-preset bundle either had to pick the closest preset
(over-grant) or drop to the API and hand-craft the JSON. Both undercut
the dashboard's purpose of "cold-start UX without ever holding an
admin bearer." This PR adds a Custom mode where operators check
exactly the capabilities they want — same form, same endpoint, same
security boundary.

## What changed

- `web/src/app/api/dashboard/agent-tokens/route.ts` — `GET` now also
  returns `capabilities: string[]`, the non-admin capability
  vocabulary in subsystem-grouped order. Filtered through the same
  `ADMIN_CLASS_CAPABILITIES` deny list as the issuance path so the
  catalog and the security boundary stay in sync.
- `web/src/app/api/dashboard/agent-tokens/route.test.ts` — three new
  tests for the catalog: admin-class filtering, full vocabulary
  inclusion, and subsystem-ordering preservation. All 21 GET/POST
  tests pass.
- `web/src/app/dashboard/credentials/CredentialsPanel.tsx` — adds an
  `IssueMode = "preset" | "custom"` toggle to the issue form. In
  `custom` mode, capabilities render as grouped checkboxes (group
  prefix → friendly label via `CAPABILITY_GROUP_LABELS`). Submission
  builds `{ name, preset }` for preset mode, `{ name, capabilities }`
  for custom mode. Empty selection blocked client-side.

## Security

The admin-class deny list is enforced **server-side** (issuance
handler still rejects `*` / `agent_tokens.manage` regardless of
mode). The catalog filter on `GET` is a UX optimization — operators
never see the dangerous capabilities in the picker — not the security
control. So even a stale UI shipping with `agent_tokens.manage` in
the catalog would still get a 400 on submit.

## What it looks like

**Preset mode (unchanged):**
```
[ Issue new token ]
[Preset] Custom    ← mode toggle (Preset highlighted)

Name: [queen____]   Preset: [queen ▼]   [Issue]
```

**Custom mode (new):**
```
[ Issue new token ]
Preset [Custom]    ← mode toggle (Custom highlighted)

Name: [my-token____]                      [Issue]

  Selected: 3 of 17                       Clear

  Installation token
    ☐ installation_token.mint
  Agent health
    ☑ agent_health.report
    ☐ agent_health.read
  Tasks
    ☑ tasks.claim
    ☐ tasks.progress
    ☐ tasks.complete
    ...
  War rooms
    ☐ rooms.watch
    ...
```

## Test plan

- [x] `npx vitest run src/app/api/dashboard/agent-tokens/route.test.ts` (21/21)
- [x] `npx vitest run src/app/api/dashboard/` (57/57)
- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (no errors in changed files)
- [ ] Smoke test in dashboard: issue token with custom caps, verify capabilities list matches selection in the one-time-display modal
- [ ] Verify admin-class capabilities (`*`, `agent_tokens.manage`) are NOT visible as checkboxes
- [ ] Verify zero-capability submit is blocked with helpful error