### PR TITLE
fix(agent): pass agent_id through handler.py /present to match lifecycle reporter

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -801,12 +801,22 @@ class HivemootPlugin:
             else None
         )
 
+        # Thread the AGENT_ID through so handler.py's /present matches
+        # the lifecycle reporter's earlier /present (which already
+        # passed agent_id from the same env var). Without this, the
+        # second /present hits owner_conflict — server falls back
+        # to bearer.name when body.agentId is missing — and the
+        # handler treats the (now-classified-as-race) error as a
+        # benign skip, silently dropping the contribution.
+        agent_id_env = self.resolved_agent_id() or None
+
         handle_war_room_job_finished(
             job,
             result,
             base_url=cfg.war_rooms.base_url,
             bearer=bearer,
             extracted_markdown=markdown,
+            agent_id=agent_id_env,
             on_post_failure=evict,
         )
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
@@ -149,6 +149,7 @@ def handle_war_room_job_finished(
     base_url: str,
     bearer: str,
     extracted_markdown: str,
+    agent_id: Optional[str] = None,
     on_post_failure: Optional[PostFailureCallback] = None,
 ) -> TriageDecision:
     """Parse the agent's response and act on it.
@@ -158,7 +159,18 @@ def handle_war_room_job_finished(
     war-room API. All API failures swallowed-and-logged; this
     function never raises.
 
-    `on_post_failure`, when supplied, is invoked exactly once per
+    ``agent_id`` (added in the PR-E hotfix): the per-runner identity
+    threaded through to ``/present`` so it matches the lifecycle
+    reporter's earlier ``/present`` call. Without this, the lifecycle
+    reporter created the slot at ``agent_id=AGENT_ID`` but this
+    handler's ``/present`` POSTed without ``body.agentId`` — the
+    server fell back to ``bearer.name`` and saw an owner mismatch,
+    raising owner_conflict. Per PR-C's race classification, the
+    handler then treated it as a benign race and silently skipped
+    ``/contribute``. The fix is to pass the same ``agent_id`` to
+    both call sites.
+
+    ``on_post_failure``, when supplied, is invoked exactly once per
     call when the post sequence terminates without successfully
     transitioning participant state — i.e. RSVP failed (and
     therefore the follow-on contribute/withdraw was skipped).
@@ -180,6 +192,7 @@ def handle_war_room_job_finished(
             subject_ref=subject_ref,
             decision=decision,
             result=result,
+            agent_id=agent_id,
             on_post_failure=on_post_failure,
         )
     else:
@@ -190,6 +203,7 @@ def handle_war_room_job_finished(
             current_sequence=current_sequence,
             subject_ref=subject_ref,
             decision=decision,
+            agent_id=agent_id,
             on_post_failure=on_post_failure,
         )
 
@@ -205,6 +219,7 @@ def _do_present_and_contribute(
     subject_ref: str,
     decision: TriageDecision,
     result: AgentResult,
+    agent_id: Optional[str],
     on_post_failure: Optional[PostFailureCallback],
 ) -> None:
     """RSVP via /present, then submit the contribution.
@@ -234,6 +249,7 @@ def _do_present_and_contribute(
             sequence_observed_by_client=current_sequence,
             bearer=bearer,
             intent_hint=decision.summary,
+            agent_id=agent_id,
         )
     except wr_api.RoomStateRaceError as exc:
         # Room moved on between watching → triage → present.  No
