### PR TITLE
feat(dashboard): heartbeat freshness indicator on room detail

### DIFF
--- a/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
+++ b/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
@@ -3,6 +3,9 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import {
+  heartbeatFreshnessDotClass,
+  heartbeatFreshnessTitle,
+  participantHeartbeatFreshness,
   participantStatusCounts,
   relativeTime,
   statusLabel,
@@ -232,22 +235,38 @@ function ParticipantsTable({
           <th className="py-1 pr-4">Role</th>
           <th className="py-1 pr-4">Agent</th>
           <th className="py-1 pr-4">Status</th>
-          <th className="py-1">RSVP&apos;d</th>
+          {/* Renamed from "RSVP'd" — heartbeats now bump rsvp_at every
+              ~45s for pending participants (PRs A + C of the
+              JOB_LIFECYCLE_UNIFICATION RFC), so the column reflects
+              ongoing liveness, not just the initial RSVP. */}
+          <th className="py-1">Heartbeat</th>
         </tr>
       </thead>
       <tbody className="divide-y divide-white/5">
-        {rows.map(([role, p]) => (
-          <tr key={role}>
-            <td className="py-1.5 pr-4 font-medium text-zinc-200">{role}</td>
-            <td className="py-1.5 pr-4 font-mono text-xs text-zinc-400">
-              {p.agent_id}
-            </td>
-            <td className="py-1.5 pr-4 text-zinc-300">{p.status}</td>
-            <td className="py-1.5 text-xs text-zinc-500">
-              {relativeTime(p.rsvp_at)}
-            </td>
-          </tr>
-        ))}
+        {rows.map(([role, p]) => {
+          const freshness = participantHeartbeatFreshness(p);
+          return (
+            <tr key={role}>
+              <td className="py-1.5 pr-4 font-medium text-zinc-200">{role}</td>
+              <td className="py-1.5 pr-4 font-mono text-xs text-zinc-400">
+                {p.agent_id}
+              </td>
+              <td className="py-1.5 pr-4 text-zinc-300">{p.status}</td>
+              <td className="py-1.5 text-xs text-zinc-500">
+                <span
+                  className="inline-flex items-center gap-1.5"
+                  title={heartbeatFreshnessTitle(freshness)}
+                >
+                  <span
+                    aria-label={`heartbeat ${freshness}`}
+                    className={`inline-block h-2 w-2 rounded-full ${heartbeatFreshnessDotClass(freshness)}`}
+                  />
+                  {relativeTime(p.rsvp_at)}
+                </span>
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/web/src/app/dashboard/rooms/room-helpers.test.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.test.ts
@@ -3,8 +3,11 @@ import {
   ACTIVE_STATUSES,
   countRoomsByFilter,
   hasDiffDriftedPostVerdict,
+  heartbeatFreshnessDotClass,
+  heartbeatFreshnessTitle,
   isActiveStatus,
   isRoomStuck,
+  participantHeartbeatFreshness,
   participantStatusCounts,
   relativeTime,
   relevantDeadlineSecs,
@@ -587,4 +590,124 @@ describe("hasDiffDriftedPostVerdict", () => {
       ).toBe(false);
     },
   );
+});
+
+// ── participantHeartbeatFreshness (PR E of the
+//    JOB_LIFECYCLE_UNIFICATION RFC) ──────────────────────────────────
+
+describe("participantHeartbeatFreshness", () => {
+  // Anchor: pretend it's exactly noon UTC so the boundary tests
+  // produce stable, readable timestamps. The function is pure on
+  // (rsvp_at, status, nowMs) so tests don't need time mocking.
+  const NOW = Date.parse("2026-05-06T12:00:00.000Z");
+
+  function rsvpAt(secondsAgo: number): string {
+    return new Date(NOW - secondsAgo * 1000).toISOString();
+  }
+
+  it("returns inactive for any non-pending status", () => {
+    // Resolved / withdrew / timed_out: heartbeats no longer fire
+    // and rsvp_at is frozen — no liveness signal to derive.
+    for (const status of ["resolved", "withdrew", "timed_out"]) {
+      expect(
+        participantHeartbeatFreshness(
+          { status, rsvp_at: rsvpAt(1) },
+          NOW,
+        ),
+      ).toBe("inactive");
+    }
+  });
+
+  it("returns fresh for pending participant within 90s", () => {
+    // 45s is the default heartbeat interval; just-bumped is fresh.
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: rsvpAt(10) },
+        NOW,
+      ),
+    ).toBe("fresh");
+    // Right under the 90s threshold.
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: rsvpAt(89) },
+        NOW,
+      ),
+    ).toBe("fresh");
+  });
+
+  it("returns stale at the 90s boundary", () => {
+    // 90s is "missed at most one heartbeat" — flips to stale.
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: rsvpAt(90) },
+        NOW,
+      ),
+    ).toBe("stale");
+    // Right under the 5min dead threshold.
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: rsvpAt(299) },
+        NOW,
+      ),
+    ).toBe("stale");
+  });
+
+  it("returns dead at and beyond the 5min boundary", () => {
+    // 5min: several missed heartbeats. The watchdog times out
+    // around this window too; the dot turning red is meant to
+    // pre-warn an operator before the slot itself goes terminal.
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: rsvpAt(300) },
+        NOW,
+      ),
+    ).toBe("dead");
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: rsvpAt(3600) },
+        NOW,
+      ),
+    ).toBe("dead");
+  });
+
+  it("returns dead for unparseable rsvp_at on a pending participant", () => {
+    // Defensive: malformed timestamps shouldn't render as
+    // "fresh" by accident. Surface as dead so an operator
+    // notices the data corruption.
+    expect(
+      participantHeartbeatFreshness(
+        { status: "pending", rsvp_at: "not-a-date" },
+        NOW,
+      ),
+    ).toBe("dead");
+  });
+});
+
+describe("heartbeatFreshnessDotClass", () => {
+  it("returns a distinct Tailwind color class per freshness level", () => {
+    // The dot is the at-a-glance liveness signal — the four levels
+    // must map to four visually distinct colors. Exact classes
+    // pinned so a Tailwind upgrade or a typo can't silently fall
+    // through to a default.
+    expect(heartbeatFreshnessDotClass("fresh")).toBe("bg-emerald-400");
+    expect(heartbeatFreshnessDotClass("stale")).toBe("bg-amber-400");
+    expect(heartbeatFreshnessDotClass("dead")).toBe("bg-rose-500");
+    expect(heartbeatFreshnessDotClass("inactive")).toBe("bg-zinc-600");
+  });
+});
+
+describe("heartbeatFreshnessTitle", () => {
+  it("returns a non-empty actionable description for each level", () => {
+    // The title attribute is the operator's tooltip. Empty
+    // strings would render no tooltip at all — pin that every
+    // level has user-facing text.
+    for (const level of ["fresh", "stale", "dead", "inactive"] as const) {
+      const title = heartbeatFreshnessTitle(level);
+      expect(title.length).toBeGreaterThan(10);
+      // Sanity: each tooltip references the underlying mechanism
+      // ("heartbeat" or non-pending status) so the operator
+      // understands WHY the dot is that color.
+      expect(title.toLowerCase()).toMatch(/heartbeat|pending/);
+    }
+  });
 });

