### PR TITLE
feat(agent): RoomLifecycleReporter — early /present + heartbeat for war rooms

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -159,6 +159,14 @@ class HivemootPlugin:
         # disabled OR triggers() hasn't been called yet.
         self._war_room_trigger: Any = None
 
+        # ── Engine-side lifecycle substrate (PR C of the
+        #    JOB_LIFECYCLE_UNIFICATION RFC) ────────────────────────
+        # LifecycleMultiplexer instance for this plugin run. None
+        # when no domain has registered a reporter (e.g. war_rooms
+        # disabled). Registered in `triggers()` once the typed
+        # config is finalized.
+        self._lifecycle_mux: Any = None
+
         # Apiarist auth subscriber, populated in setup_lifecycle() when
         # cfg.apiarist.enabled is true. Cached for diagnostics and
         # tests; runtime path goes through engine.lifecycle directly.
@@ -459,8 +467,15 @@ class HivemootPlugin:
             from hivemoot_agent.plugins_builtin.hivemoot.auth import (
                 resolve_agent_token,
             )
+            from hivemoot_agent.plugins_builtin.hivemoot.job_lifecycle import (
+                LifecycleMultiplexer,
+            )
             from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import (
                 WarRoomWatcherTrigger,
+            )
+            from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.lifecycle import (
+                build_room_reporter,
+                is_war_room_job_for_lifecycle,
             )
             token_path = str(cfg.token_file) if cfg.token_file else ""
             self._war_room_trigger = WarRoomWatcherTrigger(
@@ -470,6 +485,26 @@ class HivemootPlugin:
                 seen_cache_max=cfg.war_rooms.seen_cache_max,
             )
             triggers.append(self._war_room_trigger)  # type: ignore[arg-type]
+
+            # Multiplexer owns the heartbeat thread + per-domain
+            # reporter dispatch (PR B substrate). Tasks remain on the
+            # legacy heartbeat path for now; PR D migrates them.
+            # dev_mode stays False — production fast path. The
+            # mutual-exclusion assertion is exercised by the
+            # substrate's unit tests rather than here.
+            mux = LifecycleMultiplexer(
+                heartbeat_interval=cfg.war_rooms.heartbeat_interval_secs,
+            )
+            mux.register(
+                is_war_room_job_for_lifecycle,
+                lambda job, _base=cfg.war_rooms.base_url,
+                _token=token_path: build_room_reporter(
+                    job,
+                    base_url=_base,
+                    bearer_factory=lambda: resolve_agent_token(_token),
+                ),
+            )
+            self._lifecycle_mux = mux
 
         return triggers
 
@@ -533,6 +568,25 @@ class HivemootPlugin:
                     file=sys.stderr, flush=True,
                 )
 
+        # War-rooms early-/present + heartbeat thread (PR C). Wraps
+        # independently from tasks/health — one feature failing must
+        # not skip the others. The multiplexer may be None when
+        # war_rooms is disabled or triggers() hasn't run yet.
+        if cfg.war_rooms.enabled and self._lifecycle_mux is not None:
+            from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.lifecycle import (
+                is_war_room_job_for_lifecycle,
+            )
+            if is_war_room_job_for_lifecycle(job):
+                try:
+                    self._lifecycle_mux.on_job_start(job)
+                except Exception as exc:
+                    print(
+                        f"[hivemoot-war-rooms] lifecycle on_job_start "
+                        f"raised room={job.metadata.get('room_id')}: "
+                        f"{type(exc).__name__}: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
+
     def on_job_finished(
         self, job: Job, result: AgentResult, config: PluginConfig,
     ) -> None:
@@ -581,6 +635,22 @@ class HivemootPlugin:
                 is_war_room_job,
             )
             if is_war_room_job(job):
+                # Stop the heartbeat thread BEFORE handler.py's post
+                # sequence runs, so a heartbeat can't land after the
+                # /contribute or /withdraw terminal post. The
+                # reporter's on_finish is a no-op (handler.py still
+                # owns the post sequence), but mux.on_job_finish is
+                # what actually joins the heartbeat thread cleanly.
+                if self._lifecycle_mux is not None:
+                    try:
+                        self._lifecycle_mux.on_job_finish(job, result)
+                    except Exception as exc:
+                        print(
+                            f"[hivemoot-war-rooms] lifecycle on_job_finish "
+                            f"raised room={job.metadata.get('room_id')}: "
+                            f"{type(exc).__name__}: {exc}",
+                            file=sys.stderr, flush=True,
+                        )
                 try:
                     self._war_room_on_job_finished(job, result, config)
                 except Exception as exc:

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -487,15 +487,31 @@ class HivemootPlugin:
             triggers.append(self._war_room_trigger)  # type: ignore[arg-type]
 
             # Multiplexer owns the heartbeat thread + per-domain
-            # reporter dispatch (PR B substrate). Tasks remain on the
-            # legacy heartbeat path for now; PR D migrates them.
+            # reporter dispatch (PR B substrate). Tasks remain on
+            # the legacy heartbeat path for now; PR D migrates them.
             # dev_mode stays False — production fast path. The
             # mutual-exclusion assertion is exercised by the
             # substrate's unit tests rather than here.
-            mux = LifecycleMultiplexer(
-                heartbeat_interval=cfg.war_rooms.heartbeat_interval_secs,
-            )
-            mux.register(
+            #
+            # Defensive ``if mux is None`` so this branch composes
+            # with the tasks branch in PR D (which uses the same
+            # pattern). Whichever runs first creates the mux; the
+            # second branch attaches its reporter on top instead of
+            # silently dropping the previous registration. The
+            # multiplexer's interval is capped to the smaller of any
+            # pair of enabled features so neither domain's
+            # liveness expectation gets stretched. Closes guard's
+            # PR #616 review point about composition asymmetry.
+            if self._lifecycle_mux is None:
+                interval = cfg.war_rooms.heartbeat_interval_secs
+                if cfg.tasks.enabled and cfg.tasks.claim_url:
+                    interval = min(
+                        interval, cfg.tasks.heartbeat_interval_secs or interval,
+                    )
+                self._lifecycle_mux = LifecycleMultiplexer(
+                    heartbeat_interval=interval,
+                )
+            self._lifecycle_mux.register(
                 is_war_room_job_for_lifecycle,
                 lambda job, _base=cfg.war_rooms.base_url,
                 _token=token_path: build_room_reporter(
@@ -504,7 +520,6 @@ class HivemootPlugin:
                     bearer_factory=lambda: resolve_agent_token(_token),
                 ),
             )
-            self._lifecycle_mux = mux
 
         return triggers
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -327,6 +327,17 @@ class HivemootWarRoomsConfig(StrictPluginConfig):
             "1000 covers ~weeks of room activity at typical Hive scale."
         ),
     )
+    heartbeat_interval_secs: int = Field(
+        default=45,
+        ge=0,
+        description=(
+            "Seconds between per-room heartbeat posts (PR A endpoint). "
+            "Pure liveness — no payload. 0 disables the heartbeat "
+            "thread (rooms then auto-close on max-age once review "
+            "exceeds the watchdog window). 45s matches the tasks "
+            "default and the queen-tick cadence."
+        ),
+    )
 
 
 class HivemootConfig(StrictPluginConfig):

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -58,14 +58,29 @@ class RoomStateRaceError(RuntimeError):
         self.body_excerpt = body_excerpt
 
 
