### PR TITLE
feat(agent): TaskLifecycleReporter — share heartbeat substrate with war-rooms

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -112,12 +112,13 @@ class HivemootPlugin:
 
     def __init__(self) -> None:
         # ── Task subsystem state ─────────────────────────────────
-        # Per-job heartbeat state — overwritten on each on_job_started
-        # so an orphan thread from a slow shutdown cannot be revived by
-        # the next job (its closure-captured task_id would post for the
-        # wrong task otherwise).
-        self._task_heartbeat_stop: threading.Event | None = None
-        self._task_heartbeat_thread: threading.Thread | None = None
+        # Per-job heartbeat thread is now owned by the
+        # ``LifecycleMultiplexer`` instance below (PR D of the
+        # JOB_LIFECYCLE_UNIFICATION RFC). Previously the plugin had
+        # its own ``_task_heartbeat_stop`` + ``_task_heartbeat_thread``
+        # — the substrate's per-job stop_event provides the same
+        # orphan-prevention guarantee plus mutex-asserted matcher
+        # dispatch across tasks + war-rooms.
         # Codex sidecar path resolved at job-start, consumed at finish.
         self._codex_sidecar_path: str = ""
         # In-flight gate for the async dispatcher.  The engine's
@@ -159,12 +160,14 @@ class HivemootPlugin:
         # disabled OR triggers() hasn't been called yet.
         self._war_room_trigger: Any = None
 
-        # ── Engine-side lifecycle substrate (PR C of the
+        # ── Engine-side lifecycle substrate (PRs C+D of the
         #    JOB_LIFECYCLE_UNIFICATION RFC) ────────────────────────
-        # LifecycleMultiplexer instance for this plugin run. None
-        # when no domain has registered a reporter (e.g. war_rooms
-        # disabled). Registered in `triggers()` once the typed
-        # config is finalized.
+        # LifecycleMultiplexer instance that drives the heartbeat
+        # thread + per-domain reporter dispatch (war_rooms +
+        # tasks). None when no domain has registered a reporter;
+        # created lazily in ``triggers()`` once the typed config is
+        # finalized. Both branches use a defensive ``if mux is
+        # None`` guard so registration order doesn't matter.
         self._lifecycle_mux: Any = None
 
         # Apiarist auth subscriber, populated in setup_lifecycle() when
@@ -457,6 +460,50 @@ class HivemootPlugin:
             )
             triggers.append(HivemootTaskTrigger(self))  # type: ignore[arg-type]
 
+            # Wire tasks onto the engine-side lifecycle substrate
+            # (PR D of the JOB_LIFECYCLE_UNIFICATION RFC). The
+            # multiplexer's heartbeat thread now owns what the
+            # plugin's ``_task_heartbeat_loop`` did before — same
+            # per-job stop_event semantics, same 5s join, same
+            # bearer re-resolve per tick. Defensive ``if mux is
+            # None`` so this branch composes with PR C's war-rooms
+            # registration without conflict — whichever runs first
+            # creates the mux with min(tasks, war_rooms) interval
+            # so neither domain's liveness expectation gets stretched.
+            if self._lifecycle_mux is None:
+                from hivemoot_agent.plugins_builtin.hivemoot.job_lifecycle import (
+                    LifecycleMultiplexer,
+                )
+                interval = cfg.tasks.heartbeat_interval_secs
+                if cfg.war_rooms.enabled:
+                    interval = min(
+                        interval,
+                        cfg.war_rooms.heartbeat_interval_secs or interval,
+                    )
+                self._lifecycle_mux = LifecycleMultiplexer(
+                    heartbeat_interval=interval,
+                )
+            from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+                resolve_agent_token,
+            )
+            from hivemoot_agent.plugins_builtin.hivemoot.tasks.lifecycle import (
+                build_task_reporter,
+                is_task_job_for_lifecycle,
+            )
+            task_token_path = (
+                str(cfg.token_file) if cfg.token_file else ""
+            )
+            task_execute_base = cfg.tasks.execute_base_url
+            self._lifecycle_mux.register(
+                is_task_job_for_lifecycle,
+                lambda job, _base=task_execute_base,
+                _token=task_token_path: build_task_reporter(
+                    job,
+                    execute_base=_base,
+                    bearer_factory=lambda: resolve_agent_token(_token),
+                ),
+            )
+
         if cfg.health.enabled:
             from hivemoot_agent.plugins_builtin.hivemoot.health.trigger import (
                 HealthHeartbeatTrigger,
@@ -583,6 +630,23 @@ class HivemootPlugin:
                     file=sys.stderr, flush=True,
                 )
 
