### PR TITLE
fix(bot): queen decision-poster handles mention_response + issue_triage

### DIFF
--- a/bot/api/lib/queen/decision-poster.test.ts
+++ b/bot/api/lib/queen/decision-poster.test.ts
@@ -101,28 +101,44 @@ describe("GitHubDecisionPoster.postDecision — pr_review subjects", () => {
   });
 });
 
-describe("GitHubDecisionPoster.postDecision — non-pr_review subjects (V1 skip)", () => {
-  it("skips mention_response (V1: pr_review only)", async () => {
-    const { octokit, createCommentFn } = makeOctokit({});
+describe("GitHubDecisionPoster.postDecision — non-PR subject types (mention / issue)", () => {
+  // pr_review, mention_response, and issue_triage all share the
+  // `{owner}/{repo}#{number}` ref shape; GitHub's
+  // `issues.createComment` works for both PRs and plain issues, so
+  // the poster handles all three uniformly.
+  it("posts mention_response decisions to the mentioned issue", async () => {
+    const { octokit, createCommentFn } = makeOctokit({
+      htmlUrl: "https://github.com/o/r/issues/9#issuecomment-123",
+    });
     const poster = new GitHubDecisionPoster({ octokit });
     const result = await poster.postDecision({
       ...PR_ARGS,
       subjectType: "mention_response",
+      subjectRef: "o/r#9",
     });
-    expect(result.attempted).toBe(false);
-    expect(result.commentUrl).toBeNull();
-    expect(createCommentFn).not.toHaveBeenCalled();
+    expect(result.attempted).toBe(true);
+    expect(result.commentUrl).toBe(
+      "https://github.com/o/r/issues/9#issuecomment-123",
+    );
+    expect(createCommentFn).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "o", repo: "r", issue_number: 9 }),
+    );
   });
 
-  it("skips issue_triage (V1: pr_review only)", async () => {
-    const { octokit, createCommentFn } = makeOctokit({});
+  it("posts issue_triage decisions to the triaged issue", async () => {
+    const { octokit, createCommentFn } = makeOctokit({
+      htmlUrl: "https://github.com/o/r/issues/42#issuecomment-456",
+    });
     const poster = new GitHubDecisionPoster({ octokit });
     const result = await poster.postDecision({
       ...PR_ARGS,
       subjectType: "issue_triage",
+      subjectRef: "o/r#42",
     });
-    expect(result.attempted).toBe(false);
-    expect(createCommentFn).not.toHaveBeenCalled();
+    expect(result.attempted).toBe(true);
+    expect(createCommentFn).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "o", repo: "r", issue_number: 42 }),
+    );
   });
 });
 
@@ -199,21 +215,21 @@ describe("GitHubDecisionPoster.postDecision — strict subject_ref regex (R1 #54
   });
 
   it.each([
-    ["org/repo#1", { owner: "org", repo: "repo", prNumber: 1 }],
-    ["a/b#42", { owner: "a", repo: "b", prNumber: 42 }],
+    ["org/repo#1", { owner: "org", repo: "repo", number: 1 }],
+    ["a/b#42", { owner: "a", repo: "b", number: 42 }],
     [
       "my-org/my-repo#100",
-      { owner: "my-org", repo: "my-repo", prNumber: 100 },
+      { owner: "my-org", repo: "my-repo", number: 100 },
     ],
     [
       "my.org/my.repo#7",
-      { owner: "my.org", repo: "my.repo", prNumber: 7 },
+      { owner: "my.org", repo: "my.repo", number: 7 },
     ],
     [
       "my_org/my_repo#9999",
-      { owner: "my_org", repo: "my_repo", prNumber: 9999 },
+      { owner: "my_org", repo: "my_repo", number: 9999 },
     ],
-    ["1org/2repo#1", { owner: "1org", repo: "2repo", prNumber: 1 }],
+    ["1org/2repo#1", { owner: "1org", repo: "2repo", number: 1 }],
   ])("accepts %j", async (goodRef, expected) => {
     const { octokit, createCommentFn } = makeOctokit({
       htmlUrl: "https://github.com/example/example/pull/1",
@@ -224,7 +240,7 @@ describe("GitHubDecisionPoster.postDecision — strict subject_ref regex (R1 #54
       expect.objectContaining({
         owner: expected.owner,
         repo: expected.repo,
-        issue_number: expected.prNumber,
+        issue_number: expected.number,
       }),
     );
   });

--- a/bot/api/lib/queen/decision-poster.test.ts
+++ b/bot/api/lib/queen/decision-poster.test.ts
@@ -140,6 +140,20 @@ describe("GitHubDecisionPoster.postDecision — non-PR subject types (mention / 
       expect.objectContaining({ owner: "o", repo: "r", issue_number: 42 }),
     );
   });
