### PR TITLE
feat(agent): JobLifecycleReporter substrate + multiplexer

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/job_lifecycle/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/job_lifecycle/__init__.py
@@ -1,0 +1,342 @@
+"""Engine-side lifecycle substrate shared by tasks and war rooms.
+
+This module is the central piece of the JOB_LIFECYCLE_UNIFICATION RFC
+(``docs/architecture/JOB_LIFECYCLE_UNIFICATION.md``). It owns the
+heartbeat thread, the per-domain reporter dispatch, and the matcher
+registry. Per-domain plugins (``tasks/``, ``war_rooms/``) provide
+``JobLifecycleReporter`` subclasses that translate lifecycle events
+into domain-specific HTTP calls — but the threading / lifecycle
+orchestration lives here, in one place.
+
+The fleet's RFC review locked the following:
+
+* **Reporter shape (Q2):** ``ABC`` with ``abstractmethod`` rather than
+  ``Protocol`` — guard's call. ABC fails compilation when a subclass
+  forgets a new abstract method; Protocol is duck-typed and silently
+  lets new methods become unimplemented. Forward-compat matters here
+  because hooks like ``on_progress`` and ``on_cancellation`` will be
+  added incrementally.
+* **Heartbeat semantics (Q3):** pure liveness, no payload. Progress
+  streaming, if it ever ships, lives on a separate ``on_progress``
+  hook with its own dispatch path — never piggybacked on the
+  heartbeat. Closes a payload-injection / data-leakage vector.
+* **Matcher fall-through (Q6):** explicit precedence + dev-mode
+  mutex assert + zero-match-error fallback.
+
+  * Registrations are an ordered list of ``(JobMatcher, ReporterFactory)``
+    pairs. **First match wins** in production for cheap dispatch.
+  * In dev/test, ``select_reporter`` iterates ALL matchers and asserts
+    at most one returned ``True``. Any overlap is a programming error
+    surfaced at unit-test time, not at runtime.
+  * If zero matchers claim a ``Job``, the multiplexer raises
+    ``NoMatchingReporterError`` rather than silently dropping. An
+    operator gets a clear signal that a ``Job`` arrived with metadata
+    no plugin recognizes.
+
+The substrate is deliberately decoupled from the HTTP wire shapes —
+each reporter knows how to translate ``on_heartbeat`` into the right
+endpoint (``POST /api/tasks/<id>/heartbeat`` vs
+``POST /api/rooms/<id>/heartbeat``). Token re-resolution per tick
+(needed so token rotation takes effect within one interval rather
+than waiting for process restart) is also the reporter's
+responsibility — the substrate just passes the ``Job`` through.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from abc import ABC, abstractmethod
+from typing import Callable
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+
+__all__ = [
+    "JobLifecycleReporter",
+    "JobMatcher",
+    "ReporterFactory",
+    "LifecycleMultiplexer",
+    "NoMatchingReporterError",
+    "MultipleMatchingReportersError",
+]
+
+
+class JobLifecycleReporter(ABC):
+    """Domain-specific server-side reporting for a single ``Job``.
+
+    One concrete subclass per domain (``RoomLifecycleReporter``,
+    ``TaskLifecycleReporter``). One instance per ``Job`` — the
+    multiplexer constructs a fresh reporter each time
+    ``on_job_start`` runs so subclasses can cache the bearer / role /
+    job_id without worrying about cross-job leakage.
+
+    All hooks are best-effort: a reporter raising in any hook should
+    log the error and return; the multiplexer guards the heartbeat
+    loop so an exception there cannot kill the thread.
+    """
+
+    @abstractmethod
+    def on_start(self, job: Job) -> None:
+        """Job has been claimed and the engine is about to spawn the
+        agent subprocess. Domains use this for the initial "starting"
+        progress post (tasks) or the ``/present`` RSVP (war rooms).
+        """
+
+    @abstractmethod
+    def on_heartbeat(self, job: Job) -> None:
+        """Liveness ping fired every ``heartbeat_interval`` seconds.
+
+        **Pure liveness — no payload.** Reporters MUST NOT include
+        progress text, partial output, or any other domain data here.
+        The fleet's RFC review (Q3) made this an explicit invariant.
+        """
+
+    def on_progress(self, job: Job, text: str) -> None:
+        """Optional hook for streaming partial progress to the dashboard.
+
+        Default no-op so existing reporters compile after the hook is
+        added. Override only when a domain has a real progress channel
+        — never piggyback on ``on_heartbeat``.
+        """
+        del job, text
+
+    @abstractmethod
+    def on_finish(self, job: Job, result: AgentResult) -> None:
+        """Agent subprocess exited normally. ``result.exit_code == 0``
+        is the happy path; non-zero with a result still flows here so
+        the reporter can decide whether to treat it as failure
+        (tasks) or as a withdraw with parse_error (war rooms).
+        """
+
+    @abstractmethod
+    def on_failure(self, job: Job, error_text: str) -> None:
+        """Engine-side failure that prevented a normal finish (timeout,
+        provider auth error, internal exception). The reporter posts
+        a domain-specific failure record.
+        """
+
+
+JobMatcher = Callable[[Job], bool]
+"""Predicate that returns True iff this domain's reporter should
+handle the given Job. Matchers inspect ``Job.metadata`` keys
+(``task_id``, ``room_id``, ``kind``, etc.) and MUST be mutually
+exclusive across domains — see :class:`MultipleMatchingReportersError`.
+"""
+
+ReporterFactory = Callable[[Job], JobLifecycleReporter]
+"""Builds a fresh reporter instance for a single Job. The factory is
+responsible for capturing per-job context (job_id, role, bearer
+source) so the returned reporter can serve every lifecycle hook
+without re-deriving it.
+"""
+
+
+class NoMatchingReporterError(RuntimeError):
+    """Raised when zero registered matchers claim a ``Job``.
+
+    Per RFC Q6, this is fail-loud — the operator sees immediately
+    that a ``Job`` arrived with metadata no plugin recognizes,
+    instead of the multiplexer silently dropping it.
+    """
+
+
+class MultipleMatchingReportersError(AssertionError):
+    """Raised in dev/test when 2+ matchers claim the same ``Job``.
+
+    Per RFC Q6, mutual exclusion across domains is an enforced
+    invariant. Subclassing ``AssertionError`` (rather than plain
+    ``Exception``) makes it obvious in test output that a programming
+    error was caught — not a runtime data issue.
+    """
+
+
+class LifecycleMultiplexer:
+    """Owns the heartbeat thread + reporter dispatch for one engine run.
+
+    Usage from the plugin layer::
+
+        mux = LifecycleMultiplexer(dev_mode=True, heartbeat_interval=45)
+        mux.register(is_task_job, build_task_reporter)
+        mux.register(is_war_room_job, build_room_reporter)
+
+        # In on_job_started hook:
+        mux.on_job_start(job)
+
+        # In on_job_finished hook:
+        mux.on_job_finish(job, result)
+
+    Threading invariants:
+
+    * ``_spawn_heartbeat`` creates a fresh ``threading.Event`` per job
+      so an orphaned thread from a slow shutdown cannot post heartbeats
+      for a stale job_id once the next job starts.
+    * ``_stop_heartbeat`` joins with a 5s timeout. Stops the thread
+      *before* invoking the reporter's ``on_finish`` so a heartbeat
+      cannot land AFTER the terminal post.
+    * Reporter exceptions in ``_heartbeat_loop`` are caught and logged;
+      a single failure does not kill the thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        dev_mode: bool = False,
+        heartbeat_interval: int = 45,
+    ) -> None:
+        self._registrations: list[tuple[JobMatcher, ReporterFactory]] = []
+        self._dev_mode = dev_mode
+        self._interval = heartbeat_interval
+        self._stop_event: threading.Event | None = None
+        self._thread: threading.Thread | None = None
+        self._reporter: JobLifecycleReporter | None = None
+
+    @property
+    def reporter(self) -> JobLifecycleReporter | None:
+        """The active reporter for the in-flight job, or ``None``."""
+        return self._reporter
+
+    @property
+    def heartbeat_interval(self) -> int:
+        return self._interval
+
+    def register(
+        self, matcher: JobMatcher, factory: ReporterFactory,
+    ) -> None:
+        """Register a (matcher, factory) pair.
+
+        Order matters in production: ``select_reporter`` returns the
+        FIRST factory whose matcher returns ``True``. In ``dev_mode``,
+        the multiplexer iterates all matchers and asserts at most one
+        matched; the ordering then becomes a tiebreaker that should
+        never fire (because the assertion would have caught the
+        overlap first).
+        """
+        self._registrations.append((matcher, factory))
+
+    def select_reporter(self, job: Job) -> JobLifecycleReporter:
+        """Pick a reporter for ``job`` per the matcher registry.
+
+        Raises:
+            MultipleMatchingReportersError: in dev_mode when 2+
+              matchers claim the job (programming error — fix matchers).
+            NoMatchingReporterError: when zero matchers claim the job.
+        """
+        if self._dev_mode:
+            matched = [
+                (matcher, factory)
+                for matcher, factory in self._registrations
+                if matcher(job)
+            ]
+            if len(matched) > 1:
+                raise MultipleMatchingReportersError(
+                    f"Job {job.session_key!r} matched by "
+                    f"{len(matched)} reporters; matchers must be "
+                    "mutually exclusive. Job metadata: "
+                    f"{sorted(job.metadata.keys())}",
+                )
+            if not matched:
+                raise NoMatchingReporterError(
+                    f"No reporter matched Job {job.session_key!r}. "
+                    f"Job metadata keys: {sorted(job.metadata.keys())}. "
+                    "Register a matcher or fix the dispatcher.",
+                )
+            return matched[0][1](job)
+
+        # Production fast path — first match wins; no all-matchers scan.
+        for matcher, factory in self._registrations:
+            if matcher(job):
+                return factory(job)
+        raise NoMatchingReporterError(
+            f"No reporter matched Job {job.session_key!r}. "
+            f"Job metadata keys: {sorted(job.metadata.keys())}.",
+        )
+
+    def on_job_start(self, job: Job) -> None:
+        """Pick a reporter, fire ``on_start``, and spawn the heartbeat.
+
+        Idempotency: calling twice without an intervening
+        ``on_job_finish`` / ``on_job_failure`` will leak the previous
+        reporter's heartbeat thread; callers must drive the lifecycle
+        in pairs. The plugin's existing
+        ``on_job_started``/``on_job_finished`` hooks already do.
+        """
+        self._reporter = self.select_reporter(job)
+        self._reporter.on_start(job)
+        self._spawn_heartbeat(job)
+
+    def on_job_finish(self, job: Job, result: AgentResult) -> None:
+        """Stop the heartbeat (ordering invariant), then dispatch
+        ``on_finish``. The reporter is cleared so a stray callback
+        cannot fire on stale state.
+        """
+        self._stop_heartbeat()
+        reporter = self._reporter
+        self._reporter = None
+        if reporter is not None:
+            reporter.on_finish(job, result)
+
+    def on_job_failure(self, job: Job, error_text: str) -> None:
+        """Failure path twin of :meth:`on_job_finish`. Reporter is
+        cleared after dispatch, regardless of whether ``on_failure``
+        raises.
+        """
+        self._stop_heartbeat()
+        reporter = self._reporter
+        self._reporter = None
+        if reporter is not None:
+            reporter.on_failure(job, error_text)
+
+    def _spawn_heartbeat(self, job: Job) -> None:
+        # interval=0 disables heartbeats; skip thread startup entirely
+        # to avoid a tight Event.wait(0) busy-loop. Mirrors the
+        # tasks/__init__.py convention so operators rolling out the
+        # substrate can keep the existing AGENT_TASK_HEARTBEAT_INTERVAL=0
+        # opt-out semantics.
+        if self._interval <= 0:
+            self._stop_event = None
+            self._thread = None
+            return
+        stop_event = threading.Event()
+        self._stop_event = stop_event
+        self._thread = threading.Thread(
+            target=self._heartbeat_loop,
+            args=(job, stop_event),
+            name=f"lifecycle-heartbeat-{job.session_key}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _stop_heartbeat(self) -> None:
+        # Clear instance refs first so a fresh on_job_start during the
+        # join window cannot resurrect this stop_event.
+        stop_event = self._stop_event
+        thread = self._thread
+        self._stop_event = None
+        self._thread = None
+        if stop_event is not None:
+            stop_event.set()
+        if thread is not None:
+            thread.join(timeout=5)
+
+    def _heartbeat_loop(
+        self, job: Job, stop_event: threading.Event,
+    ) -> None:
+        # `Event.wait(timeout)` returns True iff the event was set
+        # within `timeout` seconds — i.e. shutdown signal received.
+        # Returning False means the timeout expired and we should fire
+        # another heartbeat.
+        while not stop_event.wait(self._interval):
+            reporter = self._reporter
+            if reporter is None:
+                # Job finished between ticks; bail without firing a
+                # heartbeat that would race the terminal post.
+                return
+            try:
+                reporter.on_heartbeat(job)
+            except Exception as exc:  # noqa: BLE001 — best-effort log
+                print(
+                    f"[lifecycle] heartbeat error for "
+                    f"{job.session_key}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )

--- a/agent/cli/tests/test_job_lifecycle.py
+++ b/agent/cli/tests/test_job_lifecycle.py
@@ -289,22 +289,57 @@ class LifecycleOrderingTests(unittest.TestCase):
         self.assertIsNot(second_event, first_event)
         mux.on_job_finish(_job("j2"), AgentResult(0, ""))
 
-    def test_heartbeat_loop_bails_if_reporter_cleared_mid_tick(self):
-        # If on_job_finish clears self._reporter while the loop is
-        # between ticks, the loop must notice and return without
-        # firing a stale heartbeat.
+    def test_heartbeat_loop_inner_guard_terminates_thread_when_reporter_cleared(self):
+        # Specifically exercises the `if reporter is None: return`
+        # guard INSIDE the loop body, distinct from the outer
+        # `while not stop_event.wait(...)` exit.
+        #
+        # Guard-feedback fix (#614): an earlier version of this test
+        # checked `len(reporter.heartbeats)` after clearing
+        # _reporter. That assertion held regardless of the inner
+        # guard — when the loop reads `self._reporter` into a fresh
+        # local on each tick, both paths (guard or no guard) end up
+        # with `reporter = None` and the original FakeReporter never
+        # gets called. So the test couldn't fail.
+        #
+        # The actual observable difference is **thread liveness**:
+        # WITH the guard, the loop sees `reporter is None` and
+        # returns, terminating the thread.
+        # WITHOUT the guard, the loop calls `None.on_heartbeat(job)`,
+        # the except clause logs AttributeError, and the loop spins
+        # forever (until stop_event is set). So we assert the thread
+        # has terminated WITHOUT setting stop_event.
         reporter = FakeReporter()
-        mux = LifecycleMultiplexer(heartbeat_interval=10)  # long
+        mux = LifecycleMultiplexer(heartbeat_interval=0.02)
         mux.register(lambda j: True, lambda j: reporter)
         mux.on_job_start(_job())
-        # Manually clear the reporter (simulating a race) and signal
-        # stop. The thread should observe the clear (or stop signal)
-        # and exit cleanly without firing on_heartbeat.
+        thread = mux._thread
+        self.assertIsNotNone(thread)
+        time.sleep(0.06)  # ~3 ticks; proves the loop is iterating
+        self.assertGreater(
+            len(reporter.heartbeats), 0,
+            "loop never ticked — test setup broken",
+        )
+        self.assertTrue(thread.is_alive())
+
+        # Clear the reporter ref. Crucially, do NOT set stop_event —
+        # the only way the thread can terminate is via the inner
+        # guard's `return`.
         mux._reporter = None
-        mux._stop_event.set() if mux._stop_event else None
-        if mux._thread is not None:
-            mux._thread.join(timeout=2)
-        self.assertEqual(len(reporter.heartbeats), 0)
+        time.sleep(0.15)  # several intervals — guard has had time to fire
+
+        # If the inner guard worked, the thread is dead AND
+        # stop_event was never set.
+        self.assertFalse(
+            thread.is_alive(),
+            "thread is still spinning after _reporter cleared — "
+            "inner guard did not fire",
+        )
+        self.assertFalse(
+            mux._stop_event.is_set() if mux._stop_event else False,
+            "stop_event was set — test would have passed even "
+            "without the inner guard via the outer while-condition",
+        )
 
 
 # ── Smoke test exercising both reporters at once (the realistic

--- a/agent/cli/tests/test_job_lifecycle.py
+++ b/agent/cli/tests/test_job_lifecycle.py
@@ -1,0 +1,350 @@
+"""Tests for the engine-side lifecycle substrate (PR B of the
+JOB_LIFECYCLE_UNIFICATION RFC). The substrate itself is domain-agnostic
+— these tests pin its threading invariants, the matcher registry's
+fall-through semantics, and the per-job ABC contract that future
+domain reporters will subclass.
+
+What's NOT tested here: the per-domain reporters (TaskLifecycleReporter,
+RoomLifecycleReporter). Those land in PRs C and D and have their own
+test files. PR B's substrate is exercised here against fake reporters
+that record what happened.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import unittest
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.job_lifecycle import (
+    JobLifecycleReporter,
+    LifecycleMultiplexer,
+    MultipleMatchingReportersError,
+    NoMatchingReporterError,
+)
+
+
+# ── Fake reporter used in most tests ─────────────────────────────────
+
+
+@dataclass
+class FakeReporter(JobLifecycleReporter):
+    """Records every callback so tests can assert ordering + counts."""
+
+    label: str = "fake"
+    starts: list[Job] = field(default_factory=list)
+    heartbeats: list[Job] = field(default_factory=list)
+    progresses: list[tuple[Job, str]] = field(default_factory=list)
+    finishes: list[tuple[Job, AgentResult]] = field(default_factory=list)
+    failures: list[tuple[Job, str]] = field(default_factory=list)
+    raise_in_heartbeat: bool = False
+
+    def on_start(self, job: Job) -> None:
+        self.starts.append(job)
+
+    def on_heartbeat(self, job: Job) -> None:
+        self.heartbeats.append(job)
+        if self.raise_in_heartbeat:
+            raise RuntimeError("simulated heartbeat failure")
+
+    def on_progress(self, job: Job, text: str) -> None:
+        self.progresses.append((job, text))
+
+    def on_finish(self, job: Job, result: AgentResult) -> None:
+        self.finishes.append((job, result))
+
+    def on_failure(self, job: Job, error_text: str) -> None:
+        self.failures.append((job, error_text))
+
+
+def _job(session_key: str = "j1", **metadata: Any) -> Job:
+    return Job(session_key=session_key, prompt="p", metadata=dict(metadata))
+
+
+# ── ABC enforcement (Q2: ABC over Protocol for forward-compat) ─────
+
+
+class AbcContractTests(unittest.TestCase):
+    """The fleet picked ABC over Protocol so future hooks fail
+    compile if a subclass forgets them. Pin that promise."""
+
+    def test_subclass_missing_required_method_cannot_instantiate(self):
+        class Incomplete(JobLifecycleReporter):
+            # Only implements on_start; missing heartbeat/finish/failure
+            def on_start(self, job: Job) -> None:
+                pass
+
+        with self.assertRaises(TypeError) as ctx:
+            Incomplete()  # type: ignore[abstract]
+        self.assertIn("abstract", str(ctx.exception).lower())
+
+    def test_on_progress_default_is_noop(self):
+        # on_progress is intentionally optional — subclasses that
+        # don't have a progress channel inherit a no-op.
+        class NoProgress(JobLifecycleReporter):
+            def on_start(self, job: Job) -> None: pass
+            def on_heartbeat(self, job: Job) -> None: pass
+            def on_finish(self, job: Job, r: AgentResult) -> None: pass
+            def on_failure(self, job: Job, e: str) -> None: pass
+
+        # Construct + call — must not raise.
+        NoProgress().on_progress(_job(), "anything")
+
+
+# ── Matcher registry (Q6 decisions) ──────────────────────────────────
+
+
+class MatcherRegistryTests(unittest.TestCase):
+
+    def test_first_match_wins_in_production_mode(self):
+        # Two matchers both match — production picks the first one
+        # registered without scanning the rest.
+        mux = LifecycleMultiplexer(dev_mode=False)
+        first = FakeReporter(label="first")
+        second = FakeReporter(label="second")
+        mux.register(lambda j: True, lambda j: first)
+        mux.register(lambda j: True, lambda j: second)
+        chosen = mux.select_reporter(_job())
+        self.assertIs(chosen, first)
+
+    def test_dev_mode_raises_on_matcher_overlap(self):
+        # Mutual exclusion is the invariant — dev_mode=True iterates
+        # ALL matchers and rejects any overlap.
+        mux = LifecycleMultiplexer(dev_mode=True)
+        mux.register(lambda j: True, lambda j: FakeReporter("a"))
+        mux.register(lambda j: True, lambda j: FakeReporter("b"))
+        with self.assertRaises(MultipleMatchingReportersError) as ctx:
+            mux.select_reporter(_job(task_id="t1"))
+        # Error message exposes job context for debugging.
+        self.assertIn("task_id", str(ctx.exception))
+
+    def test_zero_match_raises_no_matching_reporter(self):
+        # Per Q6, zero-match is fail-loud rather than silent drop.
+        mux = LifecycleMultiplexer(dev_mode=False)
+        mux.register(lambda j: False, lambda j: FakeReporter())
+        with self.assertRaises(NoMatchingReporterError):
+            mux.select_reporter(_job())
+
+    def test_zero_match_raises_in_dev_mode_too(self):
+        mux = LifecycleMultiplexer(dev_mode=True)
+        mux.register(lambda j: False, lambda j: FakeReporter())
+        with self.assertRaises(NoMatchingReporterError):
+            mux.select_reporter(_job())
+
+    def test_matcher_inspects_metadata(self):
+        # Realistic shape: matchers discriminate on metadata keys
+        # (`task_id` for tasks, `room_id` for war rooms).
+        mux = LifecycleMultiplexer(dev_mode=True)
+        task_reporter = FakeReporter("task")
+        room_reporter = FakeReporter("room")
+        mux.register(
+            lambda j: "task_id" in j.metadata,
+            lambda j: task_reporter,
+        )
+        mux.register(
+            lambda j: "room_id" in j.metadata,
+            lambda j: room_reporter,
+        )
+        self.assertIs(
+            mux.select_reporter(_job(task_id="t1")),
+            task_reporter,
+        )
+        self.assertIs(
+            mux.select_reporter(_job(room_id="r1")),
+            room_reporter,
+        )
+
+    def test_dev_mode_overlap_message_is_actionable(self):
+        # The error message has to tell the operator what to fix.
+        mux = LifecycleMultiplexer(dev_mode=True)
+        mux.register(lambda j: True, lambda j: FakeReporter())
+        mux.register(lambda j: True, lambda j: FakeReporter())
+        with self.assertRaises(MultipleMatchingReportersError) as ctx:
+            mux.select_reporter(_job(task_id="t1", room_id="r1"))
+        msg = str(ctx.exception)
+        self.assertIn("mutually exclusive", msg)
+        self.assertIn("metadata", msg)
+
+
+# ── Lifecycle ordering + heartbeat threading ────────────────────────
+
+
+class LifecycleOrderingTests(unittest.TestCase):
+
+    def _build(self, **kwargs: Any) -> tuple[LifecycleMultiplexer, FakeReporter]:
+        reporter = FakeReporter()
+        mux = LifecycleMultiplexer(
+            heartbeat_interval=kwargs.pop("interval", 0),
+            **kwargs,
+        )
+        mux.register(lambda j: True, lambda j: reporter)
+        return mux, reporter
+
+    def test_on_job_start_invokes_on_start_then_spawns_heartbeat(self):
+        mux, reporter = self._build(interval=0)  # interval=0 → no thread
+        job = _job()
+        mux.on_job_start(job)
+        self.assertEqual(reporter.starts, [job])
+        # interval=0 path skips thread spawn entirely.
+        self.assertIsNone(mux._stop_event)
+        self.assertIsNone(mux._thread)
+
+    def test_interval_zero_disables_heartbeat_thread(self):
+        # Mirrors the existing AGENT_TASK_HEARTBEAT_INTERVAL=0 opt-out.
+        mux, reporter = self._build(interval=0)
+        mux.on_job_start(_job())
+        time.sleep(0.05)
+        self.assertEqual(len(reporter.heartbeats), 0)
+        mux.on_job_finish(_job(), AgentResult(exit_code=0, response=""))
+
+    def test_heartbeat_thread_fires_at_interval(self):
+        # Use a tiny interval so the test runs fast. The substrate's
+        # default is 45s in production.
+        mux, reporter = self._build(interval=0.05)
+        job = _job()
+        mux.on_job_start(job)
+        time.sleep(0.18)  # ~3 ticks worth
+        # At least 2 heartbeats should have fired by now.
+        observed = len(reporter.heartbeats)
+        mux.on_job_finish(job, AgentResult(exit_code=0, response=""))
+        self.assertGreaterEqual(observed, 2)
+        for hb in reporter.heartbeats:
+            self.assertIs(hb, job)
+
+    def test_on_job_finish_stops_heartbeat_before_calling_on_finish(self):
+        # The ordering invariant: a heartbeat must NEVER land after
+        # on_finish — that would race the terminal post and confuse
+        # the dashboard.
+        mux, reporter = self._build(interval=0.02)
+        mux.on_job_start(_job())
+        time.sleep(0.08)  # let some heartbeats fire
+        result = AgentResult(exit_code=0, response="ok")
+        mux.on_job_finish(_job(), result)
+        # After on_finish, no further heartbeats can land.
+        snapshot_count = len(reporter.heartbeats)
+        time.sleep(0.10)
+        self.assertEqual(len(reporter.heartbeats), snapshot_count)
+        # And on_finish itself was called exactly once.
+        self.assertEqual(len(reporter.finishes), 1)
+        self.assertIs(reporter.finishes[0][1], result)
+
+    def test_on_job_failure_stops_heartbeat_and_dispatches(self):
+        mux, reporter = self._build(interval=0.02)
+        mux.on_job_start(_job())
+        time.sleep(0.06)
+        mux.on_job_failure(_job(), "kaboom")
+        time.sleep(0.10)
+        # Heartbeat thread is dead.
+        self.assertIsNone(mux._thread)
+        # on_failure was called with the error text.
+        self.assertEqual(len(reporter.failures), 1)
+        self.assertEqual(reporter.failures[0][1], "kaboom")
+
+    def test_heartbeat_exception_does_not_kill_thread(self):
+        # The thread guards reporter exceptions — one bad tick must
+        # not silently end heartbeats for the rest of the job.
+        reporter = FakeReporter(raise_in_heartbeat=True)
+        mux = LifecycleMultiplexer(heartbeat_interval=0.03)
+        mux.register(lambda j: True, lambda j: reporter)
+        mux.on_job_start(_job())
+        time.sleep(0.15)  # ~5 ticks; every one raises
+        observed = len(reporter.heartbeats)
+        mux.on_job_finish(_job(), AgentResult(exit_code=0, response=""))
+        # Thread kept firing despite raising every time.
+        self.assertGreaterEqual(observed, 3)
+
+    def test_reporter_cleared_after_finish(self):
+        # Stray callbacks must not fire on stale state once the job
+        # ends. .reporter is the public observable.
+        mux, reporter = self._build(interval=0)
+        mux.on_job_start(_job())
+        self.assertIs(mux.reporter, reporter)
+        mux.on_job_finish(_job(), AgentResult(exit_code=0, response=""))
+        self.assertIsNone(mux.reporter)
+
+    def test_reporter_cleared_after_failure(self):
+        mux, reporter = self._build(interval=0)
+        mux.on_job_start(_job())
+        mux.on_job_failure(_job(), "boom")
+        self.assertIsNone(mux.reporter)
+
+    def test_per_job_stop_event_isolation(self):
+        # Job 2's start must spawn a fresh stop_event so a slow
+        # join from job 1 cannot bleed into job 2.
+        mux, reporter = self._build(interval=0.05)
+        mux.on_job_start(_job("j1"))
+        first_event = mux._stop_event
+        mux.on_job_finish(_job("j1"), AgentResult(0, ""))
+        mux.on_job_start(_job("j2"))
+        second_event = mux._stop_event
+        self.assertIsNotNone(second_event)
+        self.assertIsNot(second_event, first_event)
+        mux.on_job_finish(_job("j2"), AgentResult(0, ""))
+
+    def test_heartbeat_loop_bails_if_reporter_cleared_mid_tick(self):
+        # If on_job_finish clears self._reporter while the loop is
+        # between ticks, the loop must notice and return without
+        # firing a stale heartbeat.
+        reporter = FakeReporter()
+        mux = LifecycleMultiplexer(heartbeat_interval=10)  # long
+        mux.register(lambda j: True, lambda j: reporter)
+        mux.on_job_start(_job())
+        # Manually clear the reporter (simulating a race) and signal
+        # stop. The thread should observe the clear (or stop signal)
+        # and exit cleanly without firing on_heartbeat.
+        mux._reporter = None
+        mux._stop_event.set() if mux._stop_event else None
+        if mux._thread is not None:
+            mux._thread.join(timeout=2)
+        self.assertEqual(len(reporter.heartbeats), 0)
+
+
+# ── Smoke test exercising both reporters at once (the realistic
+#    end-state where tasks + war_rooms each register one matcher). ──
+
+
+class MultiDomainSmokeTests(unittest.TestCase):
+
+    def test_two_domains_with_disjoint_matchers(self):
+        mux = LifecycleMultiplexer(dev_mode=True, heartbeat_interval=0)
+        task_reporter = FakeReporter("task")
+        room_reporter = FakeReporter("room")
+        mux.register(
+            lambda j: "task_id" in j.metadata,
+            lambda j: task_reporter,
+        )
+        mux.register(
+            lambda j: "room_id" in j.metadata,
+            lambda j: room_reporter,
+        )
+
+        # Drive a task job end-to-end.
+        task_job = _job("task-job", task_id="t1")
+        mux.on_job_start(task_job)
+        mux.on_job_finish(task_job, AgentResult(exit_code=0, response="r"))
+
+        # Then a room job.
+        room_job = _job("room-job", room_id="r1")
+        mux.on_job_start(room_job)
+        mux.on_job_failure(room_job, "timeout")
+
+        # Each reporter saw only its own job.
+        self.assertEqual([j.session_key for j in task_reporter.starts], ["task-job"])
+        self.assertEqual([j.session_key for j in room_reporter.starts], ["room-job"])
+        self.assertEqual(len(task_reporter.finishes), 1)
+        self.assertEqual(len(room_reporter.failures), 1)
+        # No cross-talk:
+        self.assertEqual(task_reporter.failures, [])
+        self.assertEqual(room_reporter.finishes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the JOB_LIFECYCLE_UNIFICATION RFC, **PR B** — the engine-side substrate for unified lifecycle wiring across tasks and war rooms. PRs C and D will migrate \`tasks/\` and \`war_rooms/\` onto this module; **no domain code is touched here**, so this PR is independently shippable.

The substrate owns:
- The **heartbeat thread** with per-job \`threading.Event\` isolation, 5s graceful join, and reporter-exception guards.
- A \`JobLifecycleReporter\` ABC with hooks \`on_start\`, \`on_heartbeat\`, \`on_progress\` (default no-op), \`on_finish\`, \`on_failure\`.
- A \`LifecycleMultiplexer\` that picks a reporter per Job using a registry of \`(JobMatcher, ReporterFactory)\` pairs.

## What it looks like

**Plugin wiring (what PRs C and D will look like):**

\`\`\`python
mux = LifecycleMultiplexer(dev_mode=is_dev_mode(), heartbeat_interval=45)
mux.register(is_task_job, build_task_reporter)
mux.register(is_war_room_job, build_room_reporter)

# In on_job_started:
mux.on_job_start(job)

# In on_job_finished:
mux.on_job_finish(job, result)
\`\`\`

**Matcher fall-through (Q6 decision):**

| Scenario | Production (\`dev_mode=False\`) | Dev/Test (\`dev_mode=True\`) |
|---|---|---|
| Exactly one matcher returns True | First-match-wins, cheap dispatch | Same |
| Two+ matchers return True | First-match-wins (last-match never reached) | \`MultipleMatchingReportersError\` raised — programming error caught at test time |
| Zero matchers return True | \`NoMatchingReporterError\` raised — operator sees the unrecognized job immediately | Same |

**ABC enforcement (Q2 decision):** subclasses missing a required hook fail to instantiate (\`TypeError: Can't instantiate abstract class …\`). Forward-compat for hooks added later.

## Decisions baked in (from RFC fleet review)

| Q | Decision | Why |
|---|---|---|
| Q2 — Reporter shape | ABC, not Protocol | Forward-compat — ABC fails compile when subclass forgets a new method |
| Q3 — Heartbeat | Pure liveness, no payload | Payload-injection / data-leakage vector — \`on_progress\` lives on a separate hook |
| Q6 — Matcher fall-through | First-match + dev-mode mutex assert + zero-match-error | Mutual exclusion is invariant; dev catches overlaps; prod fails loud on unknown jobs |

Threading invariants the substrate enforces (already proven by the tasks heartbeat thread; now generalized):

- **Per-job \`stop_event\`** — slow shutdown of job 1 cannot post heartbeats for a stale job 1 once job 2 starts. Verified by \`test_per_job_stop_event_isolation\`.
- **Stop before terminal post** — \`_stop_heartbeat\` joins (5s timeout) before the reporter's \`on_finish\` fires, so a heartbeat cannot race the dashboard's terminal write. Verified by \`test_on_job_finish_stops_heartbeat_before_calling_on_finish\`.
- **Reporter exceptions don't kill the thread** — one bad tick logs to stderr; the loop keeps firing. Verified by \`test_heartbeat_exception_does_not_kill_thread\`.
- **Mid-tick reporter clear** — if the loop's reporter ref is cleared between ticks, the loop bails without firing on stale state. Verified by \`test_heartbeat_loop_bails_if_reporter_cleared_mid_tick\`.

## Test plan

- [x] 19 new tests in \`agent/cli/tests/test_job_lifecycle.py\` covering ABC enforcement (2), matcher registry semantics (6), lifecycle ordering + threading (10), and a multi-domain smoke (1).
- [x] Full Python agent suite: **616 tests pass**, no regressions.
- [x] No domain code touched; PRs C and D wire reporters in.

## What's next in the stack

| PR | What it does |
|---|---|
| ✅ A — #613 | Server endpoint \`POST /api/rooms/:roomId/heartbeat\` (independently shippable) |
| 🟢 **B (this PR)** | Engine substrate — substrate-only, no domain change |
| ⏳ C | War-rooms migration — \`RoomLifecycleReporter\` subclasses \`JobLifecycleReporter\`; deletes the \`war_rooms/\` heartbeat wiring |
| ⏳ D | Tasks migration — \`TaskLifecycleReporter\` subclasses \`JobLifecycleReporter\`; deletes \`tasks/\` heartbeat wiring |
| ⏳ E | Dashboard — surface last-heartbeat per participant on the room detail view (the UX motivation) |

PR B is **not** stacked on PR A at the code level — the substrate has no HTTP wire dependency. C and D will both depend on B. C also depends on A (its reporter calls \`POST /api/rooms/.../heartbeat\`).