+            # Drive the lifecycle substrate (PR D). Codex sidecar
+            # setup ran above, so providers/codex.py will see
+            # CODEX_ANSWER_FILE before the agent subprocess starts.
+            # mux.on_job_start picks the task reporter via the
+            # matcher, posts the initial progress + spawns the
+            # heartbeat thread.
+            if self._lifecycle_mux is not None:
+                try:
+                    self._lifecycle_mux.on_job_start(job)
+                except Exception as exc:
+                    print(
+                        f"[hivemoot-tasks] lifecycle on_job_start raised "
+                        f"for {job.metadata.get('task_id')}: "
+                        f"{type(exc).__name__}: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
+
         # War-rooms early-/present + heartbeat thread (PR C). Wraps
         # independently from tasks/health — one feature failing must
         # not skip the others. The multiplexer may be None when
@@ -614,6 +678,20 @@ class HivemootPlugin:
         # catches up.  Both wrapped independently — one failing must
         # not skip the other.
         if cfg.tasks.enabled and _is_task_job(job):
+            # Stop the substrate's heartbeat thread BEFORE the
+            # terminal post, so a heartbeat can't race the
+            # post_complete/fail/timeout (PR D, mirrors the legacy
+            # in-line stop_event.set + join 5s).
+            if self._lifecycle_mux is not None:
+                try:
+                    self._lifecycle_mux.on_job_finish(job, result)
+                except Exception as exc:
+                    print(
+                        f"[hivemoot-tasks] lifecycle on_job_finish raised "
+                        f"for {job.metadata.get('task_id')}: "
+                        f"{type(exc).__name__}: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
             try:
                 self._task_on_job_finished(job, result, config)
             except Exception as exc:
@@ -924,11 +1002,6 @@ class HivemootPlugin:
     # ── Private: task subsystem ───────────────────────────────────
 
     def _task_on_job_started(self, job: Job, config: PluginConfig) -> None:
-        from hivemoot_agent.plugins_builtin.hivemoot.auth import (
-            resolve_agent_token,
-        )
-        from hivemoot_agent.plugins_builtin.hivemoot.tasks import api
-
         cfg = self._cfg
         task_id = str(job.metadata.get("task_id") or "")
         claim_token = str(job.metadata.get("claim_token") or "")
@@ -938,16 +1011,17 @@ class HivemootPlugin:
             self._codex_sidecar_path = ""
             return
 
-        bearer = resolve_agent_token(
-            str(cfg.token_file) if cfg and cfg.token_file else "",
-        )
-        interval = cfg.tasks.heartbeat_interval_secs if cfg else 45
-
         # Codex writes its final markdown to a sidecar when invoked
         # with --output-last-message; remember the path so finish can
         # pick it up, and export CODEX_ANSWER_FILE so providers/codex.py
         # wires the flag.  AGENT_PROVIDER is engine-level, not plugin
         # config — read from settings (env) rather than the typed schema.
+        #
+        # Initial progress post + heartbeat thread were here in
+        # the legacy code; PR D moved them to
+        # ``TaskLifecycleReporter.on_start`` and the substrate's
+        # multiplexer respectively. ``on_job_started`` calls
+        # ``mux.on_job_start(job)`` after this method returns.
         provider = config.get("AGENT_PROVIDER", "claude")
         if provider == "codex":
             workspace = str(cfg.tasks.workspace) if cfg else "/workspace"
@@ -962,39 +1036,6 @@ class HivemootPlugin:
             self._codex_sidecar_path = ""
             os.environ.pop("CODEX_ANSWER_FILE", None)
 
-        if not api.post_progress(
-            execute_base, task_id, bearer, claim_token,
-            f"Task {task_id} claimed. Starting execution.",
-        ):
-            print(
-                f"[hivemoot-tasks] failed to post initial progress for "
-                f"task {task_id}",
-                file=sys.stderr, flush=True,
-            )
-
-        # interval=0 disables heartbeats; skip thread startup entirely
-        # to avoid a tight Event.wait(0) busy loop.
-        if interval <= 0:
-            self._task_heartbeat_stop = None
-            self._task_heartbeat_thread = None
-            return
-
-        # Per-job stop event so an orphaned thread from a slow shutdown
-        # cannot post heartbeats for a stale task_id once the next job
-        # starts.  Pass the token *file*, not the resolved bearer, so
-        # the heartbeat loop re-resolves per tick — an operator
-        # rotating HIVEMOOT_AGENT_TOKEN{,_FILE} takes effect within
-        # one interval instead of waiting for process restart.
-        token_file = str(cfg.token_file) if cfg and cfg.token_file else ""
-        stop_event = threading.Event()
-        self._task_heartbeat_stop = stop_event
-        self._task_heartbeat_thread = threading.Thread(
-            target=self._task_heartbeat_loop,
-            args=(execute_base, task_id, token_file, claim_token, interval, stop_event),
-            daemon=True,
-        )
-        self._task_heartbeat_thread.start()
-
     def _task_on_job_finished(
         self, job: Job, result: AgentResult, config: PluginConfig,
     ) -> None:
@@ -1007,15 +1048,11 @@ class HivemootPlugin:
             result_extractor,
         )
 
-        # Stop the heartbeat first so it can't race with the final post.
-        stop_event = self._task_heartbeat_stop
-        thread = self._task_heartbeat_thread
-        self._task_heartbeat_stop = None
-        self._task_heartbeat_thread = None
-        if stop_event is not None:
-            stop_event.set()
-        if thread is not None:
-            thread.join(timeout=5)
+        # Heartbeat thread is stopped by the multiplexer's
+        # ``on_job_finish`` (called from ``on_job_finished`` BEFORE
+        # this method runs). The substrate's _stop_heartbeat
+        # already enforces the same 5s join + race-prevention
+        # invariant the legacy in-line code had.
 
         cfg = self._cfg
         task_id = str(job.metadata.get("task_id") or "")
@@ -1125,28 +1162,12 @@ class HivemootPlugin:
                 file=sys.stderr, flush=True,
             )
 
