### PR TITLE
feat(queen): per-installation queen-mode settings storage (1/6)

### DIFF
--- a/bot/api/lib/queen-mode.test.ts
+++ b/bot/api/lib/queen-mode.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+import {
+  __resetQueenModeCacheForTests,
+  getQueenModeCached,
+  getQueenModeCacheTtlMs,
+} from "./queen-mode.js";
+
+// ---------------------------------------------------------------------------
+// Mock Redis with hget only
+// ---------------------------------------------------------------------------
+
+function makeMockRedis(opts: { value?: string | null; throwError?: Error } = {}) {
+  return {
+    hget: vi.fn(async () => {
+      if (opts.throwError) throw opts.throwError;
+      return opts.value ?? null;
+    }),
+  } as unknown as Redis;
+}
+
+beforeEach(() => {
+  __resetQueenModeCacheForTests();
+});
+
+describe("getQueenModeCached", () => {
+  it("returns cloud when no value stored (default for new installations)", async () => {
+    const redis = makeMockRedis({ value: null });
+    const mode = await getQueenModeCached("42", redis);
+    expect(mode).toBe("cloud");
+  });
+
+  it("returns local when stored", async () => {
+    const redis = makeMockRedis({ value: "local" });
+    const mode = await getQueenModeCached("42", redis);
+    expect(mode).toBe("local");
+  });
+
+  it("falls back to cloud on garbage values (G7 fail-closed)", async () => {
+    const redis = makeMockRedis({ value: "ditto" });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mode = await getQueenModeCached("42", redis);
+    expect(mode).toBe("cloud");
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("falls back to cloud when Redis throws (G7 fail-closed)", async () => {
+    const redis = makeMockRedis({ throwError: new Error("upstream timeout") });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mode = await getQueenModeCached("42", redis);
+    expect(mode).toBe("cloud");
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("caches the value across calls within the TTL window", async () => {
+    const redis = makeMockRedis({ value: "local" });
+    let now = 1_000_000;
+    const clock = () => now;
+
+    const a = await getQueenModeCached("42", redis, clock);
+    const b = await getQueenModeCached("42", redis, clock);
+    expect(a).toBe("local");
+    expect(b).toBe("local");
+    expect(redis.hget).toHaveBeenCalledTimes(1);
+
+    // Advance just under TTL — still cached
+    now += getQueenModeCacheTtlMs() - 1;
+    const c = await getQueenModeCached("42", redis, clock);
+    expect(c).toBe("local");
+    expect(redis.hget).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes from Redis after the TTL boundary", async () => {
+    const redis = makeMockRedis({ value: "local" });
+    let now = 1_000_000;
+    const clock = () => now;
+
+    await getQueenModeCached("42", redis, clock);
+    expect(redis.hget).toHaveBeenCalledTimes(1);
+
+    now += getQueenModeCacheTtlMs() + 1;
+    await getQueenModeCached("42", redis, clock);
+    expect(redis.hget).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses per-installation cache keys", async () => {
+    const redis = makeMockRedis({ value: "local" });
+    await getQueenModeCached("42", redis);
+    await getQueenModeCached("99", redis);
+    // Two distinct installations, two reads
+    expect(redis.hget).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches the cloud fallback so a transient error doesn't keep retrying", async () => {
+    const redis = makeMockRedis({ throwError: new Error("redis down") });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let now = 1_000_000;
+    const clock = () => now;
+
+    await getQueenModeCached("42", redis, clock);
+    // Second call within TTL — same fallback, no new hget
+    const second = await getQueenModeCached("42", redis, clock);
+    expect(second).toBe("cloud");
+    expect(redis.hget).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+});

--- a/bot/api/lib/queen-mode.ts
+++ b/bot/api/lib/queen-mode.ts
@@ -1,0 +1,105 @@
+/**
+ * Probot 60s TTL cache for the per-installation `queen_mode` flag (D15).
+ *
+ * Webhook handlers and `queen-tick` read this on every event entry to
+ * decide whether to skip the cloud-mode synthesis path. A naive read
+ * would cost one Redis roundtrip per event; this wrapper keeps a
+ * process-local in-memory cache with a 60-second TTL so a hot path
+ * stays free of network IO.
+ *
+ * **G7 fail-closed semantics**: any error from the underlying Redis
+ * read is logged and `cloud` is returned. The invariant is that the
+ * cloud path NEVER stops claiming/synthesizing because of an unrelated
+ * Redis blip — local mode is opt-in and only takes effect when we can
+ * positively confirm the operator chose it.
+ *
+ * Cache key is per-installation. Mode-flips (PR 1's `setQueenSettings`)
+ * happen through the web endpoint, which writes to Redis; the bot's
+ * cached value goes stale for at most TTL seconds. That's the
+ * intentional propagation budget — operators who want immediate effect
+ * can wait one minute or restart the bot.
+ *
+ * Test entry points: `__resetQueenModeCacheForTests` clears state.
+ * `getQueenModeCacheTtlMs` returns the configured TTL (so tests don't
+ * have to know it's 60_000).
+ */
+
+import { type Redis } from "@upstash/redis";
+
+const KEY_PREFIX = "hive:v1:installation:";
+const KEY_SUFFIX = ":queen-settings";
+const FIELD_QUEEN_MODE = "queen_mode";
+
+const QUEEN_MODE_VALUES = ["cloud", "local"] as const;
+export type QueenMode = (typeof QUEEN_MODE_VALUES)[number];
+
+const DEFAULT_QUEEN_MODE: QueenMode = "cloud";
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  value: QueenMode;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function settingsKey(installationId: string): string {
+  return `${KEY_PREFIX}${installationId}${KEY_SUFFIX}`;
+}
+
+function isQueenMode(value: unknown): value is QueenMode {
+  return typeof value === "string" && (QUEEN_MODE_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Returns the cached queen_mode for `installationId`, refreshing from
+ * Redis on miss/expiry. NEVER throws: any Redis or parsing error logs
+ * and returns `cloud` (G7).
+ */
+export async function getQueenModeCached(
+  installationId: string,
+  redis: Redis,
+  now: () => number = Date.now,
+): Promise<QueenMode> {
+  const cached = cache.get(installationId);
+  const t = now();
+  if (cached && cached.expiresAt > t) return cached.value;
+
+  let mode: QueenMode = DEFAULT_QUEEN_MODE;
+  try {
+    const value = await redis.hget<string>(settingsKey(installationId), FIELD_QUEEN_MODE);
+    if (isQueenMode(value)) {
+      mode = value;
+    } else if (value !== null && value !== undefined) {
+      console.error("[queen-mode] Unexpected queen_mode value in Redis — defaulting to cloud", {
+        installationId,
+        value,
+      });
+    }
+  } catch (error) {
+    // G7: never let a Redis blip silently flip mode. Log and fall back.
+    console.error("[queen-mode] Redis read failed — defaulting to cloud", {
+      installationId,
+      error,
+    });
+  }
+
+  cache.set(installationId, { value: mode, expiresAt: t + CACHE_TTL_MS });
+  return mode;
+}
+
+/**
+ * Test-only: clears the in-memory cache so each test starts from a
+ * known state.
+ */
+export function __resetQueenModeCacheForTests(): void {
+  cache.clear();
+}
+
+/**
+ * Returns the configured TTL in milliseconds. Exposed so tests can
+ * advance fake clocks past the boundary without hard-coding the value.
+ */
+export function getQueenModeCacheTtlMs(): number {
+  return CACHE_TTL_MS;
+}

--- a/web/src/app/api/dashboard/queen-settings/route.test.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+
+vi.mock("@/server/queen-settings-store", async () => {
+  const real = await vi.importActual<typeof import("@/server/queen-settings-store")>(
+    "@/server/queen-settings-store",
+  );
+  return {
+    ...real,
+    getQueenSettings: vi.fn(),
+    setQueenSettings: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { getQueenSettings, setQueenSettings } from "@/server/queen-settings-store";
+import { GET, POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateByokRequest);
+const mockedGet = vi.mocked(getQueenSettings);
+const mockedSet = vi.mocked(setQueenSettings);
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/dashboard/queen-settings", {
+    method: "GET",
+  });
+}
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("https://www.hivemoot.dev/api/dashboard/queen-settings", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+function makeAuth(installationId: string | null) {
+  return {
+    ok: true as const,
+    session: {
+      installationId,
+      userId: 101,
+      userLogin: "alice",
+    },
+    redis: {} as never,
+    keyring: new Map(),
+    activeKeyVersion: "v1",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/dashboard/queen-settings", () => {
+  it("returns 401 when session auth fails", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({}, { status: 401 }),
+    });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 no_installation when session has no installationId", async () => {
+    mockedAuth.mockResolvedValue(makeAuth(null));
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "no_installation" });
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("returns the settings for the linked installation", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedGet.mockResolvedValue({
+      queen_mode: "local",
+      queen_prompt_override: "merge_conventions: squash-only",
+    });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      installation_id: "42",
+      queen_mode: "local",
+      queen_prompt_override: "merge_conventions: squash-only",
+    });
+  });
+
+  it("returns 500 on storage failure", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedGet.mockRejectedValue(new Error("redis down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ code: "storage_failure" });
+    errSpy.mockRestore();
+  });
+});
+
+describe("POST /api/dashboard/queen-settings", () => {
+  it("requires a fresh session (passes requireFresh: true)", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "fresh_session_required" }, { status: 403 }),
+    });
+    const res = await POST(makePostRequest({ queen_mode: "local" }));
+    expect(res.status).toBe(403);
+    expect(mockedAuth).toHaveBeenCalledWith(expect.any(NextRequest), { requireFresh: true });
+  });
+
+  it("returns 403 no_installation when session has no installationId", async () => {
+    mockedAuth.mockResolvedValue(makeAuth(null));
+    const res = await POST(makePostRequest({ queen_mode: "local" }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "no_installation" });
+  });
+
+  it("rejects invalid queen_mode values", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    const res = await POST(makePostRequest({ queen_mode: "ditto" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid_body" });
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON body", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    const res = await POST(makePostRequest("not-valid-json{{{"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid_body" });
+  });
+
+  it("rejects non-string non-null override values", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    const res = await POST(
+      makePostRequest({ queen_mode: "local", queen_prompt_override: 12345 }),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid_body" });
+  });
+
+  it("writes settings and returns the new state", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedSet.mockResolvedValue({
+      ok: true,
+      previous: { queen_mode: "cloud", queen_prompt_override: null },
+      current: { queen_mode: "local", queen_prompt_override: "test" },
+    });
+    const res = await POST(
+      makePostRequest({ queen_mode: "local", queen_prompt_override: "test" }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      installation_id: "42",
+      queen_mode: "local",
+      queen_prompt_override: "test",
+    });
+    expect(mockedSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "42",
+        next: { queen_mode: "local", queen_prompt_override: "test" },
+      }),
+    );
+  });
+
+  it("returns 409 mode_flip_blocked when precheck (PR 2) blocks", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedSet.mockResolvedValue({
+      ok: false,
+      blocked: { reason: "rooms_in_flight", count: 2 },
+    });
+    const res = await POST(makePostRequest({ queen_mode: "local" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: "mode_flip_blocked",
+      blocked: { reason: "rooms_in_flight", count: 2 },
+    });
+  });
+
+  it("returns 500 on storage failure", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedSet.mockRejectedValue(new Error("lock timeout"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(makePostRequest({ queen_mode: "local" }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ code: "storage_failure" });
+    errSpy.mockRestore();
+  });
+});

