### PR TITLE
feat(dashboard): war-room UI cleanup + richer list signals

### DIFF
--- a/web/src/app/dashboard/rooms/RoomsList.tsx
+++ b/web/src/app/dashboard/rooms/RoomsList.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   countRoomsByFilter,
+  extractDecisionVerdict,
   hasDiffDriftedPostVerdict,
   isRoomStuck,
   relativeTime,
@@ -14,6 +15,8 @@ import {
   statusLabel,
   statusPillClass,
   subjectLabel,
+  timeUntilDeadline,
+  verdictPillClass,
   type RoomStatusFilter,
 } from "./room-helpers";
 import type { RoomCoreWithId } from "./types";
@@ -320,6 +323,21 @@ function RoomRow({ room }: { room: RoomCoreWithId }) {
         ? ` (head ${room.last_post_close_drift_head_sha.slice(0, 7)})`
         : "")
     : undefined;
+  // Verdict pill for decided rooms — extracted from the queen's
+  // synthesis content. Falls back to ``null`` when the decision
+  // doesn't match the synthesizer template; we render a plain
+  // "closed" badge in that case rather than guessing.
+  const verdict = room.decision
+    ? extractDecisionVerdict(room.decision.content)
+    : null;
+  // Countdown for active rooms — gives operators a sense of urgency
+  // before the "near deadline" red badge kicks in. Null for terminal
+  // statuses (no deadline applies once a room is closed/expired).
+  const timeLeft = timeUntilDeadline(
+    room.opened_at,
+    room.status,
+    room.timing_config,
+  );
   return (
     <li className={stuckHighlight}>
       <Link
@@ -333,6 +351,14 @@ function RoomRow({ room }: { room: RoomCoreWithId }) {
             >
               {statusLabel(room.status)}
             </span>
+            {verdict && (
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${verdictPillClass(verdict)}`}
+                title="Verdict from the queen's synthesis"
+              >
+                {verdict}
+              </span>
+            )}
             {stuck && (
               <span className="rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-medium text-red-300 ring-1 ring-red-500/30">
                 near deadline
@@ -355,6 +381,16 @@ function RoomRow({ room }: { room: RoomCoreWithId }) {
           </div>
           <span className="text-xs text-zinc-500">
             opened {relativeTime(room.opened_at)}
+            {timeLeft && (
+              // Subtle visual cue: green when there's plenty of time,
+              // red once we cross into stuck territory. Operators
+              // already have the "near deadline" pill but the
+              // countdown gives the WHEN, not just the IF.
+              <span className={stuck ? "text-red-400" : "text-zinc-400"}>
+                {" · "}
+                {timeLeft}
+              </span>
+            )}
             {room.closed_at && ` · closed ${relativeTime(room.closed_at)}`}
           </span>
         </div>

--- a/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
+++ b/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
+import { MarkdownContent } from "../../MarkdownContent";
 import {
   heartbeatFreshnessDotClass,
   heartbeatFreshnessTitle,
@@ -277,57 +278,101 @@ function ParticipantsTable({
   );
 }
 
+/**
+ * Pick a deterministic Tailwind color class for a role's avatar
+ * circle. Same role always gets the same hue across refreshes so
+ * an operator can scan a long thread and recognize "the green one
+ * is guard" without re-reading every label.
+ */
+function roleAccentClass(role: string): string {
+  // Cheap hash → palette index. The palette is hand-picked to
+  // stay legible against the zinc-950 page background while
+  // keeping enough contrast between adjacent hues.
+  const palette = [
+    "bg-emerald-500/20 text-emerald-300 ring-emerald-500/30",
+    "bg-sky-500/20 text-sky-300 ring-sky-500/30",
+    "bg-amber-500/20 text-amber-300 ring-amber-500/30",
+    "bg-rose-500/20 text-rose-300 ring-rose-500/30",
+    "bg-violet-500/20 text-violet-300 ring-violet-500/30",
+    "bg-teal-500/20 text-teal-300 ring-teal-500/30",
+  ];
+  let hash = 0;
+  for (let i = 0; i < role.length; i++) {
+    hash = (hash * 31 + role.charCodeAt(i)) >>> 0;
+  }
+  return palette[hash % palette.length];
+}
+
 function ContributionsList({
   contributions,
 }: {
   contributions: Record<string, RoomContribution>;
 }) {
   return (
-    <ul className="space-y-3">
+    <ol className="space-y-4">
       {Object.entries(contributions)
         .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([role, c]) => (
-          <li
-            key={role}
-            className="rounded-lg border border-white/5 bg-zinc-900/50 p-3"
-          >
-            <div className="mb-1 flex items-center gap-2 text-xs">
-              <span className="font-medium text-zinc-200">{role}</span>
-              {c.withdrawn ? (
-                <span className="rounded-full bg-zinc-700/30 px-2 py-0.5 text-zinc-400">
-                  withdrawn
-                </span>
-              ) : (
-                c.body?.verdict !== undefined && (
-                  <span className="rounded-full bg-honey-500/10 px-2 py-0.5 text-honey-400">
-                    {String(c.body.verdict)}
-                  </span>
-                )
-              )}
-              {c.contributed_at && (
-                <span className="text-zinc-500">
-                  · {relativeTime(c.contributed_at)}
-                </span>
-              )}
-            </div>
-            {!c.withdrawn && c.body?.summary !== undefined && (
-              <p className="text-sm text-zinc-300">
-                {String(c.body.summary)}
-              </p>
-            )}
-            {!c.withdrawn && c.raw_md && (
-              <details className="mt-2">
-                <summary className="cursor-pointer text-xs text-zinc-500 hover:text-zinc-400">
-                  Show review body ({c.raw_md.length} chars)
-                </summary>
-                <pre className="mt-2 overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-2 text-xs text-zinc-300">
-                  {c.raw_md}
-                </pre>
-              </details>
-            )}
-          </li>
-        ))}
-    </ul>
+        .map(([role, c]) => {
+          const initial = role.charAt(0).toUpperCase() || "?";
+          return (
+            <li key={role} className="flex gap-3">
+              {/* Avatar — role initial, deterministic accent color
+                  per role. Operators can pattern-match on color
+                  across a long thread without re-reading labels. */}
+              <div
+                className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-semibold ring-1 ${roleAccentClass(role)}`}
+                aria-hidden="true"
+              >
+                {initial}
+              </div>
+              <div className="min-w-0 flex-1 rounded-2xl border border-white/5 bg-zinc-900/60 px-4 py-3">
+                {/* Header: role · verdict · timestamp. Time pushed
+                    to the right via ml-auto so the visual rhythm
+                    is consistent with chat clients (sender top-left,
+                    timestamp top-right). */}
+                <header className="mb-2 flex items-center gap-2 text-xs">
+                  <span className="font-medium text-zinc-200">{role}</span>
+                  {c.withdrawn ? (
+                    <span className="rounded-full bg-zinc-700/30 px-2 py-0.5 text-zinc-400">
+                      withdrawn
+                    </span>
+                  ) : (
+                    c.body?.verdict !== undefined && (
+                      <span className="rounded-full bg-honey-500/10 px-2 py-0.5 font-medium text-honey-400 ring-1 ring-honey-500/20">
+                        {String(c.body.verdict)}
+                      </span>
+                    )
+                  )}
+                  {c.contributed_at && (
+                    <span className="ml-auto text-zinc-500">
+                      {relativeTime(c.contributed_at)}
+                    </span>
+                  )}
+                </header>
+                {c.withdrawn ? (
+                  // Muted body for withdrawals — keep the slot but
+                  // don't render the (typically empty) raw_md as a
+                  // chat message; it's not a real contribution.
+                  <p className="text-xs italic text-zinc-500">
+                    Withdrew without contributing.
+                  </p>
+                ) : (
+                  <>
+                    {c.body?.summary !== undefined && (
+                      <p className="mb-2 text-sm font-medium text-zinc-200">
+                        {String(c.body.summary)}
+                      </p>
+                    )}
+                    {c.raw_md && (
+                      <MarkdownContent>{c.raw_md}</MarkdownContent>
+                    )}
+                  </>
+                )}
+              </div>
+            </li>
+          );
+        })}
+    </ol>
   );
 }
 
