### PR TITLE
fix(web): V1 Bearer auth 503 — replace cjson.decode Lua with two TS GETs

### DIFF
--- a/web/src/server/agent-token-v1.test.ts
+++ b/web/src/server/agent-token-v1.test.ts
@@ -137,26 +137,11 @@ function makeMockRedis() {
         return [1];
       }
 
-      // RESOLVE_BEARER_SCRIPT — 1 key, 2 args (R3: + envelopePrefix + presentedHash)
-      if (
-        keys.length === 1 &&
-        argv.length === 2 &&
-        script.includes("unknown_bearer")
-      ) {
-        const [hashIdxK] = keys;
-        const [envelopePrefix, presentedHash] = argv;
-        const hashRecord = store.get(hashIdxK) as
-          | { installationId: string; name: string }
-          | undefined;
-        if (!hashRecord) return [-1, "unknown_bearer"];
-        const envKey = `${envelopePrefix}${hashRecord.installationId}:${hashRecord.name}`;
-        const envelope = store.get(envKey) as
-          | { tokenHash: string }
-          | undefined;
-        if (!envelope) return [-2, "envelope_missing"];
-        if (envelope.tokenHash !== presentedHash) return [-3, "stale_bearer"];
-        return [1, JSON.stringify(envelope), hashRecord.installationId];
-      }
+      // RESOLVE_BEARER_SCRIPT was removed — bearer→envelope resolution
+      // is now two TS-side `redis.get` calls (the Lua version used
+      // cjson.decode which Upstash's sandboxed Lua does not expose).
+      // Tests for `resolveBearerToEnvelope` exercise the live `get` mock
+      // below directly.
 
       // ROTATE_TOKEN_SCRIPT — 4 keys, 5 args (R2: + auditStreamKey + name first + auditEntry)
       if (
@@ -1237,5 +1222,72 @@ describe("ROTATE_TOKEN_SCRIPT — {-1, no_envelope} race path (G7)", () => {
         redis,
       }),
     ).rejects.toThrow(TokenNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upstash-Lua compatibility lint
+// ---------------------------------------------------------------------------
+//
+// The mock above simulates each Lua script in JS — it does NOT execute
+// the actual Lua. So a Lua-side bug (e.g. `cjson.decode` not existing
+// in Upstash's sandboxed Lua) sails through unit tests and only
+// surfaces in production. To close that gap, lint the SOURCE FILE for
+// Lua features that don't exist in Upstash's serverless runtime.
+//
+// History: an earlier RESOLVE_BEARER_SCRIPT used `cjson.decode` which
+// caused every `/api/whoami` and Bearer-authenticated request to 503
+// with `agent_auth_v1_server_misconfiguration` in production while
+// every test passed. Resolution moved to two TS-side `redis.get`
+// calls; this test prevents anyone reintroducing the same pattern.
+
+describe("Upstash-Lua compatibility (regression: cjson.decode in production)", () => {
+  const sourcePath = new URL("./agent-token-v1.ts", import.meta.url).pathname;
+  const source = readFileSync(sourcePath, "utf-8");
+
+  // Extract every backtick-template-literal that LOOKS like a Lua
+  // script (contains a Redis call invocation). Comments / docblocks
+  // aren't delimited by backticks so this is safe.
+  const REDIS_INVOCATION_TOKEN = "redis." + "call(";
+  function extractLuaScripts(src: string): string[] {
+    const scripts: string[] = [];
+    const regex = /`([^`]+)`/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(src)) !== null) {
+      const body = match[1];
+      if (body.includes(REDIS_INVOCATION_TOKEN)) scripts.push(body);
+    }
+    return scripts;
+  }
+
+  // Sandbox-incompatible Lua std-libs — Upstash's serverless Redis
+  // strips these from the eval context. Adding any of these to a
+  // script will make `redis["eval"]` throw at runtime even though
+  // mocked unit tests pass.
+  const INCOMPATIBLE_LUA_PATTERNS: { pattern: RegExp; lib: string }[] = [
+    { pattern: /\bcjson\./, lib: "cjson" },
+    { pattern: /\bcmsgpack\./, lib: "cmsgpack" },
+    { pattern: /\bbit\./, lib: "bit" },
+    { pattern: /\bstruct\./, lib: "struct" },
+  ];
+
+  it("source contains at least one Lua script (sanity)", () => {
+    const scripts = extractLuaScripts(source);
+    expect(scripts.length).toBeGreaterThan(0);
+  });
+
+  it("no Lua script uses cjson / cmsgpack / bit / struct (Upstash sandbox missing them)", () => {
+    const scripts = extractLuaScripts(source);
+    const offences: string[] = [];
+    for (const script of scripts) {
+      for (const { pattern, lib } of INCOMPATIBLE_LUA_PATTERNS) {
+        if (pattern.test(script)) {
+          offences.push(
+            `Script using \`${lib}\` (first 80 chars: "${script.trim().slice(0, 80)}…")`,
+          );
+        }
+      }
+    }
+    expect(offences).toEqual([]);
   });
 });

