### PR TITLE
fix(bot): quiet-period gate before claim — wait for slow workers

### DIFF
--- a/bot/api/lib/queen/manager-loop.test.ts
+++ b/bot/api/lib/queen/manager-loop.test.ts
@@ -32,6 +32,16 @@ function makeRoom(overrides: Partial<RoomListEntry> = {}): RoomListEntry {
     subject_ref: "owner/repo#42",
     status: "awaiting_contributions",
     opened_at: "2026-04-28T20:00:00Z",
+    // 0s quiet_period_secs disables the manager-loop's quiet-period
+    // gate so the existing test scenarios — which assert "claim
+    // happens THIS tick when participants are eligible" — keep
+    // working without each test having to supply a faraway nowMs.
+    // Scenarios that exercise the gate explicitly override this.
+    timing_config: {
+      max_age_secs: 3600,
+      drop_threshold_secs: 1200,
+      quiet_period_secs: 0,
+    },
     ...overrides,
   };
 }
@@ -338,6 +348,95 @@ describe("runQueenManagerLoop — eligibility check", () => {
     expect(result.scannedAwaitingContributions).toBe(1);
     expect(result.eligible).toBe(0);
     expect(calls.claimCalls).toEqual([]);
+  });
+});
+
+describe("runQueenManagerLoop — quiet-period gate", () => {
+  // The gate prevents the bot from claiming a room the moment the
+  // first fast worker resolves, which would let slower workers
+  // 409 against `awaiting_contributions` and never make it into
+  // the participants map (observed on PR #595/#596 with builder
+  // running ~2-3min behind guard).  Tests below cover both the
+  // hold and the eventual release.
+
+  it("holds a fast-eligible room until quiet_period_secs has elapsed", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [
+        makeRoom({
+          timing_config: {
+            max_age_secs: 3600,
+            drop_threshold_secs: 1200,
+            quiet_period_secs: 180,
+          },
+        }),
+      ],
+      participants: {
+        [ROOM_ID]: { guard: resolvedParticipant("guard") },
+      },
+    });
+    // Latest event (guard.resolved_at) is 2026-04-28T20:05:00Z.
+    // 60s later — under the 180s gate → hold.
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+      nowMs: Date.parse("2026-04-28T20:06:00Z"),
+    });
+    expect(result.eligible).toBe(1);
+    expect(result.quietPeriodHeld).toBe(1);
+    expect(result.claimed).toBe(0);
+    expect(calls.claimCalls).toEqual([]);
+  });
+
+  it("claims once quiet_period_secs has elapsed since the last event", async () => {
+    const { client, calls } = makeFakeClient({
+      rooms: [
+        makeRoom({
+          timing_config: {
+            max_age_secs: 3600,
+            drop_threshold_secs: 1200,
+            quiet_period_secs: 180,
+          },
+        }),
+      ],
+      participants: {
+        [ROOM_ID]: { guard: resolvedParticipant("guard") },
+      },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    // 200s after the latest event — past the 180s gate → claim.
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+      nowMs: Date.parse("2026-04-28T20:08:20Z"),
+    });
+    expect(result.quietPeriodHeld).toBe(0);
+    expect(result.claimed).toBe(1);
+    expect(result.closed).toBe(1);
+  });
+
+  it("zero quiet_period_secs disables the gate (claims immediately)", async () => {
+    // The default makeRoom() fixture uses quiet_period_secs: 0
+    // exactly so existing tests don't have to thread an explicit
+    // nowMs.  This test pins that contract — a 0 in timing_config
+    // means "no gate" regardless of how recent the events are.
+    const { client, calls } = makeFakeClient({
+      rooms: [makeRoom()],
+      participants: {
+        [ROOM_ID]: { guard: resolvedParticipant("guard") },
+      },
+      contributions: { [ROOM_ID]: { guard: presentContribution() } },
+    });
+    const result = await runQueenManagerLoop({
+      client,
+      synthesizer: new StubSynthesizer(),
+      runnerId: RUNNER_ID,
+      nowMs: Date.parse("2026-04-28T20:05:01Z"), // 1s after last event
+    });
+    expect(result.quietPeriodHeld).toBe(0);
+    expect(result.claimed).toBe(1);
+    expect(calls.claimCalls).toHaveLength(1);
   });
 });
 