+
+  it("returns attempted=false for an unknown subject type (defensive catch-all)", async () => {
+    // Forces the not-in-POSTABLE branch — guards against a future
+    // PR adding to the union without wiring a posting handler.
+    const { octokit, createCommentFn } = makeOctokit({});
+    const poster = new GitHubDecisionPoster({ octokit });
+    const result = await poster.postDecision({
+      ...PR_ARGS,
+      subjectType: "future_subject" as PostDecisionArgs["subjectType"],
+    });
+    expect(result.attempted).toBe(false);
+    expect(result.commentUrl).toBeNull();
+    expect(createCommentFn).not.toHaveBeenCalled();
+  });
 });
 
 describe("GitHubDecisionPoster.postDecision — malformed subject_ref", () => {
@@ -266,15 +280,43 @@ describe("RecordingDecisionPoster", () => {
     expect(result.commentUrl).toContain(PR_ARGS.roomId);
   });
 
-  it("returns attempted=false for non-pr_review subjects", async () => {
+  // Aligned with GitHubDecisionPoster's subject coverage so manager-
+  // loop tests using this double don't silently diverge from
+  // production behaviour for non-PR subject types.
+  it("records calls and returns a fake URL for mention_response", async () => {
     const poster = new RecordingDecisionPoster();
     const result = await poster.postDecision({
       ...PR_ARGS,
       subjectType: "mention_response",
     });
+    expect(poster.calls).toHaveLength(1);
+    expect(result.attempted).toBe(true);
+    expect(result.commentUrl).toContain(PR_ARGS.roomId);
+  });
+
+  it("records calls and returns a fake URL for issue_triage", async () => {
+    const poster = new RecordingDecisionPoster();
+    const result = await poster.postDecision({
+      ...PR_ARGS,
+      subjectType: "issue_triage",
+    });
+    expect(poster.calls).toHaveLength(1);
+    expect(result.attempted).toBe(true);
+    expect(result.commentUrl).toContain(PR_ARGS.roomId);
+  });
+
+  it("returns attempted=false for an unknown subject type (defensive catch-all)", async () => {
+    // Forces the not-in-POSTABLE branch — guards against a future
+    // PR adding to the union without wiring a posting handler.
+    const poster = new RecordingDecisionPoster();
+    const result = await poster.postDecision({
+      ...PR_ARGS,
+      // Intentional cast to bypass the type union — exercises the
+      // defensive runtime check.
+      subjectType: "future_subject" as PostDecisionArgs["subjectType"],
+    });
     expect(result.attempted).toBe(false);
     expect(result.commentUrl).toBeNull();
-    // Still records the call (so tests can verify the loop tried).
     expect(poster.calls).toHaveLength(1);
   });
 });

--- a/bot/api/lib/queen/decision-poster.ts
+++ b/bot/api/lib/queen/decision-poster.ts
@@ -7,13 +7,19 @@
  * `closeRoom`, but the implementation is swappable for tests +
  * deployment variations.
  *
- * V1 scope: pr_review subjects only. mention_response and
- * issue_triage land in V1.1 alongside their respective workflows.
+ * Subject support: `pr_review`, `mention_response`, and
+ * `issue_triage` all share the `{owner}/{repo}#{number}` ref shape
+ * (validated identically at room-create time) and post via the same
+ * `issues.createComment` GitHub API — which works for both PRs and
+ * plain issues. The `POSTABLE` set below is the single source of
+ * truth and is shared between `GitHubDecisionPoster` and
+ * `RecordingDecisionPoster` so the test double can't drift from
+ * production behavior.
  *
  * Failure model: a post failure does NOT undo the room close. The
  * decision is durably stored on the room (closeRoom succeeded);
- * operators can manually re-post or wait for V1.1 retry. The
- * manager loop counts `postsFailed` separately so ops can alert.
+ * operators can manually re-post. The manager loop counts
+ * `postsFailed` separately so ops can alert.
  */
 
 import type { Logger } from "../logger.js";
@@ -29,10 +35,25 @@ export interface PostDecisionArgs {
   roomId: string;
 }
 
+/**
+ * Subject types that have a concrete posting handler. Module-level
+ * const so it's allocated once and shared between
+ * `GitHubDecisionPoster` and `RecordingDecisionPoster` — the test
+ * double then can't silently lag the production class on subject
+ * coverage. Add a new subject type here AND its parser/poster path
+ * in lockstep.
+ */
+const POSTABLE: ReadonlySet<PostDecisionArgs["subjectType"]> = new Set([
+  "pr_review",
+  "mention_response",
+  "issue_triage",
+]);
+
 export interface PostDecisionResult {
-  /** Whether the post path was attempted. False when the subject
-   * type isn't supported in V1 (mention_response, issue_triage).
-   * The manager loop should treat this as a no-op, not an error. */
+  /** Whether the post path was attempted. False only when the
+   * subject type has no posting handler (i.e. not in the module's
+   * `POSTABLE` set). The manager loop should treat this as a
+   * no-op, not an error. */
   attempted: boolean;
   /** Issue/PR comment URL on success. Null when not attempted OR
    * the underlying GitHub call returned no html_url (defensive). */
@@ -80,15 +101,10 @@ export class GitHubDecisionPoster implements DecisionPoster {
   }
 
   async postDecision(args: PostDecisionArgs): Promise<PostDecisionResult> {
-    // V1 supports `pr_review`, `mention_response`, and `issue_triage`.
-    // All three use the same `{owner}/{repo}#{number}` subject_ref
-    // shape and the same `issues.createComment` GitHub API (which
-    // works for both PRs and plain issues).
-    const POSTABLE: ReadonlySet<typeof args.subjectType> = new Set([
-      "pr_review",
-      "mention_response",
-      "issue_triage",
-    ]);
+    // POSTABLE is module-level so the test double in this file uses
+    // the SAME set — see file-level docstring. Defensive catch-all
+    // here in case a future PR adds a subject type to the union but
+    // forgets to wire its posting path.
     if (!POSTABLE.has(args.subjectType)) {
       this.logger.info(
         `[queen.poster] skip subject_type=${args.subjectType} roomId=${args.roomId} (no posting handler)`,
@@ -152,7 +168,8 @@ export class DecisionPostError extends Error {
  *   - owner / repo: `[A-Za-z0-9._-]+` (GitHub's allowed charset for
  *     org / repo names; rejects spaces, slashes-other-than-the-
  *     separator, and unicode)
- *   - PR number: `[1-9][0-9]*` (no leading zeros; positive integer)
+ *   - issue/PR number: `[1-9][0-9]*` (no leading zeros; positive
+ *     integer; same per-repo number space serves both)
  *   - Anchored at start AND end of input (no trailing whitespace,
  *     no extra path segments)
  *
@@ -190,13 +207,20 @@ function parseSubjectRef(
 /**
  * Test/observability poster that records calls without making any
  * network requests.
+ *
+ * Mirrors `GitHubDecisionPoster`'s subject-coverage gate via the
+ * shared module-level `POSTABLE` set so tests using this double
+ * see the same `attempted` truth as production. Without this
+ * alignment, a manager-loop test wired with a `mention_response`
+ * room would observe `attempted=false` here while production posts
+ * it — silently masking regressions in the real poster.
  */
 export class RecordingDecisionPoster implements DecisionPoster {
   public readonly calls: PostDecisionArgs[] = [];
 
   async postDecision(args: PostDecisionArgs): Promise<PostDecisionResult> {
     this.calls.push(args);
-    if (args.subjectType !== "pr_review") {
+    if (!POSTABLE.has(args.subjectType)) {
       return { attempted: false, commentUrl: null };
     }
     return {

--- a/bot/api/lib/queen/decision-poster.ts
+++ b/bot/api/lib/queen/decision-poster.ts
@@ -194,14 +194,12 @@ function parseSubjectRef(
   const match = SUBJECT_REF_REGEX.exec(ref);
   if (!match) return { ok: false, reason: "shape_mismatch" };
   const [, owner, repo, numberStr] = match;
-  const number = Number(numberStr);
-  if (!Number.isInteger(number) || number <= 0) {
-    // Unreachable given the regex (which already enforces positive
-    // non-zero-leading integers), but defensive against Number()
-    // edge cases on extreme inputs.
-    return { ok: false, reason: "invalid_number" };
-  }
-  return { ok: true, owner, repo, number };
+  // The regex's `[1-9][0-9]*` capture already enforces a positive
+  // integer with no leading zero, so `Number()` here is total — no
+  // need for a defensive Integer/range guard. Trusting the regex
+  // boundary keeps the function fully covered by the negative-shape
+  // tests above without the dead defensive branch.
+  return { ok: true, owner, repo, number: Number(numberStr) };
 }
 
 /**

--- a/bot/api/lib/queen/decision-poster.ts
+++ b/bot/api/lib/queen/decision-poster.ts
@@ -80,32 +80,41 @@ export class GitHubDecisionPoster implements DecisionPoster {
   }
 
   async postDecision(args: PostDecisionArgs): Promise<PostDecisionResult> {
-    if (args.subjectType !== "pr_review") {
+    // V1 supports `pr_review`, `mention_response`, and `issue_triage`.
+    // All three use the same `{owner}/{repo}#{number}` subject_ref
+    // shape and the same `issues.createComment` GitHub API (which
+    // works for both PRs and plain issues).
+    const POSTABLE: ReadonlySet<typeof args.subjectType> = new Set([
+      "pr_review",
+      "mention_response",
+      "issue_triage",
+    ]);
+    if (!POSTABLE.has(args.subjectType)) {
       this.logger.info(
-        `[queen.poster] skip subject_type=${args.subjectType} roomId=${args.roomId} (V1: pr_review only)`,
+        `[queen.poster] skip subject_type=${args.subjectType} roomId=${args.roomId} (no posting handler)`,
       );
       return { attempted: false, commentUrl: null };
     }
 
-    const parsed = parsePrSubjectRef(args.subjectRef);
+    const parsed = parseSubjectRef(args.subjectRef);
     if (!parsed.ok) {
       this.logger.warn(
         `[queen.poster] subject_ref parse failed roomId=${args.roomId} subject_ref=${args.subjectRef} reason=${parsed.reason}`,
       );
       throw new DecisionPostError(
-        `Invalid pr_review subject_ref: ${parsed.reason}`,
+        `Invalid ${args.subjectType} subject_ref: ${parsed.reason}`,
         args.roomId,
       );
     }
 
     this.logger.info(
-      `[queen.poster] posting roomId=${args.roomId} repo=${parsed.owner}/${parsed.repo} pr=${parsed.prNumber} bytes=${new TextEncoder().encode(args.content).length}`,
+      `[queen.poster] posting roomId=${args.roomId} subject_type=${args.subjectType} repo=${parsed.owner}/${parsed.repo} number=${parsed.number} bytes=${new TextEncoder().encode(args.content).length}`,
     );
 
     const response = await this.octokit.rest.issues.createComment({
       owner: parsed.owner,
       repo: parsed.repo,
-      issue_number: parsed.prNumber,
+      issue_number: parsed.number,
       body: args.content,
     });
 
@@ -132,7 +141,10 @@ export class DecisionPostError extends Error {
 }
 
 /**
- * Parse a `pr_review` subject_ref of the form `{owner}/{repo}#{prNumber}`.
+ * Parse a war-room subject_ref of the form `{owner}/{repo}#{number}`.
+ * The same shape covers `pr_review`, `mention_response`, and
+ * `issue_triage` (PR numbers and issue numbers share the per-repo
+ * sequence on GitHub, and `issues.createComment` works for both).
  * Mirrors the format documented at WAR_ROOM_DESIGN.md L165-167 and
  * the storage layer's regex at room-create time.
  *
@@ -150,29 +162,29 @@ export class DecisionPostError extends Error {
  * rather than reaching Octokit with a malformed ref and getting
  * a confusing GitHub 404.
  */
-const PR_SUBJECT_REF_REGEX = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)#([1-9][0-9]*)$/;
+const SUBJECT_REF_REGEX = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)#([1-9][0-9]*)$/;
 
-function parsePrSubjectRef(
+function parseSubjectRef(
   ref: string,
 ):
-  | { ok: true; owner: string; repo: string; prNumber: number }
+  | { ok: true; owner: string; repo: string; number: number }
   | { ok: false; reason: string } {
   // Defense-in-depth: explicit length cap to keep regex backtracking
   // bounded even though the regex is linear-time.
   if (ref.length === 0 || ref.length > 256) {
     return { ok: false, reason: "shape_mismatch" };
   }
-  const match = PR_SUBJECT_REF_REGEX.exec(ref);
+  const match = SUBJECT_REF_REGEX.exec(ref);
   if (!match) return { ok: false, reason: "shape_mismatch" };
-  const [, owner, repo, prNumberStr] = match;
-  const prNumber = Number(prNumberStr);
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+  const [, owner, repo, numberStr] = match;
+  const number = Number(numberStr);
+  if (!Number.isInteger(number) || number <= 0) {
     // Unreachable given the regex (which already enforces positive
     // non-zero-leading integers), but defensive against Number()
     // edge cases on extreme inputs.
-    return { ok: false, reason: "invalid_pr_number" };
+    return { ok: false, reason: "invalid_number" };
   }
-  return { ok: true, owner, repo, prNumber };
+  return { ok: true, owner, repo, number };
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes the V1 hard-coded skip in \`GitHubDecisionPoster.postDecision\` that silently dropped synthesized decisions for any non-\`pr_review\` room. Verified live: a \`mention_response\` room from \`hivemoot/sandbox#21\` reached \`closed\` with a full LLM-synthesized decision body in Redis, but the issue stayed at 7 comments — queen never posted.

## Root cause

\`\`\`ts
async postDecision(args) {
  if (args.subjectType !== "pr_review") {
    return { attempted: false, commentUrl: null };  // silent skip
  }
  // ...
}
\`\`\`

The docstring framed this as "V1 supports pr_review only," but the implementation underneath is already general:

- \`pr_review\`, \`mention_response\`, and \`issue_triage\` all use the \`{owner}/{repo}#{number}\` subject_ref shape (storage validates this identically at \`createRoom\` time).
- GitHub's \`POST /repos/{owner}/{repo}/issues/{issue_number}/comments\` works for both PRs and plain issues — the per-repo number sequence is shared.

So the gate was protecting against a non-existent failure mode while suppressing real synthesis output.

## Fix

\`POSTABLE\` set covers all three subject types. \`parsePrSubjectRef\` → \`parseSubjectRef\`, captured field \`prNumber\` → \`number\` (it carries either depending on subject type — one honest name).

## What it looks like

**Before** (live, post-#590 deploy):

- Room \`ab0cc165-…\` opens, worker RSVPs + contributes, queen synthesizes a full decision, room closes.
- Decision body stored on the room (visible at \`/dashboard/rooms/<id>\`).
- sandbox#21 — the issue the \`@hivemoot\` mention came from — stays at 7 comments. No decision posted.

**After** (this PR):

- Same chain, plus the queen calls \`issues.createComment\` on the original issue with the synthesized markdown. \`postsSucceeded\` increments instead of \`postsSkipped\`.

## Test plan

- [x] Two new positive tests cover \`mention_response\` and \`issue_triage\` posting paths (replacing the deleted V1-skip tests).
- [x] Strict-regex test fixtures updated for the renamed field.
- [x] Bot 1951 tests pass; \`tsc --noEmit\` clean.
- [ ] CI green
- [ ] Post-deploy: re-run the manual E2E (post \`@hivemoot\` → present → contribute) and verify queen posts a decision comment back to the issue