### PR TITLE
chore(war-room): downgrade 409 race log noise + drop dup doc section

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -26,12 +26,73 @@ from hivemoot_agent.plugins_builtin.hivemoot.http import (
 
 
 __all__ = (
+    "RoomStateRaceError",
     "WatchingRoom",
     "list_watching_rooms",
     "present_to_room",
     "submit_contribution",
     "withdraw_participant",
 )
+
+
+class RoomStateRaceError(RuntimeError):
+    """The room moved to a status that no longer accepts this op
+    while the worker was producing its triage.  Distinguishes
+    benign races (e.g. queen claimed → `deciding` between the
+    worker's triage finishing and its /present) from real failures
+    (network, 5xx, malformed bearer, etc.).
+
+    Carries the underlying API error code (`status_precondition_failed`,
+    etc.) so the handler can log it at info level and skip the
+    post-failure callback — there's nothing to retry, the room is
+    already past us.
+    """
+
+    def __init__(self, op: str, code: str, body_excerpt: str) -> None:
+        super().__init__(
+            f"{op} lost race to room state transition (code={code}): {body_excerpt}",
+        )
+        self.op = op
+        self.code = code
+        self.body_excerpt = body_excerpt
+
+
+# API error codes the storage layer returns on a status-precondition
+# 409.  Listed here so the api module can distinguish them from
+# other 409s (e.g. `participant_already_present` is also 409 but
+# means "you already RSVP'd, harmless replay" — handled separately
+# by the handler's continue-to-contribute path).
+_RACE_409_CODES: frozenset[str] = frozenset(
+    {"status_precondition_failed"},
+)
+
+
+def _maybe_raise_race(
+    *,
+    op: str,
+    status: int,
+    parsed: Any,
+    raw: bytes,
+) -> None:
+    """Raise `RoomStateRaceError` when the response is a 409 with a
+    known room-state-race code.  No-op for 2xx, 4xx with unknown
+    code, or any other status — caller still wraps those as a
+    generic `RuntimeError` so the failure-mode signal isn't lost.
+    """
+    if status != 409:
+        return
+    if not isinstance(parsed, dict):
+        return
+    code = parsed.get("code")
+    if not isinstance(code, str):
+        return
+    if code not in _RACE_409_CODES:
+        return
+    raise RoomStateRaceError(
+        op=op,
+        code=code,
+        body_excerpt=raw.decode(errors="replace")[:200],
+    )
 
 
 @dataclass
@@ -161,6 +222,7 @@ def present_to_room(
 
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 
+    _maybe_raise_race(op="present", status=status, parsed=parsed, raw=raw)
     if status != 200:
         raise RuntimeError(
             f"present returned status {status}: "
@@ -203,6 +265,7 @@ def submit_contribution(
     }
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 
+    _maybe_raise_race(op="contributions", status=status, parsed=parsed, raw=raw)
     if status != 200:
         raise RuntimeError(
             f"contributions returned status {status}: "
@@ -247,6 +310,7 @@ def withdraw_participant(
 
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 
+    _maybe_raise_race(op="withdraw", status=status, parsed=parsed, raw=raw)
     if status != 200:
         raise RuntimeError(
             f"withdraw returned status {status}: "

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
@@ -215,6 +215,15 @@ def _do_present_and_contribute(
     side). Only when BOTH fail do we fire `on_post_failure` — at
     that point no participant-state change has landed and the
     worker dropped this room silently without re-dispatch.
+
+    `RoomStateRaceError` (the room moved to `deciding` / `closed`
+    while the worker was triaging) is treated as a benign race:
+    both legs are skipped, no callback fires, and the operator log
+    line is INFO-level instead of WARN/ERROR.  This is the
+    expected outcome whenever the bot's quiet-period gate hasn't
+    quite expired by the time a fast worker reaches /present;
+    elevating it to a noisy error trains operators to ignore the
+    log lines that DO indicate real problems.
     """
 
     present_failed_exc: Optional[Exception] = None
@@ -226,6 +235,19 @@ def _do_present_and_contribute(
             bearer=bearer,
             intent_hint=decision.summary,
         )
+    except wr_api.RoomStateRaceError as exc:
+        # Room moved on between watching → triage → present.  No
+        # state change landed; nothing to retry.  /contribute will
+        # also race so we skip it AND the post-failure callback
+        # (the trigger's seen-cache eviction would re-dispatch a
+        # room that no longer accepts our event — pointless work).
+        _log(
+            f"raced room transition on present "
+            f"room={room_id} subject={subject_ref} seq={current_sequence} "
+            f"code={exc.code} — skipping contribute",
+            level="info",
+        )
+        return
     except Exception as exc:  # noqa: BLE001 — log + continue
         present_failed_exc = exc
         _log(
@@ -255,6 +277,18 @@ def _do_present_and_contribute(
             f"contributed room={room_id} subject={subject_ref} "
             f"verdict={decision.verdict} body_bytes={len(raw_md.encode('utf-8'))} "
             f"truncated={truncated} landed_seq={seq} agent_exit={result.exit_code}",
+            level="info",
+        )
+    except wr_api.RoomStateRaceError as exc:
+        # Same race as the /present case but reached on the second
+        # leg.  Do NOT fire on_post_failure — the room moved on,
+        # not a transient failure; re-dispatching would just race
+        # again.  The agent's exit code is preserved by the trigger
+        # for observability.
+        _log(
+            f"raced room transition on contribute "
+            f"room={room_id} subject={subject_ref} seq={current_sequence} "
+            f"verdict={decision.verdict} code={exc.code}",
             level="info",
         )
     except Exception as exc:  # noqa: BLE001
@@ -306,6 +340,16 @@ def _do_present_then_withdraw(
             bearer=bearer,
             intent_hint=decision.reason,
         )
+    except wr_api.RoomStateRaceError as exc:
+        # See `_do_present_and_contribute` for the rationale: the
+        # room moved on, /withdraw will also race, no callback.
+        _log(
+            f"raced room transition on present (for withdraw) "
+            f"room={room_id} subject={subject_ref} seq={current_sequence} "
+            f"code={exc.code} — skipping withdraw",
+            level="info",
+        )
+        return
     except Exception as exc:  # noqa: BLE001
         present_failed = True
         _log(
@@ -329,6 +373,13 @@ def _do_present_then_withdraw(
             f"seq={current_sequence} reason={decision.reason or 'unspecified'} "
             f"landed_seq={seq} parse_error={decision.parse_error}",
             level=level,
+        )
+    except wr_api.RoomStateRaceError as exc:
+        _log(
+            f"raced room transition on withdraw "
+            f"room={room_id} subject={subject_ref} seq={current_sequence} "
+            f"code={exc.code}",
+            level="info",
         )
     except Exception as exc:  # noqa: BLE001
         _log(

--- a/agent/cli/tests/test_hivemoot_war_rooms_api.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_api.py
@@ -306,6 +306,97 @@ class WithdrawParticipantTests(unittest.TestCase):
         self.assertEqual(sent["reason"], "out of scope")
 
 
+class RoomStateRaceErrorTests(unittest.TestCase):
+    """The /present, /contributions, and /withdraw POST helpers
+    must distinguish 409 `status_precondition_failed` (the room
+    moved on while the worker was triaging — benign race) from
+    other 409s and other failures, so the handler can log the race
+    at info level instead of WARN/ERROR.  Without this distinction
+    operator log volume is high enough to mask real errors."""
+
+    ROOM_ID = "01234567-89ab-4cde-9012-3456789abcde"
+
+    def _race_409(self) -> bytes:
+        return json.dumps({
+            "code": "status_precondition_failed",
+            "message": "room is currently 'deciding'",
+        }).encode()
+
+    def test_present_raises_RoomStateRaceError_on_409_status_precondition_failed(
+        self,
+    ) -> None:
+        with patch.object(
+            hm_http._OPENER,
+            "open",
+            return_value=_fake_response(409, self._race_409()),
+        ):
+            with self.assertRaises(wr_api.RoomStateRaceError) as cm:
+                wr_api.present_to_room(
+                    "https://api.example", self.ROOM_ID, 1, "tok",
+                )
+        self.assertEqual(cm.exception.op, "present")
+        self.assertEqual(cm.exception.code, "status_precondition_failed")
+        # RoomStateRaceError is itself a RuntimeError so existing
+        # callers that catch the broader type still match.
+        self.assertIsInstance(cm.exception, RuntimeError)
+
+    def test_contributions_raises_RoomStateRaceError_on_race(self) -> None:
+        with patch.object(
+            hm_http._OPENER,
+            "open",
+            return_value=_fake_response(409, self._race_409()),
+        ):
+            with self.assertRaises(wr_api.RoomStateRaceError) as cm:
+                wr_api.submit_contribution(
+                    "https://api.example",
+                    self.ROOM_ID,
+                    1,
+                    {"verdict": "APPROVE", "summary": "ok"},
+                    "# body",
+                    "tok",
+                )
+        self.assertEqual(cm.exception.op, "contributions")
+
+    def test_withdraw_raises_RoomStateRaceError_on_race(self) -> None:
+        with patch.object(
+            hm_http._OPENER,
+            "open",
+            return_value=_fake_response(409, self._race_409()),
+        ):
+            with self.assertRaises(wr_api.RoomStateRaceError) as cm:
+                wr_api.withdraw_participant(
+                    "https://api.example", self.ROOM_ID, 1, "tok",
+                    reason="out of scope",
+                )
+        self.assertEqual(cm.exception.op, "withdraw")
+
+    def test_other_409_codes_still_raise_generic_RuntimeError(self) -> None:
+        # owner_conflict, participant_already_present, etc. are
+        # distinct race classes that the handler treats differently.
+        # They MUST NOT collapse into RoomStateRaceError.
+        body = json.dumps({"code": "owner_conflict"}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(409, body),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.present_to_room(
+                    "https://api.example", self.ROOM_ID, 1, "tok",
+                )
+        self.assertNotIsInstance(cm.exception, wr_api.RoomStateRaceError)
+        self.assertIn("status 409", str(cm.exception))
+
+    def test_409_without_recognizable_code_still_raises_generic(self) -> None:
+        body = json.dumps({"message": "no code field"}).encode()
+        with patch.object(
+            hm_http._OPENER, "open", return_value=_fake_response(409, body),
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                wr_api.present_to_room(
+                    "https://api.example", self.ROOM_ID, 1, "tok",
+                )
+        self.assertNotIsInstance(cm.exception, wr_api.RoomStateRaceError)
+
+
 class GetJsonTransportTests(unittest.TestCase):
     """Sanity checks on the new shared `get_json` helper that the
     war-room watcher depends on. Mirrors the post_json invariants."""

--- a/agent/cli/tests/test_hivemoot_war_rooms_handler.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_handler.py
@@ -18,6 +18,7 @@ from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
     is_war_room_job,
     truncate_raw_md,
 )
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import api as wr_api
 from hivemoot_agent.plugins.interfaces import AgentResult, Job
 
 
@@ -331,6 +332,157 @@ class HandleWithdrawPathTests(unittest.TestCase):
             )
         # Still doesn't raise; decision returned for caller introspection.
         self.assertEqual(decision.kind, "withdraw")
+
+
+class RoomStateRaceTests(unittest.TestCase):
+    """Closes the log-noise issue from PR #599 follow-up: when the
+    bot's quiet-period gate hasn't quite expired and a fast worker
+    reaches /present, the room may have transitioned to `deciding`
+    in the race window.  The handler must:
+      - Treat `RoomStateRaceError` as a benign no-op (info-level
+        log, no on_post_failure callback, no follow-up call).
+      - Stop the post sequence at the failed leg — don't try
+        /contribute or /withdraw against a room that won't accept
+        them.
+    """
+
+    def test_present_race_skips_contribute_no_callback(self) -> None:
+        """Race on /present (the first leg) must short-circuit the
+        whole sequence: no /contribute call, no on_post_failure."""
+        contribute_called: list[bool] = []
+        callback_invocations: list[tuple] = []
+
+        def _race_present(**_kwargs: Any) -> int:
+            raise wr_api.RoomStateRaceError(
+                op="present",
+                code="status_precondition_failed",
+                body_excerpt="room is currently 'deciding'",
+            )
+
+        def _contribute(**_kwargs: Any) -> int:
+            contribute_called.append(True)
+            return 7
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=_race_present,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=_contribute,
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+                on_post_failure=lambda *args: callback_invocations.append(args),
+            )
+
+        self.assertEqual(decision.kind, "present")  # parse still works
+        self.assertEqual(contribute_called, [], "race must skip /contribute")
+        self.assertEqual(callback_invocations, [], "race must NOT fire callback")
+
+    def test_contribute_race_after_successful_present_no_callback(self) -> None:
+        """Present succeeded; /contribute hits the race.  Still no
+        callback (the room moved on, re-dispatching is pointless —
+        it would just race again next tick)."""
+        callback_invocations: list[tuple] = []
+
+        def _present(**_kwargs: Any) -> int:
+            return 6
+
+        def _race_contribute(**_kwargs: Any) -> int:
+            raise wr_api.RoomStateRaceError(
+                op="contributions",
+                code="status_precondition_failed",
+                body_excerpt="room is currently 'deciding'",
+            )
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=_present,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.submit_contribution",
+            side_effect=_race_contribute,
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_present_response(),
+                on_post_failure=lambda *args: callback_invocations.append(args),
+            )
+
+        self.assertEqual(decision.kind, "present")
+        self.assertEqual(callback_invocations, [])
+
+    def test_withdraw_path_present_race_skips_withdraw(self) -> None:
+        """Same race on the withdraw path: /present (RSVP-then-
+        withdraw step 1) hits the race → skip the /withdraw call."""
+        withdraw_called: list[bool] = []
+
+        def _race_present(**_kwargs: Any) -> int:
+            raise wr_api.RoomStateRaceError(
+                op="present",
+                code="status_precondition_failed",
+                body_excerpt="room is currently 'deciding'",
+            )
+
+        def _withdraw(**_kwargs: Any) -> int:
+            withdraw_called.append(True)
+            return 6
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=_race_present,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.withdraw_participant",
+            side_effect=_withdraw,
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_withdraw_response(),
+            )
+
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertEqual(withdraw_called, [], "race must skip /withdraw")
+
+    def test_withdraw_race_after_successful_present_no_callback(self) -> None:
+        callback_invocations: list[tuple] = []
+
+        def _present(**_kwargs: Any) -> int:
+            return 6
+
+        def _race_withdraw(**_kwargs: Any) -> int:
+            raise wr_api.RoomStateRaceError(
+                op="withdraw",
+                code="status_precondition_failed",
+                body_excerpt="room is currently 'deciding'",
+            )
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.present_to_room",
+            side_effect=_present,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.handler.wr_api.withdraw_participant",
+            side_effect=_race_withdraw,
+        ):
+            decision = handle_war_room_job_finished(
+                _job(),
+                _result(),
+                base_url="https://api",
+                bearer="bearer",
+                extracted_markdown=_withdraw_response(),
+                on_post_failure=lambda *args: callback_invocations.append(args),
+            )
+
+        self.assertEqual(decision.kind, "withdraw")
+        self.assertEqual(callback_invocations, [])
 
 
 class HandlerSafetyInvariantTests(unittest.TestCase):

--- a/docs/architecture/WAR_ROOM_DESIGN.md
+++ b/docs/architecture/WAR_ROOM_DESIGN.md
@@ -657,28 +657,6 @@ denormalized SQL tables, and the events sorted set replaces
 code, same as the existing `agent-token.ts` and `task-store.ts`
 patterns.
 
-### Why Redis is sufficient for V1
-
-The relational queries the original SQL design relied on (list by
-status, filter by repo, join events + participants) decompose into
-narrow Redis lookups:
-
-- "List open rooms in installation X" → `SMEMBERS
-  hive:v1:idx:room:status:{X}:awaiting_rsvp ∪ awaiting_contributions ∪
-  deciding`, then `HMGET` per room key.
-- "List rooms by repo" → fetched set intersected against a per-repo
-  index `hive:v1:idx:room:repo:{installationId}:{owner}/{repo}` (added
-  on room open, removed on room close).
-- "Stuck-room watchdog" — same status set + per-room hash read.
-
-Avoiding SQL is an explicit project value (see CONCEPT.md: *"There is
-no external database, no hidden state, no admin panel"*). The
-materialized hashes (participants, contributions) replace the
-denormalized SQL tables, and the events sorted set replaces
-`war_room_events`. Foreign-key consistency moves to application
-code, same as the existing `agent-token.ts` and `task-store.ts`
-patterns.
-
 ---
 
 ## Authoritative role binding (S1)


### PR DESCRIPTION
## Summary

Two narrow polish items:

### 1. Worker handler treats 409 race as benign info, not ERROR

When the bot's quiet-period gate (#597) hasn't quite expired and a fast worker reaches `/present`, the room may have flipped to `deciding` in the race window. The strict ERROR-level log was correct semantics but trained operators to ignore lines that DO indicate real problems (5xx, network, malformed bearer).

**Before** (logs from PR #595/#596 chain):
```
[hivemoot-war-rooms] WARN present failed (continuing to contribute) … status 409: status_precondition_failed
[hivemoot-war-rooms] ERROR contribute failed … status 409: status_precondition_failed
```

**After**:
```
[hivemoot-war-rooms] raced room transition on present … code=status_precondition_failed — skipping contribute
```

Implementation:
- New `RoomStateRaceError` typed exception in `api.py`, raised by `_maybe_raise_race` when the response is 409 with `code: status_precondition_failed` (the only race code recognized — others like `owner_conflict` still raise generic `RuntimeError`).
- Handler catches it specifically on each leg, logs INFO, skips the next call (no /contribute or /withdraw against a room that won't accept them), does NOT fire `on_post_failure` (re-dispatching just races again).

### 2. Drop duplicate doc section

Drone flagged this in the #599 review: `## Why Redis is sufficient for V1` appeared twice in `WAR_ROOM_DESIGN.md` (lines 638 + 660) with near-identical content. Keep the slightly-more-specific copy that names the Lua scripts.

## Out of scope (split out)

The dashboard stuckness fix that was originally bundled here has moved to its own dedicated PR (#603) at the war-room reviewer's request — that change is a real behavior shift, not a "polish" line item, and deserves a focused review.

## What it looks like

| Event | Pre-fix | Post-fix |
|---|---|---|
| `/present` 409 race | `WARN present failed` then `ERROR contribute failed` (2 lines, both legs attempted) | `raced room transition on present … skipping contribute` (1 INFO line, second leg skipped) |
| `/contribute` after successful `/present` 409 | `ERROR contribute failed` | `raced room transition on contribute` (INFO) |
| Other 409 (e.g. `owner_conflict`) | unchanged | unchanged |
| 5xx / network | unchanged ERROR/WARN | unchanged ERROR/WARN |

## Test plan

- [x] 5 new `api.py` tests pin `RoomStateRaceError` raising for each POST endpoint + the "other 409 codes don't collapse into the race type" invariant
- [x] 4 new handler tests pin the skip-second-leg + no-callback contract on both PRESENT and WITHDRAW paths
- [x] All 119 war-room agent tests pass
- [ ] After agent docker rebuild + hive redeploy: log volume on next race occurrence drops to a single INFO line per worker per race