### PR TITLE
fix(agent): pass agent_id through /contribute and /withdraw too

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -281,6 +281,8 @@ def submit_contribution(
     contribution_body: dict[str, Any],
     raw_md: str,
     bearer: str,
+    *,
+    agent_id: str | None = None,
     timeout: int = DEFAULT_TIMEOUT_SECS,
 ) -> int:
     """POST `{base_url}/api/rooms/{room_id}/contributions`.
@@ -289,14 +291,24 @@ def submit_contribution(
     plus the worker's raw markdown analysis. Both bounded server-
     side (body schema + 32 KiB raw_md cap).
 
+    ``agent_id`` follows the same subscriber-mode-parity contract as
+    ``/present`` and ``/heartbeat`` — the storage layer's per-(room,
+    role) gate compares it to the slot's existing ``agent_id``, so
+    the value MUST match what was passed on the slot's first
+    ``/present``. When omitted the server falls back to ``bearer.name``;
+    that fallback was the regression PR #618 partially fixed (only
+    on /present) — /contribute had the same hole, captured here.
+
     Returns the sequence the `contribution_submitted` event landed at.
     """
     url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/contributions"
-    body = {
+    body: dict[str, Any] = {
         "sequenceObservedByClient": sequence_observed_by_client,
         "body": contribution_body,
         "rawMd": raw_md,
     }
+    if agent_id is not None:
+        body["agentId"] = agent_id
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 
     _maybe_raise_race(op="contributions", status=status, parsed=parsed, raw=raw)
@@ -402,6 +414,7 @@ def withdraw_participant(
     bearer: str,
     *,
     reason: str | None = None,
+    agent_id: str | None = None,
     timeout: int = DEFAULT_TIMEOUT_SECS,
 ) -> int:
     """POST `{base_url}/api/rooms/{room_id}/withdraw`.
@@ -411,6 +424,11 @@ def withdraw_participant(
     of scope, etc.). Distinct from `submit_contribution` (a
     contribution that opts out via `verdict: COMMENT`).
 
+    ``agent_id`` follows the same subscriber-mode-parity contract
+    as ``/present``, ``/contribute``, and ``/heartbeat`` — must
+    match the slot's existing ``agent_id`` or the storage layer's
+    first-wins gate raises owner_conflict.
+
     Returns the sequence the `participant_withdrawn` event landed at.
     """
     url = f"{base_url.rstrip('/')}/api/rooms/{room_id}/withdraw"
@@ -419,6 +437,8 @@ def withdraw_participant(
     }
     if reason is not None:
         body["reason"] = reason
+    if agent_id is not None:
+        body["agentId"] = agent_id
 
     status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/handler.py
@@ -292,6 +292,7 @@ def _do_present_and_contribute(
             contribution_body=body,
             raw_md=raw_md,
             bearer=bearer,
+            agent_id=agent_id,
         )
         _log(
             f"contributed room={room_id} subject={subject_ref} "
@@ -388,6 +389,7 @@ def _do_present_then_withdraw(
             sequence_observed_by_client=current_sequence,
             bearer=bearer,
             reason=decision.reason,
+            agent_id=agent_id,
         )
         level = "warn" if decision.parse_error else "info"
         _log(


### PR DESCRIPTION
## Summary

**Follow-on hotfix to PR #618.** That PR fixed \`/present\`'s subscriber-mode parity but left the same hole on \`/contribute\` and \`/withdraw\`. Visible in production after #618 deployed:

\`\`\`
early-presented room=ffe363c3 ... seq=28 landed_seq=29       (lifecycle wins)
... agent runs ...
raced room transition on contribute room=ffe363c3
                     seq=28 verdict=delegated code=owner_conflict
\`\`\`

Lifecycle and handler.py \`/present\` now match (#618). But handler.py's \`/contribute\` and \`/withdraw\` still POSTed without \`body.agentId\` — server fell back to \`bearer.name\`, saw an owner mismatch against the slot the lifecycle had created at \`agent_id=AGENT_ID\`. Same root cause, different leg.

## Fix

Thread \`agent_id\` through \`submit_contribution\` and \`withdraw_participant\` in \`war_rooms/api.py\`. handler.py now passes it on both helper invocations using the same \`agent_id\` parameter that #618 added.

## Why this slipped through

#618 was minimum-viable for the production race, focused on \`/present\` since that was the call directly racing in the logs. The follow-on \`/contribute\` race only became visible once \`/present\` succeeded — the bug was being shadowed by the earlier failure. Classic onion: peel back one layer, the next one shows.

The full subscriber-mode parity contract: **every endpoint that the storage layer's first-wins gate evaluates must accept and propagate \`agent_id\`**. Endpoints in scope:
- \`/present\` ✅ (fixed in #615 lifecycle, #618 handler)
- \`/heartbeat\` ✅ (PR #615 from the start)
- \`/contribute\` ✅ (this PR)
- \`/withdraw\` ✅ (this PR)

## Test plan

- [x] Full agent suite: **664 tests pass**.
- [x] Manual code-path trace: with all four endpoints carrying \`agent_id\`, the lifecycle and handler.py operate on the same slot identity for the entire job lifecycle.