@@ -337,17 +382,18 @@ function DecisionBlock({
   decision: NonNullable<RoomDetailResponse["core"]["decision"]>;
 }) {
   return (
-    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-      <div className="mb-2 flex items-center gap-3 text-xs text-zinc-500">
-        <span>synthesized {relativeTime(decision.synthesized_at)}</span>
+    <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] px-4 py-3">
+      <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+        <span>
+          <span className="text-emerald-400">●</span> synthesized{" "}
+          {relativeTime(decision.synthesized_at)}
+        </span>
         <span>·</span>
         <span className="font-mono">{decision.synthesis_runner}</span>
         <span>·</span>
         <span>through seq {decision.sequence_closed}</span>
       </div>
-      <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-3 text-sm text-zinc-200">
-        {decision.content}
-      </pre>
+      <MarkdownContent>{decision.content}</MarkdownContent>
     </div>
   );
 }

--- a/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
+++ b/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
@@ -152,7 +152,12 @@ function RoomDetailContent({
             <span className="font-mono">{core.subject_ref}</span>
           )}
         </h1>
-        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-500">
+        {/* `grid-cols-[auto_1fr]` keeps the label column at its
+            content width so values sit right next to their labels
+            instead of being pushed to the far right of the page
+            (which `grid-cols-2`'s 50/50 split caused on wide
+            viewports). */}
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-zinc-500">
           <dt>Room ID</dt>
           <dd className="font-mono text-zinc-400">{roomId}</dd>
           <dt>Manager</dt>

