### PR TITLE
feat(dashboard): subject_ref search on rooms list

### DIFF
--- a/web/src/app/dashboard/rooms/RoomsList.tsx
+++ b/web/src/app/dashboard/rooms/RoomsList.tsx
@@ -7,6 +7,7 @@ import {
   isRoomStuck,
   relativeTime,
   roomMatchesFilter,
+  roomMatchesSubjectQuery,
   sortRoomsByStuckness,
   statusLabel,
   statusPillClass,
@@ -40,6 +41,9 @@ export default function RoomsList() {
   // (no querystring sync) since the rooms list is a transient
   // operator inspection surface, not a shareable view.
   const [filter, setFilter] = useState<RoomStatusFilter>("all");
+  // Substring match against subject_ref. Empty = no filter.  Like
+  // `filter`, this is component state only — no URL sync.
+  const [search, setSearch] = useState<string>("");
 
   const fetchRooms = useCallback(async () => {
     try {
@@ -93,9 +97,12 @@ export default function RoomsList() {
 
   const visibleRooms = useMemo(() => {
     if (state.status !== "ready") return [];
-    const filtered = state.rooms.filter((r) => roomMatchesFilter(r, filter));
+    const filtered = state.rooms.filter(
+      (r) =>
+        roomMatchesFilter(r, filter) && roomMatchesSubjectQuery(r, search),
+    );
     return sortRoomsByStuckness(filtered);
-  }, [state, filter]);
+  }, [state, filter, search]);
 
   return (
     <div className="space-y-6">
@@ -110,11 +117,18 @@ export default function RoomsList() {
       </header>
 
       {state.status === "ready" && state.rooms.length > 0 && (
-        <FilterBar
-          current={filter}
-          onChange={setFilter}
-          counts={counts}
-        />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <FilterBar
+            current={filter}
+            onChange={setFilter}
+            counts={counts}
+          />
+          <SearchBox
+            value={search}
+            onChange={setSearch}
+            placeholder="Filter by subject (e.g. owner/repo#42)"
+          />
+        </div>
       )}
 
       {state.status === "loading" && (
@@ -148,7 +162,8 @@ export default function RoomsList() {
         visibleRooms.length === 0 && (
           <div className="rounded-lg border border-white/5 bg-zinc-900/50 p-6 text-center">
             <p className="text-sm text-zinc-400">
-              No rooms match the current filter.
+              No rooms match the current filter
+              {search.trim() !== "" && ` and search "${search.trim()}"`}.
             </p>
           </div>
         )}
@@ -212,6 +227,52 @@ function FilterBar({
         );
       })}
     </nav>
+  );
+}
+
+function SearchBox({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <label
+      className="flex items-center gap-2 rounded-full bg-zinc-800/60 px-3 py-1 text-xs ring-1 ring-white/5 focus-within:ring-honey-500/40"
+    >
+      <span className="sr-only">Filter rooms by subject</span>
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="h-3.5 w-3.5 text-zinc-500"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <circle cx="7" cy="7" r="4.5" />
+        <path d="M10.5 10.5l3 3" strokeLinecap="round" />
+      </svg>
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-64 max-w-full bg-transparent text-zinc-200 placeholder:text-zinc-500 focus:outline-none"
+      />
+      {value !== "" && (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onChange("")}
+          className="text-zinc-500 hover:text-zinc-300"
+        >
+          ×
+        </button>
+      )}
+    </label>
   );
 }
 

--- a/web/src/app/dashboard/rooms/room-helpers.test.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   relativeTime,
   relevantDeadlineSecs,
   roomMatchesFilter,
+  roomMatchesSubjectQuery,
   sortRoomsByStuckness,
   statusLabel,
   statusPillClass,
@@ -468,5 +469,40 @@ describe("countRoomsByFilter", () => {
     ];
     const counts = countRoomsByFilter(rooms);
     expect(counts.active + counts.closed + counts.expired).toBe(counts.all);
+  });
+});
+
+describe("roomMatchesSubjectQuery", () => {
+  const r = (subject_ref: string) => ({ subject_ref });
+
+  it("empty query matches every room", () => {
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "")).toBe(true);
+    expect(roomMatchesSubjectQuery(r("any/repo#1"), "")).toBe(true);
+  });
+
+  it("whitespace-only query matches every room", () => {
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "   ")).toBe(true);
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "\t\n")).toBe(true);
+  });
+
+  it("substring match against subject_ref", () => {
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "hivemoot")).toBe(true);
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "#42")).toBe(true);
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "42")).toBe(true);
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "/hivemoot#")).toBe(true);
+  });
+
+  it("case-insensitive on both sides", () => {
+    expect(roomMatchesSubjectQuery(r("hivemoot/hivemoot#42"), "HIVEMOOT")).toBe(true);
+    expect(roomMatchesSubjectQuery(r("HiveMoot/Hivemoot#42"), "hivemoot")).toBe(true);
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(roomMatchesSubjectQuery(r("owner/repo#7"), "  repo#7  ")).toBe(true);
+  });
+
+  it("returns false on no match", () => {
+    expect(roomMatchesSubjectQuery(r("owner/repo#1"), "999")).toBe(false);
+    expect(roomMatchesSubjectQuery(r("owner/repo#1"), "different")).toBe(false);
   });
 });