-    def _task_heartbeat_loop(
-        self, execute_base: str, task_id: str, token_file: str,
-        claim_token: str, interval: int, stop_event: threading.Event,
-    ) -> None:
-        from hivemoot_agent.plugins_builtin.hivemoot.auth import (
-            resolve_agent_token,
-        )
-        from hivemoot_agent.plugins_builtin.hivemoot.tasks import api
-
-        while not stop_event.wait(interval):
-            try:
-                # Re-resolve the bearer every tick so token rotation
-                # takes effect within one interval rather than
-                # waiting for process restart.
-                bearer = resolve_agent_token(token_file)
-                api.post_heartbeat(execute_base, task_id, bearer, claim_token)
-            except Exception as exc:
-                print(
-                    f"[hivemoot-tasks] heartbeat error for {task_id}: "
-                    f"{type(exc).__name__}",
-                    file=sys.stderr, flush=True,
-                )
+    # _task_heartbeat_loop was deleted in PR D — superseded by
+    # ``TaskLifecycleReporter.on_heartbeat`` driven by the
+    # substrate's ``LifecycleMultiplexer._heartbeat_loop``. Same
+    # body shape (re-resolve bearer per tick + post_heartbeat in
+    # try/except), but the substrate now owns the thread + interval
+    # + stop-event + 5s join.
 
     def _resolve_provider_log_path(self, config: PluginConfig) -> str:
         explicit = config.get("AGENT_LAST_RUN_LOG", "")

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/tasks/lifecycle.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/tasks/lifecycle.py
@@ -1,0 +1,211 @@
+"""Tasks domain reporter — the tasks plugin's adapter onto the
+engine-side ``JobLifecycleReporter`` substrate (PR B).
+
+Closes the JOB_LIFECYCLE_UNIFICATION RFC, **PR D**. The substrate
+was modeled directly on the existing tasks heartbeat thread, so
+this PR is mostly a port: extract the heartbeat-loop body + the
+initial-progress post into reporter hooks; delete the local
+``_task_heartbeat_loop`` / ``_task_heartbeat_stop`` /
+``_task_heartbeat_thread`` machinery from the parent plugin.
+
+# What's in scope here
+
+* ``on_start`` posts the initial "starting execution" progress
+  message — same one the legacy ``_task_on_job_started`` posted
+  before spawning its heartbeat thread.
+* ``on_heartbeat`` calls ``api.post_heartbeat`` (PR-A pre-existing
+  endpoint) — re-resolves the bearer per tick so token rotation
+  takes effect within one interval.
+* ``on_finish`` / ``on_failure`` are explicit no-ops. The legacy
+  ``_task_on_job_finished`` keeps owning ``post_complete`` /
+  ``post_fail`` / ``post_timeout`` because that path branches on
+  exit code, codex auth-error detection, sidecar resolution, and
+  the in-flight gate (release_task_slot) — non-trivial and
+  orthogonal to lifecycle wiring. A future PR can fold those in.
+
+# Bearer rotation
+
+The reporter captures a ``bearer_factory`` (a callable returning
+a fresh bearer per call), not a resolved bearer. This is the
+same convention the legacy heartbeat thread used:
+``resolve_agent_token(token_file)`` per tick so an operator
+rotating ``HIVEMOOT_AGENT_TOKEN`` takes effect within one
+``heartbeat_interval`` without process restart.
+
+# Failure model
+
+Every hook (on_start, on_heartbeat) wraps its post in
+try/except: a transient post-heartbeat failure logs to stderr
+and returns; the substrate's loop keeps firing. Same behaviour
+the legacy heartbeat thread had — one bad tick must not kill
+the thread.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable, Optional
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.job_lifecycle import (
+    JobLifecycleReporter,
+)
+
+from . import api as task_api
+
+__all__ = (
+    "TaskLifecycleReporter",
+    "build_task_reporter",
+    "is_task_job_for_lifecycle",
+)
+
+
+def is_task_job_for_lifecycle(job: Job) -> bool:
+    """Discriminator predicate for the multiplexer. Mirrors the
+    parent plugin's private ``_is_task_job`` exactly — a Job is
+    a task iff both ``task_id`` and ``claim_token`` are present.
+    Mutually exclusive with the war-rooms matcher (which requires
+    ``job_kind == "war_room_triage"`` AND ``room_id``)."""
+    return bool(job.metadata.get("task_id")) and bool(
+        job.metadata.get("claim_token")
+    )
+
+
+# A nullary callable returning a fresh bearer string. Re-resolved
+# every tick so token rotation takes effect within one heartbeat
+# interval. The caller (parent plugin) typically supplies
+# ``lambda: resolve_agent_token(token_file)``.
+BearerFactory = Callable[[], str]
+
+
+class TaskLifecycleReporter(JobLifecycleReporter):
+    """Per-job tasks reporter. Owns the initial-progress post and
+    heartbeat. Defers complete/fail/timeout posting to the legacy
+    ``_task_on_job_finished`` flow for now.
+
+    The reporter is constructed fresh per Job — the parent plugin's
+    ReporterFactory closes over its config (execute_base_url,
+    bearer_factory) and binds the per-job task_id + claim_token
+    here.
+    """
+
+    def __init__(
+        self,
+        job: Job,
+        *,
+        execute_base: str,
+        bearer_factory: BearerFactory,
+    ) -> None:
+        self._execute_base = execute_base
+        self._bearer_factory = bearer_factory
+        self._task_id = str(job.metadata.get("task_id") or "")
+        self._claim_token = str(job.metadata.get("claim_token") or "")
+
+    # ── JobLifecycleReporter contract ────────────────────────────
+
+    def on_start(self, job: Job) -> None:
+        """Post the initial "starting execution" progress message.
+
+        Mirrors the legacy ``_task_on_job_started`` step that ran
+        before the heartbeat thread spawned. ``api.post_progress``
+        returns a bool (False on transport failure); we log on
+        failure so the operator sees the issue, but don't raise —
+        the substrate then proceeds to spawn the heartbeat thread,
+        which will keep retrying via post_heartbeat.
+        """
+        del job  # task_id captured in __init__
+        if not self._task_id or not self._claim_token or not self._execute_base:
+            self._log(
+                "on_start skipped — incomplete job metadata "
+                f"(task_id='{self._task_id}', execute_base='{self._execute_base}')",
+                level="warn",
+            )
+            return
+        try:
+            ok = task_api.post_progress(
+                self._execute_base,
+                self._task_id,
+                self._bearer_factory(),
+                self._claim_token,
+                f"Task {self._task_id} claimed. Starting execution.",
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._log(
+                f"initial progress post raised "
+                f"task={self._task_id}: {type(exc).__name__}: {exc}",
+                level="warn",
+            )
+            return
+        if not ok:
+            self._log(
+                f"failed to post initial progress for task {self._task_id}",
+                level="warn",
+            )
+
+    def on_heartbeat(self, job: Job) -> None:
+        """Post a per-task heartbeat. Same shape as the legacy
+        ``_task_heartbeat_loop`` body — the substrate just owns the
+        thread + interval + stop-event now.
+        """
+        del job
+        if not self._task_id or not self._claim_token or not self._execute_base:
+            return
+        try:
+            task_api.post_heartbeat(
+                self._execute_base,
+                self._task_id,
+                self._bearer_factory(),
+                self._claim_token,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Same log shape as the legacy loop. Keep it terse —
+            # the substrate's loop already logs at the [lifecycle]
+            # prefix; we add task-domain context.
+            self._log(
+                f"heartbeat error for {self._task_id}: "
+                f"{type(exc).__name__}",
+                level="warn",
+            )
+
+    def on_finish(self, job: Job, result: AgentResult) -> None:
+        """No-op — legacy ``_task_on_job_finished`` owns
+        post_complete / post_fail / post_timeout dispatch (branches
+        on exit_code, codex auth-error detection, etc.). PR-follow-up
+        can fold those in."""
+        del job, result
+
+    def on_failure(self, job: Job, error_text: str) -> None:
+        """No-op — legacy ``_task_best_effort_fail`` already handles
+        engine-side failures with its own log + post_fail attempt.
+        Wiring the multiplexer in does not change that path."""
+        del job, error_text
+
+    # ── Helpers ──────────────────────────────────────────────────
+
+    def _log(self, message: str, *, level: str) -> None:
+        """Match the legacy ``[hivemoot-tasks]`` prefix so operator
+        greps continue to work after the migration."""
+        prefix = "[hivemoot-tasks]"
+        if level == "error":
+            print(f"{prefix} ERROR {message}", file=sys.stderr, flush=True)
+        elif level == "warn":
+            print(f"{prefix} WARN {message}", file=sys.stderr, flush=True)
+        else:
+            print(f"{prefix} {message}", file=sys.stderr, flush=True)
+
+
+def build_task_reporter(
+    job: Job,
+    *,
+    execute_base: str,
+    bearer_factory: BearerFactory,
+) -> TaskLifecycleReporter:
+    """ReporterFactory shape — bound to per-engine context
+    (execute_base + bearer_factory) at registration time, takes the
+    per-job ``Job`` at dispatch time. Parent plugin closes over its
+    config when registering with the multiplexer."""
+    return TaskLifecycleReporter(
+        job,
+        execute_base=execute_base,
+        bearer_factory=bearer_factory,
+    )

--- a/agent/cli/tests/test_hivemoot_plugin.py
+++ b/agent/cli/tests/test_hivemoot_plugin.py
@@ -434,6 +434,11 @@ class TaskLifecycleTests(unittest.TestCase):
     def _primed_plugin(self) -> HivemootPlugin:
         plugin = HivemootPlugin()
         plugin._cfg = self.config.typed
+        # PR D: heartbeat thread + initial progress post are now
+        # owned by the lifecycle substrate registered in triggers().
+        # Initialize it so on_job_started has a multiplexer to
+        # dispatch through.
+        plugin.triggers()
         return plugin
 
     def test_on_job_started_posts_progress_and_starts_heartbeat(self) -> None:
@@ -442,9 +447,13 @@ class TaskLifecycleTests(unittest.TestCase):
                 patch.object(task_api, "post_heartbeat") as heartbeat_mock:
             plugin.on_job_started(self._job(), self.config)
             time.sleep(1.5)
-            plugin._task_heartbeat_stop.set()
-            if plugin._task_heartbeat_thread:
-                plugin._task_heartbeat_thread.join(timeout=2)
+            # Stop the substrate's heartbeat thread by signalling
+            # on_job_finish with a placeholder result; the test
+            # would normally let on_job_finished call this.
+            plugin._lifecycle_mux.on_job_finish(
+                self._job(),
+                AgentResult(exit_code=0, response=""),
+            )
 
         progress_mock.assert_called_once()
         args, _kw = progress_mock.call_args
@@ -452,7 +461,6 @@ class TaskLifecycleTests(unittest.TestCase):
         self.assertGreaterEqual(heartbeat_mock.call_count, 1)
 
     def test_on_job_started_noop_without_execute_base(self) -> None:
-        plugin = self._primed_plugin()
         bare = _mk_plugin_config(
             tasks=HivemootTasksConfig(
                 enabled=True,
@@ -461,11 +469,27 @@ class TaskLifecycleTests(unittest.TestCase):
             ),
             settings={"AGENT_PROVIDER": "claude"},
         )
+        plugin = HivemootPlugin()
         plugin._cfg = bare.typed
-        with patch.object(task_api, "post_progress") as progress_mock:
+        plugin.triggers()  # wire substrate
+        with patch.object(task_api, "post_progress") as progress_mock, \
+                patch.object(task_api, "post_heartbeat") as heartbeat_mock:
             plugin.on_job_started(self._job(), bare)
+            # The substrate's heartbeat thread may have spawned (it
+            # only inspects interval, not metadata), but the
+            # reporter's on_start guards on empty execute_base and
+            # returns without posting progress.
+            time.sleep(0.2)
+            if plugin._lifecycle_mux is not None:
+                plugin._lifecycle_mux.on_job_finish(
+                    self._job(),
+                    AgentResult(exit_code=0, response=""),
+                )
         progress_mock.assert_not_called()
-        self.assertIsNone(plugin._task_heartbeat_thread)
+        # post_heartbeat was guarded by the same empty-metadata
+        # check inside the reporter, so no actual heartbeat fired
+        # despite the thread existing.
+        heartbeat_mock.assert_not_called()
 
     def test_on_job_finished_posts_complete(self) -> None:
         plugin = self._primed_plugin()
@@ -557,11 +581,15 @@ class TaskLifecycleTests(unittest.TestCase):
         )
         plugin = HivemootPlugin()
         plugin._cfg = zero_config.typed
+        plugin.triggers()  # wire the substrate (with interval=0)
         with patch.object(task_api, "post_progress", return_value=True), \
                 patch.object(task_api, "post_heartbeat") as hb:
             plugin.on_job_started(self._job(), zero_config)
-        self.assertIsNone(plugin._task_heartbeat_thread)
-        self.assertIsNone(plugin._task_heartbeat_stop)
+            # interval=0 in the substrate's _spawn_heartbeat skips
+            # thread startup entirely. Pin the same opt-out
+            # semantics the legacy code had.
+            self.assertIsNone(plugin._lifecycle_mux._thread)
+            self.assertIsNone(plugin._lifecycle_mux._stop_event)
         time.sleep(0.2)
         hb.assert_not_called()
 
@@ -584,6 +612,12 @@ class TaskLifecycleTests(unittest.TestCase):
         self.assertIn("FAILED to post complete", stderr.getvalue())
 
     def test_orphan_heartbeat_does_not_revive_into_next_job(self) -> None:
+        # Per-job stop_event isolation invariant — a slow shutdown
+        # of job A's heartbeat thread cannot bleed into job B.
+        # Substrate guarantees this via fresh threading.Event per
+        # _spawn_heartbeat (pinned by the substrate's own
+        # test_per_job_stop_event_isolation); this test exercises
+        # the contract through the plugin's full lifecycle.
         plugin = self._primed_plugin()
 
         def _job(tid: str) -> Job:
@@ -598,7 +632,7 @@ class TaskLifecycleTests(unittest.TestCase):
         with patch.object(task_api, "post_progress", return_value=True), \
                 patch.object(task_api, "post_heartbeat", return_value=True):
             plugin.on_job_started(_job("task-A"), self.config)
-            stop_a = plugin._task_heartbeat_stop
+            stop_a = plugin._lifecycle_mux._stop_event
             self.assertIsNotNone(stop_a)
 
         log_dir = os.path.join(self.workspace, "runs", "current")
@@ -612,20 +646,27 @@ class TaskLifecycleTests(unittest.TestCase):
                 AgentResult(exit_code=0, response=""),
                 self.config,
             )
-        self.assertIsNone(plugin._task_heartbeat_stop)
-        self.assertIsNone(plugin._task_heartbeat_thread)
+        # After on_job_finished, the substrate clears its per-job
+        # state — both _stop_event and _thread back to None.
+        self.assertIsNone(plugin._lifecycle_mux._stop_event)
+        self.assertIsNone(plugin._lifecycle_mux._thread)
 
         with patch.object(task_api, "post_progress", return_value=True), \
                 patch.object(task_api, "post_heartbeat", return_value=True):
             plugin.on_job_started(_job("task-B"), self.config)
-            stop_b = plugin._task_heartbeat_stop
+            stop_b = plugin._lifecycle_mux._stop_event
         self.assertIsNotNone(stop_b)
+        # Fresh event per job — and the previous job's event was
+        # signalled on its on_job_finish (so any orphan thread sees
+        # the stop signal).
         self.assertIsNot(stop_a, stop_b)
         self.assertTrue(stop_a.is_set())
 
-        plugin._task_heartbeat_stop.set()
-        if plugin._task_heartbeat_thread:
-            plugin._task_heartbeat_thread.join(timeout=2)
+        # Tear down job B's thread to avoid leaking.
+        plugin._lifecycle_mux.on_job_finish(
+            _job("task-B"),
+            AgentResult(exit_code=0, response=""),
+        )
 
 
 # ── Health-subsystem lifecycle ────────────────────────────────────

--- a/agent/cli/tests/test_hivemoot_tasks_lifecycle.py
+++ b/agent/cli/tests/test_hivemoot_tasks_lifecycle.py
@@ -1,0 +1,302 @@
+"""Tests for the tasks TaskLifecycleReporter (PR D of the
+JOB_LIFECYCLE_UNIFICATION RFC).
+
+Exercises the per-job hooks against mocks of the existing
+``tasks.api`` helpers so the wire shapes don't need a server.
+
+The substrate already has tests covering the multiplexer's
+threading invariants (per-job stop_event, 5s join, bearer
+re-resolution per tick); these tests focus on the **task-domain
+contract**:
+
+* on_start — posts initial progress with the correct task_id +
+  message; tolerates post_progress returning False; tolerates
+  unexpected exceptions.
+* on_heartbeat — calls post_heartbeat with task_id + claim_token;
+  re-resolves the bearer per tick; transient exception is logged
+  and swallowed (loop must not die).
+* on_finish / on_failure — explicit no-ops; the legacy
+  ``_task_on_job_finished`` keeps owning post_complete /
+  post_fail / post_timeout.
+* Matcher disjointness — task matcher returns True only for
+  jobs with both ``task_id`` AND ``claim_token``; rejects
+  war-room jobs and partial-marker jobs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.tasks import api as task_api
+from hivemoot_agent.plugins_builtin.hivemoot.tasks.lifecycle import (
+    TaskLifecycleReporter,
+    build_task_reporter,
+    is_task_job_for_lifecycle,
+)
+
+
+def _job(**metadata: Any) -> Job:
+    md: dict[str, Any] = {
+        "task_id": "task-42",
+        "claim_token": "ct-abc",
+    }
+    md.update(metadata)
+    return Job(session_key="task-42", prompt="p", metadata=md)
+
+
+class _FakeBearerFactory:
+    """Counts calls to assert per-tick re-resolution."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> str:
+        self.calls += 1
+        return f"hmt_call_{self.calls}"
+
+
+# ── on_start ────────────────────────────────────────────────────────
+
+
+class TaskLifecycleReporterStartTests(unittest.TestCase):
+
+    def test_on_start_posts_initial_progress(self):
+        bearer = _FakeBearerFactory()
+        with patch.object(
+            task_api, "post_progress", return_value=True,
+        ) as m:
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="https://www.hivemoot.dev/api/tasks",
+                bearer_factory=bearer,
+            )
+            r.on_start(_job())
+        m.assert_called_once_with(
+            "https://www.hivemoot.dev/api/tasks",
+            "task-42",
+            "hmt_call_1",
+            "ct-abc",
+            "Task task-42 claimed. Starting execution.",
+        )
+
+    def test_on_start_skips_with_empty_metadata(self):
+        # Defensive: a Job with empty task_id should not produce
+        # an HTTP call. Same guard the legacy code had.
+        bad_job = Job(session_key="x", prompt="p", metadata={})
+        with patch.object(task_api, "post_progress") as m:
+            r = TaskLifecycleReporter(
+                bad_job,
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_start(bad_job)
+        m.assert_not_called()
+
+    def test_on_start_logs_when_post_progress_returns_false(self):
+        # post_progress returns bool — False means transport
+        # failure. Reporter logs but doesn't raise (heartbeat
+        # thread will retry).
+        with patch.object(
+            task_api, "post_progress", return_value=False,
+        ) as m:
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_start(_job())
+        m.assert_called_once()  # called; failure swallowed
+
+    def test_on_start_swallows_exception(self):
+        # A network error in the initial post must not propagate;
+        # the substrate proceeds to spawn the heartbeat thread.
+        with patch.object(
+            task_api, "post_progress",
+            side_effect=RuntimeError("network blip"),
+        ):
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_start(_job())  # must not raise
+
+
+# ── on_heartbeat ────────────────────────────────────────────────────
+
+
+class TaskLifecycleReporterHeartbeatTests(unittest.TestCase):
+
+    def test_on_heartbeat_posts_with_task_id(self):
+        with patch.object(
+            task_api, "post_heartbeat", return_value=True,
+        ) as m:
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="https://www.hivemoot.dev/api/tasks",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_heartbeat(_job())
+        m.assert_called_once_with(
+            "https://www.hivemoot.dev/api/tasks",
+            "task-42",
+            "hmt_call_1",
+            "ct-abc",
+        )
+
+    def test_on_heartbeat_re_resolves_bearer_per_tick(self):
+        # Token rotation invariant — every tick gets a fresh
+        # bearer. Three calls → three bearer_factory invocations.
+        bearer = _FakeBearerFactory()
+        with patch.object(
+            task_api, "post_heartbeat", return_value=True,
+        ):
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="x",
+                bearer_factory=bearer,
+            )
+            r.on_heartbeat(_job())
+            r.on_heartbeat(_job())
+            r.on_heartbeat(_job())
+        self.assertEqual(bearer.calls, 3)
+
+    def test_on_heartbeat_swallows_exception(self):
+        # A transient error in post_heartbeat must not propagate
+        # — the substrate's loop catches whatever escapes anyway,
+        # but the reporter's own try/except gives task-domain
+        # context in the log line.
+        with patch.object(
+            task_api, "post_heartbeat",
+            side_effect=RuntimeError("transient 503"),
+        ):
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_heartbeat(_job())  # must not raise
+
+    def test_on_heartbeat_skips_with_empty_metadata(self):
+        bad_job = Job(session_key="x", prompt="p", metadata={})
+        with patch.object(task_api, "post_heartbeat") as m:
+            r = TaskLifecycleReporter(
+                bad_job,
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_heartbeat(bad_job)
+        m.assert_not_called()
+
+
+# ── on_finish / on_failure (explicit no-op contract) ──────────────
+
+
+class TaskLifecycleReporterFinishTests(unittest.TestCase):
+
+    def test_on_finish_is_noop(self):
+        # The legacy _task_on_job_finished still owns post_complete
+        # / post_fail / post_timeout. Reporter explicitly delegates;
+        # if this changes, the contract update should be deliberate.
+        with (
+            patch.object(task_api, "post_complete") as mc,
+            patch.object(task_api, "post_fail") as mf,
+            patch.object(task_api, "post_timeout") as mt,
+        ):
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_finish(_job(), AgentResult(exit_code=0, response="x"))
+        mc.assert_not_called()
+        mf.assert_not_called()
+        mt.assert_not_called()
+
+    def test_on_failure_is_noop(self):
+        with patch.object(task_api, "post_fail") as m:
+            r = TaskLifecycleReporter(
+                _job(),
+                execute_base="x",
+                bearer_factory=_FakeBearerFactory(),
+            )
+            r.on_failure(_job(), "agent crashed")
+        m.assert_not_called()
+
+
+# ── Matcher disjointness (Q6 invariant) ───────────────────────────
+
+
+class TaskMatcherDisjointnessTests(unittest.TestCase):
+
+    def test_matches_well_formed_task_job(self):
+        self.assertTrue(is_task_job_for_lifecycle(_job()))
+
+    def test_does_not_match_war_room_job(self):
+        # A war-room job has room_id + job_kind but no task_id.
+        # Mutual exclusion holds.
+        wr_job = Job(
+            session_key="war-room",
+            prompt="p",
+            metadata={
+                "job_kind": "war_room_triage",
+                "room_id": "room-A",
+                "current_sequence": 5,
+            },
+        )
+        self.assertFalse(is_task_job_for_lifecycle(wr_job))
+
+    def test_does_not_match_partial_metadata(self):
+        # task_id without claim_token is partial — matcher rejects
+        # to avoid false-positive dispatch (mirrors the legacy
+        # _is_task_job's strict check).
+        partial = Job(
+            session_key="x",
+            prompt="p",
+            metadata={"task_id": "t-1"},
+        )
+        self.assertFalse(is_task_job_for_lifecycle(partial))
+
+        partial2 = Job(
+            session_key="x",
+            prompt="p",
+            metadata={"claim_token": "ct-1"},
+        )
+        self.assertFalse(is_task_job_for_lifecycle(partial2))
+
+    def test_does_not_match_health_job(self):
+        # Health jobs have no shared markers with tasks.
+        health_job = Job(session_key="h", prompt="p", metadata={})
+        self.assertFalse(is_task_job_for_lifecycle(health_job))
+
+
+# ── Factory smoke ──────────────────────────────────────────────────
+
+
+class FactorySmokeTests(unittest.TestCase):
+
+    def test_build_task_reporter_returns_configured_instance(self):
+        bearer = _FakeBearerFactory()
+        r = build_task_reporter(
+            _job(),
+            execute_base="https://staging.hivemoot.dev/api/tasks",
+            bearer_factory=bearer,
+        )
+        self.assertIsInstance(r, TaskLifecycleReporter)
+        self.assertEqual(
+            r._execute_base,
+            "https://staging.hivemoot.dev/api/tasks",
+        )
+        self.assertEqual(r._task_id, "task-42")
+        self.assertEqual(r._claim_token, "ct-abc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes JOB_LIFECYCLE_UNIFICATION RFC, **PR D**. Tasks now share the engine-side lifecycle substrate with war rooms (PR C). The substrate was modeled directly on the legacy tasks heartbeat loop, so this is mostly a port: extract the heartbeat-loop body + the initial-progress post into reporter hooks; delete the local \`_task_heartbeat_*\` machinery from the parent plugin.

## What it looks like

**Before — duplicated lifecycle wiring across two domains:**

\`\`\`
plugins_builtin/hivemoot/__init__.py:
  _task_heartbeat_stop (per-instance)
  _task_heartbeat_thread (per-instance)
  _task_on_job_started: post initial progress, spawn heartbeat thread
  _task_on_job_finished: stop heartbeat (set + join 5s), post terminal
  _task_heartbeat_loop: while not stop.wait(interval): post_heartbeat

war_rooms/handler.py: no heartbeat at all (the bug PR C fixes)
\`\`\`

**After — single substrate driving both domains:**

\`\`\`
LifecycleMultiplexer:
  - per-job stop_event (mutex-asserted across registered matchers)
  - 5s join on stop_heartbeat
  - mutex assertion in dev_mode catches matcher overlap

TaskLifecycleReporter:
  on_start: post_progress("starting execution")
  on_heartbeat: post_heartbeat (re-resolve bearer per tick)
  on_finish/on_failure: no-op (legacy _task_on_job_finished owns terminal post)

RoomLifecycleReporter (PR C):
  on_start: present_to_room (early RSVP)
  on_heartbeat: heartbeat_room_participant
  on_finish/on_failure: no-op (legacy handler.py owns /contribute / /withdraw)
\`\`\`

## Lifecycle ordering

\`on_job_started\`:
1. \`_task_on_job_started\` — codex sidecar setup (must run BEFORE agent subprocess so \`providers/codex.py\` sees \`CODEX_ANSWER_FILE\`).
2. \`mux.on_job_start(job)\` — picks the task reporter via the matcher, fires \`reporter.on_start\` (initial progress post), spawns the heartbeat thread.

\`on_job_finished\`:
1. \`mux.on_job_finish(job, result)\` — stops heartbeat (5s join — same as legacy).
2. \`_task_on_job_finished\` — branches on exit_code, posts complete/fail/timeout.
3. \`release_task_slot()\` — unchanged.

The ordering invariant from the legacy code (heartbeat must stop before the terminal post) is preserved by the substrate.

## What's deleted

| Symbol | Replaced by |
|---|---|
| \`_task_heartbeat_stop\` (instance state) | \`LifecycleMultiplexer._stop_event\` |
| \`_task_heartbeat_thread\` (instance state) | \`LifecycleMultiplexer._thread\` |
| \`_task_heartbeat_loop\` (method) | \`LifecycleMultiplexer._heartbeat_loop\` + \`TaskLifecycleReporter.on_heartbeat\` |
| In-line spawn block in \`_task_on_job_started\` | \`mux.on_job_start\` call |
| In-line stop block in \`_task_on_job_finished\` | \`mux.on_job_finish\` call |

## Bearer rotation

Same convention as the legacy loop and the war-rooms reporter (PR C): \`bearer_factory\` is a callable returning a fresh bearer per call, re-resolved every heartbeat tick so an operator rotating \`HIVEMOOT_AGENT_TOKEN\` takes effect within one interval without process restart. Tested by call-count assertion on a fake factory.

## Composes with PR C

Both PRs touch \`__init__.py\`'s \`triggers()\` (registering domain reporters) and the lifecycle hooks. PR D uses a defensive \`if self._lifecycle_mux is None\` guard at multiplexer creation so it composes with PR C's war-rooms registration without conflict — whichever lands first creates the multiplexer; the other branch attaches its reporter.

## Test plan

- [x] **15 new tests** in \`agent/cli/tests/test_hivemoot_tasks_lifecycle.py\` covering on_start (4), on_heartbeat (4), on_finish/on_failure no-op contract (2), matcher disjointness (4), factory smoke (1).
- [x] Updated 4 existing \`test_hivemoot_plugin.py\` tests to reference the new substrate internals (\`_lifecycle_mux._stop_event\` / \`_thread\`) instead of the removed legacy fields.
- [x] Full agent suite: **631 tests pass** (was 616 on main; +15 new + 4 updated). Bearer re-resolved per-tick verified by call-count assertion.

## Stack

| PR | Status |
|---|---|
| ✅ A — server endpoint | merged |
| ✅ B — engine substrate | merged |
| 🔄 C — war-rooms migration | open #615 (REQUEST_CHANGES from queen — addressing) |
| 🟢 **D (this PR)** | tasks migration |
| ⏳ E | dashboard heartbeat indicator |