--- a/web/src/app/dashboard/rooms/room-helpers.test.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ACTIVE_STATUSES,
   countRoomsByFilter,
+  extractDecisionVerdict,
   hasDiffDriftedPostVerdict,
   heartbeatFreshnessDotClass,
   heartbeatFreshnessTitle,
@@ -20,6 +21,8 @@ import {
   stucknessRatio,
   subjectGithubUrl,
   subjectLabel,
+  timeUntilDeadline,
+  verdictPillClass,
 } from "./room-helpers";
 import type { RoomCoreWithId, RoomParticipant, RoomStatus } from "./types";
 
@@ -709,5 +712,116 @@ describe("heartbeatFreshnessTitle", () => {
       // understands WHY the dot is that color.
       expect(title.toLowerCase()).toMatch(/heartbeat|pending/);
     }
+  });
+});
+
+
+// ── timeUntilDeadline + extractDecisionVerdict + verdictPillClass
+//    (rooms-list richer signals) ─────────────────────────────────────
+
+describe("timeUntilDeadline", () => {
+  const NOW = Date.parse("2026-04-28T12:00:00Z");
+
+  it("returns null for terminal statuses", () => {
+    expect(
+      timeUntilDeadline("2026-04-28T11:00:00Z", "closed",
+        { max_age_secs: 3600 }, NOW),
+    ).toBeNull();
+    expect(
+      timeUntilDeadline("2026-04-28T11:00:00Z", "expired",
+        { max_age_secs: 3600 }, NOW),
+    ).toBeNull();
+  });
+
+  it("returns null when timing_config is missing or has no max_age", () => {
+    expect(
+      timeUntilDeadline("2026-04-28T11:00:00Z",
+        "awaiting_contributions", undefined, NOW),
+    ).toBeNull();
+    expect(
+      timeUntilDeadline("2026-04-28T11:00:00Z",
+        "awaiting_contributions", { quiet_period_secs: 60 }, NOW),
+    ).toBeNull();
+  });
+
+  it("formats remaining seconds correctly across thresholds", () => {
+    // 30 min elapsed of a 60 min deadline → 30 min left
+    expect(
+      timeUntilDeadline("2026-04-28T11:30:00Z",
+        "awaiting_contributions", { max_age_secs: 3600 }, NOW),
+    ).toBe("30m left");
+    // 50 min elapsed of a 1h deadline → 10 min left
+    expect(
+      timeUntilDeadline("2026-04-28T11:10:00Z",
+        "awaiting_contributions", { max_age_secs: 3600 }, NOW),
+    ).toBe("10m left");
+    // 5 hours of a 24h deadline → 19h left
+    expect(
+      timeUntilDeadline("2026-04-28T07:00:00Z",
+        "awaiting_contributions", { max_age_secs: 24 * 3600 }, NOW),
+    ).toBe("19h left");
+  });
+
+  it("returns \"expired\" for rooms past their deadline", () => {
+    // 2h elapsed, 1h deadline — overdue. The watchdog has not yet
+    // swept; the marker is the bridge state.
+    expect(
+      timeUntilDeadline("2026-04-28T10:00:00Z",
+        "awaiting_contributions", { max_age_secs: 3600 }, NOW),
+    ).toBe("expired");
+  });
+
+  it("returns null on unparseable opened_at (defensive)", () => {
+    expect(
+      timeUntilDeadline("not-a-date", "awaiting_contributions",
+        { max_age_secs: 3600 }, NOW),
+    ).toBeNull();
+  });
+});
+
+describe("extractDecisionVerdict", () => {
+  it("extracts the verdict from the standard synthesis template", () => {
+    const content =
+      "## Synthesis — owner/repo#42\n\n" +
+      "**Verdict:** `APPROVE` _(LLM-derived from 2 contributions)_\n";
+    expect(extractDecisionVerdict(content)).toBe("APPROVE");
+  });
+
+  it("handles all four enum values", () => {
+    for (const v of ["APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"] as const) {
+      expect(
+        extractDecisionVerdict("**Verdict:** `" + v + "` etc"),
+      ).toBe(v);
+    }
+  });
+
+  it("tolerates missing backticks (looser synth output)", () => {
+    expect(extractDecisionVerdict("**Verdict:** APPROVE")).toBe("APPROVE");
+  });
+
+  it("returns null for content without the template", () => {
+    expect(extractDecisionVerdict("plain old prose")).toBeNull();
+    expect(extractDecisionVerdict("")).toBeNull();
+  });
+
+  it("returns null for unrecognized verdict values (avoid garbage pills)", () => {
+    // Custom synthesizer might emit something off-enum — caller
+    // falls back to a plain "decided" badge instead of rendering
+    // the unknown string as a pill.
+    expect(
+      extractDecisionVerdict("**Verdict:** `MAYBE_LATER`"),
+    ).toBeNull();
+  });
+});
+
+describe("verdictPillClass", () => {
+  it("returns a distinct color class per verdict", () => {
+    // The four verdicts must map to four visually distinct hues.
+    // Pin the exact classes so a Tailwind upgrade or typo cant
+    // silently fall through to a default.
+    expect(verdictPillClass("APPROVE")).toContain("emerald");
+    expect(verdictPillClass("COMMENT")).toContain("zinc");
+    expect(verdictPillClass("CONCERNS")).toContain("amber");
+    expect(verdictPillClass("REQUEST_CHANGES")).toContain("rose");
   });
 });