--- a/web/src/server/agent-token-v1.ts
+++ b/web/src/server/agent-token-v1.ts
@@ -477,75 +477,13 @@ end
 return {1}
 `;
 
-/**
- * RESOLVE_BEARER_SCRIPT — single-RTT bearer→envelope resolution.
- *
- * Closes builder R3: the design doc's earlier "pipeline both reads"
- * pseudocode was impossible because the envelope key requires
- * `{installationId, name}` from the hash record returned by the
- * FIRST get. The reads are dependent, so a JS-side
- * `redis.pipeline().get().get().all()` can't construct the second
- * key before the pipeline has run.
- *
- * Resolution: do both reads + the bearer-resurrection invariant
- * check (`envelope.tokenHash === presentedHash`) inside a single
- * Lua EVAL. The script:
- *   1. GET the hash index for the presented bearer.
- *   2. If missing → `{-1, "unknown_bearer"}`.
- *   3. cjson.decode the hash record → `{installationId, name}`.
- *   4. Compute the envelope key in Lua + GET it.
- *   5. If missing → `{-2, "envelope_missing"}` (TTL-swept or
- *      revoke race).
- *   6. cjson.decode the envelope + check `envelope.tokenHash ===
- *      ARGV[2]`. If mismatch → `{-3, "stale_bearer"}` (the
- *      same-name-reissue bearer-resurrection scenario the storage
- *      shape is designed to defend against — see the BEARER-
- *      RESURRECTION INVARIANT block at the top of this file).
- *   7. Otherwise return `{1, envelopeJson}`.
- *
- * Middleware (B.1.c) then:
- *   - Checks `envelope.expiresAt` against current time (Lua can't
- *     reliably compare wall-clock time across instances; the +300s
- *     TTL margin guarantees the envelope outlives its expiresAt
- *     by at least 5 min so this check is the user-visible gate).
- *   - Returns the typed auth result with capabilities + agent_role.
- *
- * KEYS: [hashIndexKey]
- * ARGV: [envelopeKeyPrefix, presentedHash]
- *   envelopeKeyPrefix = "hive:v1:agent-token:" — passed as ARGV
- *                       so the prefix lives in TS code (single
- *                       source of truth) rather than the Lua
- *                       string. Lua does
- *                         envelopeKey = prefix + installationId
- *                                      + ":" + name
- *
- * Returns:
- *   {1, envelopeJson, installationId}  success — caller cjson.parses
- *                                       envelope; installationId is
- *                                       surfaced from the hash record
- *                                       so the middleware can construct
- *                                       the meta-key (lastUsedAt write)
- *                                       and return it on the auth
- *                                       result without an extra round-
- *                                       trip. The V1 envelope schema
- *                                       does NOT carry installationId;
- *                                       it lives only in the storage
- *                                       key + the hash record.
- *   {-1, "unknown_bearer"}             hash index miss
- *   {-2, "envelope_missing"}           hash record points at a TTL'd or revoked envelope
- *   {-3, "stale_bearer"}               bearer-resurrection: hash → envelope but envelope.tokenHash differs
- */
-const RESOLVE_BEARER_SCRIPT = `
-local hashRecord = redis.call("get", KEYS[1])
-if not hashRecord then return {-1, "unknown_bearer"} end
-local parsed = cjson.decode(hashRecord)
-local envKey = ARGV[1] .. parsed.installationId .. ":" .. parsed.name
-local envelope = redis.call("get", envKey)
-if not envelope then return {-2, "envelope_missing"} end
-local envParsed = cjson.decode(envelope)
-if envParsed.tokenHash ~= ARGV[2] then return {-3, "stale_bearer"} end
-return {1, envelope, parsed.installationId}
-`;
+// Bearer→envelope resolution lives in `resolveBearerToEnvelope` below
+// as two sequential TS-side `redis.get` calls. An earlier design used a
+// Lua EVAL with `cjson.decode` to atomicize both reads, but Upstash's
+// serverless Redis does not expose `cjson` in its sandboxed Lua, so the
+// script erred at runtime and every authenticated Bearer request 503'd.
+// See the docblock on `resolveBearerToEnvelope` for the full
+// rationale + the +1 RTT trade-off.
 
 /**
  * ROTATE_TOKEN_SCRIPT — atomic bearer swap. Replaces the envelope +
@@ -1322,52 +1260,49 @@ export type ResolveBearerResult =
       code: "unknown_bearer" | "envelope_missing" | "stale_bearer";
     };
 
+/**
+ * Resolves a presented bearer to its envelope + installationId via two
+ * sequential Redis GETs (hash index → envelope). Originally a single
+ * Lua EVAL with `cjson.decode` for atomicity, but Upstash's serverless
+ * Redis sandbox does not expose `cjson` — the script erred at runtime
+ * and every authenticated Bearer request 503'd with
+ * `agent_auth_v1_server_misconfiguration`. Mocked unit tests passed
+ * because the test mock simulated the script in JS and never executed
+ * the Lua. The two-RTT TS form trades ~1 RTT of latency for portability
+ * and correctness; both reads are GETs, so a transient Redis blip on
+ * the second read produces the same `envelope_missing` result the Lua
+ * would have, with no race window worth defending against (the Lua
+ * version was already non-atomic vs concurrent revoke).
+ */
 export async function resolveBearerToEnvelope(args: {
   rawBearer: string;
   redis: Redis;
 }): Promise<ResolveBearerResult> {
   const presentedHash = hashToken(args.rawBearer);
-  const raw = await args.redis.eval(
-    RESOLVE_BEARER_SCRIPT,
-    [hashIndexKey(presentedHash)],
-    [ENVELOPE_PREFIX, presentedHash],
+
+  const hashRecord = await args.redis.get<AgentTokenHashRecordV1>(
+    hashIndexKey(presentedHash),
   );
-  // Custom dispatch: success returns {1, envelopeJson, installationId}
-  // (3 elements) whereas the standard dispatchScriptResult only
-  // surfaces position [1] as `reason`. Inline the parsing.
-  if (!Array.isArray(raw) || raw.length === 0) {
-    throw new Error(
-      `RESOLVE_BEARER_SCRIPT returned malformed result: ${JSON.stringify(raw)}`,
-    );
-  }
-  const tag = Number(raw[0]);
-  if (tag === 1) {
-    if (raw.length !== 3) {
-      throw new Error(
-        `RESOLVE_BEARER_SCRIPT success expected 3-element tuple, got ${raw.length}`,
-      );
-    }
-    const envelopeJson = String(raw[1]);
-    const installationId = String(raw[2]);
-    return {
-      ok: true,
-      envelope: JSON.parse(envelopeJson) as AgentTokenEnvelopeV1,
-      installationId,
-    };
-  }
-  const reason = raw.length > 1 ? String(raw[1]) : undefined;
-  if (tag === -1 && reason === "unknown_bearer") {
-    return { ok: false, code: "unknown_bearer" };
-  }
-  if (tag === -2 && reason === "envelope_missing") {
-    return { ok: false, code: "envelope_missing" };
-  }
-  if (tag === -3 && reason === "stale_bearer") {
+  if (!hashRecord) return { ok: false, code: "unknown_bearer" };
+
+  const envelope = await args.redis.get<AgentTokenEnvelopeV1>(
+    envelopeKey(hashRecord.installationId, hashRecord.name),
+  );
+  if (!envelope) return { ok: false, code: "envelope_missing" };
+
+  // Bearer-resurrection guard: rotation issues a new hash record under a
+  // fresh hashIndexKey but the previous bearer's hashIndex is DELed in the
+  // same EVAL — so a presented bearer whose hash maps to an envelope whose
+  // tokenHash differs has been rotated out from under it.
+  if (envelope.tokenHash !== presentedHash) {
     return { ok: false, code: "stale_bearer" };
   }
-  throw new Error(
-    `RESOLVE_BEARER_SCRIPT returned unexpected result: ${JSON.stringify(raw)}`,
-  );
+
+  return {
+    ok: true,
+    envelope,
+    installationId: hashRecord.installationId,
+  };
 }
 
 /** Read a single token summary by name. Throws TokenNotFoundError. */


### PR DESCRIPTION
Resolves #576.

## TL;DR

Every authenticated Bearer request 503'd in production with
`agent_auth_v1_server_misconfiguration`. `RESOLVE_BEARER_SCRIPT`
called `cjson.decode` which Upstash's serverless Redis sandbox does
not expose. Replace with two TS-side `redis.get` calls. Add a CI
regression test.

## Root cause

`RESOLVE_BEARER_SCRIPT` in `web/src/server/agent-token-v1.ts:538` did:

\`\`\`lua
local hashRecord = redis.call("get", KEYS[1])
...
local parsed = cjson.decode(hashRecord)
local envKey = ARGV[1] .. parsed.installationId .. ":" .. parsed.name
local envelope = redis.call("get", envKey)
local envParsed = cjson.decode(envelope)
\`\`\`

`cjson` is a standard Lua library shipped by Redis OSS but **stripped from Upstash's serverless Lua sandbox**. The script errors at runtime, `redis["eval"]` throws, gets caught by `agent-token-v1-auth.ts`'s try/catch which maps to the generic "Auth resolution failed" 503.

The other 4 Lua scripts in the file (ISSUE / REVOKE / SET_CAPABILITIES / ROTATE) use only plain `redis.call(...)` operations and work fine — that's why issuance via the dashboard worked while authentication via Bearer didn't.

## Why this passed CI

The Vitest mock for `redis["eval"]` (in `agent-token-v1.test.ts:60-228`) simulates each Lua script in JavaScript by inspecting the script source and dispatching to a JS reimplementation. The actual Lua never runs. So `cjson.decode` in the script was opaque to the mock.

## Fix

\`\`\`typescript
export async function resolveBearerToEnvelope(args: {...}) {
  const presentedHash = hashToken(args.rawBearer);

  const hashRecord = await args.redis.get<AgentTokenHashRecordV1>(
    hashIndexKey(presentedHash),
  );
  if (!hashRecord) return { ok: false, code: "unknown_bearer" };

  const envelope = await args.redis.get<AgentTokenEnvelopeV1>(
    envelopeKey(hashRecord.installationId, hashRecord.name),
  );
  if (!envelope) return { ok: false, code: "envelope_missing" };

  if (envelope.tokenHash !== presentedHash) {
    return { ok: false, code: "stale_bearer" };
  }

  return { ok: true, envelope, installationId: hashRecord.installationId };
}
\`\`\`

`@upstash/redis`'s `redis.get<T>()` auto-deserializes JSON payloads when `T` is non-primitive — both the hash record and envelope are already stored as `JSON.stringify(...)` payloads, so the round-trip is clean.

## Trade-offs

**+1 RTT per authenticated request** (~50ms on Upstash REST). Acceptable because:

- The original Lua wasn't atomic vs concurrent revoke anyway. `REVOKE_TOKEN_SCRIPT` can DEL the envelope between our two reads, returning `envelope_missing` — same outcome the eval would produce in the same race (GET is point-in-time too).
- The previous "single-RTT" framing in the docblock was true mechanically but didn't buy any consistency guarantee that the two-GET form lacks.

## Regression test

New test in `agent-token-v1.test.ts`:

\`\`\`typescript
describe("Upstash-Lua compatibility (regression: cjson.decode in production)", () => {
  it("no Lua script uses cjson / cmsgpack / bit / struct", () => {
    // Reads agent-token-v1.ts source, extracts every backtick template
    // literal containing redis.call(...), asserts none use the listed
    // sandbox-incompatible std-libs.
  });
});
\`\`\`

Catches future regressions of the same class. Source-string lint, not a runtime check — bypasses the mock entirely.

## What it looks like

**Before:**
\`\`\`
$ curl -H "Authorization: Bearer <fresh-V1-bearer>" https://www.hivemoot.dev/api/whoami
HTTP 503
{"code":"agent_auth_v1_server_misconfiguration","message":"Auth resolution failed"}
\`\`\`

**After (post-deploy):**
\`\`\`
$ curl -H "Authorization: Bearer <fresh-V1-bearer>" https://www.hivemoot.dev/api/whoami
HTTP 200
{"installationId":"...","agent_role":"apiarist","capabilities":["installation_token.mint"],"fingerprint":"..."}
\`\`\`

## Test plan

- [x] `npx vitest run src/server/agent-token-v1.test.ts` — 59/59 (was 57, +2 regression tests)
- [x] `npx vitest run` — 1382/1382 + 1 skipped, no failures
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings
- [ ] Post-deploy: hit `/api/whoami` with a V1 bearer, expect 200
- [ ] Post-deploy: confirm hive drone/builder/guard auth refresh stops failing
- [ ] Post-deploy: confirm bot queen tick (cron */2) starts succeeding

## Discovery context

Found while exercising the war-room V1 end-to-end after #571 merged. Issued 4 capability tokens via the new dashboard UI, wrote them to hive secrets and Vercel env, restarted services — all 4 hit BACKEND_UNAUTHORIZED. Tracing confirmed it's not an apiarist-vs-worker preset choice, not a token-format issue, and not specific to my new tokens — *every* V1 bearer 503s, including ones issued and used in the same JS run.