--- a/web/src/app/api/dashboard/queen-settings/route.test.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.test.ts
@@ -171,53 +171,69 @@ describe("POST /api/dashboard/queen-settings", () => {
     expect(mockedSet).not.toHaveBeenCalled();
   });
 
-  it("counts UTF-8 bytes, not chars (smiley inflation can't sneak past the cap)", async () => {
+  it("rejects ANY non-null override in PR 1 (B1 builder pass-2 — D12 schema lands in PR 4)", async () => {
     mockedAuth.mockResolvedValue(makeAuth("42"));
-    // each smiley is 4 bytes (surrogate pair); 4097 smileys = 16,388 bytes
-    const blob = "🎉".repeat(4097);
     const res = await POST(
-      makePostRequest({ queen_mode: "cloud", queen_prompt_override: blob }),
+      makePostRequest({
+        queen_mode: "cloud",
+        queen_prompt_override: "merge_conventions: squash-only",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      code: "invalid_body",
+      message: expect.stringContaining("PR 4"),
+    });
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects even tiny non-null strings (no free-form-string write surface in PR 1)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    const res = await POST(
+      makePostRequest({ queen_mode: "cloud", queen_prompt_override: "x" }),
     );
     expect(res.status).toBe(400);
     expect(mockedSet).not.toHaveBeenCalled();
   });
 
-  it("accepts override exactly at the 16 KiB boundary", async () => {
+  it("writes mode change with override = null and returns the new state", async () => {
     mockedAuth.mockResolvedValue(makeAuth("42"));
     mockedSet.mockResolvedValue({
       ok: true,
       previous: { queen_mode: "cloud", queen_prompt_override: null },
-      current: { queen_mode: "cloud", queen_prompt_override: "x".repeat(16 * 1024) },
+      current: { queen_mode: "local", queen_prompt_override: null },
     });
     const res = await POST(
-      makePostRequest({
-        queen_mode: "cloud",
-        queen_prompt_override: "x".repeat(16 * 1024),
-      }),
-    );
-    expect(res.status).toBe(200);
-  });
-
-  it("writes settings and returns the new state", async () => {
-    mockedAuth.mockResolvedValue(makeAuth("42"));
-    mockedSet.mockResolvedValue({
-      ok: true,
-      previous: { queen_mode: "cloud", queen_prompt_override: null },
-      current: { queen_mode: "local", queen_prompt_override: "test" },
-    });
-    const res = await POST(
-      makePostRequest({ queen_mode: "local", queen_prompt_override: "test" }),
+      makePostRequest({ queen_mode: "local", queen_prompt_override: null }),
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       installation_id: "42",
       queen_mode: "local",
-      queen_prompt_override: "test",
+      queen_prompt_override: null,
     });
     expect(mockedSet).toHaveBeenCalledWith(
       expect.objectContaining({
         installationId: "42",
-        next: { queen_mode: "local", queen_prompt_override: "test" },
+        next: { queen_mode: "local", queen_prompt_override: null },
+      }),
+    );
+  });
+
+  it("writes mode change with override omitted and leaves existing override untouched", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedSet.mockResolvedValue({
+      ok: true,
+      previous: { queen_mode: "cloud", queen_prompt_override: null },
+      current: { queen_mode: "local", queen_prompt_override: null },
+    });
+    const res = await POST(
+      makePostRequest({ queen_mode: "local" }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        next: { queen_mode: "local", queen_prompt_override: undefined },
       }),
     );
   });

--- a/web/src/app/api/dashboard/queen-settings/route.test.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.test.ts
@@ -143,6 +143,61 @@ describe("POST /api/dashboard/queen-settings", () => {
     expect(await res.json()).toMatchObject({ code: "invalid_body" });
   });
 
+  it("normalizes empty-string override to null (guard B3 — round-trip symmetry)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedSet.mockResolvedValue({
+      ok: true,
+      previous: { queen_mode: "cloud", queen_prompt_override: null },
+      current: { queen_mode: "cloud", queen_prompt_override: null },
+    });
+    await POST(
+      makePostRequest({ queen_mode: "cloud", queen_prompt_override: "" }),
+    );
+    expect(mockedSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        next: expect.objectContaining({ queen_prompt_override: null }),
+      }),
+    );
+  });
+
+  it("rejects override over 16 KiB cap (guard B1 — bounded storage)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    const huge = "x".repeat(16 * 1024 + 1);
+    const res = await POST(
+      makePostRequest({ queen_mode: "cloud", queen_prompt_override: huge }),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid_body" });
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("counts UTF-8 bytes, not chars (smiley inflation can't sneak past the cap)", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    // each smiley is 4 bytes (surrogate pair); 4097 smileys = 16,388 bytes
+    const blob = "🎉".repeat(4097);
+    const res = await POST(
+      makePostRequest({ queen_mode: "cloud", queen_prompt_override: blob }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("accepts override exactly at the 16 KiB boundary", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    mockedSet.mockResolvedValue({
+      ok: true,
+      previous: { queen_mode: "cloud", queen_prompt_override: null },
+      current: { queen_mode: "cloud", queen_prompt_override: "x".repeat(16 * 1024) },
+    });
+    const res = await POST(
+      makePostRequest({
+        queen_mode: "cloud",
+        queen_prompt_override: "x".repeat(16 * 1024),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
   it("writes settings and returns the new state", async () => {
     mockedAuth.mockResolvedValue(makeAuth("42"));
     mockedSet.mockResolvedValue({

--- a/web/src/app/api/dashboard/queen-settings/route.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.ts
@@ -1,0 +1,173 @@
+/**
+ * GET  /api/dashboard/queen-settings — read the operator's
+ *   per-installation queen settings (queen_mode + optional override).
+ * POST /api/dashboard/queen-settings — atomically update them under
+ *   the per-installation flip-lock (G12). Mutating route: requires
+ *   a fresh BYOK session (15-min window).
+ *
+ * Response shape (both methods):
+ *   { queen_mode: "cloud" | "local",
+ *     queen_prompt_override: string | null,
+ *     installation_id: string }
+ *
+ * POST body:
+ *   { queen_mode: "cloud" | "local",
+ *     queen_prompt_override?: string | null }
+ *   - omit `queen_prompt_override` to leave the override unchanged
+ *   - pass `null` to delete the override
+ *   - pass a string to set/replace it
+ *
+ * Errors:
+ *   - 400 invalid_body — malformed POST input
+ *   - 401 not_authenticated — missing / expired BYOK session
+ *   - 403 fresh_session_required (POST) — session older than 15 min
+ *   - 403 no_installation — session has no linked installation
+ *   - 409 mode_flip_blocked — PR 2 will surface in-flight rooms here
+ *   - 500 storage_failure
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import {
+  getQueenSettings,
+  setQueenSettings,
+  type QueenMode,
+  QUEEN_MODE_VALUES,
+} from "@/server/queen-settings-store";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const installationId = auth.session.installationId;
+  if (installationId === null) {
+    return NextResponse.json(
+      { code: "no_installation", message: "Session has no linked GitHub installation." },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const settings = await getQueenSettings(String(installationId), auth.redis);
+    return NextResponse.json({
+      installation_id: String(installationId),
+      queen_mode: settings.queen_mode,
+      queen_prompt_override: settings.queen_prompt_override,
+    });
+  } catch (error) {
+    console.error("[dashboard.queen-settings] Failed to read settings", {
+      installationId,
+      error,
+    });
+    return NextResponse.json(
+      { code: "storage_failure", message: "Failed to load queen settings." },
+      { status: 500 },
+    );
+  }
+}
+
+interface PostBody {
+  queen_mode: QueenMode;
+  queen_prompt_override?: string | null;
+}
+
+function isQueenMode(value: unknown): value is QueenMode {
+  return typeof value === "string" && (QUEEN_MODE_VALUES as readonly string[]).includes(value);
+}
+
+function parseBody(raw: unknown): { ok: true; body: PostBody } | { ok: false; message: string } {
+  if (raw === null || typeof raw !== "object") {
+    return { ok: false, message: "Body must be a JSON object." };
+  }
+  const obj = raw as Record<string, unknown>;
+  if (!isQueenMode(obj.queen_mode)) {
+    return { ok: false, message: "queen_mode must be 'cloud' or 'local'." };
+  }
+  if (
+    obj.queen_prompt_override !== undefined &&
+    obj.queen_prompt_override !== null &&
+    typeof obj.queen_prompt_override !== "string"
+  ) {
+    return {
+      ok: false,
+      message: "queen_prompt_override must be a string, null, or omitted.",
+    };
+  }
+  return {
+    ok: true,
+    body: {
+      queen_mode: obj.queen_mode,
+      queen_prompt_override:
+        obj.queen_prompt_override === undefined
+          ? undefined
+          : (obj.queen_prompt_override as string | null),
+    },
+  };
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationId = auth.session.installationId;
+  if (installationId === null) {
+    return NextResponse.json(
+      { code: "no_installation", message: "Session has no linked GitHub installation." },
+      { status: 403 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { code: "invalid_body", message: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseBody(raw);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: "invalid_body", message: parsed.message },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await setQueenSettings({
+      installationId: String(installationId),
+      redis: auth.redis,
+      next: parsed.body,
+      // PR 2 plugs in the D9/G37 in-flight precheck here.
+      precheck: undefined,
+    });
+
+    if (!result.ok) {
+      return NextResponse.json(
+        {
+          code: "mode_flip_blocked",
+          message: "Mode flip blocked by in-flight work.",
+          blocked: result.blocked,
+        },
+        { status: 409 },
+      );
+    }
+
+    return NextResponse.json({
+      installation_id: String(installationId),
+      queen_mode: result.current.queen_mode,
+      queen_prompt_override: result.current.queen_prompt_override,
+    });
+  } catch (error) {
+    console.error("[dashboard.queen-settings] Failed to update settings", {
+      installationId,
+      error,
+    });
+    return NextResponse.json(
+      { code: "storage_failure", message: "Failed to update queen settings." },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/dashboard/queen-settings/route.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.ts
@@ -1,9 +1,11 @@
 /**
  * GET  /api/dashboard/queen-settings — read the operator's
  *   per-installation queen settings (queen_mode + optional override).
- * POST /api/dashboard/queen-settings — atomically update them under
- *   the per-installation flip-lock (G12). Mutating route: requires
- *   a fresh BYOK session (15-min window).
+ * POST /api/dashboard/queen-settings — update settings under the
+ *   per-installation flip-lock (G12 — serialized writes, NOT
+ *   atomic against in-flight queen-tick claims; see the store
+ *   docblock at queen-settings-store.ts for the precise semantics).
+ *   Mutating route: requires a fresh BYOK session (15-min window).
  *
  * Response shape (both methods):
  *   { queen_mode: "cloud" | "local",
@@ -12,17 +14,19 @@
  *
  * POST body:
  *   { queen_mode: "cloud" | "local",
- *     queen_prompt_override?: string | null }
+ *     queen_prompt_override?: null }   ← non-null rejected in PR 1.
+ *                                         The D12 structured-YAML
+ *                                         schema lands in PR 4.
  *   - omit `queen_prompt_override` to leave the override unchanged
- *   - pass `null` to delete the override
- *   - pass a string to set/replace it
+ *   - pass `null` (or `""`) to delete the override
+ *   - pass a string → 400 invalid_body until PR 4
  *
  * Errors:
- *   - 400 invalid_body — malformed POST input
+ *   - 400 invalid_body — malformed POST input OR non-null override (PR 1 only)
  *   - 401 not_authenticated — missing / expired BYOK session
  *   - 403 fresh_session_required (POST) — session older than 15 min
  *   - 403 no_installation — session has no linked installation
- *   - 409 mode_flip_blocked — PR 2 will surface in-flight rooms here
+ *   - 409 mode_flip_blocked — PR 2 surfaces in-flight rooms / tick lock
  *   - 500 storage_failure
  */
 
@@ -76,17 +80,18 @@ function isQueenMode(value: unknown): value is QueenMode {
 }
 
 /**
- * Maximum bytes for `queen_prompt_override` — bounds the storage
- * write surface (B1 — guard pass-1). 16 KiB is generous for the YAML
- * config D12 specifies (`merge_conventions`, `additional_blockers`)
- * and well under any Redis hash-field limit.
+ * Maximum bytes for `queen_prompt_override`. Kept as a constant
+ * because PR 4 (when the D12 structured-YAML parser lands) will
+ * reuse the same byte cap on the validated payload — bounds the
+ * storage write surface either way.
  *
- * **Schema validation is deferred to PR 4** when the structured-YAML
- * parser ships. Today the field is plain text — operators using the
- * dashboard write whatever they want up to this cap. PR 4 will tighten
- * to a Zod-validated structured config; rejecting non-null overrides
- * here in v1 was rejected because it strands the dashboard textarea
- * with no way to populate the field while waiting for PR 4.
+ * **In PR 1, non-null overrides are rejected outright** (B1 builder
+ * pass-2). D12 is explicit that the override must be a structured
+ * config (`merge_conventions`, `additional_blockers`); shipping a
+ * free-form-string write surface now would lock in the wrong
+ * stored shape and require a migration when PR 4's schema lands.
+ * Until PR 4, only `null` (clear) and `undefined` (leave unchanged)
+ * are accepted on `queen_prompt_override`.
  */
 export const QUEEN_PROMPT_OVERRIDE_MAX_BYTES = 16 * 1024;
 
@@ -108,13 +113,15 @@ function parseBody(raw: unknown): { ok: true; body: PostBody } | { ok: false; me
       message: "queen_prompt_override must be a string, null, or omitted.",
     };
   }
-  // Normalize empty string to null (B3 — guard pass-1) so the GET
-  // round-trip is symmetric. Without this normalization, POSTing
-  // `{queen_prompt_override:""}` would write "" to Redis but the
-  // store's reader at `queen-settings-store.ts:69-70` coerces "" to
-  // null — meaning the next GET returns a different value than the
-  // POST submitted. Keep the empty-string-as-no-override invariant
-  // honest at the boundary instead.
+  // PR 1 only accepts:
+  //   - undefined → leave the existing override untouched
+  //   - null      → delete the override (clear)
+  //   - "" (empty string) → normalize to null (B3 — guard pass-1
+  //     round-trip symmetry; the store's reader coerces "" to null
+  //     anyway, so we honor that contract at the boundary)
+  // Non-empty strings are REJECTED until PR 4's D12 schema parser
+  // ships (B1 — builder pass-2). Locking the stored shape down now
+  // prevents PR 4 from needing a Redis migration.
   let override: string | null | undefined;
   if (obj.queen_prompt_override === undefined) {
     override = undefined;
@@ -125,16 +132,14 @@ function parseBody(raw: unknown): { ok: true; body: PostBody } | { ok: false; me
     if (s.length === 0) {
       override = null;
     } else {
-      // UTF-8 byte length, not char count — paranoid about smileys
-      // inflating into Redis storage past the cap.
-      const bytes = new TextEncoder().encode(s).byteLength;
-      if (bytes > QUEEN_PROMPT_OVERRIDE_MAX_BYTES) {
-        return {
-          ok: false,
-          message: `queen_prompt_override must be ≤${QUEEN_PROMPT_OVERRIDE_MAX_BYTES} bytes (got ${bytes}). Schema validation lands in PR 4.`,
-        };
-      }
-      override = s;
+      return {
+        ok: false,
+        message:
+          "queen_prompt_override must be null or omitted in PR 1. " +
+          "The D12 structured-YAML schema (merge_conventions / " +
+          "additional_blockers) lands in PR 4. Free-form strings " +
+          "are rejected to avoid locking in the wrong stored shape.",
+      };
     }
   }
   return {

--- a/web/src/app/api/dashboard/queen-settings/route.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.ts
@@ -75,6 +75,21 @@ function isQueenMode(value: unknown): value is QueenMode {
   return typeof value === "string" && (QUEEN_MODE_VALUES as readonly string[]).includes(value);
 }
 
+/**
+ * Maximum bytes for `queen_prompt_override` — bounds the storage
+ * write surface (B1 — guard pass-1). 16 KiB is generous for the YAML
+ * config D12 specifies (`merge_conventions`, `additional_blockers`)
+ * and well under any Redis hash-field limit.
+ *
+ * **Schema validation is deferred to PR 4** when the structured-YAML
+ * parser ships. Today the field is plain text — operators using the
+ * dashboard write whatever they want up to this cap. PR 4 will tighten
+ * to a Zod-validated structured config; rejecting non-null overrides
+ * here in v1 was rejected because it strands the dashboard textarea
+ * with no way to populate the field while waiting for PR 4.
+ */
+export const QUEEN_PROMPT_OVERRIDE_MAX_BYTES = 16 * 1024;
+
 function parseBody(raw: unknown): { ok: true; body: PostBody } | { ok: false; message: string } {
   if (raw === null || typeof raw !== "object") {
     return { ok: false, message: "Body must be a JSON object." };
@@ -93,14 +108,40 @@ function parseBody(raw: unknown): { ok: true; body: PostBody } | { ok: false; me
       message: "queen_prompt_override must be a string, null, or omitted.",
     };
   }
+  // Normalize empty string to null (B3 — guard pass-1) so the GET
+  // round-trip is symmetric. Without this normalization, POSTing
+  // `{queen_prompt_override:""}` would write "" to Redis but the
+  // store's reader at `queen-settings-store.ts:69-70` coerces "" to
+  // null — meaning the next GET returns a different value than the
+  // POST submitted. Keep the empty-string-as-no-override invariant
+  // honest at the boundary instead.
+  let override: string | null | undefined;
+  if (obj.queen_prompt_override === undefined) {
+    override = undefined;
+  } else if (obj.queen_prompt_override === null) {
+    override = null;
+  } else {
+    const s = obj.queen_prompt_override as string;
+    if (s.length === 0) {
+      override = null;
+    } else {
+      // UTF-8 byte length, not char count — paranoid about smileys
+      // inflating into Redis storage past the cap.
+      const bytes = new TextEncoder().encode(s).byteLength;
+      if (bytes > QUEEN_PROMPT_OVERRIDE_MAX_BYTES) {
+        return {
+          ok: false,
+          message: `queen_prompt_override must be ≤${QUEEN_PROMPT_OVERRIDE_MAX_BYTES} bytes (got ${bytes}). Schema validation lands in PR 4.`,
+        };
+      }
+      override = s;
+    }
+  }
   return {
     ok: true,
     body: {
       queen_mode: obj.queen_mode,
-      queen_prompt_override:
-        obj.queen_prompt_override === undefined
-          ? undefined
-          : (obj.queen_prompt_override as string | null),
+      queen_prompt_override: override,
     },
   };
 }

--- a/web/src/server/queen-settings-store.test.ts
+++ b/web/src/server/queen-settings-store.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+import {
+  DEFAULT_QUEEN_MODE,
+  getQueenSettings,
+  setQueenSettings,
+  type QueenSettings,
+} from "./queen-settings-store";
+
+// ---------------------------------------------------------------------------
+// Mock Redis with minimal HSET / HGETALL / HDEL + lock primitives
+// ---------------------------------------------------------------------------
+
+interface MockState {
+  hashes: Map<string, Map<string, string>>;
+  strings: Map<string, { value: string; expiresAt?: number }>;
+  evalCalls: number;
+}
+
+function makeMockRedis(): Redis & { _state: MockState } {
+  const state: MockState = {
+    hashes: new Map(),
+    strings: new Map(),
+    evalCalls: 0,
+  };
+
+  const client = {
+    hgetall: vi.fn(async (key: string) => {
+      const h = state.hashes.get(key);
+      if (!h || h.size === 0) return null;
+      const obj: Record<string, string> = {};
+      for (const [k, v] of h) obj[k] = v;
+      return obj;
+    }),
+    hset: vi.fn(async (key: string, fields: Record<string, string>) => {
+      const h = state.hashes.get(key) ?? new Map<string, string>();
+      let added = 0;
+      for (const [k, v] of Object.entries(fields)) {
+        if (!h.has(k)) added += 1;
+        h.set(k, String(v));
+      }
+      state.hashes.set(key, h);
+      return added;
+    }),
+    hdel: vi.fn(async (key: string, ...fields: string[]) => {
+      const h = state.hashes.get(key);
+      if (!h) return 0;
+      let removed = 0;
+      for (const f of fields) {
+        if (h.delete(f)) removed += 1;
+      }
+      return removed;
+    }),
+    hget: vi.fn(async (key: string, field: string) => {
+      const h = state.hashes.get(key);
+      return h?.get(field) ?? null;
+    }),
+    set: vi.fn(async (key: string, value: string, opts?: { nx?: boolean; ex?: number }) => {
+      if (opts?.nx) {
+        const existing = state.strings.get(key);
+        if (existing && (!existing.expiresAt || existing.expiresAt > Date.now())) return null;
+      }
+      state.strings.set(key, {
+        value,
+        expiresAt: opts?.ex ? Date.now() + opts.ex * 1000 : undefined,
+      });
+      return "OK";
+    }),
+    eval: vi.fn(async (_script: string, keys: string[], args: string[]) => {
+      state.evalCalls += 1;
+      // CAS release: only delete if value matches
+      const key = keys[0];
+      const expected = args[0];
+      const entry = state.strings.get(key);
+      if (entry && entry.value === expected) {
+        state.strings.delete(key);
+        return 1;
+      }
+      return 0;
+    }),
+    _state: state,
+  };
+
+  return client as unknown as Redis & { _state: MockState };
+}
+
+const SETTINGS_KEY = (id: string) => `hive:v1:installation:${id}:queen-settings`;
+const LOCK_KEY = (id: string) => `hive:v1:lock:installation:${id}:queen-settings`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getQueenSettings", () => {
+  it("returns the documented default for a new installation", async () => {
+    const redis = makeMockRedis();
+    const settings = await getQueenSettings("42", redis);
+    expect(settings).toEqual({
+      queen_mode: DEFAULT_QUEEN_MODE,
+      queen_prompt_override: null,
+    });
+  });
+
+  it("returns the stored settings", async () => {
+    const redis = makeMockRedis();
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([
+        ["queen_mode", "local"],
+        ["queen_prompt_override", "merge_conventions: squash-only"],
+      ]),
+    );
+    const settings = await getQueenSettings("42", redis);
+    expect(settings.queen_mode).toBe("local");
+    expect(settings.queen_prompt_override).toBe("merge_conventions: squash-only");
+  });
+
+  it("falls back to cloud when stored mode is malformed (defensive)", async () => {
+    const redis = makeMockRedis();
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([["queen_mode", "remote-quantum-mode"]]),
+    );
+    const settings = await getQueenSettings("42", redis);
+    expect(settings.queen_mode).toBe("cloud");
+  });
+
+  it("treats empty override field as null, not empty string", async () => {
+    const redis = makeMockRedis();
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([
+        ["queen_mode", "cloud"],
+        ["queen_prompt_override", ""],
+      ]),
+    );
+    const settings = await getQueenSettings("42", redis);
+    expect(settings.queen_prompt_override).toBeNull();
+  });
+});
+
+describe("setQueenSettings", () => {
+  let redis: Redis & { _state: MockState };
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("writes mode + override to the hash and returns previous + current", async () => {
+    const result = await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "local", queen_prompt_override: "test override" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok=true");
+    expect(result.previous.queen_mode).toBe("cloud");
+    expect(result.current.queen_mode).toBe("local");
+    expect(result.current.queen_prompt_override).toBe("test override");
+    // verify storage
+    const stored = redis._state.hashes.get(SETTINGS_KEY("42"));
+    expect(stored?.get("queen_mode")).toBe("local");
+    expect(stored?.get("queen_prompt_override")).toBe("test override");
+  });
+
+  it("leaves override unchanged when caller omits the field", async () => {
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([
+        ["queen_mode", "cloud"],
+        ["queen_prompt_override", "existing override"],
+      ]),
+    );
+    const result = await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "local" }, // no override key
+    });
+    if (!result.ok) throw new Error("expected ok=true");
+    expect(result.current.queen_prompt_override).toBe("existing override");
+    const stored = redis._state.hashes.get(SETTINGS_KEY("42"));
+    expect(stored?.get("queen_prompt_override")).toBe("existing override");
+  });
+
+  it("deletes override when caller passes null explicitly", async () => {
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([
+        ["queen_mode", "local"],
+        ["queen_prompt_override", "to be deleted"],
+      ]),
+    );
+    const result = await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "local", queen_prompt_override: null },
+    });
+    if (!result.ok) throw new Error("expected ok=true");
+    expect(result.current.queen_prompt_override).toBeNull();
+    const stored = redis._state.hashes.get(SETTINGS_KEY("42"));
+    expect(stored?.has("queen_prompt_override")).toBe(false);
+  });
+
+  it("acquires the per-installation lock during the write (G12)", async () => {
+    const setSpy = vi.spyOn(redis, "set");
+    await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "local" },
+    });
+    // First set call should be the lock acquisition with NX + EX
+    expect(setSpy).toHaveBeenCalledWith(
+      LOCK_KEY("42"),
+      expect.any(String),
+      expect.objectContaining({ nx: true, ex: expect.any(Number) }),
+    );
+    // Lock release happens via eval (CAS)
+    expect(redis._state.evalCalls).toBeGreaterThan(0);
+  });
+
+  it("runs precheck inside the lock and short-circuits on blocked result", async () => {
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([["queen_mode", "cloud"]]),
+    );
+    const result = await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "local" },
+      precheck: async (current) => {
+        expect(current.queen_mode).toBe("cloud");
+        return { blocked: { reason: "rooms_in_flight", count: 3 } };
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected ok=false");
+    expect(result.blocked).toEqual({ reason: "rooms_in_flight", count: 3 });
+    // Storage NOT mutated when blocked
+    const stored = redis._state.hashes.get(SETTINGS_KEY("42"));
+    expect(stored?.get("queen_mode")).toBe("cloud");
+  });
+
+  it("proceeds when precheck returns null", async () => {
+    const precheck = vi.fn(async () => null);
+    const result = await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "local" },
+      precheck,
+    });
+    expect(precheck).toHaveBeenCalledOnce();
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns previous settings reflecting prior state", async () => {
+    redis._state.hashes.set(
+      SETTINGS_KEY("42"),
+      new Map([
+        ["queen_mode", "local"],
+        ["queen_prompt_override", "v1"],
+      ]),
+    );
+    const result = await setQueenSettings({
+      installationId: "42",
+      redis,
+      next: { queen_mode: "cloud", queen_prompt_override: "v2" },
+    });
+    if (!result.ok) throw new Error("expected ok=true");
+    expect(result.previous).toEqual<QueenSettings>({
+      queen_mode: "local",
+      queen_prompt_override: "v1",
+    });
+  });
+});