--- a/web/src/app/dashboard/rooms/room-helpers.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.ts
@@ -128,6 +128,25 @@ export function countRoomsByFilter<T extends { status: RoomStatus }>(
 }
 
 /**
+ * Substring match against a room's `subject_ref` (e.g.
+ * `owner/repo#42`).  Case-insensitive so `HIVEMOOT/HIVEMOOT#42`
+ * matches `hivemoot/hivemoot#42`, and a bare `42` matches the
+ * trailing `#42`.  Empty / whitespace-only query matches every
+ * room — that's the "no filter" default the UI starts in.
+ *
+ * Pure on `(room, query)` so the rooms-list component can run it
+ * client-side over the full fetched set without thrashing the API.
+ */
+export function roomMatchesSubjectQuery<T extends { subject_ref: string }>(
+  room: T,
+  query: string,
+): boolean {
+  const normalized = query.trim().toLowerCase();
+  if (normalized === "") return true;
+  return room.subject_ref.toLowerCase().includes(normalized);
+}
+
+/**
  * Pick the relevant deadline for a room based on its current status.
  * - awaiting_contributions / deciding → quiet_period_secs (the
  *   queen's settling window before claiming the room)


### PR DESCRIPTION
## Summary

Builds on the status filter (#601) by adding a search input next to the filter chips. Operators looking for a specific PR's room can type `#42` or `hivemoot/hivemoot` or `42` and find it without scrolling — case-insensitive substring match against `subject_ref`.

## What it looks like

```
[ All  7 ]  [ Active 1 ]  [ Closed 4 ]  [ Expired 2 ]    🔍 [ #42        × ]
                                                          ↑
                                                          new search box
```

- Click any chip → filter by status
- Type in search → narrow by `subject_ref` substring (case-insensitive, trims whitespace)
- Both compose: e.g. "Closed + #42" finds closed rooms whose subject contains `#42`
- Empty / whitespace-only query is the no-filter default; explicit × button clears it
- Empty-state copy distinguishes "no rooms in this filter" from "no rooms in this filter+search"

## Implementation

- New `roomMatchesSubjectQuery(room, query)` pure helper in `room-helpers.ts`
- `RoomsList.tsx` keeps the search query in component state (no querystring sync — same posture as the status filter)
- New `<SearchBox>` subcomponent — uses native `<input type="search">` for browser-standard rendering, with an explicit × button for consistency on macOS Safari
- aria-label + sr-only text for screen readers

## Test plan

- [x] 7 new unit tests pin the substring + case-insensitive + trim contract
- [x] Existing 50 tests still pass (57 total)
- [x] Web typecheck clean
- [ ] After deploy: open `https://www.hivemoot.dev/dashboard/rooms`, type a query, verify it narrows the list correctly and composes with the status filter