--- a/bot/api/lib/queen/manager-loop.ts
+++ b/bot/api/lib/queen/manager-loop.ts
@@ -138,6 +138,13 @@ export interface QueenManagerLoopResult {
   scannedAwaitingContributions: number;
   /** Subset where every participant resolved (synthesis-eligible). */
   eligible: number;
+  /** Eligible rooms held back by the quiet-period gate (last
+   * participant transition newer than `quiet_period_secs`). They'll
+   * be retried on the next tick once the room has been quiet long
+   * enough.  Closes the race where a fast worker contributes,
+   * eligibility flips true, and the bot claims before slower
+   * workers can /present. */
+  quietPeriodHeld: number;
   /** Eligible rooms where claim succeeded (drives synthesis call). */
   claimed: number;
   /** Rooms successfully closed with a synthesis decision. */
@@ -184,6 +191,7 @@ export async function runQueenManagerLoop(
     totalRoomsScanned: 0,
     scannedAwaitingContributions: 0,
     eligible: 0,
+    quietPeriodHeld: 0,
     claimed: 0,
     closed: 0,
     conflicts: 0,
@@ -301,6 +309,31 @@ async function processOneRoom(args: {
     return;
   }
   result.eligible += 1;
+
+  // 1b. Quiet-period gate.  Eligibility being true on its first
+  //     fast worker would let the bot claim before slower workers
+  //     can /present — they then 409 against `awaiting_contributions`
+  //     and never make it into the participants map (observed on
+  //     PR #595/#596: builder triage runs ~minutes; guard finished
+  //     first; bot claimed before builder could /present).  Wait
+  //     until the room has been quiet for `quiet_period_secs`
+  //     since the last participant transition.  Late workers'
+  //     /present + /contribute lands inside the window, and the
+  //     next tick claims with everyone included.
+  const remainingSecs = quietPeriodRemainingSecs(
+    room,
+    participantsResp.participants,
+    nowMs,
+  );
+  if (remainingSecs > 0) {
+    result.quietPeriodHeld += 1;
+    log.info("queen.manager_loop.waiting_quiet_period", {
+      roomId: room.roomId,
+      remainingSecs,
+      quietPeriodSecs: room.timing_config.quiet_period_secs,
+    });
+    return;
+  }
 
   // 2. Claim.
   let throughSequence: number;
@@ -500,6 +533,43 @@ function isSynthesisEligible(
     if (p.status === "resolved") hasResolved = true;
   }
   return hasResolved;
+}
+
+/**
+ * Quiet-period gate.  Eligibility flips true the moment the first
+ * fast worker finishes (no pending + at least one resolved), but
+ * other workers may still be running their triage.  Wait until the
+ * room has been quiet for `timing_config.quiet_period_secs` since
+ * the last participant transition before claiming, so late workers'
+ * /present + /contribute can land inside the window.
+ *
+ * Reference timestamp is the latest of (room opened, every
+ * participant's `resolved_at` ?? `rsvp_at`).  Returns the seconds
+ * still remaining (0 = ready to claim, positive = wait that long).
+ *
+ * The gate uses the room's stored `quiet_period_secs` so per-room
+ * tuning is possible at `createRoom` time without changing the
+ * manager-loop.
+ */
+function quietPeriodRemainingSecs(
+  room: RoomListEntry,
+  participants: Record<string, RoomParticipant>,
+  nowMs: number,
+): number {
+  const quietSecs = room.timing_config.quiet_period_secs;
+  if (!Number.isFinite(quietSecs) || quietSecs <= 0) return 0;
+
+  let latestMs = Date.parse(room.opened_at);
+  if (!Number.isFinite(latestMs)) latestMs = 0;
+  for (const p of Object.values(participants)) {
+    const ts = Date.parse(p.resolved_at ?? p.rsvp_at);
+    if (Number.isFinite(ts) && ts > latestMs) latestMs = ts;
+  }
+  if (latestMs === 0) return 0;
+
+  const ageSecs = (nowMs - latestMs) / 1000;
+  const remaining = quietSecs - ageSecs;
+  return remaining > 0 ? remaining : 0;
 }
 
 /**

--- a/bot/api/lib/war-room-routing.test.ts
+++ b/bot/api/lib/war-room-routing.test.ts
@@ -103,6 +103,8 @@ describe("maybeCreatePrReviewRoom", () => {
     expect(createRoom).toHaveBeenCalledWith({
       subject: { type: "pr_review", ref: "hivemoot/hivemoot#42" },
       roomId: expectedRoomId,
+      // 180s tuned for PR review fleets; see war-room-routing.ts.
+      timing: { quiet_period_secs: 180 },
     });
     expect(log.info).toHaveBeenCalledWith(
       expect.objectContaining({ roomId: result.roomId }),
@@ -587,6 +589,7 @@ describe("maybeCreateMentionRoom", () => {
     expect(createRoom).toHaveBeenCalledWith({
       subject: { type: "mention_response", ref: "hivemoot/hivemoot#42" },
       roomId: expectedRoomId,
+      timing: { quiet_period_secs: 180 },
     });
   });
 

--- a/bot/api/lib/war-room-routing.ts
+++ b/bot/api/lib/war-room-routing.ts
@@ -260,7 +260,20 @@ export async function maybeCreatePrReviewRoom(
   });
 
   try {
-    await store.createRoom({ subject, roomId });
+    // 180s quiet_period_secs: tuned for PR review fleets where
+    // each agent's triage takes ~1-3min.  The default 600s leaves
+    // every PR sitting for 10min after the first contribution
+    // before synthesis fires, which is too long for reviewer
+    // feedback.  At 180s, the manager-loop's quiet-period gate
+    // gives slower agents up to 3min after the latest event to
+    // catch up before claiming.  Combined with the 2-min cron
+    // cadence, end-to-end is ~4-5min from last contribution to
+    // synthesis comment.
+    await store.createRoom({
+      subject,
+      roomId,
+      timing: { quiet_period_secs: 180 },
+    });
     args.log.info(
       {
         owner: args.owner,
@@ -556,7 +569,13 @@ export async function maybeCreateMentionRoom(
   });
 
   try {
-    await store.createRoom({ subject, roomId });
+    // 180s quiet_period_secs: see pr_review path above for the
+    // tuning rationale — same fleet, same engine wall-time profile.
+    await store.createRoom({
+      subject,
+      roomId,
+      timing: { quiet_period_secs: 180 },
+    });
     args.log.info(
       {
         owner: args.owner,

--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -232,6 +232,7 @@ function emptyManagerLoopResult(): Awaited<
     totalRoomsScanned: 0,
     scannedAwaitingContributions: 0,
     eligible: 0,
+    quietPeriodHeld: 0,
     claimed: 0,
     closed: 0,
     conflicts: 0,


### PR DESCRIPTION
## Summary

When a fresh PR opens, the war-room dashboard fans out to every reviewer agent (drone / builder / guard) via the agent-side `war_rooms` plugin. Each agent runs its triage independently — engine wall-times range from ~10s (zai withdraws on parse error) to ~3min (codex on a non-trivial PR).

**Pre-fix:** the bot manager-loop's eligibility check flipped `true` the moment ONE worker resolved (no `pending` + at least one `resolved`), and the next 2-min cron tick claimed the room into `deciding`. Slower workers then `409`'d against `status_precondition_failed` on `/present` and never made it into the participants map.

**Observed live:** on PRs #595 and #596, builder consistently lost the race to guard:
```
[hivemoot-war-rooms] WARN present failed (continuing to contribute)
  room=… seq=N: present returned status 409:
  {"code":"status_precondition_failed", "message":"... room is currently \"deciding\"."}
[hivemoot-war-rooms] ERROR contribute failed
  room=… seq=N verdict=APPROVE: 409 status_precondition_failed
```

## What it looks like

**Before** — synthesis comment shipped with 1-2 contributions instead of 3:
```
## Synthesis — hivemoot/hivemoot#596
**Verdict:** `APPROVE` _(aggregated from 1 contribution, downgrade-only floor per WAR_ROOM_DESIGN.md §S2)_

The hive-guard reviewed... The hive-drone withdrew without comment.
[builder never made it into the participants map]
```

**After** — gate holds the eligible room for `quiet_period_secs` so all reviewers can /present:
```
## Synthesis — hivemoot/hivemoot#NNN
**Verdict:** `APPROVE` _(aggregated from 3 contributions, …)_

The hive-builder reviewed… The hive-guard reviewed… The hive-drone withdrew without comment.
```

## Implementation

| File | Change |
|---|---|
| `bot/api/lib/queen/manager-loop.ts` | New `quietPeriodRemainingSecs(room, participants, nowMs)` helper. After eligibility passes, skip claim if `now - latest(opened_at, every participant's resolved_at ?? rsvp_at) < timing_config.quiet_period_secs`. Holds get counted as `quietPeriodHeld` in the loop result. |
| `bot/api/lib/war-room-routing.ts` | Bot's `createPrReviewRoom` and `createMentionResponseRoom` pass `timing: { quiet_period_secs: 180 }` instead of inheriting the design default 600s. 180s tuned for the hive's wall-time profile. |
| `bot/api/queen/tick.ts` | `emptyManagerLoopResult` initializes the new `quietPeriodHeld: 0` counter. |
| `bot/api/lib/queen/manager-loop.test.ts` | Adds `timing_config: { quiet_period_secs: 0, ... }` to the `makeRoom` fixture so existing tests keep passing (0 = gate disabled). Three new tests pin the hold/release/zero-disables contract. |
| `bot/api/lib/war-room-routing.test.ts` | Asserts the new `timing` arg on `createRoom` calls. |

## Test plan

- [x] `npm test` in `bot/`: all 1957 tests pass (39 → 42 in `manager-loop.test.ts`, +3 new for the gate)
- [x] `npm run typecheck`: clean
- [x] Web tests still pass (1381 + 1 skipped) since the gate lives entirely in the bot
- [ ] Deploy to bot Vercel project + open a fresh test PR; expect 3 participants in the room and a synthesis aggregating ALL contributions