--- a/web/src/app/dashboard/rooms/room-helpers.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.ts
@@ -295,6 +295,91 @@ export function sortRoomsByStuckness<
 }
 
 /**
+ * Liveness classification for a participant's last-seen timestamp,
+ * driven by the heartbeat endpoint that bumps ``rsvp_at`` every
+ * ``heartbeat_interval`` seconds (PRs A + C of the
+ * JOB_LIFECYCLE_UNIFICATION RFC).
+ *
+ * * ``fresh`` — pending participant with rsvp_at within ~2 heartbeat
+ *   intervals (90s). Agent is actively heartbeating.
+ * * ``stale`` — pending participant with rsvp_at 90s–5min old.
+ *   Possibly slow agent; one or two missed heartbeats.
+ * * ``dead`` — pending participant with rsvp_at >5min old. Several
+ *   missed heartbeats; agent is likely stalled. The watchdog will
+ *   typically time the slot out around the same threshold.
+ * * ``inactive`` — non-pending statuses (resolved / withdrew /
+ *   timed_out). Heartbeats no longer fire; rsvp_at is frozen at
+ *   the last update. No freshness signal needed.
+ */
+export type ParticipantHeartbeatFreshness =
+  | "fresh"
+  | "stale"
+  | "dead"
+  | "inactive";
+
+const FRESH_THRESHOLD_MS = 90 * 1000;     // 2× the 45s default interval
+const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5min — beyond this, agent is gone
+
+/**
+ * Classify a participant's heartbeat liveness. Pure function so the
+ * test suite can pin the boundaries without time mocking. Default
+ * ``nowMs`` mirrors ``relativeTime`` for ergonomics.
+ */
+export function participantHeartbeatFreshness(
+  participant: { rsvp_at: string; status: string },
+  nowMs: number = Date.now(),
+): ParticipantHeartbeatFreshness {
+  if (participant.status !== "pending") return "inactive";
+  const t = Date.parse(participant.rsvp_at);
+  if (!Number.isFinite(t)) return "dead";
+  const ageMs = nowMs - t;
+  if (ageMs < FRESH_THRESHOLD_MS) return "fresh";
+  if (ageMs < STALE_THRESHOLD_MS) return "stale";
+  return "dead";
+}
+
+/**
+ * Tailwind classes for the heartbeat-freshness indicator dot.
+ * Centralized so the room detail view + any future surfacings (the
+ * rooms list, etc.) render consistent colors.
+ */
+export function heartbeatFreshnessDotClass(
+  freshness: ParticipantHeartbeatFreshness,
+): string {
+  switch (freshness) {
+    case "fresh":
+      return "bg-emerald-400";
+    case "stale":
+      return "bg-amber-400";
+    case "dead":
+      return "bg-rose-500";
+    case "inactive":
+      return "bg-zinc-600";
+  }
+}
+
+/**
+ * Human-readable tooltip text for a freshness classification.
+ * Surfaces the rationale ("agent is actively heartbeating", etc.)
+ * so operators understand what the colored dot means without
+ * leaving the page.
+ */
+export function heartbeatFreshnessTitle(
+  freshness: ParticipantHeartbeatFreshness,
+): string {
+  switch (freshness) {
+    case "fresh":
+      return "Agent is actively heartbeating (≤90s since last ping)";
+    case "stale":
+      return "Agent's last heartbeat was 90s–5min ago — possibly slow";
+    case "dead":
+      return "No heartbeat in >5min — agent is likely stalled";
+    case "inactive":
+      return "Participant is not pending — heartbeats no longer fire";
+  }
+}
+
+/**
  * Format an ISO 8601 timestamp as a human-readable relative time
  * ("3m ago", "2h ago"). Returns absolute date for >7d ago.
  */


