### PR TITLE
fix(web): watchdog reads HIVEMOOT_REDIS_REST_URL not UPSTASH_*

### DIFF
--- a/web/src/app/api/internal/queen/tick/route.test.ts
+++ b/web/src/app/api/internal/queen/tick/route.test.ts
@@ -11,8 +11,18 @@ vi.mock("@upstash/redis", () => {
     eval: vi.fn(),
     get: vi.fn(),
   };
+  // Mock both shapes so the test stays decoupled from how the route
+  // constructs its client (we moved off Redis.fromEnv to read the
+  // canonical HIVEMOOT_REDIS_REST_URL/_TOKEN names directly).
+  // class-style so `new Redis(...)` works alongside `Redis.fromEnv()`.
+  class Redis {
+    constructor() {
+      Object.assign(this, fakeRedis);
+    }
+    static fromEnv = vi.fn(() => fakeRedis);
+  }
   return {
-    Redis: { fromEnv: vi.fn(() => fakeRedis) },
+    Redis,
     __fakeRedis: fakeRedis,
   };
 });
@@ -53,6 +63,8 @@ function makeRequest(body: unknown, opts?: { authHeader?: string }): NextRequest
 describe("POST /api/internal/queen/tick", () => {
   beforeEach(() => {
     vi.stubEnv("CRON_SECRET", CRON_SECRET);
+    vi.stubEnv("HIVEMOOT_REDIS_REST_URL", "https://test.upstash.io");
+    vi.stubEnv("HIVEMOOT_REDIS_REST_TOKEN", "test-token");
     fakeRedis.set.mockReset();
     fakeRedis.eval.mockReset();
     fakeRedis.get.mockReset();
@@ -237,6 +249,8 @@ describe("GET /api/internal/queen/tick (Vercel Cron entrypoint)", () => {
 
   beforeEach(() => {
     vi.stubEnv("CRON_SECRET", CRON_SECRET);
+    vi.stubEnv("HIVEMOOT_REDIS_REST_URL", "https://test.upstash.io");
+    vi.stubEnv("HIVEMOOT_REDIS_REST_TOKEN", "test-token");
     fakeRedis.set.mockReset();
     fakeRedis.eval.mockReset();
     mockedTick.mockReset();

--- a/web/src/app/api/internal/queen/tick/route.ts
+++ b/web/src/app/api/internal/queen/tick/route.ts
@@ -58,7 +58,19 @@ function getCronSecret(): string | null {
 }
 
 function getRedis(): Redis {
-  return Redis.fromEnv();
+  // Web standardised on HIVEMOOT_REDIS_REST_URL / _TOKEN (used by
+  // BYOK auth + war-room storage). Redis.fromEnv() defaults to
+  // UPSTASH_REDIS_REST_URL / _TOKEN, which we don't set — read the
+  // canonical names directly so the watchdog matches the rest of
+  // the codebase.
+  const url = process.env.HIVEMOOT_REDIS_REST_URL;
+  const token = process.env.HIVEMOOT_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    throw new Error(
+      "queen-tick watchdog Redis is misconfigured: set both HIVEMOOT_REDIS_REST_URL and HIVEMOOT_REDIS_REST_TOKEN.",
+    );
+  }
+  return new Redis({ url, token });
 }
 
 function makeRunnerId(): string {


### PR DESCRIPTION
## Summary

Web's war-room watchdog cron route (`/api/internal/queen/tick`) was failing on every fire (every minute) with:

```
[Upstash Redis] Unable to find environment variable: \`UPSTASH_REDIS_REST_URL\`
```

`Redis.fromEnv()` looks for `UPSTASH_REDIS_REST_URL` / `_TOKEN` by default, but this project standardised on `HIVEMOOT_REDIS_REST_URL` / `_TOKEN` (used by BYOK auth, war-room storage, bot's queen-tick). Only the HIVEMOOT_* names are provisioned on the `hivemoot-web` Vercel project — there are no UPSTASH_* env vars.

Effect: the watchdog never advances `awaiting_rsvp` rooms past their `max_age_secs`, so unreplied `@hivemoot` mention rooms accumulate indefinitely. (Verified live: a `mention_response` room from `hivemoot/sandbox#21` was stuck in `Awaiting RSVPs` 3h+ after creation despite a 1h `max_age_secs`.)

## Fix

Read `HIVEMOOT_REDIS_REST_URL` / `_TOKEN` directly with a fail-loud guard, mirroring `bot/api/lib/redis.ts`.

## What it looks like

**Before**

```
$ vercel logs --project hivemoot-web --since 5m
[/api/internal/queen/tick] [Upstash Redis] Unable to find environment variable: \`UPSTASH_REDIS_REST_URL\`
```

**After (verified locally — 1385/1386 web tests pass)**

```
$ npm test -- --run queen/tick
Test Files  1 passed (1)
Tests  19 passed (19)
```

## Test plan
- [x] All 19 watchdog route tests pass
- [x] Web full suite 1385 passed, 1 pre-existing skip (no regressions)
- [ ] CI green
- [ ] Post-deploy: watchdog returns 200 on cron fires
- [ ] Post-deploy: stuck `awaiting_rsvp` rooms past `max_age_secs` transition to `expired`