--- a/web/src/app/dashboard/rooms/room-helpers.ts
+++ b/web/src/app/dashboard/rooms/room-helpers.ts
@@ -212,6 +212,91 @@ export function stucknessRatio(
   return ageSecs / deadline;
 }
 
+/**
+ * Human-friendly "expires in 57m" string for an active room. Pure
+ * function so the rooms-list view can render without time mocking.
+ *
+ * Returns ``null`` when no deadline applies (terminal status, no
+ * timing_config, etc.) so callers can omit the indicator instead
+ * of rendering empty/garbage strings. Returns "expired" for rooms
+ * past their deadline (the watchdog typically sweeps these within
+ * one tick; the marker is the bridge state).
+ */
+export function timeUntilDeadline(
+  openedAtIso: string,
+  status: RoomStatus,
+  timingConfig?: StuckTimingConfig,
+  nowMs: number = Date.now(),
+): string | null {
+  const deadlineSecs = relevantDeadlineSecs(status, timingConfig);
+  if (deadlineSecs === null || deadlineSecs <= 0) return null;
+  const openedMs = Date.parse(openedAtIso);
+  if (!Number.isFinite(openedMs)) return null;
+  const remainingSecs =
+    deadlineSecs - Math.max(0, (nowMs - openedMs) / 1000);
+  if (remainingSecs <= 0) return "expired";
+  if (remainingSecs < 60) return `${Math.floor(remainingSecs)}s left`;
+  const mins = Math.floor(remainingSecs / 60);
+  if (mins < 60) return `${mins}m left`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h left`;
+  const days = Math.floor(hours / 24);
+  return `${days}d left`;
+}
+
+/** Recognized verdict strings the queen can synthesize. Mirrors the
+ * Zod enum on the synthesizer side so the dashboard's pill colors
+ * stay in sync with the structural enum. */
+export type Verdict =
+  | "APPROVE"
+  | "COMMENT"
+  | "CONCERNS"
+  | "REQUEST_CHANGES";
+
+const _VERDICT_VALUES: ReadonlySet<string> = new Set([
+  "APPROVE",
+  "COMMENT",
+  "CONCERNS",
+  "REQUEST_CHANGES",
+]);
+
+/**
+ * Extract the verdict from a decision's markdown body. The queen's
+ * synthesizer template starts each comment with the line
+ * ``**Verdict:** `<VERDICT>`'' followed by parenthesized provenance
+ * — a single regex captures the value without needing to parse
+ * the rest.
+ *
+ * Returns ``null`` when the content doesn't match the template
+ * (older rooms, custom synthesizers, etc.) so the caller can fall
+ * back to a generic "decided" pill instead of rendering garbage.
+ */
+export function extractDecisionVerdict(content: string): Verdict | null {
+  const match = /\*\*Verdict:\*\*\s*`?([A-Z_]+)`?/i.exec(content);
+  if (!match) return null;
+  const candidate = match[1].toUpperCase();
+  return _VERDICT_VALUES.has(candidate) ? (candidate as Verdict) : null;
+}
+
+/**
+ * Tailwind class fragment for a verdict pill. Centralized so the
+ * rooms-list and the room-detail synthesis surfaces stay visually
+ * consistent. Matches the dashboard's status-pill vocabulary —
+ * emerald for approve, amber for caution, rose for blocking.
+ */
+export function verdictPillClass(verdict: Verdict): string {
+  switch (verdict) {
+    case "APPROVE":
+      return "bg-emerald-500/10 text-emerald-300 ring-1 ring-emerald-500/20";
+    case "COMMENT":
+      return "bg-zinc-500/10 text-zinc-300 ring-1 ring-zinc-500/20";
+    case "CONCERNS":
+      return "bg-amber-500/10 text-amber-300 ring-1 ring-amber-500/20";
+    case "REQUEST_CHANGES":
+      return "bg-rose-500/10 text-rose-300 ring-1 ring-rose-500/20";
+  }
+}
+
 /** Per WAR_ROOM_DESIGN.md L1248: red highlight when past 80% of
  * the relevant deadline. */
 export const STUCK_THRESHOLD = 0.8;


### PR DESCRIPTION
## Summary

Three visual improvements to the war-room dashboard, bundled because they all touch the same surfaces.

### 1. Tighten the room-detail metadata grid

Labels and values were being pushed to opposite edges of the page on wide viewports because the grid used \`grid-cols-2\` (50/50 split). Switched to \`grid-cols-[auto_1fr]\` so labels shrink to content width and values flow immediately to their right.

**Before:**
\`\`\`
Room ID                                                 2122b9be-3cc8-4c58-bbd5-9aedcdb916a5
Manager                                                                              hivemoot
Opened                                                                               just now
\`\`\`

**After:**
\`\`\`
Room ID  2122b9be-3cc8-4c58-bbd5-9aedcdb916a5
Manager  hivemoot
Opened   just now
\`\`\`

### 2. Render contributions + decision as chat with markdown

Were rendered as raw preformatted text behind a "Show review body (1192 chars)" disclosure. For the 1KB+ guard reviews this surface exists to display, headings showed as \`# literal\` and bullets as \`- literal\`. Reused the existing \`MarkdownContent\` component (already used by the agent-health surface) so contributions get full markdown rendering — headings, lists, code fences, inline code, links.

Restructured each contribution as a chat row with a role-colored avatar, verdict pill, and timestamp aligned right:

\`\`\`
[G] hive-guard · APPROVE                                       12s ago
    Guard contribution
    Subject is just `HI` with no body, no linked artifact, no
    scenario. As guard my mandate is to look for security…
    • Empty / placeholder subjects like `HI` are essentially
      indistinguishable from accidental form submits…
\`\`\`

The avatar is the role's first letter on a deterministic accent color (sky for drone, emerald for guard, etc.) so operators scanning a long thread can pattern-match by color without re-reading every label.

\`DecisionBlock\` got the same treatment — synthesis output is markdown-shaped (the queen's prose has headers, bullets, code references) and rendering it as \`<pre>\` threw all that away.

### 3. Richer signals on the rooms-list page

Two clean additions per row, both derivable from data the list endpoint already returns:

- **Verdict pill on closed rooms.** Extracts \`APPROVE\` / \`COMMENT\` / \`CONCERNS\` / \`REQUEST_CHANGES\` from the queen's synthesis content and renders a colored pill alongside the status. Falls back to nothing on rooms whose decision doesn't match the synthesizer template (older / custom rooms).
- **Time-until-deadline countdown** for active rooms. The "near deadline" red badge already triggers at 80% stuckness; this gives the WHEN, not just the IF. \`opened 37m ago · 23m left\` — turns red when the stuck threshold is crossed so the visual progression is continuous.

\`\`\`
[Awaiting contributions] [APPROVE] PR REVIEW  hivemoot/hivemoot#620   opened 3m ago · 57m left
[Closed]                 [REQUEST_CHANGES] PR REVIEW  hivemoot/hivemoot#615   closed 14m ago
\`\`\`

## Test plan

- [x] Full web suite: **1477 tests pass** (was 1466; +11 new for the helpers).
- [x] \`tsc --noEmit\` clean.
- [x] All additions are pure client-side — no API change, no extra storage round trips. Reused \`MarkdownContent\` (already production-tested on the agent-health surface).