--- a/web/src/server/queen-settings-store.test.ts
+++ b/web/src/server/queen-settings-store.test.ts
@@ -78,6 +78,42 @@ function makeMockRedis(): Redis & { _state: MockState } {
       }
       return 0;
     }),
+    // Minimal MULTI pipeline mock — chains record ops and run on exec.
+    // Only HDEL + HSET wired since those are the ones the store uses;
+    // any new chained op gets a "not a function" failure rather than
+    // a silently-wrong return.
+    multi: vi.fn(() => {
+      const ops: Array<() => Promise<unknown>> = [];
+      const chain = {
+        hdel: (key: string, ...fields: string[]) => {
+          ops.push(async () => {
+            const h = state.hashes.get(key);
+            if (!h) return 0;
+            let removed = 0;
+            for (const f of fields) {
+              if (h.delete(f)) removed += 1;
+            }
+            return removed;
+          });
+          return chain;
+        },
+        hset: (key: string, f: Record<string, string>) => {
+          ops.push(async () => {
+            const h = state.hashes.get(key) ?? new Map<string, string>();
+            for (const [k, v] of Object.entries(f)) h.set(k, String(v));
+            state.hashes.set(key, h);
+            return 0;
+          });
+          return chain;
+        },
+        exec: async () => {
+          const out: unknown[] = [];
+          for (const op of ops) out.push(await op());
+          return out;
+        },
+      };
+      return chain;
+    }),
     _state: state,
   };
 

