### PR TITLE
fix(dashboard): anchor room stuckness to max_age_secs not quiet_period

### DIFF
--- a/web/src/app/dashboard/rooms/room-helpers.test.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.test.ts
@@ -155,35 +155,47 @@ describe("isActiveStatus + ACTIVE_STATUSES", () => {
 });
 
 describe("relevantDeadlineSecs", () => {
-  it("awaiting_contributions uses quiet_period_secs", () => {
+  it("awaiting_contributions uses max_age_secs (room expiration)", () => {
     expect(
       relevantDeadlineSecs("awaiting_contributions", {
-        quiet_period_secs: 1200,
-        drop_threshold_secs: 600,
+        max_age_secs: 3600,
+        quiet_period_secs: 180,
+        drop_threshold_secs: 1200,
       }),
-    ).toBe(1200);
+    ).toBe(3600);
   });
 
-  it("deciding uses quiet_period_secs", () => {
+  it("deciding uses max_age_secs", () => {
     expect(
       relevantDeadlineSecs("deciding", {
-        quiet_period_secs: 1200,
-        drop_threshold_secs: 600,
+        max_age_secs: 3600,
+        quiet_period_secs: 180,
       }),
-    ).toBe(1200);
+    ).toBe(3600);
   });
 
   it("returns null for terminal statuses", () => {
     expect(
-      relevantDeadlineSecs("closed", { quiet_period_secs: 600 }),
+      relevantDeadlineSecs("closed", { max_age_secs: 3600 }),
     ).toBeNull();
     expect(
-      relevantDeadlineSecs("expired", { quiet_period_secs: 600 }),
+      relevantDeadlineSecs("expired", { max_age_secs: 3600 }),
     ).toBeNull();
   });
 
   it("returns null when timing_config is undefined", () => {
     expect(relevantDeadlineSecs("awaiting_contributions", undefined)).toBeNull();
+  });
+
+  it("returns null when max_age_secs is missing (older rooms / fixtures)", () => {
+    // quiet_period_secs alone is NOT a fallback — it's the gate
+    // before claim, not the room expiration.  Stuckness is anchored
+    // to the actual expiration deadline only.
+    expect(
+      relevantDeadlineSecs("awaiting_contributions", {
+        quiet_period_secs: 180,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -195,7 +207,7 @@ describe("stucknessRatio", () => {
       stucknessRatio(
         "2026-04-28T11:00:00Z",
         "closed",
-        { quiet_period_secs: 1200 },
+        { max_age_secs: 3600 },
         NOW,
       ),
     ).toBe(0);
@@ -212,30 +224,30 @@ describe("stucknessRatio", () => {
       stucknessRatio(
         "2026-04-28T11:00:00Z",
         "awaiting_contributions",
-        { quiet_period_secs: 0 },
+        { max_age_secs: 0 },
         NOW,
       ),
     ).toBe(0);
   });
 
-  it("computes ratio as (now - opened) / deadline_secs", () => {
-    // 30 minutes elapsed, deadline=3600s (1h) → ratio=0.5
+  it("computes ratio as (now - opened) / max_age_secs", () => {
+    // 30 minutes elapsed, max_age=3600s (1h) → ratio=0.5
     expect(
       stucknessRatio(
         "2026-04-28T11:30:00Z",
         "awaiting_contributions",
-        { quiet_period_secs: 3600 },
+        { max_age_secs: 3600 },
         NOW,
       ),
     ).toBeCloseTo(0.5);
   });
 
-  it("returns >1 when past deadline", () => {
+  it("returns >1 when past max_age (overdue for expiration)", () => {
     expect(
       stucknessRatio(
         "2026-04-28T10:00:00Z",
         "awaiting_contributions",
-        { quiet_period_secs: 600 }, // 10m deadline, 2h elapsed
+        { max_age_secs: 600 }, // 10m max_age, 2h elapsed
         NOW,
       ),
     ).toBeCloseTo(12);
@@ -246,10 +258,25 @@ describe("stucknessRatio", () => {
       stucknessRatio(
         "not-a-date",
         "awaiting_contributions",
-        { quiet_period_secs: 600 },
+        { max_age_secs: 3600 },
         NOW,
       ),
     ).toBe(0);
+  });
+
+  it("a fresh room with default 1h max_age + 180s quiet_period is NOT stuck", () => {
+    // Regression case for the previous bug where stuckness was
+    // computed against quiet_period_secs (180s).  A 4-min-old room
+    // mid-triage would have rated 4*60/180 = 1.33 → flagged as stuck.
+    // Anchored to max_age_secs (3600), it's 0.067 → not stuck.
+    expect(
+      stucknessRatio(
+        "2026-04-28T11:56:00Z", // 4 minutes old
+        "awaiting_contributions",
+        { max_age_secs: 3600, quiet_period_secs: 180 },
+        NOW,
+      ),
+    ).toBeCloseTo(0.067, 2);
   });
 });
 
@@ -261,24 +288,24 @@ describe("isRoomStuck", () => {
   });
 
   it("true when ratio >= 0.8", () => {
-    // 8m elapsed of 10m deadline = 0.8
+    // 8m elapsed of 10m max_age = 0.8
     expect(
       isRoomStuck(
         "2026-04-28T11:52:00Z",
         "awaiting_contributions",
-        { quiet_period_secs: 600 },
+        { max_age_secs: 600 },
         NOW,
       ),
     ).toBe(true);
   });
 
   it("false when ratio < 0.8", () => {
-    // 7m elapsed of 10m deadline = 0.7
+    // 7m elapsed of 10m max_age = 0.7
     expect(
       isRoomStuck(
         "2026-04-28T11:53:00Z",
         "awaiting_contributions",
-        { quiet_period_secs: 600 },
+        { max_age_secs: 600 },
         NOW,
       ),
     ).toBe(false);
@@ -289,7 +316,7 @@ describe("isRoomStuck", () => {
       isRoomStuck(
         "2026-01-01T00:00:00Z", // ancient
         "closed",
-        { quiet_period_secs: 600 },
+        { max_age_secs: 3600 },
         NOW,
       ),
     ).toBe(false);
@@ -307,8 +334,8 @@ describe("sortRoomsByStuckness", () => {
       | "closed"
       | "expired",
     opened_at: string,
-    quietPeriod = 1200,
-    dropThreshold = 600,
+    maxAge = 600,
+    quietPeriod = 180,
   ): RoomCoreWithId {
     return {
       roomId: id,
@@ -318,8 +345,9 @@ describe("sortRoomsByStuckness", () => {
       status,
       opened_at,
       timing_config: {
+        max_age_secs: maxAge,
         quiet_period_secs: quietPeriod,
-        drop_threshold_secs: dropThreshold,
+        drop_threshold_secs: 1200,
       },
     };
   }

--- a/web/src/app/dashboard/rooms/room-helpers.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.ts
@@ -147,25 +147,45 @@ export function roomMatchesSubjectQuery<T extends { subject_ref: string }>(
 }
 
 /**
+ * Shape of the timing-config the stuckness helpers below read.
+ * Mirrors `RoomCoreWithId['timing_config']` from `./types` but
+ * inlined as a narrow structural type so each helper's signature
+ * documents exactly which fields it touches.
+ */
+type StuckTimingConfig = {
+  max_age_secs?: number;
+  quiet_period_secs?: number;
+  drop_threshold_secs?: number;
+};
+
+/**
  * Pick the relevant deadline for a room based on its current status.
- * - awaiting_contributions / deciding → quiet_period_secs (the
- *   queen's settling window before claiming the room)
- * - terminal statuses → null (no deadline applies)
+ * - awaiting_contributions / deciding → max_age_secs (the hard cap
+ *   on room lifetime; rooms past this get terminated by the
+ *   watchdog as `expired`).
+ * - terminal statuses → null (no deadline applies).
  *
  * Falls back to undefined when the room has no timing_config (older
  * rooms or test fixtures).
  *
- * Heartbeat-model note: there is no separate `awaiting_rsvp` state
- * anymore, so a single relevant deadline (`quiet_period_secs`)
- * covers both pre- and post-contribution waiting.
+ * Why `max_age_secs` and not `quiet_period_secs` (the previous
+ * choice): under the heartbeat model, `quiet_period_secs` is the
+ * bot manager-loop's settling window BEFORE claiming a room — it
+ * resets every time a participant transition lands.  Treating it
+ * as the dashboard "deadline" highlighted every active room as
+ * "near deadline" within a couple minutes of opening, which is
+ * normal triage progress, not a stuck-room signal.  `max_age_secs`
+ * is the actual expiration deadline (3600s default = 1h) and the
+ * one operators care about: "this room has been open long enough
+ * that it's about to be force-expired."
  */
 export function relevantDeadlineSecs(
   status: RoomStatus,
-  timingConfig?: { quiet_period_secs?: number; drop_threshold_secs?: number },
+  timingConfig?: StuckTimingConfig,
 ): number | null {
   if (!isActiveStatus(status)) return null;
   if (!timingConfig) return null;
-  return timingConfig.quiet_period_secs ?? null;
+  return timingConfig.max_age_secs ?? null;
 }
 
 /**
@@ -180,7 +200,7 @@ export function relevantDeadlineSecs(
 export function stucknessRatio(
   openedAtIso: string,
   status: RoomStatus,
-  timingConfig?: { quiet_period_secs?: number; drop_threshold_secs?: number },
+  timingConfig?: StuckTimingConfig,
   nowMs: number = Date.now(),
 ): number {
   const deadline = relevantDeadlineSecs(status, timingConfig);
@@ -198,7 +218,7 @@ export const STUCK_THRESHOLD = 0.8;
 export function isRoomStuck(
   openedAtIso: string,
   status: RoomStatus,
-  timingConfig?: { quiet_period_secs?: number; drop_threshold_secs?: number },
+  timingConfig?: StuckTimingConfig,
   nowMs: number = Date.now(),
 ): boolean {
   return (
@@ -219,10 +239,7 @@ export function sortRoomsByStuckness<
   T extends {
     status: RoomStatus;
     opened_at: string;
-    timing_config?: {
-      quiet_period_secs?: number;
-      drop_threshold_secs?: number;
-    };
+    timing_config?: StuckTimingConfig;
   },
 >(rooms: T[], nowMs: number = Date.now()): T[] {
   return [...rooms].sort((a, b) => {


### PR DESCRIPTION
## Summary

The dashboard "stuck" highlighting and the rooms-list sort both anchored their `(now - opened_at) / deadline` math to `quiet_period_secs`. Under the heartbeat model that's the bot manager-loop's settling window before claiming a room — not the room's expiration deadline. With the new pr_review default of `quiet_period_secs: 180` (introduced in #597), every active room flashes "near deadline" within 144 seconds of opening — i.e. during normal triage. The signal is noise.

## Why max_age_secs

`max_age_secs` (3600 default = 1h) is the actual expiration deadline — the watchdog terminates rooms past it as `expired`. 80% of that window is the genuine "this room is about to be force-killed" warning operators care about.

## What it looks like

| Room state | Pre-fix stuckness | Post-fix stuckness |
|---|---|---|
| 4-min-old mid-triage room | 1.33 (flashed "near deadline") | 0.067 (not flagged) |
| 50-min-old room (no progress) | many× (long flagged) | 0.83 (flagged "near deadline") |
| 30-min-old healthy room | 10× (flashed) | 0.5 (not flagged) |

## Implementation

- `relevantDeadlineSecs(status, timing_config)` now returns `timing_config.max_age_secs ?? null` instead of `quiet_period_secs ?? null`
- New structural type `StuckTimingConfig` documents which timing fields the helpers read
- 8 existing tests updated; 1 new regression test pins "fresh room mid-triage NOT flagged"
- 12 new dashboard tests from #601 unaffected

## Out of scope

This is a behavior change scoped narrowly to the dashboard's stuckness math. It was originally bundled with #602 (polish) but split out at the war-room reviewer's request — the stuckness change is a real behavior change that deserves its own focused review, not a "polish" line item.

## Test plan

- [x] All 46 dashboard helper tests pass (8 updated + 1 new regression test)
- [x] Web typecheck clean
- [x] Full web test suite (1383 + 1 skipped) unaffected
- [ ] After deploy: open the dashboard with active rooms and verify "near deadline" only fires on rooms approaching the 1h max_age cutoff