### PR TITLE
fix(dashboard): drop "operator-" prefix from manually-created room manager

### DIFF
--- a/web/src/app/api/dashboard/rooms/route.test.ts
+++ b/web/src/app/api/dashboard/rooms/route.test.ts
@@ -234,7 +234,7 @@ describe("POST /api/dashboard/rooms — operator-driven create", () => {
   it("happy path: creates a general room and returns 201 with roomId + room", async () => {
     mockedAuth.mockResolvedValue(makeAuth("12345"));
     mockedCreate.mockResolvedValue({
-      manager: "operator-queen",
+      manager: "queen",
       subject_type: "general",
       subject_ref: "Plan the release",
       status: "awaiting_contributions",
@@ -256,10 +256,12 @@ describe("POST /api/dashboard/rooms — operator-driven create", () => {
     );
     expect(body.room.subject_type).toBe("general");
     expect(body.room.subject_ref).toBe("Plan the release");
+    // Manager is the operator's GitHub login (no "operator-" prefix)
+    // — the `general` subject_type already signals "operator-created".
     expect(mockedCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         installationId: "12345",
-        manager: "operator-queen",
+        manager: "queen",
         subject: { type: "general", ref: "Plan the release" },
       }),
     );

--- a/web/src/app/api/dashboard/rooms/route.test.ts
+++ b/web/src/app/api/dashboard/rooms/route.test.ts
@@ -308,6 +308,31 @@ describe("POST /api/dashboard/rooms — operator-driven create", () => {
     expect(body.existingRoomId).toBe("01234567-89ab-4cde-9012-3456789abcde");
   });
 
+  it.each(["watchdog", "vercel-cron", "hivemoot-bot"])(
+    "rejects user login %s as collision with system actor sentinel (audit-impersonation guard)",
+    async (login) => {
+      // Closes guard's concern on PR #608: the room_opened event uses
+      // actor_role="system" + actor_id=manager. A GitHub user with
+      // login "watchdog" / "vercel-cron" / "hivemoot-bot" would emit
+      // an event indistinguishable from a real system actor in the
+      // audit log. Reject at the route boundary.
+      mockedAuth.mockResolvedValue({
+        ok: true,
+        session: { installationId: "12345", userId: 999, userLogin: login },
+        redis: {} as never,
+        keyring: new Map(),
+        activeKeyVersion: "v1",
+      });
+      const res = await POST(makePostRequest({
+        subject_type: "general",
+        subject_ref: "Plan the release",
+      }));
+      expect(res.status).toBe(403);
+      expect((await res.json()).code).toBe("username_reserved");
+      expect(mockedCreate).not.toHaveBeenCalled();
+    },
+  );
+
   it("returns 500 on unexpected storage failure", async () => {
     mockedAuth.mockResolvedValue(makeAuth("12345"));
     mockedCreate.mockRejectedValue(new Error("Redis down"));

--- a/web/src/app/api/dashboard/rooms/route.ts
+++ b/web/src/app/api/dashboard/rooms/route.ts
@@ -165,10 +165,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const roomId = crypto.randomUUID();
   // Manager string surfaces on the room as `manager` and on the
-  // room_opened event's actor_id. `operator-{login}` lets dashboard
-  // viewers see who created an ad-hoc room without joining a
-  // separate user table.
-  const manager = `operator-${auth.session.userLogin}`;
+  // room_opened event's actor_id. We use the operator's GitHub
+  // login directly — the `general` subject_type already signals
+  // "operator-created, not bot-created", so an extra prefix would
+  // just clutter the dashboard's manager field.
+  const manager = auth.session.userLogin;
 
   try {
     const room = await createRoom({

--- a/web/src/app/api/dashboard/rooms/route.ts
+++ b/web/src/app/api/dashboard/rooms/route.ts
@@ -163,12 +163,40 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
+  // Reject GitHub logins that collide with system-actor sentinels.
+  // Closes guard's concern on the prefix-removal review (PR #608):
+  // the room_opened event uses `actor_role="system"` + `actor_id=manager`,
+  // so an operator with login "watchdog" or "vercel-cron" would emit
+  // events indistinguishable from real watchdog / cron actions in the
+  // audit log. Block at the boundary; explicit rejection beats audit
+  // ambiguity.
+  //
+  // Source of truth: WAR_ROOM_DESIGN.md §System-actor exception
+  // (shared/war-room/src/war-room.ts:312-322) + the explicit sentinel
+  // exports in web/src/server/queen-tick.ts.
+  const RESERVED_MANAGER_IDS: ReadonlySet<string> = new Set([
+    "watchdog",       // recovery + timeout actor
+    "vercel-cron",    // expire-on-cron actor
+    "hivemoot-bot",   // default manager for bot-created rooms
+  ]);
+  if (RESERVED_MANAGER_IDS.has(auth.session.userLogin)) {
+    return NextResponse.json(
+      {
+        code: "username_reserved",
+        message: `GitHub login "${auth.session.userLogin}" collides with a system actor sentinel; manual room creation is blocked for this account.`,
+      },
+      { status: 403 },
+    );
+  }
+
   const roomId = crypto.randomUUID();
   // Manager string surfaces on the room as `manager` and on the
   // room_opened event's actor_id. We use the operator's GitHub
   // login directly — the `general` subject_type already signals
   // "operator-created, not bot-created", so an extra prefix would
-  // just clutter the dashboard's manager field.
+  // just clutter the dashboard's manager field. The
+  // RESERVED_MANAGER_IDS gate above prevents the audit-impersonation
+  // collision guard flagged.
   const manager = auth.session.userLogin;
 
   try {


### PR DESCRIPTION
## Why

When you create a war-room from the dashboard, the `manager` field stores `operator-${userLogin}`. For an operator signed in as `hivemoot` (the queen GH account), that renders as `operator-hivemoot` — which reads like a made-up identity rather than the actual GitHub login.

The `general` subject_type on the room already signals "this is operator-created, not bot-created" — the prefix is redundant.

## What it looks like

**Before** (room detail page):

\`\`\`
Manager   operator-hivemoot
\`\`\`

**After:**

\`\`\`
Manager   hivemoot
\`\`\`

Same change in the `room_opened` event's `actor_id` field on the audit log.

## Tests

Existing route test updated to assert the un-prefixed manager. Full route test suite (18 tests) green.

## Out of scope

Separate gap I noticed when manually creating a room: agents still try to triage it like a PR (`gh pr view ...` against the free-form title), fail, and withdraw — producing a noisy event log. Filing that as a follow-up issue; it's a per-subject-type triage concern that needs its own PR on the agent side.