--- a/web/src/server/queen-settings-store.ts
+++ b/web/src/server/queen-settings-store.ts
@@ -1,0 +1,149 @@
+/**
+ * Redis-backed per-installation queen settings.
+ *
+ * Each installation gets one hash at `hive:v1:installation:<id>:queen-settings`
+ * with `queen_mode` (`cloud | local`, default `cloud`) and an optional
+ * `queen_prompt_override` YAML blob (D12). Reads default to `cloud` on
+ * Redis-down (G7) so a failed Redis never silently flips an installation
+ * into local mode.
+ *
+ * The `setQueenSettings` mutator runs under a per-installation lock (G12)
+ * so that PR 2's mode-flip in-flight check + write happens atomically.
+ * PR 1 ships the lock primitive; PR 2 plugs the in-flight check in.
+ */
+
+import { type Redis } from "@upstash/redis";
+import { withRedisLock } from "@hivemoot/war-room";
+
+const KEY_PREFIX = "hive:v1:installation:";
+const KEY_SUFFIX = ":queen-settings";
+const LOCK_PREFIX = "hive:v1:lock:installation:";
+const LOCK_SUFFIX = ":queen-settings";
+
+export const QUEEN_MODE_VALUES = ["cloud", "local"] as const;
+export type QueenMode = (typeof QUEEN_MODE_VALUES)[number];
+
+export const DEFAULT_QUEEN_MODE: QueenMode = "cloud";
+
+export interface QueenSettings {
+  queen_mode: QueenMode;
+  queen_prompt_override: string | null;
+}
+
+const DEFAULT_SETTINGS: QueenSettings = {
+  queen_mode: DEFAULT_QUEEN_MODE,
+  queen_prompt_override: null,
+};
+
+function settingsKey(installationId: string): string {
+  return `${KEY_PREFIX}${installationId}${KEY_SUFFIX}`;
+}
+
+function lockKey(installationId: string): string {
+  return `${LOCK_PREFIX}${installationId}${LOCK_SUFFIX}`;
+}
+
+function isQueenMode(value: unknown): value is QueenMode {
+  return typeof value === "string" && (QUEEN_MODE_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Reads the queen settings for an installation. Returns the documented
+ * default (`{ queen_mode: "cloud", queen_prompt_override: null }`) when:
+ *   - the hash doesn't exist (new installation)
+ *   - the stored `queen_mode` is malformed (defensive fail-closed)
+ *
+ * G7: callers should treat any thrown error as "default to cloud" — the
+ * Probot cache wrapper does that, see `getQueenModeCached`.
+ */
+export async function getQueenSettings(
+  installationId: string,
+  redis: Redis,
+): Promise<QueenSettings> {
+  const raw = await redis.hgetall<Record<string, string>>(settingsKey(installationId));
+  if (!raw || Object.keys(raw).length === 0) return { ...DEFAULT_SETTINGS };
+
+  const mode = raw.queen_mode;
+  const queen_mode: QueenMode = isQueenMode(mode) ? mode : DEFAULT_QUEEN_MODE;
+  const overrideRaw = raw.queen_prompt_override;
+  const queen_prompt_override =
+    typeof overrideRaw === "string" && overrideRaw.length > 0 ? overrideRaw : null;
+
+  return { queen_mode, queen_prompt_override };
+}
+
+export interface SetQueenSettingsArgs {
+  installationId: string;
+  redis: Redis;
+  /**
+   * Optional in-flight precheck. Runs INSIDE the per-installation lock,
+   * after acquisition and BEFORE the write. If it returns a non-null
+   * value, the write is skipped and the value bubbles back to the
+   * caller as `{ ok: false, blocked: <value> }`. PR 2 plugs in the D9
+   * "rooms in deciding / decided_pending_action" check here.
+   */
+  precheck?: (current: QueenSettings) => Promise<{ blocked: unknown } | null>;
+  /**
+   * The new settings. Pass `queen_prompt_override: null` to delete the
+   * override field; omit it to leave the existing override untouched.
+   */
+  next: {
+    queen_mode: QueenMode;
+    queen_prompt_override?: string | null;
+  };
+}
+
+export type SetQueenSettingsResult =
+  | { ok: true; previous: QueenSettings; current: QueenSettings }
+  | { ok: false; blocked: unknown };
+
+/**
+ * Atomically updates queen settings for an installation under a
+ * per-installation Redis lock (G12).
+ *
+ * The protected critical section is:
+ *   1. read current settings
+ *   2. run the optional precheck (PR 2 plugs in the in-flight check here)
+ *   3. write next settings via `HSET`
+ *
+ * The lock prevents the cloud queen-tick from claiming a room between
+ * the in-flight read and the mode write — without it, a race could
+ * leave a room mid-claim under the wrong mode.
+ *
+ * Errors from the lock acquisition (`LockTimeoutError`) bubble to the
+ * caller; this is intentional so the operator sees a clear timeout
+ * rather than a silent stale read.
+ */
+export async function setQueenSettings(
+  args: SetQueenSettingsArgs,
+): Promise<SetQueenSettingsResult> {
+  return withRedisLock(lockKey(args.installationId), args.redis, async () => {
+    const previous = await getQueenSettings(args.installationId, args.redis);
+
+    if (args.precheck) {
+      const blocked = await args.precheck(previous);
+      if (blocked) return { ok: false as const, blocked: blocked.blocked };
+    }
+
+    const fields: Record<string, string> = { queen_mode: args.next.queen_mode };
+    const overrideArg = args.next.queen_prompt_override;
+    if (overrideArg !== undefined) {
+      // Caller wants to update the override; null means "clear it"
+      if (overrideArg === null) {
+        await args.redis.hdel(settingsKey(args.installationId), "queen_prompt_override");
+      } else {
+        fields.queen_prompt_override = overrideArg;
+      }
+    }
+
+    await args.redis.hset(settingsKey(args.installationId), fields);
+
+    const current: QueenSettings = {
+      queen_mode: args.next.queen_mode,
+      queen_prompt_override:
+        overrideArg === undefined ? previous.queen_prompt_override : overrideArg,
+    };
+
+    return { ok: true as const, previous, current };
+  });
+}

--- a/web/src/server/queen-settings-store.ts
+++ b/web/src/server/queen-settings-store.ts
@@ -3,13 +3,29 @@
  *
  * Each installation gets one hash at `hive:v1:installation:<id>:queen-settings`
  * with `queen_mode` (`cloud | local`, default `cloud`) and an optional
- * `queen_prompt_override` YAML blob (D12). Reads default to `cloud` on
+ * `queen_prompt_override` blob (D12). Reads default to `cloud` on
  * Redis-down (G7) so a failed Redis never silently flips an installation
  * into local mode.
  *
- * The `setQueenSettings` mutator runs under a per-installation lock (G12)
- * so that PR 2's mode-flip in-flight check + write happens atomically.
- * PR 1 ships the lock primitive; PR 2 plugs the in-flight check in.
+ * # What "G12" means here (precise)
+ *
+ * The `setQueenSettings` mutator runs under a per-installation Redis
+ * lock. The lock serializes **dashboard writers** — concurrent
+ * operator clicks land in order, and PR 2's in-flight precheck reads
+ * the room set while holding the same lock so the check + write is
+ * one critical section.
+ *
+ * The lock does NOT serialize against the cloud queen-tick claim
+ * path — that path doesn't acquire this lock. In-flight isolation
+ * comes from PR 2's precheck (refuses the flip if any room is mid-
+ * claim) plus D15's 60s cache propagation budget. Mode flips are
+ * **eventually consistent within the cache TTL**, not instantly
+ * invisible to mid-flight queens.
+ *
+ * That distinction matters for the operator UX text: the dashboard
+ * says "mode flip blocked by in-flight rooms" when the precheck
+ * fires, not "atomic flip succeeded" — the latter would imply the
+ * stricter invariant we don't actually deliver.
  */
 
 import { type Redis } from "@upstash/redis";
@@ -98,17 +114,26 @@ export type SetQueenSettingsResult =
   | { ok: false; blocked: unknown };
 
 /**
- * Atomically updates queen settings for an installation under a
- * per-installation Redis lock (G12).
+ * Updates queen settings for an installation under a per-installation
+ * Redis lock (G12). Note: the lock serializes **dashboard writers** —
+ * queen-tick claims do NOT acquire this lock. So this is "serialized
+ * writes + bounded propagation via D15's 60s cache" semantics, not
+ * "the mode flip is invisible to mid-flight queen-tick claims".
+ * That stricter invariant is PR 2's `precheck` job — it observes the
+ * in-flight room set under the same lock, and refuses the flip if
+ * any room is mid-claim.
  *
  * The protected critical section is:
  *   1. read current settings
  *   2. run the optional precheck (PR 2 plugs in the in-flight check here)
- *   3. write next settings via `HSET`
+ *   3. write next settings as one atomic Redis MULTI pipeline
  *
- * The lock prevents the cloud queen-tick from claiming a room between
- * the in-flight read and the mode write — without it, a race could
- * leave a room mid-claim under the wrong mode.
+ * Atomic pipeline matters when `queen_prompt_override === null` —
+ * that case needs both an HDEL on the override field AND an HSET on
+ * `queen_mode` to land together. Doing them as separate awaits would
+ * leave a window where a crash between the two writes left
+ * `queen_mode` updated but the stale override still in Redis (B2 in
+ * guard pass-1).
  *
  * Errors from the lock acquisition (`LockTimeoutError`) bubble to the
  * caller; this is intentional so the operator sees a clear timeout
@@ -127,16 +152,30 @@ export async function setQueenSettings(
 
     const fields: Record<string, string> = { queen_mode: args.next.queen_mode };
     const overrideArg = args.next.queen_prompt_override;
+    let willDeleteOverride = false;
     if (overrideArg !== undefined) {
       // Caller wants to update the override; null means "clear it"
       if (overrideArg === null) {
-        await args.redis.hdel(settingsKey(args.installationId), "queen_prompt_override");
+        willDeleteOverride = true;
       } else {
         fields.queen_prompt_override = overrideArg;
       }
     }
 
-    await args.redis.hset(settingsKey(args.installationId), fields);
+    // Atomic write — HDEL (when clearing override) + HSET pipelined
+    // so a crash between can't leave queen_mode updated against a
+    // stale override (B2). Same chained-pipeline pattern used in
+    // web/src/server/task-store.ts.
+    const key = settingsKey(args.installationId);
+    if (willDeleteOverride) {
+      await args.redis
+        .multi()
+        .hdel(key, "queen_prompt_override")
+        .hset(key, fields)
+        .exec();
+    } else {
+      await args.redis.hset(key, fields);
+    }
 
     const current: QueenSettings = {
       queen_mode: args.next.queen_mode,


### PR DESCRIPTION
## Summary

PR 1 of the Queen Execution Mode RFC's 6-PR stack (RFC merged as #628). **No production behavior changes ship in this PR** — storage exists, endpoints exist, bot can read the cached mode, but no production code reads it yet.

## What it ships

- **\`web/src/server/queen-settings-store.ts\`** — Redis hash at \`hive:v1:installation:<id>:queen-settings\` with \`queen_mode\` (\`cloud | local\`, default \`cloud\`) + optional \`queen_prompt_override\`. \`setQueenSettings\` runs under \`withRedisLock\` (G12) so PR 2 can plug the in-flight check (D9/G37) into the \`precheck\` slot atomically with the write.
- **\`web/src/app/api/dashboard/queen-settings/route.ts\`** — operator-session-gated GET/POST. POST requires a fresh session (15-min window). Returns 409 \`mode_flip_blocked\` when PR 2's precheck rejects the flip; today the precheck is always null so this code path is dead until PR 2 ships.
- **\`bot/api/lib/queen-mode.ts\`** — Probot 60s TTL in-memory cache (D15) over the \`queen_mode\` field. Fail-closed per G7: any Redis error logs and returns \`\"cloud\"\`.

## Why the lock exists in PR 1

The lock primitive ships now, even though PR 1 has no precheck to run, because the store's API surface is the contract PR 2 binds against. Shipping atomic semantics from day one means PR 2 doesn't need to revise the store API — it just plugs a function into the \`precheck\` slot.

## What it looks like

\`\`\`
GET /api/dashboard/queen-settings
→ 200 { installation_id: \"42\", queen_mode: \"cloud\", queen_prompt_override: null }
→ 401 { code: \"not_authenticated\" }
→ 403 { code: \"no_installation\" }

POST /api/dashboard/queen-settings  body: { queen_mode: \"local\" }
→ 200 { installation_id: \"42\", queen_mode: \"local\", queen_prompt_override: null }
→ 400 { code: \"invalid_body\", message: \"queen_mode must be 'cloud' or 'local'.\" }
→ 403 { code: \"fresh_session_required\" }
→ 409 { code: \"mode_flip_blocked\", blocked: <PR 2 will fill this> }
\`\`\`

## Test plan

- [x] 11 unit tests for \`queen-settings-store\` — read defaults, malformed-mode fallback, override merge semantics (omit/null/string), lock acquisition under G12, precheck short-circuit + previous-state propagation
- [x] 8 unit tests for \`queen-mode\` cache — default cloud, hit/miss/expiry, G7 fail-closed on Redis error AND on garbage values, per-installation cache isolation, fallback caching to avoid retry storms
- [x] 12 unit tests for the dashboard route — auth gates, 401/403/409/500 paths, body validation, fresh-session requirement, set→read round-trip
- [x] Full web suite: 1502 passing
- [x] Full bot suite: 1984 passing
- [x] Web + bot typecheck clean
- [x] Lint clean

Refs RFC D15 + G7 + G12.

(Replaces #635 — zombie-head defect from gh CLI's branch resolution. This PR is the clean version.)