### PR TITLE
fix(bot): drop misleading "will retry" log on E.1 createRoom transient

### DIFF
--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -264,8 +264,9 @@ export async function maybeCreatePrReviewRoom(
       );
       return { roomId: null, skipped: "api_error" };
     }
-    // Network / 5xx → transient. Log + skip; webhook re-delivery
-    // will retry.
+    // Network / 5xx → transient. Log + skip; the helper still
+    // returns 200 to GitHub via the webhook handler, so there is no
+    // automatic re-delivery. See file docstring.
     args.log.warn(
       {
         err,
@@ -273,7 +274,7 @@ export async function maybeCreatePrReviewRoom(
         repo: args.repo,
         pr: args.prNumber,
       },
-      "[war-room] createRoom transient error — skipping (will retry on next webhook delivery)",
+      "[war-room] createRoom transient error — skipping (no auto-retry; see file docstring)",
     );
     return { roomId: null, skipped: "api_error" };
   }


### PR DESCRIPTION
Closes the carry-forward I flagged in #526 guard N1 (R1 review). The
runtime warn-log line on E.1's `createRoom` transient path still claims
GitHub will re-deliver, but the helper swallows the error and the
webhook handler returns 200 — so there is no automatic retry. Operators
reading prod logs will incorrectly assume auto-recovery is in progress.

The file docstring (lines 17-26) already documents the real recovery
posture honestly. The analogous helpers shipped in E.2 (`subject_updated`,
line 429) and E.4 (`mention_response`, line 620) both use
`(no auto-retry; see file docstring)`. This PR brings the E.1 helper in
line with its siblings.

## Diff scope

One log message + the adjacent comment block. No behavior change, no
control-flow change, no test changes (existing tests assert
`stringContaining("transient error")`, which still matches).

```diff
-    // Network / 5xx → transient. Log + skip; webhook re-delivery
-    // will retry.
+    // Network / 5xx → transient. Log + skip; the helper still
+    // returns 200 to GitHub via the webhook handler, so there is no
+    // automatic re-delivery. See file docstring.
     args.log.warn(
       …,
-      "[war-room] createRoom transient error — skipping (will retry on next webhook delivery)",
+      "[war-room] createRoom transient error — skipping (no auto-retry; see file docstring)",
     );
```

## Validation

- `tsc --noEmit` clean
- `vitest run api/lib/war-room-routing.test.ts api/lib/war-room-client.test.ts`: **89 passed** (51 routing + 38 client)
- Lint clean on the touched file

## Not in scope

A real recovery story (re-throw on 5xx so Probot/GitHub retry, OR a
queueable retry shelf) is the underlying gap behind both #526 N1 and
the structural caveats noted in the file docstring + #545 (drone
NB2's two-phase dispatch comment). That's V1.1 scope per the Queen's
prior R2; this PR is purely operator-log honesty.


Closes #664