### PR DESCRIPTION
## Summary

Closes JOB_LIFECYCLE_UNIFICATION RFC, **PR E** — the UX motivation behind the whole stack. Operators can now see at a glance which participants are actively heartbeating vs stalling on the room detail page.

This PR depends on PRs A (server endpoint) and C (war-rooms reporter) being deployed — both are merged to main and live in production.

## What it looks like

**Before** — the participants table:

\`\`\`
Role       Agent        Status     RSVP'd
guard      hive-guard   pending    2m ago
drone      hive-drone   pending    5m ago
\`\`\`

The "RSVP'd" label was misleading after the heartbeat work — \`rsvp_at\` is now bumped every ~45s for pending participants, so the column reflects ongoing liveness, not just initial RSVP.

**After** — column renamed and freshness-coded:

\`\`\`
Role       Agent        Status     Heartbeat
guard      hive-guard   pending    🟢 30s ago    (fresh)
drone      hive-drone   pending    🟡 2m ago     (stale)
heater     hive-heater  pending    🔴 8m ago     (dead — likely stalled)
worker     hive-worker  resolved   ⚫ 12m ago    (inactive — finished)
\`\`\`

(In the actual UI, the icons are colored \`<span>\` dots, not emoji. Hovering shows a tooltip explaining the threshold.)

## Freshness classification

| State | Trigger | Tooltip |
|---|---|---|
| **fresh** (emerald) | pending + rsvp_at < 90s ago | "Agent is actively heartbeating (≤90s since last ping)" |
| **stale** (amber) | pending + rsvp_at 90s–5min ago | "Agent's last heartbeat was 90s–5min ago — possibly slow" |
| **dead** (rose) | pending + rsvp_at > 5min ago | "No heartbeat in >5min — agent is likely stalled" |
| **inactive** (zinc) | non-pending status | "Participant is not pending — heartbeats no longer fire" |

The 90s threshold is 2× the default 45s heartbeat interval (one missed tick is normal jitter; two missed = real). The 5min threshold roughly matches the watchdog's drop_threshold_secs — the dot turns red just before the slot itself goes terminal, so operators get a pre-warning rather than discovering the timeout after the fact.

## Why this matters

Pre-stack, an operator looking at a war room couldn't tell the difference between:
* an agent actively reviewing a 1000-line PR (alive — wait longer)
* an agent that crashed mid-review (dead — re-dispatch)

Both showed "RSVP'd 8m ago" identically. Post-stack, the heartbeat dot makes it obvious. The 6KB+ reviews drone keeps wasting on race-out rooms (visible in fleet logs throughout PRs #613–#616) won't happen anymore — but when an agent does stall for unrelated reasons, the dashboard surfaces it immediately instead of waiting for the timeout.

## Test plan

- [x] **7 new tests** in \`room-helpers.test.ts\` covering boundary classifications (10s / 89s / 90s / 299s / 300s / 3600s), non-pending → inactive across all three statuses, defensive handling of unparseable \`rsvp_at\`, all 4 color classes, and tooltip text presence.
- [x] Full web suite: **1466 tests pass** (was 1459; +7 new).
- [x] \`tsc --noEmit\` clean.
- [x] Tooltip uses standard \`title\` attribute; \`aria-label\` on the dot for screen readers.

## Stack

| PR | Status |
|---|---|
| ✅ A — server endpoint | merged + deployed |
| ✅ B — engine substrate | merged |
| ✅ C — war-rooms migration | merged + deployed |
| ✅ D — tasks migration | merged |
| 🟢 **E (this PR)** | dashboard heartbeat indicator |