### PR TITLE
docs(war-room): record triage prompt + parser hardening

### DIFF
--- a/docs/architecture/WAR_ROOM_DESIGN.md
+++ b/docs/architecture/WAR_ROOM_DESIGN.md
@@ -12,6 +12,20 @@
 > deprecated model and are being updated alongside the code that
 > implements the new one. When in doubt, the §Presence-driven
 > lifecycle section is authoritative.
+>
+> **Triage prompt + parser hardening (2026-05-02):** the triage
+> prompt now includes a tool-call budget (~3-5 calls) and an
+> explicit truncation-protection instruction so models that cap
+> their response budget mid-investigation still emit a clean
+> WITHDRAW rather than nothing parseable.  The parser regex is
+> case-insensitive and tolerates markdown decoration around the
+> `DECISION:` / `VERDICT:` keys (bold emphasis, blockquote prefix,
+> list bullets); when the `## Triage decision` heading is missing,
+> it falls back to scanning the whole document for bare DECISION
+> markers.  Originally drone (zai/glm-5.1) withdrew from every PR
+> with `unparseable_triage_output:*` — log inspection showed
+> mid-tool-call truncation was the dominant failure mode (failed
+> runs were 57-227 bytes vs 1500+ for successful ones).
 > Depends on: Phase B (capability system), Phase C (apiarist V1.6
 > `allowed_permissions` for read-only worker tokens — security claim
 > "workers physically cannot write to GitHub" is FALSE until Phase C


### PR DESCRIPTION
## Summary

Documents the triage hardening fix landed in #599. Adds a callout to the design doc masthead noting:
- Tool-call budget (~3-5 calls) added to the triage prompt
- Explicit truncation-protection instruction (clean WITHDRAW preferred over silent nothing)
- Parser regex is now case-insensitive + tolerates markdown decoration
- Whole-document scan fallback when `## Triage decision` heading is absent

This PR also serves as the live validation test: with the new agent docker image deployed to the fleet, expected to see drone (zai/glm-5.1) finally produce a parseable triage block instead of always withdrawing with `unparseable_triage_output:*`.

## Test plan

- [x] PR #599 merged + agent docker image rebuilt + fleet redeployed (`./deploy-apiary.sh --rebuild`)
- [ ] Verify drone produces a parseable triage on this PR
- [ ] Verify all 3 reviewers contribute (drone + builder + guard) and bot synthesis aggregates all three