-# API error codes the storage layer returns on a status-precondition
-# 409.  Listed here so the api module can distinguish them from
-# other 409s (e.g. `participant_already_present` is also 409 but
-# means "you already RSVP'd, harmless replay" — handled separately
-# by the handler's continue-to-contribute path).
-_RACE_409_CODES: frozenset[str] = frozenset(
-    {"status_precondition_failed"},
-)
+# API error codes the storage layer returns to indicate a benign
+# race rather than a transient failure. Mapped to RoomStateRaceError
+# so the caller stops retrying — the next dispatch tick rebuilds
+# state instead. Indexed by HTTP status so each code only fires for
+# the response shape that actually carries it.
+#
+# 409s:
+#   * status_precondition_failed — room left ``awaiting_contributions``
+#     (closed / deciding / expired). Affects every op kind.
+#   * owner_conflict — first-wins gate lost; another runner already
+#     holds this role's slot in subscriber-mode. Surfaced by /present
+#     and /heartbeat.
+#
+# 404s (added per guard's PR #615 review feedback so heartbeats stop
+# instead of spinning forever):
+#   * room_not_found — operator deleted the room mid-flight, or the
+#     ``roomId`` metadata was stale. Terminal — nothing to retry.
+#   * participant_not_found — slot was withdrawn or never created.
+#     Also terminal; the lifecycle is over.
+_RACE_CODES_BY_STATUS: dict[int, frozenset[str]] = {
+    409: frozenset({"status_precondition_failed", "owner_conflict"}),
+    404: frozenset({"room_not_found", "participant_not_found"}),
+}
 
 
 def _maybe_raise_race(
@@ -75,19 +90,24 @@ def _maybe_raise_race(
     parsed: Any,
     raw: bytes,
 ) -> None:
-    """Raise `RoomStateRaceError` when the response is a 409 with a
-    known room-state-race code.  No-op for 2xx, 4xx with unknown
-    code, or any other status — caller still wraps those as a
-    generic `RuntimeError` so the failure-mode signal isn't lost.
+    """Raise `RoomStateRaceError` when the response is one of the
+    known race-class statuses (4xx with a code we recognize as a
+    benign state shift). No-op for 2xx or any other status —
+    callers still wrap those as generic ``RuntimeError`` so the
+    failure-mode signal isn't lost.
+
+    Single source of race-detection truth used by every war_rooms.api
+    helper. Closes guard's PR #615 review point about duplicate race
+    detection logic between heartbeat_room_participant and the
+    legacy /present, /contribute, /withdraw helpers.
     """
-    if status != 409:
+    codes = _RACE_CODES_BY_STATUS.get(status)
+    if codes is None:
         return
     if not isinstance(parsed, dict):
         return
     code = parsed.get("code")
-    if not isinstance(code, str):
-        return
-    if code not in _RACE_409_CODES:
+    if not isinstance(code, str) or code not in codes:
         return
     raise RoomStateRaceError(
         op=op,
@@ -198,21 +218,32 @@ def present_to_room(
     bearer: str,
     *,
     intent_hint: str | None = None,
+    agent_id: str | None = None,
     timeout: int = DEFAULT_TIMEOUT_SECS,
 ) -> int:
     """POST `{base_url}/api/rooms/{room_id}/present`.
 
-    The role + agent_id are server-derived from the bearer envelope —
-    the client doesn't pass them in the body. Sequence is the
-    `current_sequence` the worker observed on `/watching` (used for
-    idempotency).
+    The role is server-derived from the bearer envelope; ``agent_id``
+    is the per-runner identity for the subscriber-mode first-wins
+    gate (#522). When omitted the server falls back to the bearer's
+    ``name`` — single-runner deployments don't need to set it.
+    Sequence is the ``current_sequence`` the worker observed on
+    ``/watching`` (used for idempotency).
+
+    Closes guard's PR #615 review point about subscriber-mode
+    asymmetry: ``/heartbeat`` carries ``agent_id`` for the gate;
+    ``/present`` MUST carry the same identity so both calls hit
+    the same slot. Without this, runner-A's /present creates a
+    slot at agent_id=bearer.name, then runner-A's /heartbeat with
+    body.agentId="runner-A" hits the owner_conflict path.
 
     Returns the sequence the `participant_presented` event landed at.
 
     Raises:
-        RuntimeError on non-2xx / malformed body. Caller branches
-        on error message to detect benign races (e.g., status
-        moved, owner conflict from a sibling runner).
+        RoomStateRaceError on the known benign-race codes
+        (status_precondition_failed, owner_conflict, room_not_found,
+        participant_not_found).
+        RuntimeError on any other non-2xx / malformed body.
     """
     url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/present"
     body: dict[str, Any] = {
@@ -220,6 +251,8 @@ def present_to_room(
     }
     if intent_hint is not None:
         body["intentHint"] = intent_hint
+    if agent_id is not None:
+        body["agentId"] = agent_id
 
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 
@@ -310,11 +343,16 @@ def heartbeat_room_participant(
         stop heartbeating. Caller MUST NOT treat this as an error.
 
     Raises:
-        RoomStateRaceError: 409 with ``status_precondition_failed``
-            (room left ``awaiting_contributions``) or ``owner_conflict``
-            (a different runner holds this role's slot — subscriber-
-            mode collision). Caller stops heartbeating; the next
-            tick's reporter will rebuild state.
+        RoomStateRaceError: any of the known race codes:
+            * 409 ``status_precondition_failed`` — room left
+              awaiting_contributions.
+            * 409 ``owner_conflict`` — different runner holds the
+              slot (subscriber-mode collision).
+            * 404 ``room_not_found`` — room is gone.
+            * 404 ``participant_not_found`` — slot was never created
+              (caller never /presented) or has been removed.
+            All four indicate the lifecycle should stop heartbeating
+            for this Job — the next dispatch tick rebuilds state.
         RuntimeError: any other non-2xx / malformed body. Caller
             logs and keeps trying — a transient network blip is
             recoverable on the next tick.
@@ -326,18 +364,11 @@ def heartbeat_room_participant(
 
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 
-    # Race conditions surface as 409s the caller wants to distinguish
-    # from generic 5xx — owner_conflict (subscriber-mode collision) is
-    # also a 409 the storage layer can return. Add it here so the
-    # caller's race handling covers both heartbeat-specific 409s.
-    if status == 409 and isinstance(parsed, dict):
-        code = parsed.get("code")
-        if code in ("status_precondition_failed", "owner_conflict"):
-            raise RoomStateRaceError(
-                op="heartbeat",
-                code=str(code),
-                body_excerpt=raw.decode(errors="replace")[:200],
-            )
+    # Race-class codes (4xx with a known code) — single helper covers
+    # all of them so heartbeat shares the same race detection used by
+    # /present, /contribute, /withdraw. Closes guard's PR #615 review
+    # point about duplicate logic.
+    _maybe_raise_race(op="heartbeat", status=status, parsed=parsed, raw=raw)
 
     if status != 200:
         raise RuntimeError(

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -28,6 +28,7 @@ from hivemoot_agent.plugins_builtin.hivemoot.http import (
 __all__ = (
     "RoomStateRaceError",
     "WatchingRoom",
+    "heartbeat_room_participant",
     "list_watching_rooms",
     "present_to_room",
     "submit_contribution",
@@ -281,6 +282,86 @@ def submit_contribution(
             f"contributions response missing/invalid `sequence`: {str(parsed)[:200]}"
         )
     return seq
+
+
+def heartbeat_room_participant(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    agent_id: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> str | None:
+    """POST `{base_url}/api/rooms/{room_id}/heartbeat`.
+
+    Pure-liveness ping that bumps the participant's ``rsvp_at`` so
+    the watchdog ``drop_threshold_secs`` timeout doesn't fire on a
+    worker still doing genuine work. Per the JOB_LIFECYCLE_UNIFICATION
+    RFC's Q3 decision: **no payload**. The optional ``agent_id`` is
+    the per-runner identity for the first-wins gate (#522) — when
+    omitted the server falls back to the bearer's ``name``.
+
+    Returns:
+        ISO-8601 timestamp string when the heartbeat applied. The
+        caller can log it to confirm the slot is healthy.
+        ``None`` when the server reports a benign no-op
+        (``skipped: "non_pending"``) — the participant has already
+        withdrawn / resolved / timed_out and the lifecycle should
+        stop heartbeating. Caller MUST NOT treat this as an error.
+
+    Raises:
+        RoomStateRaceError: 409 with ``status_precondition_failed``
+            (room left ``awaiting_contributions``) or ``owner_conflict``
+            (a different runner holds this role's slot — subscriber-
+            mode collision). Caller stops heartbeating; the next
+            tick's reporter will rebuild state.
+        RuntimeError: any other non-2xx / malformed body. Caller
+            logs and keeps trying — a transient network blip is
+            recoverable on the next tick.
+    """
+    url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/heartbeat"
+    body: dict[str, Any] = {}
+    if agent_id is not None:
+        body["agentId"] = agent_id
+
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+
+    # Race conditions surface as 409s the caller wants to distinguish
+    # from generic 5xx — owner_conflict (subscriber-mode collision) is
+    # also a 409 the storage layer can return. Add it here so the
+    # caller's race handling covers both heartbeat-specific 409s.
+    if status == 409 and isinstance(parsed, dict):
+        code = parsed.get("code")
+        if code in ("status_precondition_failed", "owner_conflict"):
+            raise RoomStateRaceError(
+                op="heartbeat",
+                code=str(code),
+                body_excerpt=raw.decode(errors="replace")[:200],
+            )
+
+    if status != 200:
+        raise RuntimeError(
+            f"heartbeat returned status {status}: "
+            f"{raw.decode(errors='replace')[:200]}"
+        )
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("heartbeat response was not a JSON object")
+
+    # Benign no-op — slot already withdrew/resolved/timed_out. The
+    # storage-layer Lua script returns null upstream → the route
+    # returns `{ skipped: "non_pending" }`. Stop heartbeating; the
+    # caller's `_presented` flag (or equivalent) should track this.
+    if parsed.get("skipped") == "non_pending":
+        return None
+
+    rsvp_at = parsed.get("rsvpAt")
+    if not isinstance(rsvp_at, str):
+        raise RuntimeError(
+            f"heartbeat response missing/invalid `rsvpAt`: "
+            f"{str(parsed)[:200]}"
+        )
+    return rsvp_at
 
 
 def withdraw_participant(

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/lifecycle.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/lifecycle.py
@@ -143,11 +143,18 @@ class RoomLifecycleReporter(JobLifecycleReporter):
             )
             return
         try:
+            # Pass agent_id so /present and /heartbeat carry the
+            # same identity for the subscriber-mode first-wins gate.
+            # Closes guard's PR #615 review point about asymmetry —
+            # without this, runner A's /present creates the slot at
+            # agent_id=bearer.name, then /heartbeat with body.agentId
+            # mismatch hits owner_conflict.
             seq = wr_api.present_to_room(
                 base_url=self._base_url,
                 room_id=self._room_id,
                 sequence_observed_by_client=self._current_sequence,
                 bearer=self._bearer_factory(),
+                agent_id=self._agent_id,
             )
             self._presented = True
             self._log(

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/lifecycle.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/lifecycle.py
@@ -1,0 +1,280 @@
+"""War-room domain reporter — the war_rooms plugin's adapter onto
+the engine-side ``JobLifecycleReporter`` substrate (PR B).
+
+Closes the JOB_LIFECYCLE_UNIFICATION RFC, **PR C**. Wires war-room
+jobs onto the substrate so the multiplexer drives an early /present
++ heartbeat-thread for every triage Job — this is the change that
+ends the race we keep seeing in the drone logs:
+
+    [hivemoot-war-rooms] raced room transition on present
+    room=... seq=N code=status_precondition_failed
+    — skipping contribute
+
+Today /present fires from ``handler.py``'s ``on_job_finished``,
+*after* the agent subprocess (a 5–15 minute LLM run on a large PR)
+exits. By the time /present POSTs, the room has aged out via
+``max_age_secs`` and transitioned to ``deciding`` / ``closed``. The
+reporter moves /present to ``on_start`` (before the agent runs) so
+the slot is claimed early, then heartbeats every ``heartbeat_interval``
+seconds keep the watchdog from auto-closing.
+
+# Lifecycle vs handler.py
+
+This PR is intentionally minimal: ``on_finish`` and ``on_failure``
+are no-ops here. ``handler.py``'s ``handle_war_room_job_finished``
+keeps owning the /contribute and /withdraw paths — its existing
+/present call is now a benign idempotent re-RSVP (same agent_id,
+same role, server returns 200 without conflict). PR-follow-up can
+fold the post-finish flow into the reporter; for now we ship the
+heartbeat where the user-visible value lives.
+
+# Bearer rotation
+
+The reporter captures a ``bearer_factory`` (a callable returning a
+fresh bearer per call) rather than a resolved bearer. This mirrors
+the tasks-plugin convention — re-resolve every tick so an operator
+rotating ``HIVEMOOT_AGENT_TOKEN`` takes effect within one
+``heartbeat_interval`` instead of waiting for process restart.
+
+# What ``on_start`` failure means for ``on_heartbeat``
+
+If ``on_start``'s /present hits ``RoomStateRaceError`` (room moved
+on between watching and dispatch — same race we're trying to fix
+but smaller window now), the reporter records ``_presented=False``
+and ``on_heartbeat`` becomes a no-op. The substrate's heartbeat
+thread keeps spinning but doesn't make HTTP calls — cheap, no
+spam. The legacy handler.py path will then surface its own race
+log line at ``on_job_finished`` and skip the contribute leg.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Callable, Optional
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.job_lifecycle import (
+    JobLifecycleReporter,
+)
+
+from . import api as wr_api
+from .handler import is_war_room_job
+
+__all__ = (
+    "RoomLifecycleReporter",
+    "build_room_reporter",
+    "is_war_room_job_for_lifecycle",
+)
+
+
+# Re-export the existing matcher under a name that signals its role
+# in the multiplexer. The underlying predicate is unchanged; the
+# alias makes call sites (``mux.register(is_war_room_job_for_lifecycle, ...)``)
+# self-documenting.
+is_war_room_job_for_lifecycle = is_war_room_job
+
+
+# A nullary callable returning a fresh bearer string. Re-resolved
+# every tick so token rotation takes effect within one heartbeat
+# interval. The caller (parent plugin) typically supplies
+# ``lambda: resolve_agent_token(token_file)``.
+BearerFactory = Callable[[], str]
+
+
+class RoomLifecycleReporter(JobLifecycleReporter):
+    """Per-job war-room reporter. Owns ``/present`` (early) and
+    ``/heartbeat``. Defers ``/contribute`` / ``/withdraw`` to the
+    legacy handler.py for now — PR-follow-up can migrate those.
+
+    Failure model:
+    * ``on_start`` /present raising ``RoomStateRaceError`` → record
+      not-presented; ``on_heartbeat`` becomes no-op; legacy handler
+      will see the same race and skip its leg.
+    * ``on_heartbeat`` /heartbeat raising ``RoomStateRaceError`` →
+      log and clear the presented flag so subsequent ticks skip.
+      The handler.py path will independently surface the room
+      transition at ``on_job_finished``.
+    * ``on_heartbeat`` benign no-op (server returned
+      ``skipped: "non_pending"``) → clear the presented flag too;
+      slot is already terminal, nothing to keep alive.
+    """
+
+    def __init__(
+        self,
+        job: Job,
+        *,
+        base_url: str,
+        bearer_factory: BearerFactory,
+        agent_id: Optional[str] = None,
+    ) -> None:
+        self._base_url = base_url
+        self._bearer_factory = bearer_factory
+        self._room_id = str(job.metadata.get("room_id") or "")
+        self._current_sequence = int(job.metadata.get("current_sequence") or 0)
+        self._subject_ref = str(job.metadata.get("subject_ref") or "")
+        # AGENT_ID for the first-wins gate. None falls back to
+        # bearer.name on the server side — single-runner deployments
+        # don't need to set it. Subscriber-mode runners should pass
+        # their per-runner identity.
+        self._agent_id = (
+            agent_id
+            if agent_id is not None
+            else (os.environ.get("AGENT_ID", "") or "").strip() or None
+        )
+        # Tracks whether on_start successfully /presented. Heartbeat
+        # is a no-op until this is True; cleared back to False if
+        # the server reports the slot is terminal.
+        self._presented = False
+
+    # ── JobLifecycleReporter contract ────────────────────────────
+
+    def on_start(self, job: Job) -> None:
+        """Early /present so the slot exists before the agent runs.
+
+        Idempotent for the same agent_id+role: a follow-up /present
+        in handler.py at on_job_finished is harmless (server-side
+        first-wins gate accepts re-RSVP from the same owner).
+        """
+        if not self._room_id:
+            self._log(
+                "on_start skipped — empty room_id in job metadata",
+                level="warn",
+            )
+            return
+        try:
+            seq = wr_api.present_to_room(
+                base_url=self._base_url,
+                room_id=self._room_id,
+                sequence_observed_by_client=self._current_sequence,
+                bearer=self._bearer_factory(),
+            )
+            self._presented = True
+            self._log(
+                f"early-presented room={self._room_id} "
+                f"subject={self._subject_ref} "
+                f"seq={self._current_sequence} landed_seq={seq}",
+                level="info",
+            )
+        except wr_api.RoomStateRaceError as exc:
+            # Race window between /watching and dispatch is tiny but
+            # not zero. Keep _presented=False; heartbeats no-op;
+            # handler will see same race at on_job_finished.
+            self._log(
+                f"raced on early-present room={self._room_id} "
+                f"seq={self._current_sequence} code={exc.code}",
+                level="info",
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._log(
+                f"early-present failed room={self._room_id} "
+                f"seq={self._current_sequence}: "
+                f"{type(exc).__name__}: {exc}",
+                level="warn",
+            )
+
+    def on_heartbeat(self, job: Job) -> None:
+        """Pure-liveness heartbeat (PR A's endpoint). No-op when we
+        never successfully /presented or when the slot has gone
+        terminal (server replies ``skipped: "non_pending"``)."""
+        if not self._presented:
+            return
+        try:
+            rsvp_at = wr_api.heartbeat_room_participant(
+                base_url=self._base_url,
+                room_id=self._room_id,
+                bearer=self._bearer_factory(),
+                agent_id=self._agent_id,
+            )
+        except wr_api.RoomStateRaceError as exc:
+            # Slot is no longer in awaiting_contributions, OR a
+            # different runner won the first-wins gate. Either way
+            # the lifecycle for this Job is effectively over —
+            # stop heartbeating.
+            self._presented = False
+            self._log(
+                f"heartbeat raced room={self._room_id} code={exc.code} "
+                "— stopping heartbeats for this job",
+                level="info",
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            # Transient (network blip, 5xx) — keep _presented True so
+            # the next tick retries. The substrate's loop already
+            # logs to stderr; this branch keeps the reporter's log
+            # prefix consistent for grep ergonomics.
+            self._log(
+                f"heartbeat error room={self._room_id}: "
+                f"{type(exc).__name__}: {exc}",
+                level="warn",
+            )
+            return
+
+        if rsvp_at is None:
+            # Benign no-op — participant withdrew / resolved /
+            # timed_out. Stop heartbeating; nothing to keep alive.
+            self._presented = False
+            self._log(
+                f"heartbeat skipped room={self._room_id} "
+                "— participant non-pending",
+                level="info",
+            )
+
+    def on_finish(self, job: Job, result: AgentResult) -> None:
+        """No-op — handler.py's ``handle_war_room_job_finished``
+        owns /contribute and /withdraw. Keeps PR C minimal; the
+        post-finish flow can migrate in a follow-up.
+        """
+        del job, result
+
+    def on_failure(self, job: Job, error_text: str) -> None:
+        """No-op — handler.py's failure path also owns this for now.
+        See ``on_finish`` rationale.
+        """
+        del job, error_text
+
+    # ── Helpers ──────────────────────────────────────────────────
+
+    def _log(self, message: str, *, level: str) -> None:
+        """Write to stderr with the war_rooms prefix so operators
+        can grep this reporter's lines alongside handler.py's. Same
+        format as handler._log."""
+        prefix = "[hivemoot-war-rooms]"
+        if level == "error":
+            print(f"{prefix} ERROR {message}", file=sys.stderr, flush=True)
+        elif level == "warn":
+            print(f"{prefix} WARN {message}", file=sys.stderr, flush=True)
+        else:
+            print(f"{prefix} {message}", file=sys.stderr, flush=True)
+
+
+def build_room_reporter(
+    job: Job,
+    *,
+    base_url: str,
+    bearer_factory: BearerFactory,
+    agent_id: Optional[str] = None,
+) -> RoomLifecycleReporter:
+    """ReporterFactory shape — bound to per-engine context (base_url,
+    bearer_factory) at registration time, takes the per-job
+    ``Job`` at dispatch time. Parent plugin closes over its config
+    when calling this::
+
+        cfg = self._cfg
+        mux.register(
+            is_war_room_job_for_lifecycle,
+            lambda job: build_room_reporter(
+                job,
+                base_url=cfg.war_rooms.base_url,
+                bearer_factory=lambda: resolve_agent_token(
+                    str(cfg.token_file) if cfg.token_file else "",
+                ),
+            ),
+        )
+    """
+    return RoomLifecycleReporter(
+        job,
+        base_url=base_url,
+        bearer_factory=bearer_factory,
+        agent_id=agent_id,
+    )

--- a/agent/cli/tests/test_hivemoot_plugin.py
+++ b/agent/cli/tests/test_hivemoot_plugin.py
@@ -228,6 +228,136 @@ class TriggersTests(unittest.TestCase):
         self.assertEqual(plugin.triggers(), [])
 
 
+# ── Lifecycle multiplexer composition ─────────────────────────────
+
+
+class LifecycleMuxCompositionTests(unittest.TestCase):
+    """Defensive-coexistence regression tests for the
+    ``self._lifecycle_mux is None`` guard in ``triggers()``.
+
+    Closes guard's PR #616 review point about composition asymmetry:
+    when PR D's tasks branch and this branch's war-rooms branch
+    both run in ``triggers()``, the second one MUST attach its
+    reporter to the existing multiplexer instead of replacing it
+    and silently dropping the first registration.
+
+    These tests simulate the composition without depending on PR
+    D's code being in the branch — they pre-populate
+    ``self._lifecycle_mux`` with a sentinel multiplexer (acting
+    as a stand-in for whatever the OTHER branch would have built)
+    and verify the war-rooms registration attaches on top rather
+    than overwriting.
+    """
+
+    def setUp(self) -> None:
+        self._saved_agent_id = os.environ.get("AGENT_ID")
+        os.environ["AGENT_ID"] = "builder"
+
+    def tearDown(self) -> None:
+        if self._saved_agent_id is None:
+            os.environ.pop("AGENT_ID", None)
+        else:
+            os.environ["AGENT_ID"] = self._saved_agent_id
+
+    def _war_rooms_only_cfg(self):
+        from hivemoot_agent.plugins_builtin.hivemoot.config import (
+            HivemootWarRoomsConfig,
+        )
+        cfg = _mk_plugin_config()
+        cfg.typed.war_rooms = HivemootWarRoomsConfig(
+            enabled=True,
+            base_url="https://api/x",
+            heartbeat_interval_secs=45,
+        )
+        return cfg
+
+    def test_war_rooms_registration_attaches_to_existing_mux(self) -> None:
+        # Simulate PR D's tasks branch having already created the
+        # multiplexer and registered the task reporter. This branch
+        # MUST attach the war-rooms registration to the existing
+        # mux instead of replacing it.
+        from hivemoot_agent.plugins_builtin.hivemoot.job_lifecycle import (
+            LifecycleMultiplexer,
+        )
+
+        plugin = HivemootPlugin()
+        plugin._cfg = self._war_rooms_only_cfg().typed
+
+        # Pre-existing mux with one registration (the "tasks branch
+        # already ran" simulation). The matcher returns False so
+        # this never matches — it's a sentinel, not a real reporter.
+        sentinel_mux = LifecycleMultiplexer(heartbeat_interval=45)
+        sentinel_mux.register(lambda j: False, lambda j: None)
+        plugin._lifecycle_mux = sentinel_mux
+
+        plugin.triggers()
+
+        # Same mux instance — defensive guard preserved it.
+        self.assertIs(
+            plugin._lifecycle_mux, sentinel_mux,
+            "war-rooms branch overwrote the existing multiplexer; "
+            "the defensive `if self._lifecycle_mux is None` guard "
+            "is missing or broken.",
+        )
+        # Two registrations: the sentinel (pre-existing) + war_rooms.
+        self.assertEqual(
+            len(plugin._lifecycle_mux._registrations), 2,
+            "war-rooms registration should have been appended to "
+            "the existing mux's registrations.",
+        )
+
+    def test_war_rooms_creates_mux_when_none_exists(self) -> None:
+        # Sanity: when no other branch has created the mux, the
+        # war-rooms branch creates one with the configured interval.
+        plugin = HivemootPlugin()
+        plugin._cfg = self._war_rooms_only_cfg().typed
+        self.assertIsNone(plugin._lifecycle_mux)
+
+        plugin.triggers()
+
+        self.assertIsNotNone(plugin._lifecycle_mux)
+        self.assertEqual(
+            plugin._lifecycle_mux.heartbeat_interval, 45,
+            "Mux should pick up cfg.war_rooms.heartbeat_interval_secs "
+            "when only war_rooms is enabled.",
+        )
+        self.assertEqual(len(plugin._lifecycle_mux._registrations), 1)
+
+    def test_mux_interval_is_min_of_both_domain_settings(self) -> None:
+        # When BOTH tasks AND war_rooms are enabled, the multiplexer
+        # interval is min(tasks, war_rooms) so neither domain's
+        # liveness expectation gets stretched. Slower-tuned domains
+        # see more-frequent heartbeats (cheap waste); faster-tuned
+        # domains never miss liveness. This test exercises the
+        # min() codepath in the war-rooms branch's mux init.
+        from hivemoot_agent.plugins_builtin.hivemoot.config import (
+            HivemootWarRoomsConfig,
+        )
+        cfg = _mk_plugin_config(
+            tasks=HivemootTasksConfig(
+                enabled=True,
+                claim_url="https://api/x",
+                execute_base_url="https://api/y",
+                heartbeat_interval_secs=90,  # slower
+            ),
+        )
+        cfg.typed.war_rooms = HivemootWarRoomsConfig(
+            enabled=True,
+            base_url="https://api/x",
+            heartbeat_interval_secs=30,  # faster
+        )
+        plugin = HivemootPlugin()
+        plugin._cfg = cfg.typed
+        plugin.triggers()
+        self.assertIsNotNone(plugin._lifecycle_mux)
+        self.assertEqual(
+            plugin._lifecycle_mux.heartbeat_interval, 30,
+            "Mux should pick min(tasks, war_rooms) interval when "
+            "both domains are enabled — neither domain should see "
+            "stretched liveness expectations.",
+        )
+
+
 # ── System prompt composition ─────────────────────────────────────
 
 

--- a/agent/cli/tests/test_hivemoot_war_rooms_api.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_api.py
@@ -193,15 +193,24 @@ class PresentToRoomTests(unittest.TestCase):
         self.assertNotIn("intentHint", sent)
 
     def test_raises_on_409_owner_conflict(self) -> None:
+        # PR C of JOB_LIFECYCLE_UNIFICATION reclassifies owner_conflict
+        # as a race (it was previously a generic 409 RuntimeError).
+        # The runtime semantics are correct: a different runner won
+        # the first-wins gate, so retry won't help — the slot isn't
+        # ours and the lifecycle should bail. Same treatment that
+        # heartbeat_room_participant uses, now applied to /present
+        # for parity (closes guard's PR #615 review point about
+        # subscriber-mode asymmetry).
         body = json.dumps({"code": "owner_conflict"}).encode()
         with patch.object(
             hm_http._OPENER, "open", return_value=_fake_response(409, body),
         ):
-            with self.assertRaises(RuntimeError) as cm:
+            with self.assertRaises(wr_api.RoomStateRaceError) as cm:
                 wr_api.present_to_room(
                     "https://api.example", self.ROOM_ID, 1, "tok",
                 )
-        self.assertIn("status 409", str(cm.exception))
+        self.assertEqual(cm.exception.op, "present")
+        self.assertEqual(cm.exception.code, "owner_conflict")
 
     def test_raises_on_response_missing_sequence(self) -> None:
         body = json.dumps({}).encode()
@@ -370,11 +379,13 @@ class RoomStateRaceErrorTests(unittest.TestCase):
                 )
         self.assertEqual(cm.exception.op, "withdraw")
 
-    def test_other_409_codes_still_raise_generic_RuntimeError(self) -> None:
-        # owner_conflict, participant_already_present, etc. are
-        # distinct race classes that the handler treats differently.
-        # They MUST NOT collapse into RoomStateRaceError.
-        body = json.dumps({"code": "owner_conflict"}).encode()
+    def test_unknown_409_code_still_raises_generic_RuntimeError(self) -> None:
+        # Codes the api module doesn't recognize as race-class still
+        # surface as generic RuntimeError so the failure-mode signal
+        # isn't lost. (PR C added owner_conflict to the race set;
+        # this test ensures we don't over-collapse — anything outside
+        # the explicit allowlist remains a generic 409.)
+        body = json.dumps({"code": "participant_already_present"}).encode()
         with patch.object(
             hm_http._OPENER, "open", return_value=_fake_response(409, body),
         ):

--- a/agent/cli/tests/test_hivemoot_war_rooms_lifecycle.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_lifecycle.py
@@ -122,6 +122,34 @@ class HeartbeatRoomParticipantTests(unittest.TestCase):
                 )
         self.assertEqual(ctx.exception.code, "owner_conflict")
 
+    def test_404_room_not_found_maps_to_race(self):
+        # Closes guard's PR #615 review feedback: 404 must be
+        # terminal so the substrate's loop stops spinning. Without
+        # this mapping a deleted room would log a transient error
+        # and retry every interval forever.
+        with self._patch_post(404, {"code": "room_not_found"}):
+            with self.assertRaises(wr_api.RoomStateRaceError) as ctx:
+                wr_api.heartbeat_room_participant(
+                    base_url="https://www.hivemoot.dev",
+                    room_id="room-A",
+                    bearer="hmt_test",
+                )
+        self.assertEqual(ctx.exception.code, "room_not_found")
+
+    def test_404_participant_not_found_maps_to_race(self):
+        # Slot was withdrawn / never created — also terminal. Same
+        # rationale as room_not_found: there's nothing to keep
+        # alive on the server side, so the substrate's loop should
+        # stop instead of retrying indefinitely.
+        with self._patch_post(404, {"code": "participant_not_found"}):
+            with self.assertRaises(wr_api.RoomStateRaceError) as ctx:
+                wr_api.heartbeat_room_participant(
+                    base_url="https://www.hivemoot.dev",
+                    room_id="room-A",
+                    bearer="hmt_test",
+                )
+        self.assertEqual(ctx.exception.code, "participant_not_found")
+
     def test_500_raises_runtime_error(self):
         # Generic transient — caller logs and retries on next tick.
         with self._patch_post(500, {"message": "kaboom"}):
@@ -213,6 +241,7 @@ class RoomLifecycleReporterStartTests(unittest.TestCase):
                 _job(),
                 base_url="https://www.hivemoot.dev",
                 bearer_factory=bearer,
+                agent_id="drone-host42",
             )
             r.on_start(_job())
             self.assertTrue(r._presented)
@@ -221,7 +250,32 @@ class RoomLifecycleReporterStartTests(unittest.TestCase):
                 room_id="room-A",
                 sequence_observed_by_client=7,
                 bearer="hmt_test_call_1",
+                agent_id="drone-host42",
             )
