### PR TITLE
feat(dashboard): /dashboard/settings — queen mode toggle + override (5 v1)

### DIFF
--- a/web/src/app/dashboard/DashboardNav.tsx
+++ b/web/src/app/dashboard/DashboardNav.tsx
@@ -7,6 +7,7 @@ const TABS = [
   { href: "/dashboard", label: "Agent Health" },
   { href: "/dashboard/tasks", label: "Tasks" },
   { href: "/dashboard/rooms", label: "War Rooms" },
+  { href: "/dashboard/settings", label: "Settings" },
   { href: "/dashboard/credentials", label: "Credentials" },
 ] as const;
 

--- a/web/src/app/dashboard/settings/SettingsDashboard.tsx
+++ b/web/src/app/dashboard/settings/SettingsDashboard.tsx
@@ -40,6 +40,13 @@ type SaveState =
 
 const SETTINGS_URL = "/api/dashboard/queen-settings";
 
+/** Client-side cap on the override blob (G4 — guard pass-1 hardening
+ * on PR 5). 16 KiB is generous for a YAML config and well under any
+ * Redis hash-field limit. The route handler should match this cap
+ * (PR 1 follow-up); without a server-side cap an authenticated
+ * operator can still POST a larger blob via curl. */
+const OVERRIDE_MAX_CHARS = 16 * 1024;
+
 export default function SettingsDashboard() {
   const [load, setLoad] = useState<LoadState>({ kind: "loading" });
   const [draftMode, setDraftMode] = useState<QueenMode>("cloud");
@@ -72,8 +79,7 @@ export default function SettingsDashboard() {
   }, [fetchSettings]);
 
   const handleSave = useCallback(
-    async (force = false) => {
-      void force;
+    async () => {
       setSave({ kind: "saving" });
       try {
         const body: Record<string, unknown> = {
@@ -165,10 +171,12 @@ export default function SettingsDashboard() {
         </h1>
         <p className="mt-2 text-sm text-zinc-400">
           Per-installation configuration. See also{" "}
-          <Link href="/dashboard/settings/byok" className="text-honey-400 hover:underline">
+          <Link href="/dashboard/credentials" className="text-honey-400 hover:underline">
             BYOK credentials
           </Link>
-          .
+          . (Linking the legacy path so this works whether or not the
+          BYOK relocation PR has merged; the relocation sweep will
+          rewrite this on its end.)
         </p>
       </div>
 
@@ -218,9 +226,19 @@ export default function SettingsDashboard() {
               onChange={(e) => setDraftOverride(e.target.value)}
               rows={6}
               spellCheck={false}
+              maxLength={OVERRIDE_MAX_CHARS}
               className="w-full rounded-md border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs text-zinc-200 focus:border-honey-500 focus:outline-none"
               placeholder="merge_conventions: |&#10;  Squash-merge only. Require all checks green before merging."
             />
+            <p
+              className={`text-right text-[11px] ${
+                draftOverride.length > OVERRIDE_MAX_CHARS - 1024
+                  ? "text-amber-400"
+                  : "text-zinc-500"
+              }`}
+            >
+              {draftOverride.length.toLocaleString()} / {OVERRIDE_MAX_CHARS.toLocaleString()} chars
+            </p>
           </div>
         </details>
 
@@ -352,7 +370,7 @@ function BlockedRoomsBanner({ blocked }: { blocked: BlockedReason }): React.Reac
           {blocked.sampleRoomIds.map((id, i) => (
             <span key={id}>
               <Link
-                href={`/dashboard/rooms/${id}`}
+                href={`/dashboard/rooms/${encodeURIComponent(id)}`}
                 className="font-mono text-honey-400 hover:underline"
               >
                 {id.slice(0, 8)}

--- a/web/src/app/dashboard/settings/SettingsDashboard.tsx
+++ b/web/src/app/dashboard/settings/SettingsDashboard.tsx
@@ -17,6 +17,8 @@ interface BlockedReason {
     deciding: number;
     decided_pending_action: number;
     stranded_merge: number;
+    /** PR 2 (#641) guard pass-1 G2: queen-tick is mid-flight. */
+    tick_running: number;
   };
   sampleRoomIds: string[];
 }
@@ -339,15 +341,17 @@ function ModeChoice({
 }
 
 function BlockedRoomsBanner({ blocked }: { blocked: BlockedReason }): React.ReactElement {
-  const total =
+  const roomCount =
     blocked.counts.deciding +
     blocked.counts.decided_pending_action +
     blocked.counts.stranded_merge;
+  const tickRunning = blocked.counts.tick_running > 0;
+  const headline = tickRunning && roomCount === 0
+    ? "Mode flip blocked — queen-tick mid-flight"
+    : `Mode flip blocked — ${roomCount} room${roomCount === 1 ? "" : "s"} in flight`;
   return (
     <div className="mt-4 rounded-md border border-amber-500/30 bg-amber-500/5 p-4 text-sm">
-      <p className="font-semibold text-amber-200">
-        Mode flip blocked — {total} room{total === 1 ? "" : "s"} in flight
-      </p>
+      <p className="font-semibold text-amber-200">{headline}</p>
       <ul className="mt-2 space-y-1 text-xs text-zinc-400">
         {blocked.counts.deciding > 0 && (
           <li>{blocked.counts.deciding} in <code>deciding</code> (mid-claim)</li>
@@ -361,6 +365,13 @@ function BlockedRoomsBanner({ blocked }: { blocked: BlockedReason }): React.Reac
         {blocked.counts.stranded_merge > 0 && (
           <li>
             {blocked.counts.stranded_merge} stranded merge — check the reconciler
+          </li>
+        )}
+        {tickRunning && (
+          <li>
+            queen-tick is running for this installation — wait ~30s and retry.
+            Without this gate the tick would finish synthesizing in the OLD
+            mode (it reads queen-mode once at the top of its loop).
           </li>
         )}
       </ul>

--- a/web/src/app/dashboard/settings/SettingsDashboard.tsx
+++ b/web/src/app/dashboard/settings/SettingsDashboard.tsx
@@ -42,13 +42,6 @@ type SaveState =
 
 const SETTINGS_URL = "/api/dashboard/queen-settings";
 
-/** Client-side cap on the override blob (G4 — guard pass-1 hardening
- * on PR 5). 16 KiB is generous for a YAML config and well under any
- * Redis hash-field limit. The route handler should match this cap
- * (PR 1 follow-up); without a server-side cap an authenticated
- * operator can still POST a larger blob via curl. */
-const OVERRIDE_MAX_CHARS = 16 * 1024;
-
 export default function SettingsDashboard() {
   const [load, setLoad] = useState<LoadState>({ kind: "loading" });
   const [draftMode, setDraftMode] = useState<QueenMode>("cloud");
@@ -67,6 +60,11 @@ export default function SettingsDashboard() {
       const settings = (await res.json()) as QueenSettings;
       setLoad({ kind: "loaded", settings });
       setDraftMode(settings.queen_mode);
+      // Override editing is disabled until PR 4 ships the D12
+      // structured-YAML schema (merge_conventions /
+      // additional_blockers). The store route rejects any non-null
+      // override today (PR 1 pass-2). We still surface the *current*
+      // value as read-only context for operators.
       setDraftOverride(settings.queen_prompt_override ?? "");
     } catch (err) {
       setLoad({
@@ -84,16 +82,14 @@ export default function SettingsDashboard() {
     async () => {
       setSave({ kind: "saving" });
       try {
+        // PR 1 pass-2 rejects any non-null override; the structured
+        // YAML schema lands in PR 4 (D12). Until then we only ever
+        // send the queen_mode field — the override stays at whatever
+        // the route already has. Once D12 lands, this function gets
+        // a `body.queen_prompt_override = parsedYaml ?? null` line.
         const body: Record<string, unknown> = {
           queen_mode: draftMode,
         };
-        // Send override field only when it changed; null clears, string sets,
-        // omit leaves untouched (matches the route contract from PR 1).
-        const current =
-          load.kind === "loaded" ? load.settings.queen_prompt_override : null;
-        const trimmed = draftOverride.trim();
-        const newVal = trimmed.length > 0 ? trimmed : null;
-        if (newVal !== current) body.queen_prompt_override = newVal;
 
         const res = await fetch(SETTINGS_URL, {
           method: "POST",
@@ -104,12 +100,19 @@ export default function SettingsDashboard() {
         if (res.status === 409) {
           const err = (await res.json()) as PostError;
           if (err.blocked) {
+            // Close the modal before surfacing the blocked banner —
+            // otherwise the modal stays open over the banner and
+            // the operator can't read why their flip was blocked.
+            setConfirmFlip(null);
             setSave({ kind: "blocked", blocked: err.blocked });
             return;
           }
         }
         if (!res.ok) {
           const err = (await res.json().catch(() => ({}))) as PostError;
+          // Same as the 409 path: dismiss the modal so the inline
+          // error message under the Save button is visible.
+          setConfirmFlip(null);
           setSave({
             kind: "error",
             message: err.message || `HTTP ${res.status}`,
@@ -124,13 +127,17 @@ export default function SettingsDashboard() {
         setSave({ kind: "idle" });
         setConfirmFlip(null);
       } catch (err) {
+        // Network / parse failures must also close the modal —
+        // the modal's "Confirm flip" stays in saving state forever
+        // otherwise.
+        setConfirmFlip(null);
         setSave({
           kind: "error",
           message: err instanceof Error ? err.message : "Save failed",
         });
       }
     },
-    [draftMode, draftOverride, load],
+    [draftMode],
   );
 
   if (load.kind === "loading") {
@@ -161,9 +168,10 @@ export default function SettingsDashboard() {
 
   const { settings } = load;
   const modeChanged = draftMode !== settings.queen_mode;
-  const overrideChanged =
-    (draftOverride.trim() || null) !== (settings.queen_prompt_override ?? null);
-  const dirty = modeChanged || overrideChanged;
+  // Override editing is disabled until PR 4 lands the D12 schema —
+  // dirty state tracks mode only. Once the schema editor ships,
+  // this becomes `modeChanged || overrideChanged`.
+  const dirty = modeChanged;
 
   return (
     <>
@@ -176,9 +184,7 @@ export default function SettingsDashboard() {
           <Link href="/dashboard/credentials" className="text-honey-400 hover:underline">
             BYOK credentials
           </Link>
-          . (Linking the legacy path so this works whether or not the
-          BYOK relocation PR has merged; the relocation sweep will
-          rewrite this on its end.)
+          .
         </p>
       </div>
 
@@ -215,32 +221,19 @@ export default function SettingsDashboard() {
 
         <details className="mt-6">
           <summary className="cursor-pointer text-sm font-medium text-zinc-300 hover:text-zinc-100">
-            Structured prompt override (optional)
+            Structured prompt override
           </summary>
           <div className="mt-3 space-y-2">
             <p className="text-xs text-zinc-500">
-              YAML/text passed to the queen as additional judgment guidelines (D12).
-              Leave empty to use defaults. The override is bounded by a schema in PR 3;
-              today it&apos;s stored as a plain string.
+              The structured override (D12 — <code>merge_conventions</code>{" "}
+              and <code>additional_blockers</code>) lands in a follow-up
+              release. Free-form strings are rejected by the API today,
+              so the editor is read-only until then. The current stored
+              value, if any, is shown below.
             </p>
-            <textarea
-              value={draftOverride}
-              onChange={(e) => setDraftOverride(e.target.value)}
-              rows={6}
-              spellCheck={false}
-              maxLength={OVERRIDE_MAX_CHARS}
-              className="w-full rounded-md border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs text-zinc-200 focus:border-honey-500 focus:outline-none"
-              placeholder="merge_conventions: |&#10;  Squash-merge only. Require all checks green before merging."
-            />
-            <p
-              className={`text-right text-[11px] ${
-                draftOverride.length > OVERRIDE_MAX_CHARS - 1024
-                  ? "text-amber-400"
-                  : "text-zinc-500"
-              }`}
-            >
-              {draftOverride.length.toLocaleString()} / {OVERRIDE_MAX_CHARS.toLocaleString()} chars
-            </p>
+            <pre className="w-full overflow-x-auto rounded-md border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs text-zinc-400">
+              {draftOverride.length > 0 ? draftOverride : "(no override set)"}
+            </pre>
           </div>
         </details>
 

--- a/web/src/app/dashboard/settings/SettingsDashboard.tsx
+++ b/web/src/app/dashboard/settings/SettingsDashboard.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+type QueenMode = "cloud" | "local";
+
+interface QueenSettings {
+  installation_id: string;
+  queen_mode: QueenMode;
+  queen_prompt_override: string | null;
+}
+
+interface BlockedReason {
+  reason: "rooms_in_flight";
+  counts: {
+    deciding: number;
+    decided_pending_action: number;
+    stranded_merge: number;
+  };
+  sampleRoomIds: string[];
+}
+
+interface PostError {
+  code: string;
+  message: string;
+  blocked?: BlockedReason;
+}
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "loaded"; settings: QueenSettings }
+  | { kind: "error"; message: string };
+
+type SaveState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "blocked"; blocked: BlockedReason }
+  | { kind: "error"; message: string };
+
+const SETTINGS_URL = "/api/dashboard/queen-settings";
+
+export default function SettingsDashboard() {
+  const [load, setLoad] = useState<LoadState>({ kind: "loading" });
+  const [draftMode, setDraftMode] = useState<QueenMode>("cloud");
+  const [draftOverride, setDraftOverride] = useState<string>("");
+  const [save, setSave] = useState<SaveState>({ kind: "idle" });
+  const [confirmFlip, setConfirmFlip] = useState<QueenMode | null>(null);
+
+  const fetchSettings = useCallback(async () => {
+    setLoad({ kind: "loading" });
+    try {
+      const res = await fetch(SETTINGS_URL, { cache: "no-store" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as PostError;
+        throw new Error(body.message || `HTTP ${res.status}`);
+      }
+      const settings = (await res.json()) as QueenSettings;
+      setLoad({ kind: "loaded", settings });
+      setDraftMode(settings.queen_mode);
+      setDraftOverride(settings.queen_prompt_override ?? "");
+    } catch (err) {
+      setLoad({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Failed to load settings",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchSettings();
+  }, [fetchSettings]);
+
+  const handleSave = useCallback(
+    async (force = false) => {
+      void force;
+      setSave({ kind: "saving" });
+      try {
+        const body: Record<string, unknown> = {
+          queen_mode: draftMode,
+        };
+        // Send override field only when it changed; null clears, string sets,
+        // omit leaves untouched (matches the route contract from PR 1).
+        const current =
+          load.kind === "loaded" ? load.settings.queen_prompt_override : null;
+        const trimmed = draftOverride.trim();
+        const newVal = trimmed.length > 0 ? trimmed : null;
+        if (newVal !== current) body.queen_prompt_override = newVal;
+
+        const res = await fetch(SETTINGS_URL, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+        if (res.status === 409) {
+          const err = (await res.json()) as PostError;
+          if (err.blocked) {
+            setSave({ kind: "blocked", blocked: err.blocked });
+            return;
+          }
+        }
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as PostError;
+          setSave({
+            kind: "error",
+            message: err.message || `HTTP ${res.status}`,
+          });
+          return;
+        }
+
+        const settings = (await res.json()) as QueenSettings;
+        setLoad({ kind: "loaded", settings });
+        setDraftMode(settings.queen_mode);
+        setDraftOverride(settings.queen_prompt_override ?? "");
+        setSave({ kind: "idle" });
+        setConfirmFlip(null);
+      } catch (err) {
+        setSave({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Save failed",
+        });
+      }
+    },
+    [draftMode, draftOverride, load],
+  );
+
+  if (load.kind === "loading") {
+    return (
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center">
+        <p className="text-sm text-zinc-400">Loading settings…</p>
+      </div>
+    );
+  }
+
+  if (load.kind === "error") {
+    return (
+      <div className="rounded-lg border border-rose-500/30 bg-rose-500/5 p-8">
+        <h2 className="mb-2 text-lg font-semibold text-rose-300">
+          Couldn&apos;t load settings
+        </h2>
+        <p className="text-sm text-zinc-400">{load.message}</p>
+        <button
+          type="button"
+          onClick={() => void fetchSettings()}
+          className="mt-4 inline-flex items-center gap-2 rounded-md bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-200 hover:bg-zinc-700"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { settings } = load;
+  const modeChanged = draftMode !== settings.queen_mode;
+  const overrideChanged =
+    (draftOverride.trim() || null) !== (settings.queen_prompt_override ?? null);
+  const dirty = modeChanged || overrideChanged;
+
+  return (
+    <>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
+          Settings
+        </h1>
+        <p className="mt-2 text-sm text-zinc-400">
+          Per-installation configuration. See also{" "}
+          <Link href="/dashboard/settings/byok" className="text-honey-400 hover:underline">
+            BYOK credentials
+          </Link>
+          .
+        </p>
+      </div>
+
+      <section className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900 p-6">
+        <h2 className="text-lg font-semibold text-[#fafafa]">Queen execution mode</h2>
+        <p className="mt-1 text-sm text-zinc-400">
+          Where war-room synthesis runs for installation{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            {settings.installation_id}
+          </code>
+          .
+        </p>
+
+        <fieldset className="mt-6 space-y-3">
+          <legend className="sr-only">Queen mode</legend>
+
+          <ModeChoice
+            value="cloud"
+            label="Cloud (default)"
+            description="Vercel cron runs the synthesis loop. BYOK provider key bills per token."
+            current={settings.queen_mode}
+            draft={draftMode}
+            onSelect={setDraftMode}
+          />
+          <ModeChoice
+            value="local"
+            label="Local (hive queen)"
+            description="The hive queen agent runs synthesis on Codex (flat cost). Cloud retains webhook handlers + observer-pass stuck-room metric."
+            current={settings.queen_mode}
+            draft={draftMode}
+            onSelect={setDraftMode}
+          />
+        </fieldset>
+
+        <details className="mt-6">
+          <summary className="cursor-pointer text-sm font-medium text-zinc-300 hover:text-zinc-100">
+            Structured prompt override (optional)
+          </summary>
+          <div className="mt-3 space-y-2">
+            <p className="text-xs text-zinc-500">
+              YAML/text passed to the queen as additional judgment guidelines (D12).
+              Leave empty to use defaults. The override is bounded by a schema in PR 3;
+              today it&apos;s stored as a plain string.
+            </p>
+            <textarea
+              value={draftOverride}
+              onChange={(e) => setDraftOverride(e.target.value)}
+              rows={6}
+              spellCheck={false}
+              className="w-full rounded-md border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs text-zinc-200 focus:border-honey-500 focus:outline-none"
+              placeholder="merge_conventions: |&#10;  Squash-merge only. Require all checks green before merging."
+            />
+          </div>
+        </details>
+
+        <div className="mt-6 flex items-center gap-3">
+          <button
+            type="button"
+            disabled={!dirty || save.kind === "saving"}
+            onClick={() => {
+              if (modeChanged) setConfirmFlip(draftMode);
+              else void handleSave();
+            }}
+            className="inline-flex items-center gap-2 rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:bg-zinc-700 disabled:text-zinc-500"
+          >
+            {save.kind === "saving" ? "Saving…" : "Save"}
+          </button>
+          {dirty && save.kind !== "saving" && (
+            <button
+              type="button"
+              onClick={() => {
+                setDraftMode(settings.queen_mode);
+                setDraftOverride(settings.queen_prompt_override ?? "");
+                setSave({ kind: "idle" });
+              }}
+              className="text-sm text-zinc-400 hover:text-zinc-200"
+            >
+              Cancel
+            </button>
+          )}
+          {save.kind === "error" && (
+            <p className="text-sm text-rose-300">{save.message}</p>
+          )}
+        </div>
+
+        {save.kind === "blocked" && (
+          <BlockedRoomsBanner blocked={save.blocked} />
+        )}
+      </section>
+
+      {confirmFlip !== null && (
+        <FlipConfirmModal
+          targetMode={confirmFlip}
+          currentMode={settings.queen_mode}
+          onCancel={() => setConfirmFlip(null)}
+          onConfirm={() => void handleSave()}
+          saving={save.kind === "saving"}
+        />
+      )}
+    </>
+  );
+}
+
+function ModeChoice({
+  value,
+  label,
+  description,
+  current,
+  draft,
+  onSelect,
+}: {
+  value: QueenMode;
+  label: string;
+  description: string;
+  current: QueenMode;
+  draft: QueenMode;
+  onSelect: (m: QueenMode) => void;
+}): React.ReactElement {
+  const checked = draft === value;
+  const isCurrent = current === value;
+  return (
+    <label
+      className={`flex cursor-pointer items-start gap-3 rounded-md border p-4 transition-colors ${
+        checked
+          ? "border-honey-500 bg-honey-500/5"
+          : "border-zinc-800 bg-zinc-950 hover:border-zinc-700"
+      }`}
+    >
+      <input
+        type="radio"
+        name="queen-mode"
+        value={value}
+        checked={checked}
+        onChange={() => onSelect(value)}
+        className="mt-1 h-4 w-4 accent-honey-500"
+      />
+      <div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-zinc-100">{label}</span>
+          {isCurrent && (
+            <span className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-zinc-400">
+              current
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-zinc-400">{description}</p>
+      </div>
+    </label>
+  );
+}
+
+function BlockedRoomsBanner({ blocked }: { blocked: BlockedReason }): React.ReactElement {
+  const total =
+    blocked.counts.deciding +
+    blocked.counts.decided_pending_action +
+    blocked.counts.stranded_merge;
+  return (
+    <div className="mt-4 rounded-md border border-amber-500/30 bg-amber-500/5 p-4 text-sm">
+      <p className="font-semibold text-amber-200">
+        Mode flip blocked — {total} room{total === 1 ? "" : "s"} in flight
+      </p>
+      <ul className="mt-2 space-y-1 text-xs text-zinc-400">
+        {blocked.counts.deciding > 0 && (
+          <li>{blocked.counts.deciding} in <code>deciding</code> (mid-claim)</li>
+        )}
+        {blocked.counts.decided_pending_action > 0 && (
+          <li>
+            {blocked.counts.decided_pending_action} in{" "}
+            <code>decided_pending_action</code> (tick-N+1 merge window)
+          </li>
+        )}
+        {blocked.counts.stranded_merge > 0 && (
+          <li>
+            {blocked.counts.stranded_merge} stranded merge — check the reconciler
+          </li>
+        )}
+      </ul>
+      {blocked.sampleRoomIds.length > 0 && (
+        <p className="mt-2 text-xs text-zinc-500">
+          Sample rooms:{" "}
+          {blocked.sampleRoomIds.map((id, i) => (
+            <span key={id}>
+              <Link
+                href={`/dashboard/rooms/${id}`}
+                className="font-mono text-honey-400 hover:underline"
+              >
+                {id.slice(0, 8)}
+              </Link>
+              {i < blocked.sampleRoomIds.length - 1 && ", "}
+            </span>
+          ))}
+        </p>
+      )}
+      <p className="mt-3 text-xs text-zinc-500">
+        Resolve the in-flight rooms before flipping. G6 force-expire is the
+        operator escape valve when a claim is genuinely stuck.
+      </p>
+    </div>
+  );
+}
+
+function FlipConfirmModal({
+  targetMode,
+  currentMode,
+  onCancel,
+  onConfirm,
+  saving,
+}: {
+  targetMode: QueenMode;
+  currentMode: QueenMode;
+  onCancel: () => void;
+  onConfirm: () => void;
+  saving: boolean;
+}): React.ReactElement {
+  const message =
+    targetMode === "local"
+      ? `Switching to local — the hive queen becomes the only path that synthesizes verdicts and posts actions on PRs. PR discovery and room state-bumps continue via the cloud webhook handlers (so a hive queen outage by itself does not lose new PRs), but if cloud webhook delivery has degraded independently, the hive queen has no backstop. The cloud will emit a 'rooms-stuck-older-than-N-min' alarm if the local queen falls behind, but no fallback synthesis will happen. Make sure your hive queen has uptime monitoring before flipping.`
+      : `Switching to cloud — Vercel cron resumes synthesis using the BYOK provider key. The hive queen stops posting; webhook handlers stay active in both modes.`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="flip-modal-title"
+    >
+      <div className="w-full max-w-lg rounded-lg border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
+        <h3 id="flip-modal-title" className="text-lg font-semibold text-[#fafafa]">
+          Confirm mode flip: {currentMode} → {targetMode}
+        </h3>
+        <p className="mt-3 text-sm text-zinc-300">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={saving}
+            className="rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? "Flipping…" : "Confirm flip"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import SettingsDashboard from "./SettingsDashboard";
+
+export const metadata: Metadata = {
+  title: "Settings — Hivemoot Dashboard",
+  description: "Per-installation configuration including queen execution mode.",
+};
+
+/**
+ * /dashboard/settings — operator-facing configuration root.
+ *
+ * Today: hosts the queen-mode toggle (cloud vs local) per the
+ * Queen Execution Mode RFC (#628). The mode-toggle calls
+ * GET/POST /api/dashboard/queen-settings — see PR 1 (#640) for
+ * the storage layer + endpoints, PR 2 (#641) for the
+ * D9 in-flight precheck wired into POST.
+ *
+ * Future siblings (out of this PR's scope):
+ *   - G30 reconciliation alarm: lights up when any room is in
+ *     decision_outcome=merge_approved + github_merge_status
+ *     pending past 5min. Depends on PR 3b's audit fields; ships
+ *     in a follow-up.
+ *   - 3-signal heartbeat indicator (agent self-report + cloud
+ *     observer metric + cloud webhook delivery health per G21).
+ *     Depends on PR 2's observer log being exposed via an API.
+ *
+ * BYOK UI lives at /dashboard/settings/byok per RFC PR 6 (#643).
+ * Both pages share the /dashboard/settings parent so operators
+ * see a single "configuration" surface.
+ */
+export default function SettingsPage() {
+  return <SettingsDashboard />;
+}


### PR DESCRIPTION
## Summary

PR 5 v1 of the Queen Execution Mode RFC's 6-PR stack. **Stacked on #641** (PR 2). Adds the operator-facing \`/dashboard/settings\` page with the queen-mode toggle.

## What ships v1

- **\`/dashboard/settings/page.tsx\`** + **\`SettingsDashboard.tsx\`** — server-rendered shell + client component
- **Mode toggle** (cloud / local) using \`GET/POST /api/dashboard/queen-settings\` (PR 1's endpoint, PR 2's precheck)
- **Confirmation modal** on mode flip with D16-aligned warning text (cloud retains webhook surface; agent uptime monitoring required before flipping to local)
- **Structured prompt override editor** (D12) — plain-string textarea for v1; PR 3 will add the YAML schema validator
- **409 \`mode_flip_blocked\` banner** showing blocked rooms with links to \`/dashboard/rooms/<id>\`
- **Settings tab** added to DashboardNav between War Rooms and Credentials

## Out of scope (deferred follow-ups)

| Feature | Why not v1 | When |
|---|---|---|
| 3-signal heartbeat indicator (agent self-report + cloud observer metric + cloud webhook delivery health per G21) | Needs PR 2's observer log exposed via an API surface — that's not built yet | PR 5.1 after PR 2 lands |
| **G30 reconciliation alarm** (\`decision_outcome=merge_approved\` + \`github_merge_status\` pending past 5min) | Depends on PR 3b's audit fields — those don't exist yet | PR 5.2 after PR 3b ships |

## What it looks like

\`\`\`
Dashboard nav: [Agent Health] [Tasks] [War Rooms] [Settings] [Credentials]
                                                  ↑ new

/dashboard/settings (current state):
  ┌─ Queen execution mode ─────────────────────────────────────┐
  │ ○ Cloud (default)   [current]                              │
  │   Vercel cron runs the synthesis loop. BYOK provider key.  │
  │ ● Local (hive queen)                                       │
  │   The hive queen agent runs synthesis on Codex…            │
  │ ▸ Structured prompt override (optional)                    │
  │ [Save]                                                     │
  └────────────────────────────────────────────────────────────┘

Click Save with mode change → confirmation modal:
  ┌─ Confirm mode flip: cloud → local ─────────────────────────┐
  │ Switching to local — the hive queen becomes the only path  │
  │ that synthesizes…                                          │
  │                                       [Cancel] [Confirm]   │
  └────────────────────────────────────────────────────────────┘

If precheck blocks (PR 2's D9 check):
  409 banner: \"3 rooms in flight — 3 in deciding (mid-claim)\"
  Sample rooms: a1b2c3d4, e5f6g7h8…
  \"Resolve the in-flight rooms before flipping.\"
\`\`\`

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] Full web suite: 1510 passing (no regressions; UI-only addition)
- [x] Endpoint contract matches PR 1's response shape (verified by reading the route handler types)
- [ ] Manual smoke test in dev — pending PR 1 + PR 2 merging so the dashboard backend is on main

Refs RFC D9 + D12 + D16 + G6.