@@ -318,6 +334,7 @@ def _do_present_then_withdraw(
     current_sequence: int,
     subject_ref: str,
     decision: TriageDecision,
+    agent_id: Optional[str],
     on_post_failure: Optional[PostFailureCallback],
 ) -> None:
     """RSVP via /present, then withdraw via /withdraw.
@@ -343,6 +360,7 @@ def _do_present_then_withdraw(
             sequence_observed_by_client=current_sequence,
             bearer=bearer,
             intent_hint=decision.reason,
+            agent_id=agent_id,
         )
     except wr_api.RoomStateRaceError as exc:
         # See `_do_present_and_contribute` for the rationale: the


### PR DESCRIPTION
## Summary

**Production hotfix** for a regression introduced by PR #615. Visible in drone's logs on PR #617 (and any PR opened after PR-C deployed):

\`\`\`
[hivemoot-war-rooms] early-presented room=... seq=N landed_seq=N+1
...
[hivemoot-war-rooms] raced room transition on present
room=... seq=N code=owner_conflict — skipping contribute
\`\`\`

The first \`early-presented\` is the lifecycle reporter winning. The second \`raced ... owner_conflict\` is handler.py losing — and silently dropping the agent's review.

## Root cause

After PR #615 (\`RoomLifecycleReporter\` shipped + deployed) and the apiary redeploy, every war-room job now follows this sequence:

1. \`RoomLifecycleReporter.on_start\` posts \`/present\` with \`body.agentId = AGENT_ID\` env var → server creates the slot at \`agent_id="<AGENT_ID>"\`.
2. Agent runs.
3. \`handler.py.handle_war_room_job_finished\` posts \`/present\` AGAIN at \`on_job_finished\`, but **does not** pass \`body.agentId\`.
4. Server falls back to \`bearer.name\` on the second \`/present\`. If \`AGENT_ID != bearer.name\` (subscriber-mode fleets, and most single-runner setups where AGENT_ID is "drone" but bearer.name is "hive-drone"), the server raises **owner_conflict**.
5. PR #615 reclassified \`owner_conflict\` as \`RoomStateRaceError\` for /heartbeat — and pulled /present along with it. handler.py treats races as benign and skips the \`/contribute\` leg.

**Net effect:** every drone review on PR #617 was silently dropped. The agent ran, generated 6KB+ of review prose, and handler.py threw it away.

## Fix

Thread \`agent_id\` through \`handler.handle_war_room_job_finished\` to both \`_do_present_and_contribute\` and \`_do_present_then_withdraw\`, which pass it to \`wr_api.present_to_room\`. The parent plugin reads \`AGENT_ID\` from env (same source the lifecycle reporter uses) and supplies it, so both \`/present\` calls hit the server with matching identity. The server's first-wins gate then accepts the second \`/present\` as an idempotent re-RSVP from the same owner — no \`owner_conflict\`, no race, contribution lands.

## What it looks like

**Before** (broken — every drone review on every new PR):

\`\`\`
[hivemoot-war-rooms] early-presented room=ffe363c3 seq=10 landed_seq=15
[hivemoot-war-rooms] raced room transition on present (for withdraw)
                     room=ffe363c3 seq=10 code=owner_conflict
                     — skipping withdraw
\`\`\`

**After** (drone's review actually lands):

\`\`\`
[hivemoot-war-rooms] early-presented room=ffe363c3 seq=10 landed_seq=15
[hivemoot-war-rooms] contributed room=ffe363c3 verdict=delegated
                     body_bytes=6234 truncated=False landed_seq=17
\`\`\`

## Test plan

- [x] Full agent suite: **664 tests pass**, no regressions.
- [x] Manual code-path trace: lifecycle on_start → handler.py /present now matches identity → server returns 200 (idempotent re-RSVP) → /contribute proceeds.

## Why this slipped through

PR #615's \`/present\` parity fix added \`agent_id\` to the API helper signature, but only updated the **lifecycle reporter's** call site. The handler.py call sites were left without the new param, defaulting to \`agent_id=None\` (server falls back to bearer.name). The contract test \`test_raises_on_409_owner_conflict\` was updated to expect \`RoomStateRaceError\` — proving the API helper's classification — but no integration test caught the handler.py-vs-lifecycle identity mismatch. Adding such a test is follow-up work; this PR is the immediate hotfix to unblock production reviews.