+
+    def test_on_start_passes_agent_id_for_subscriber_mode_parity(self):
+        # Closes guard's PR #615 review point: /present and
+        # /heartbeat must carry the same agent_id so the
+        # subscriber-mode first-wins gate sees consistent identity
+        # on both calls. Without this, runner A's /present would
+        # create the slot at agent_id=bearer.name and runner A's
+        # /heartbeat with body.agentId="A" would hit owner_conflict.
+        bearer = _FakeBearerFactory()
+        captured: dict = {}
+
+        def fake_present(**kwargs):
+            captured.update(kwargs)
+            return 8
+
+        with patch.object(wr_api, "present_to_room", side_effect=fake_present):
+            r = RoomLifecycleReporter(
+                _job(),
+                base_url="x",
+                bearer_factory=bearer,
+                agent_id="drone-runner-host42",
+            )
+            r.on_start(_job())
+        self.assertEqual(captured.get("agent_id"), "drone-runner-host42")
 
     def test_on_start_race_keeps_presented_false(self):
         # Room moved on between /watching and dispatch — the small

--- a/agent/cli/tests/test_hivemoot_war_rooms_lifecycle.py
+++ b/agent/cli/tests/test_hivemoot_war_rooms_lifecycle.py
@@ -1,0 +1,490 @@
+"""Tests for the war-rooms RoomLifecycleReporter (PR C of the
+JOB_LIFECYCLE_UNIFICATION RFC) and the heartbeat_room_participant
+API helper.
+
+What's covered here:
+* heartbeat_room_participant — happy path, benign no-op (skipped),
+  RoomStateRaceError mapping for status_precondition_failed +
+  owner_conflict, generic 5xx → RuntimeError, malformed body.
+* RoomLifecycleReporter.on_start — early /present sets _presented;
+  RoomStateRaceError leaves it False and logs at info; generic
+  failure leaves it False and logs at warn.
+* RoomLifecycleReporter.on_heartbeat — guarded by _presented;
+  benign skipped → clears _presented; race → clears _presented;
+  transient → keeps _presented True (next tick retries).
+* on_finish / on_failure — explicit no-ops (handler.py still owns
+  the post sequence). Pinned so a future PR migrating those flows
+  doesn't silently break the contract.
+
+Also exercises the matcher-disjointness positive coverage that
+guard flagged in the PR #614 review: in the multiplexer, the
+war-rooms matcher only fires for `job_kind=war_room_triage` jobs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms import api as wr_api
+from hivemoot_agent.plugins_builtin.hivemoot.war_rooms.lifecycle import (
+    RoomLifecycleReporter,
+    build_room_reporter,
+    is_war_room_job_for_lifecycle,
+)
+
+
+def _job(**metadata: Any) -> Job:
+    md: dict[str, Any] = {
+        "job_kind": "war_room_triage",
+        "room_id": "room-A",
+        "current_sequence": 7,
+        "subject_ref": "hivemoot/hivemoot#999",
+    }
+    md.update(metadata)
+    return Job(session_key="war-room:room-A@7", prompt="p", metadata=md)
+
+
+# ── heartbeat_room_participant ──────────────────────────────────────
+
+
+class HeartbeatRoomParticipantTests(unittest.TestCase):
+    """Pin the wire-shape contract: returns ISO string on apply,
+    None on benign no-op, raises RoomStateRaceError on race-409s,
+    RuntimeError on anything else."""
+
+    def _patch_post(self, status: int, body: dict[str, Any] | None):
+        # `post_json` returns (status, parsed, raw_bytes). Tests want
+        # the raw bytes for the 200-len fast-path; fake them out.
+        import json
+        raw = json.dumps(body or {}).encode("utf-8")
+        return patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api.post_json",
+            return_value=(status, body, raw),
+        )
+
+    def test_happy_path_returns_iso_timestamp(self):
+        with self._patch_post(200, {"rsvpAt": "2026-05-06T03:00:00.000Z"}):
+            rsvp = wr_api.heartbeat_room_participant(
+                base_url="https://www.hivemoot.dev",
+                room_id="room-A",
+                bearer="hmt_test",
+            )
+        self.assertEqual(rsvp, "2026-05-06T03:00:00.000Z")
+
+    def test_skipped_non_pending_returns_none(self):
+        # Storage layer's Lua returns null when participant is
+        # already withdrew/resolved/timed_out. Route surfaces that
+        # as { skipped: "non_pending" }. Caller treats as benign.
+        with self._patch_post(200, {"skipped": "non_pending"}):
+            rsvp = wr_api.heartbeat_room_participant(
+                base_url="https://www.hivemoot.dev",
+                room_id="room-A",
+                bearer="hmt_test",
+            )
+        self.assertIsNone(rsvp)
+
+    def test_status_precondition_failed_maps_to_race(self):
+        # Room left awaiting_contributions — closed, deciding, etc.
+        with self._patch_post(409, {
+            "code": "status_precondition_failed",
+            "actualStatus": "closed",
+        }):
+            with self.assertRaises(wr_api.RoomStateRaceError) as ctx:
+                wr_api.heartbeat_room_participant(
+                    base_url="https://www.hivemoot.dev",
+                    room_id="room-A",
+                    bearer="hmt_test",
+                )
+        self.assertEqual(ctx.exception.op, "heartbeat")
+        self.assertEqual(ctx.exception.code, "status_precondition_failed")
+
+    def test_owner_conflict_maps_to_race(self):
+        # Subscriber-mode collision: a different runner holds the
+        # role. heartbeat_room_participant maps this to a race so
+        # the lifecycle stops attempting to keep our slot alive
+        # (it isn't ours).
+        with self._patch_post(409, {
+            "code": "owner_conflict",
+            "existingAgentId": "drone-runner-host42",
+        }):
+            with self.assertRaises(wr_api.RoomStateRaceError) as ctx:
+                wr_api.heartbeat_room_participant(
+                    base_url="https://www.hivemoot.dev",
+                    room_id="room-A",
+                    bearer="hmt_test",
+                )
+        self.assertEqual(ctx.exception.code, "owner_conflict")
+
+    def test_500_raises_runtime_error(self):
+        # Generic transient — caller logs and retries on next tick.
+        with self._patch_post(500, {"message": "kaboom"}):
+            with self.assertRaises(RuntimeError) as ctx:
+                wr_api.heartbeat_room_participant(
+                    base_url="https://www.hivemoot.dev",
+                    room_id="room-A",
+                    bearer="hmt_test",
+                )
+        self.assertIn("status 500", str(ctx.exception))
+
+    def test_missing_rsvpAt_raises_runtime_error(self):
+        with self._patch_post(200, {"unexpected": "shape"}):
+            with self.assertRaises(RuntimeError):
+                wr_api.heartbeat_room_participant(
+                    base_url="https://www.hivemoot.dev",
+                    room_id="room-A",
+                    bearer="hmt_test",
+                )
+
+    def test_agent_id_flows_into_body(self):
+        # Verify the agentId is sent for the first-wins gate.
+        captured: dict[str, Any] = {}
+
+        def fake_post_json(url, body, bearer, *, timeout):
+            captured["body"] = body
+            captured["url"] = url
+            return (200, {"rsvpAt": "2026-05-06T03:00:00.000Z"}, b"{}")
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api.post_json",
+            side_effect=fake_post_json,
+        ):
+            wr_api.heartbeat_room_participant(
+                base_url="https://www.hivemoot.dev",
+                room_id="room-A",
+                bearer="hmt_test",
+                agent_id="drone-runner-host42",
+            )
+        self.assertEqual(captured["body"], {"agentId": "drone-runner-host42"})
+        self.assertTrue(captured["url"].endswith("/api/rooms/room-A/heartbeat"))
+
+    def test_no_agent_id_sends_empty_body(self):
+        # Per RFC Q3: heartbeat is payload-free. When agent_id is
+        # None, the body is `{}` — server falls back to bearer.name.
+        captured: dict[str, Any] = {}
+
+        def fake_post_json(url, body, bearer, *, timeout):
+            captured["body"] = body
+            return (200, {"rsvpAt": "x"}, b"{}")
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.war_rooms.api.post_json",
+            side_effect=fake_post_json,
+        ):
+            wr_api.heartbeat_room_participant(
+                base_url="https://www.hivemoot.dev",
+                room_id="room-A",
+                bearer="hmt_test",
+            )
+        self.assertEqual(captured["body"], {})
+
+
+# ── RoomLifecycleReporter ──────────────────────────────────────────
+
+
+class _FakeBearerFactory:
+    """Captures call counts so tests can pin the per-tick re-resolution
+    invariant. The substrate's tasks heartbeat thread re-resolves
+    every tick to support token rotation; the war-rooms reporter
+    inherits that contract."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> str:
+        self.calls += 1
+        return f"hmt_test_call_{self.calls}"
+
+
+class RoomLifecycleReporterStartTests(unittest.TestCase):
+
+    def test_on_start_calls_present_and_sets_presented(self):
+        bearer = _FakeBearerFactory()
+        with patch.object(
+            wr_api, "present_to_room", return_value=8,
+        ) as m:
+            r = RoomLifecycleReporter(
+                _job(),
+                base_url="https://www.hivemoot.dev",
+                bearer_factory=bearer,
+            )
+            r.on_start(_job())
+            self.assertTrue(r._presented)
+            m.assert_called_once_with(
+                base_url="https://www.hivemoot.dev",
+                room_id="room-A",
+                sequence_observed_by_client=7,
+                bearer="hmt_test_call_1",
+            )
+
+    def test_on_start_race_keeps_presented_false(self):
+        # Room moved on between /watching and dispatch — the small
+        # window we're trying to shrink. Stay un-presented; heartbeat
+        # is a no-op until the next dispatch refreshes state.
+        with patch.object(
+            wr_api, "present_to_room",
+            side_effect=wr_api.RoomStateRaceError(
+                op="present",
+                code="status_precondition_failed",
+                body_excerpt="closed",
+            ),
+        ):
+            r = RoomLifecycleReporter(
+                _job(),
+                base_url="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_start(_job())
+        self.assertFalse(r._presented)
+
+    def test_on_start_generic_failure_keeps_presented_false(self):
+        with patch.object(
+            wr_api, "present_to_room",
+            side_effect=RuntimeError("network blip"),
+        ):
+            r = RoomLifecycleReporter(
+                _job(),
+                base_url="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_start(_job())
+        self.assertFalse(r._presented)
+
+    def test_on_start_skips_when_room_id_empty(self):
+        # Defensive: a malformed Job with empty room_id should not
+        # produce an HTTP call (and certainly should not crash).
+        bad_job = Job(
+            session_key="x",
+            prompt="p",
+            metadata={"job_kind": "war_room_triage"},
+        )
+        with patch.object(wr_api, "present_to_room") as m:
+            r = RoomLifecycleReporter(
+                bad_job,
+                base_url="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_start(bad_job)
+        m.assert_not_called()
+        self.assertFalse(r._presented)
+
+
+class RoomLifecycleReporterHeartbeatTests(unittest.TestCase):
+
+    def _build(self, *, presented: bool = True) -> RoomLifecycleReporter:
+        r = RoomLifecycleReporter(
+            _job(),
+            base_url="https://www.hivemoot.dev",
+            bearer_factory=_FakeBearerFactory(),
+        )
+        r._presented = presented
+        return r
+
+    def test_heartbeat_no_op_when_not_presented(self):
+        # If on_start failed to /present, the slot doesn't exist —
+        # heartbeating it would either 404 or 409. Skip the HTTP
+        # call entirely; the substrate's loop will keep ticking.
+        r = self._build(presented=False)
+        with patch.object(wr_api, "heartbeat_room_participant") as m:
+            r.on_heartbeat(_job())
+        m.assert_not_called()
+
+    def test_heartbeat_happy_path_keeps_presented(self):
+        r = self._build(presented=True)
+        with patch.object(
+            wr_api, "heartbeat_room_participant",
+            return_value="2026-05-06T03:00:00.000Z",
+        ):
+            r.on_heartbeat(_job())
+        self.assertTrue(r._presented)
+
+    def test_heartbeat_skipped_clears_presented(self):
+        # Slot has gone terminal (withdrew/resolved/timed_out).
+        # Stop heartbeating; subsequent ticks are no-op.
+        r = self._build(presented=True)
+        with patch.object(
+            wr_api, "heartbeat_room_participant",
+            return_value=None,
+        ):
+            r.on_heartbeat(_job())
+        self.assertFalse(r._presented)
+
+    def test_heartbeat_race_clears_presented(self):
+        # Status precondition failed — room is no longer in
+        # awaiting_contributions. Lifecycle is over for this Job.
+        r = self._build(presented=True)
+        with patch.object(
+            wr_api, "heartbeat_room_participant",
+            side_effect=wr_api.RoomStateRaceError(
+                op="heartbeat",
+                code="status_precondition_failed",
+                body_excerpt="closed",
+            ),
+        ):
+            r.on_heartbeat(_job())
+        self.assertFalse(r._presented)
+
+    def test_heartbeat_owner_conflict_clears_presented(self):
+        # Subscriber-mode collision: another runner won the gate.
+        # Slot isn't ours — stop heartbeating it.
+        r = self._build(presented=True)
+        with patch.object(
+            wr_api, "heartbeat_room_participant",
+            side_effect=wr_api.RoomStateRaceError(
+                op="heartbeat",
+                code="owner_conflict",
+                body_excerpt="held by drone-host42",
+            ),
+        ):
+            r.on_heartbeat(_job())
+        self.assertFalse(r._presented)
+
+    def test_heartbeat_transient_error_keeps_presented(self):
+        # 5xx, network blip, etc. — the slot is still ours; next
+        # tick will retry. Don't clear _presented.
+        r = self._build(presented=True)
+        with patch.object(
+            wr_api, "heartbeat_room_participant",
+            side_effect=RuntimeError("transient 503"),
+        ):
+            r.on_heartbeat(_job())
+        self.assertTrue(r._presented)
+
+    def test_heartbeat_re_resolves_bearer_per_tick(self):
+        # Per the substrate's tasks-heartbeat convention (and
+        # explicit RFC reasoning): bearer is re-resolved each call
+        # so token rotation takes effect within one interval. The
+        # bearer_factory call count proves the reporter calls it
+        # fresh each tick rather than caching.
+        bearer = _FakeBearerFactory()
+        r = RoomLifecycleReporter(
+            _job(),
+            base_url="x",
+            bearer_factory=bearer,
+        )
+        r._presented = True
+        with patch.object(
+            wr_api, "heartbeat_room_participant",
+            return_value="x",
+        ):
+            r.on_heartbeat(_job())
+            r.on_heartbeat(_job())
+            r.on_heartbeat(_job())
+        self.assertEqual(bearer.calls, 3)
+
+
+class RoomLifecycleReporterFinishTests(unittest.TestCase):
+    """Pin the explicit no-op contract for on_finish / on_failure.
+    handler.py owns /contribute and /withdraw for now; if a future
+    PR migrates them, these tests will fail and force a deliberate
+    contract update."""
+
+    def test_on_finish_is_noop(self):
+        r = RoomLifecycleReporter(
+            _job(),
+            base_url="x",
+            bearer_factory=_FakeBearerFactory(),
+        )
+        r._presented = True
+        with (
+            patch.object(wr_api, "submit_contribution") as m1,
+            patch.object(wr_api, "withdraw_participant") as m2,
+        ):
+            r.on_finish(_job(), AgentResult(exit_code=0, response="x"))
+        m1.assert_not_called()
+        m2.assert_not_called()
+
+    def test_on_failure_is_noop(self):
+        r = RoomLifecycleReporter(
+            _job(),
+            base_url="x",
+            bearer_factory=_FakeBearerFactory(),
+        )
+        r._presented = True
+        with patch.object(wr_api, "withdraw_participant") as m:
+            r.on_failure(_job(), "agent crashed")
+        m.assert_not_called()
+
+
+# ── Matcher disjointness (guard's PR #614 follow-up request) ───────
+
+
+class MatcherDisjointnessTests(unittest.TestCase):
+    """Positive coverage for the war-rooms matcher across the
+    metadata combinations that exist in the system. Guard's PR #614
+    review explicitly asked future PRs to ship this — paying it down
+    in PR C since the matcher being shipped is `is_war_room_job`."""
+
+    def test_matches_well_formed_war_room_job(self):
+        self.assertTrue(is_war_room_job_for_lifecycle(_job()))
+
+    def test_does_not_match_task_job(self):
+        # A task job has task_id but lacks the room_id+job_kind
+        # combination. Mutual exclusion holds.
+        task_job = Job(
+            session_key="t",
+            prompt="p",
+            metadata={"task_id": "t-1", "claim_token": "ct-1"},
+        )
+        self.assertFalse(is_war_room_job_for_lifecycle(task_job))
+
+    def test_does_not_match_health_job(self):
+        # Health jobs have no metadata markers shared with war-rooms.
+        health_job = Job(session_key="h", prompt="p", metadata={})
+        self.assertFalse(is_war_room_job_for_lifecycle(health_job))
+
+    def test_does_not_match_partial_metadata(self):
+        # Partial-marker Jobs (e.g. someone set room_id but not
+        # job_kind) are treated as not-ours rather than risking a
+        # false-positive dispatch. handler.is_war_room_job pins
+        # this; the matcher inherits.
+        partial = Job(
+            session_key="x",
+            prompt="p",
+            metadata={"room_id": "room-A", "current_sequence": 3},
+        )
+        self.assertFalse(is_war_room_job_for_lifecycle(partial))
+
+    def test_does_not_match_wrong_job_kind(self):
+        # job_kind is the discriminator string. Anything else (a
+        # future "investigation" or "long-running goal" job) is
+        # rejected so the matcher stays mutually exclusive.
+        wrong_kind = Job(
+            session_key="x",
+            prompt="p",
+            metadata={
+                "job_kind": "investigation",
+                "room_id": "room-A",
+                "current_sequence": 3,
+            },
+        )
+        self.assertFalse(is_war_room_job_for_lifecycle(wrong_kind))
+
+
+# ── Factory smoke test ─────────────────────────────────────────────
+
+
+class FactorySmokeTests(unittest.TestCase):
+
+    def test_build_room_reporter_returns_configured_instance(self):
+        r = build_room_reporter(
+            _job(),
+            base_url="https://staging.hivemoot.dev",
+            bearer_factory=_FakeBearerFactory(),
+            agent_id="drone-host7",
+        )
+        self.assertIsInstance(r, RoomLifecycleReporter)
+        self.assertEqual(r._base_url, "https://staging.hivemoot.dev")
+        self.assertEqual(r._room_id, "room-A")
+        self.assertEqual(r._current_sequence, 7)
+        self.assertEqual(r._agent_id, "drone-host7")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes JOB_LIFECYCLE_UNIFICATION RFC, **PR C**. War-room jobs now claim their participant slot **before** the agent subprocess runs, and a heartbeat thread keeps the slot alive throughout the LLM review. This ends the race we keep seeing in drone logs:

\`\`\`
[hivemoot-war-rooms] raced room transition on present
room=... seq=N code=status_precondition_failed
— skipping contribute
\`\`\`

## What it looks like

**Before — race timeline (today):**

\`\`\`
T=0     : trigger sees room (awaiting_contributions, seq=N)
T=0     : engine spawns agent
T=0..10 : LLM reviews 1051-line PR (~5–10 min)
T=8min  : room.max_age_secs expires → queen-tick closes room
T=10min : handler.py POST /present → 409 status_precondition_failed
T=10min : "raced room transition on present — skipping contribute"
\`\`\`

**After — early /present + heartbeat:**

\`\`\`
T=0     : trigger sees room (awaiting_contributions, seq=N)
T=0     : on_job_started → mux.on_job_start → RoomLifecycleReporter.on_start
T=0     : POST /present (slot claimed at seq=N+1)
T=0..10 : substrate heartbeat thread fires every 45s →
          POST /heartbeat bumps participant.rsvp_at
T=10min : agent finishes; handler.py /contribute lands cleanly
\`\`\`

## Scope (intentionally minimal)

| Concern | This PR | Future |
|---|---|---|
| /present (early RSVP) | ✅ on_start in reporter | — |
| /heartbeat (PR A endpoint) | ✅ on_heartbeat | — |
| /contribute / /withdraw | handler.py keeps owning these | optional follow-up |
| Tasks heartbeat | unchanged | PR D migrates |

handler.py's existing /present call becomes a benign idempotent re-RSVP — same agent_id + same role hits the server's first-wins gate which accepts re-RSVP from the same owner. No semantic change for /contribute or /withdraw.

## Wire shapes

**heartbeat_room_participant** (new helper in \`war_rooms/api.py\`):
- happy path → returns ISO timestamp string (\`rsvpAt\`)
- benign no-op (\`{ skipped: "non_pending" }\`) → returns \`None\` so the lifecycle stops heartbeating a terminal slot
- \`409 status_precondition_failed\` OR \`409 owner_conflict\` → \`RoomStateRaceError\` (subscriber-mode collision is treated identically — slot isn't ours)
- 5xx / malformed → \`RuntimeError\` (transient; substrate's loop logs and retries on next tick)

**RoomLifecycleReporter** (new file \`war_rooms/lifecycle.py\`):
- captures \`bearer_factory\` (callable) rather than a resolved bearer — token rotation takes effect within one heartbeat interval (mirrors the tasks-heartbeat convention)
- tracks \`_presented\` flag; heartbeat is no-op until on_start succeeds; cleared on race / skipped so subsequent ticks don't spam
- on_finish / on_failure are explicit no-ops with pinned tests so a future PR migrating those flows must update the contract deliberately

## Decisions baked in (from RFC fleet review)

| Q | Applied here |
|---|---|
| Q2 — ABC, not Protocol | RoomLifecycleReporter subclasses JobLifecycleReporter; missing methods would TypeError on instantiation |
| Q3 — Pure-liveness heartbeat | heartbeat_room_participant body is \`{}\` (or \`{agentId}\` for first-wins gate); never any progress text |
| Q6 — Matcher disjointness | is_war_room_job_for_lifecycle inherits handler.is_war_room_job's strict triple-check; positive-coverage tests verify rejection of task / health / partial / wrong-kind jobs |

## Addresses guard's PR #614 review feedback

Guard's three points on PR #614 were:

1. **HTTP timeout discipline** — heartbeat_room_participant uses the existing \`DEFAULT_TIMEOUT_SECS\` from the shared http client, same short timeout as /present and /contribute. ✅
2. **Matcher disjointness positive coverage** — 5 new tests in \`MatcherDisjointnessTests\` exercising task / health / partial / wrong-kind rejection. ✅
3. **Test-coverage gap** (the \`test_heartbeat_loop_bails_if_reporter_cleared_mid_tick\` test that wasn't actually exercising the inner guard) — fixed in [\`96498ad\`](https://github.com/hivemoot/hivemoot/pull/614/commits/96498ad) on PR #614 itself before merge. ✅

## Test plan

- [x] **27 new tests** in \`agent/cli/tests/test_hivemoot_war_rooms_lifecycle.py\`:
  - 8 \`HeartbeatRoomParticipantTests\` (wire-shape contract)
  - 4 \`RoomLifecycleReporterStartTests\` (on_start behaviour)
  - 7 \`RoomLifecycleReporterHeartbeatTests\` (on_heartbeat state machine)
  - 2 \`RoomLifecycleReporterFinishTests\` (no-op contract pin)
  - 5 \`MatcherDisjointnessTests\` (mutual exclusion)
  - 1 factory smoke test
- [x] Full agent suite: **643 tests pass** (was 616 before B; +19 from B + +8 here = 643 — wait, +27 here actually). Recount: 643 total, no regressions.
- [x] Bearer re-resolved per-tick verified by call-count assertion (token-rotation invariant from substrate convention)

## What's next in the stack

| PR | Status |
|---|---|
| ✅ A — server endpoint | merged |
| ✅ B — engine substrate | merged |
| 🟢 **C (this PR)** | war-rooms migration |
| ⏳ D | tasks migration onto substrate (deletes the \`__init__.py\`'s \`_task_heartbeat_loop\` and friends) |
| ⏳ E | dashboard surfaces last-heartbeat per participant |