### PR TITLE
Revert debug commits #592 + #593 (queen-tick instrumentation)

### DIFF
--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -219,23 +219,6 @@ async function runOneTickForInstallation(args: {
       log: makeManagerLoopLogAdapter(),
     });
 
-    // TEMP DEBUG: emit one-line summary so Vercel's per-request log
-    // capture surfaces the post counters. The bot's `vercel logs`
-    // CLI only shows the FIRST log line per request, which has been
-    // hiding `[queen.poster] posted ...` and the manager-loop's
-    // `tick_complete` summary. Single-line console.log via stderr
-    // is captured separately. Revert once posting is verified.
-    console.error(
-      `[queen-tick.summary] installationId=${installationId} ` +
-        `scanned=${result.totalRoomsScanned} ` +
-        `awaiting=${result.scannedAwaitingContributions} ` +
-        `eligible=${result.eligible} claimed=${result.claimed} ` +
-        `closed=${result.closed} conflicts=${result.conflicts} ` +
-        `errors=${result.errors} ` +
-        `posts=succeeded:${result.postsSucceeded}|` +
-        `failed:${result.postsFailed}|skipped:${result.postsSkipped}`,
-    );
-
     return { result };
   } finally {
     await releaseTickLock(installationId, runnerId);

--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -219,11 +219,13 @@ async function runOneTickForInstallation(args: {
       log: makeManagerLoopLogAdapter(),
     });
 
-    // TEMP DEBUG: emit one-line summary via logger.error so it
-    // surfaces in `vercel logs` (error-level entries are reliably
-    // captured per-request even when info-level synth-factory
-    // suppresses the rest). Revert once posting is verified.
-    logger.error(
+    // TEMP DEBUG: emit one-line summary so Vercel's per-request log
+    // capture surfaces the post counters. The bot's `vercel logs`
+    // CLI only shows the FIRST log line per request, which has been
+    // hiding `[queen.poster] posted ...` and the manager-loop's
+    // `tick_complete` summary. Single-line console.log via stderr
+    // is captured separately. Revert once posting is verified.
+    console.error(
       `[queen-tick.summary] installationId=${installationId} ` +
         `scanned=${result.totalRoomsScanned} ` +
         `awaiting=${result.scannedAwaitingContributions} ` +


### PR DESCRIPTION
Reverts the two debug PRs that added `logger.error` summary instrumentation to `bot/api/queen/tick.ts`. The instrumentation never surfaced in `vercel logs` (Vercel's per-request log truncation hides everything after the first stdout line) so it added noise without value.

The actual root cause of the queen not posting was discovered separately: hivemoot/sandbox#21 was `locked` with reason=`resolved` from a prior governance flow, causing `issues.createComment` to silently 403. Verified by running the bot's App auth + Octokit `createComment` directly from a local script, which surfaced the lock error. After unlocking the issue, the queen successfully posted: https://github.com/hivemoot/sandbox/issues/21#issuecomment-4364364639 .

Bot 1954 tests pass; tsc clean.