### PR TITLE
feat(rooms): synthesis-ready + decided-pending-ready + claim-synthesis (3c slice 1)

### DIFF
--- a/web/src/app/api/rooms/[roomId]/claim-synthesis/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/claim-synthesis/route.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@hivemoot/war-room", async () => {
+  const real = await vi.importActual<typeof import("@hivemoot/war-room")>(
+    "@hivemoot/war-room",
+  );
+  return {
+    ...real,
+    claimSynthesis: vi.fn(),
+    getRoomCore: vi.fn(),
+    getRoomParticipants: vi.fn(),
+    getRoomContributions: vi.fn(),
+  };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  claimSynthesis,
+  getRoomCore,
+  getRoomParticipants,
+  getRoomContributions,
+  RoomNotFoundError,
+  RoomClaimAlreadyHeldError,
+  RoomTransitionInvalidStatusError,
+} from "@hivemoot/war-room";
+import { POST } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedClaim = vi.mocked(claimSynthesis);
+const mockedCore = vi.mocked(getRoomCore);
+const mockedParticipants = vi.mocked(getRoomParticipants);
+const mockedContributions = vi.mocked(getRoomContributions);
+
+function makeAuthOk() {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "queen",
+    agent_role: "local_queen",
+    capabilities: ["rooms.synthesize"],
+    redis: {} as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    "https://www.hivemoot.dev/api/rooms/rm-123/claim-synthesis",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer hmt_test",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const params = Promise.resolve({ roomId: "rm-123" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/rooms/:roomId/claim-synthesis", () => {
+  it("delegates 401 on missing bearer", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "agent_auth_v1_missing_bearer" }, { status: 401 }),
+    });
+    const res = await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(res.status).toBe(401);
+  });
+
+  it("requires rooms.synthesize capability", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedClaim.mockResolvedValue({ throughSequence: 7, claimTtlSecs: 900 });
+    mockedCore.mockResolvedValue({} as never);
+    mockedParticipants.mockResolvedValue({});
+    mockedContributions.mockResolvedValue({});
+    await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(mockedAuth).toHaveBeenCalledWith(expect.any(NextRequest), {
+      requires: "rooms.synthesize",
+    });
+  });
+
+  it("rejects body without queenRunner", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await POST(makeRequest({}), { params });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid_queen_runner" });
+    expect(mockedClaim).not.toHaveBeenCalled();
+  });
+
+  it("rejects negative claimTtlSecs", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await POST(
+      makeRequest({ queenRunner: "r1", claimTtlSecs: -10 }),
+      { params },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "invalid_claim_ttl" });
+  });
+
+  it("returns the composite { claim, room, participants, contributions }", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedClaim.mockResolvedValue({ throughSequence: 11, claimTtlSecs: 900 });
+    const fakeRoom = {
+      manager: "bot-queen",
+      subject_type: "pr_review",
+      subject_ref: "owner/repo#1",
+      opened_at: "2026-05-09T00:00:00Z",
+      status: "deciding",
+      timing_config: {
+        max_age_secs: 86400,
+        drop_threshold_secs: 600,
+        quiet_period_secs: 60,
+      },
+    } as never;
+    mockedCore.mockResolvedValue(fakeRoom);
+    mockedParticipants.mockResolvedValue({
+      builder: { actor_role: "builder", state: "resolved" } as never,
+    });
+    mockedContributions.mockResolvedValue({
+      builder: { actor_role: "builder", raw_md: "lgtm" } as never,
+    });
+    const res = await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      claim: { throughSequence: 11, claimTtlSecs: 900 },
+      room: fakeRoom,
+      participants: { builder: { actor_role: "builder", state: "resolved" } },
+      contributions: { builder: { actor_role: "builder", raw_md: "lgtm" } },
+    });
+  });
+
+  it("returns 404 when claim raises RoomNotFoundError", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedClaim.mockRejectedValue(new RoomNotFoundError("12345", "rm-123"));
+    const res = await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: "room_not_found" });
+  });
+
+  it("returns 409 claim_already_held", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const err = new RoomClaimAlreadyHeldError(
+      "rm-123",
+      "other-runner",
+      11,
+    );
+    mockedClaim.mockRejectedValue(err);
+    const res = await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: "claim_already_held",
+      heldByRunner: "other-runner",
+      throughSequence: 11,
+    });
+  });
+
+  it("returns 409 invalid_status_for_claim", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedClaim.mockRejectedValue(
+      new RoomTransitionInvalidStatusError(
+        "rm-123",
+        "claim",
+        ["awaiting_contributions"],
+        "closed",
+      ),
+    );
+    const res = await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      code: "invalid_status_for_claim",
+      actualStatus: "closed",
+    });
+  });
+
+  it("returns 500 if composite hydration fails after successful claim", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedClaim.mockResolvedValue({ throughSequence: 7, claimTtlSecs: 900 });
+    mockedCore.mockRejectedValue(new Error("redis blip"));
+    mockedParticipants.mockResolvedValue({});
+    mockedContributions.mockResolvedValue({});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(makeRequest({ queenRunner: "r1" }), { params });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({
+      code: "storage_failure",
+      message: expect.stringContaining("claim TTL"),
+    });
+    errSpy.mockRestore();
+  });
+});

--- a/web/src/app/api/rooms/[roomId]/claim-synthesis/route.ts
+++ b/web/src/app/api/rooms/[roomId]/claim-synthesis/route.ts
@@ -1,0 +1,213 @@
+/**
+ * POST /api/rooms/:roomId/claim-synthesis — claim the synthesis
+ * lane AND return the composite payload the local queen needs to
+ * run its prompt (RFC builder pass-9 §2).
+ *
+ * Capability: `rooms.synthesize` (RFC D14, the local-queen-side
+ * cap; cloud queen continues to use `/decide` + `rooms.decide`).
+ *
+ * # Why this exists when /decide already does the claim
+ *
+ * The cloud queen's manager loop runs in-process and reads the
+ * room state via the war-room library directly. The local queen
+ * runs in a hive container and goes over HTTP — without this
+ * composite endpoint it would need 3 sequential roundtrips after
+ * the claim:
+ *
+ *   POST /decide                  ← claim
+ *   GET /api/rooms/:id            ← room core
+ *   GET /api/rooms/:id/participants
+ *   GET /api/rooms/:id/contributions
+ *
+ * Builder pass-9 §2 specifically called out this fan-out as a
+ * latency tax + race surface. claim-synthesis bundles the four
+ * reads under a single auth check + the claim's atomic semantics:
+ * the participants and contributions snapshot ships at the same
+ * `throughSequence` cutoff the claim itself returns, so the local
+ * queen's verdict prompt can't accidentally mix a fresh contribution
+ * with a stale claim.
+ *
+ * Body: `{ queenRunner: string, claimTtlSecs?: number }` — same
+ * shape as /decide for stability.
+ *
+ * Response: `{ claim: { throughSequence, claimTtlSecs },
+ *              room: RoomCore,
+ *              participants: Record<actor_role, RoomParticipant>,
+ *              contributions: Record<actor_role, RoomContribution> }`
+ *
+ * Errors:
+ *   - 401 / 403 — auth / capability
+ *   - 400 — malformed body
+ *   - 404 — room not found in this installation
+ *   - 409 — claim_already_held / invalid_status_for_claim /
+ *           sequence_drift (D5 benign-409 set)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { parseJsonBody } from "@/server/request-utils";
+import {
+  claimSynthesis,
+  getRoomCore,
+  getRoomParticipants,
+  getRoomContributions,
+  RoomNotFoundError,
+  RoomIdFormatError,
+  RoomClaimAlreadyHeldError,
+  RoomTransitionInvalidStatusError,
+  RoomClaimPayloadCorruptError,
+  RoomRunnerFormatError,
+} from "@hivemoot/war-room";
+
+interface ClaimSynthesisBody {
+  queenRunner?: string;
+  claimTtlSecs?: number;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.synthesize",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { roomId } = await params;
+
+  const parsed = await parseJsonBody(request);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { code: parsed.code, message: parsed.message },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as ClaimSynthesisBody;
+
+  if (typeof body.queenRunner !== "string" || body.queenRunner.length === 0) {
+    return NextResponse.json(
+      {
+        code: "invalid_queen_runner",
+        message: "Body must include `queenRunner` as a non-empty string.",
+      },
+      { status: 400 },
+    );
+  }
+  if (
+    body.claimTtlSecs !== undefined &&
+    (typeof body.claimTtlSecs !== "number" ||
+      !Number.isFinite(body.claimTtlSecs) ||
+      body.claimTtlSecs <= 0)
+  ) {
+    return NextResponse.json(
+      {
+        code: "invalid_claim_ttl",
+        message: "claimTtlSecs must be a positive finite number.",
+      },
+      { status: 400 },
+    );
+  }
+
+  let claim;
+  try {
+    claim = await claimSynthesis({
+      installationId: auth.installationId,
+      roomId,
+      queenRunner: body.queenRunner,
+      claimTtlSecs: body.claimTtlSecs,
+      redis: auth.redis,
+    });
+  } catch (err) {
+    if (err instanceof RoomRunnerFormatError) {
+      return NextResponse.json(
+        { code: "invalid_queen_runner", message: err.message },
+        { status: 400 },
+      );
+    }
+    if (err instanceof RoomNotFoundError || err instanceof RoomIdFormatError) {
+      return NextResponse.json(
+        { code: "room_not_found", message: `Room ${roomId} not found.` },
+        { status: 404 },
+      );
+    }
+    if (err instanceof RoomClaimAlreadyHeldError) {
+      return NextResponse.json(
+        {
+          code: "claim_already_held",
+          message: err.message,
+          heldByRunner: err.heldByRunner,
+          throughSequence: err.throughSequence,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomTransitionInvalidStatusError) {
+      return NextResponse.json(
+        {
+          code: "invalid_status_for_claim",
+          message: err.message,
+          actualStatus: err.actualStatus,
+          expectedStatuses: err.expectedStatuses,
+        },
+        { status: 409 },
+      );
+    }
+    if (err instanceof RoomClaimPayloadCorruptError) {
+      return NextResponse.json(
+        { code: "claim_payload_corrupt", message: err.message },
+        { status: 409 },
+      );
+    }
+    console.error("[rooms.claim-synthesis] claim primitive failure", {
+      installationId: auth.installationId,
+      roomId,
+      error: err,
+    });
+    return NextResponse.json(
+      { code: "storage_failure", message: "Claim attempt failed." },
+      { status: 500 },
+    );
+  }
+
+  // Claim succeeded — fan out the three reads in parallel. Any
+  // single-read failure here is unexpected (we just held a claim
+  // on the room so it exists), and we swallow into 500 so the
+  // caller knows to retry. The claim TTL ensures the held lock
+  // releases either way.
+  try {
+    const [room, participants, contributions] = await Promise.all([
+      getRoomCore({
+        installationId: auth.installationId,
+        roomId,
+        redis: auth.redis,
+      }),
+      getRoomParticipants({ roomId, redis: auth.redis }),
+      getRoomContributions({ roomId, redis: auth.redis }),
+    ]);
+
+    return NextResponse.json(
+      {
+        claim,
+        room,
+        participants,
+        contributions,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    console.error("[rooms.claim-synthesis] composite hydrate failure", {
+      installationId: auth.installationId,
+      roomId,
+      error: err,
+    });
+    return NextResponse.json(
+      {
+        code: "storage_failure",
+        message:
+          "Claim succeeded but composite hydration failed; retry — claim TTL " +
+          "will release the lock.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/rooms/[roomId]/claim-synthesis/route.ts
+++ b/web/src/app/api/rooms/[roomId]/claim-synthesis/route.ts
@@ -21,11 +21,23 @@
  *
  * Builder pass-9 §2 specifically called out this fan-out as a
  * latency tax + race surface. claim-synthesis bundles the four
- * reads under a single auth check + the claim's atomic semantics:
- * the participants and contributions snapshot ships at the same
- * `throughSequence` cutoff the claim itself returns, so the local
- * queen's verdict prompt can't accidentally mix a fresh contribution
- * with a stale claim.
+ * reads under a single auth check.
+ *
+ * # The claim-vs-snapshot relationship (G2 — guard pass-1 clarification)
+ *
+ * The participants and contributions returned here are a *current
+ * snapshot* — they are NOT pinned at the claim's `throughSequence`
+ * cutoff. After-claim writes to those hashes are still possible.
+ * What the local queen actually relies on is the seal-decision
+ * endpoint's invariant check (PR 3c slice 2): seal rejects if the
+ * room's `throughSequence` has advanced past the claim's
+ * `throughSequence`. That's the cutoff that prevents a stale
+ * verdict from sealing.
+ *
+ * In practice the awaiting → deciding transition + the claim TTL
+ * make the window where new contributions can arrive narrow, and
+ * the snapshot is good enough as input to the verdict prompt; the
+ * seal-time check is what makes the seal itself safe.
  *
  * Body: `{ queenRunner: string, claimTtlSecs?: number }` — same
  * shape as /decide for stability.
@@ -174,6 +186,16 @@ export async function POST(
   // on the room so it exists), and we swallow into 500 so the
   // caller knows to retry. The claim TTL ensures the held lock
   // releases either way.
+  //
+  // Cross-installation isolation note (G3 — guard pass-1):
+  // `getRoomParticipants` and `getRoomContributions` read keys that
+  // are scoped only by `roomId`, not `installationId`. They're safe
+  // to call here ONLY because `claimSynthesis` above already
+  // enforced installation membership (it would have thrown
+  // RoomNotFoundError if the bearer's installation didn't own this
+  // room). Do NOT lift these reads above the claim — they would
+  // leak cross-installation data if reached without the membership
+  // check.
   try {
     const [room, participants, contributions] = await Promise.all([
       getRoomCore({

--- a/web/src/app/api/rooms/decided-pending-ready/route.test.ts
+++ b/web/src/app/api/rooms/decided-pending-ready/route.test.ts
@@ -19,7 +19,13 @@ import { GET } from "./route";
 const mockedAuth = vi.mocked(authenticateAgentRequestV1);
 const mockedCore = vi.mocked(getRoomCore);
 
-function makeAuthOk(overrides?: { redisZrange?: (...args: unknown[]) => Promise<string[]> }) {
+// ---------------------------------------------------------------------------
+// Mock Redis with smembers — guard pass-1 G1: statusIndexKey is a
+// SET (SADD/SREM in war-room.ts:2269-2526). Real Redis returns
+// WRONGTYPE for ZRANGE against a SET; .zrange is left undefined on
+// the stub so a regression to ZRANGE blows up loudly here.
+// ---------------------------------------------------------------------------
+function makeAuthOk(overrides?: { redisSmembers?: () => Promise<string[]> }) {
   return {
     ok: true as const,
     installationId: "12345",
@@ -27,25 +33,25 @@ function makeAuthOk(overrides?: { redisZrange?: (...args: unknown[]) => Promise<
     agent_role: "local_queen",
     capabilities: ["rooms.synthesize"],
     redis: {
-      zrange: vi.fn(overrides?.redisZrange ?? (async () => [])),
+      smembers: vi.fn(overrides?.redisSmembers ?? (async () => [])),
     } as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
 }
 
-function makeRoom(status: string) {
+function makeRoom(status: string, openedAt = "2026-05-09T00:00:00Z") {
   return {
     manager: "bot-queen",
     subject_type: "pr_review" as const,
     subject_ref: "owner/repo#1",
-    opened_at: "2026-05-09T00:00:00Z",
+    opened_at: openedAt,
     status: status as "decided_pending_action",
     timing_config: {
       max_age_secs: 86400,
       drop_threshold_secs: 600,
       quiet_period_secs: 60,
     },
-    last_transition_at: "2026-05-09T00:00:00Z",
+    last_transition_at: openedAt,
     last_post_close_drift_count: 0,
   };
 }
@@ -79,8 +85,8 @@ describe("GET /api/rooms/decided-pending-ready", () => {
   it("returns empty when no rooms in decided_pending_action (today's expected default)", async () => {
     // No code path SADDs to the decided_pending_action index until
     // PR 3c's seal-decision endpoint ships, so this test pins the
-    // \"today's behavior is empty\" contract.
-    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: async () => [] }));
+    // "today's behavior is empty" contract.
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisSmembers: async () => [] }));
     const res = await GET(
       new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
     );
@@ -88,23 +94,25 @@ describe("GET /api/rooms/decided-pending-ready", () => {
     expect(await res.json()).toEqual({ rooms: [], count: 0 });
   });
 
-  it("queries the decided_pending_action status index", async () => {
-    const zrangeSpy = vi.fn(async () => []);
-    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
-    await GET(
+  it("uses SMEMBERS (not ZRANGE) against the decided_pending_action status SET (G1 pin)", async () => {
+    // .zrange is intentionally undefined on the mock — if the route
+    // ever regresses to ZRANGE, GET() throws and this test fails
+    // loudly. statusIndexKey is a SET; ZRANGE returns WRONGTYPE
+    // against a SET in real Redis.
+    const smembersSpy = vi.fn(async () => []);
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisSmembers: smembersSpy }));
+    const res = await GET(
       new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
     );
-    expect(zrangeSpy).toHaveBeenCalledWith(
+    expect(res.status).toBe(200);
+    expect(smembersSpy).toHaveBeenCalledWith(
       "hive:v1:idx:room:status:12345:decided_pending_action",
-      0,
-      49,
-      { rev: true },
     );
   });
 
   it("filters to status=decided_pending_action only (race-safe vs stale index)", async () => {
     mockedAuth.mockResolvedValue(
-      makeAuthOk({ redisZrange: async () => ["rm-fresh", "rm-raced"] }),
+      makeAuthOk({ redisSmembers: async () => ["rm-fresh", "rm-raced"] }),
     );
     mockedCore
       .mockResolvedValueOnce(makeRoom("decided_pending_action"))
@@ -118,10 +126,26 @@ describe("GET /api/rooms/decided-pending-ready", () => {
     expect(body.rooms[0].roomId).toBe("rm-fresh");
   });
 
+  it("sorts the response newest-first by opened_at (post-hoc, since SETs are unordered)", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({ redisSmembers: async () => ["rm-old", "rm-new"] }),
+    );
+    mockedCore.mockImplementation(async ({ roomId }) => {
+      if (roomId === "rm-old") return makeRoom("decided_pending_action", "2026-01-01T00:00:00Z");
+      if (roomId === "rm-new") return makeRoom("decided_pending_action", "2026-05-01T00:00:00Z");
+      throw new Error(`unexpected ${roomId}`);
+    });
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    const body = await res.json();
+    expect(body.rooms.map((r: { roomId: string }) => r.roomId)).toEqual(["rm-new", "rm-old"]);
+  });
+
   it("returns 500 on storage error", async () => {
     mockedAuth.mockResolvedValue(
       makeAuthOk({
-        redisZrange: async () => {
+        redisSmembers: async () => {
           throw new Error("redis down");
         },
       }),

--- a/web/src/app/api/rooms/decided-pending-ready/route.test.ts
+++ b/web/src/app/api/rooms/decided-pending-ready/route.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@hivemoot/war-room", async () => {
+  const real = await vi.importActual<typeof import("@hivemoot/war-room")>(
+    "@hivemoot/war-room",
+  );
+  return { ...real, getRoomCore: vi.fn() };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { getRoomCore } from "@hivemoot/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedCore = vi.mocked(getRoomCore);
+
+function makeAuthOk(overrides?: { redisZrange?: (...args: unknown[]) => Promise<string[]> }) {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "queen",
+    agent_role: "local_queen",
+    capabilities: ["rooms.synthesize"],
+    redis: {
+      zrange: vi.fn(overrides?.redisZrange ?? (async () => [])),
+    } as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+function makeRoom(status: string) {
+  return {
+    manager: "bot-queen",
+    subject_type: "pr_review" as const,
+    subject_ref: "owner/repo#1",
+    opened_at: "2026-05-09T00:00:00Z",
+    status: status as "decided_pending_action",
+    timing_config: {
+      max_age_secs: 86400,
+      drop_threshold_secs: 600,
+      quiet_period_secs: 60,
+    },
+    last_transition_at: "2026-05-09T00:00:00Z",
+    last_post_close_drift_count: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/rooms/decided-pending-ready", () => {
+  it("delegates 401 on missing bearer", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "agent_auth_v1_missing_bearer" }, { status: 401 }),
+    });
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("requires rooms.synthesize capability (same as synthesis-ready)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    expect(mockedAuth).toHaveBeenCalledWith(expect.any(NextRequest), {
+      requires: "rooms.synthesize",
+    });
+  });
+
+  it("returns empty when no rooms in decided_pending_action (today's expected default)", async () => {
+    // No code path SADDs to the decided_pending_action index until
+    // PR 3c's seal-decision endpoint ships, so this test pins the
+    // \"today's behavior is empty\" contract.
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: async () => [] }));
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ rooms: [], count: 0 });
+  });
+
+  it("queries the decided_pending_action status index", async () => {
+    const zrangeSpy = vi.fn(async () => []);
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
+    await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    expect(zrangeSpy).toHaveBeenCalledWith(
+      "hive:v1:idx:room:status:12345:decided_pending_action",
+      0,
+      49,
+      { rev: true },
+    );
+  });
+
+  it("filters to status=decided_pending_action only (race-safe vs stale index)", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({ redisZrange: async () => ["rm-fresh", "rm-raced"] }),
+    );
+    mockedCore
+      .mockResolvedValueOnce(makeRoom("decided_pending_action"))
+      .mockResolvedValueOnce(makeRoom("closed")); // moved out
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(1);
+    expect(body.rooms[0].roomId).toBe("rm-fresh");
+  });
+
+  it("returns 500 on storage error", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        redisZrange: async () => {
+          throw new Error("redis down");
+        },
+      }),
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/decided-pending-ready"),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ code: "storage_failure" });
+    errSpy.mockRestore();
+  });
+});

--- a/web/src/app/api/rooms/decided-pending-ready/route.ts
+++ b/web/src/app/api/rooms/decided-pending-ready/route.ts
@@ -23,10 +23,10 @@
  * but better folded into the confirm-merge endpoint's invariant
  * check rather than duplicated in this list endpoint.
  *
- * **Today this endpoint always returns an empty list** because no
- * code path SADDs to the `decided_pending_action` status index yet.
- * The PR-3c slice that ships seal-decision will add the index
- * write. This endpoint exists now to:
+ * **Today this endpoint returns an empty list in steady state**
+ * because no code path SADDs to the `decided_pending_action` status
+ * index until seal-decision lands (PR 3c slice 2). This PR exists
+ * now to:
  *   - establish the route surface area + capability gating
  *   - let PR 4's hive queen plugin compile against the right
  *     interface
@@ -70,9 +70,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   try {
     const indexKey = statusIndexKey(auth.installationId, "decided_pending_action");
-    const roomIds = await auth.redis.zrange<string[]>(indexKey, 0, limit - 1, {
-      rev: true,
-    });
+    // `statusIndexKey` is a Redis SET (SADD/SREM in war-room.ts:
+    // 2269-2526). SMEMBERS is the only key-type-safe read; ZRANGE
+    // returns WRONGTYPE against a SET in real Redis (guard pass-1
+    // G1). Newest-first is applied post-hoc on hydrated cores.
+    const roomIds = await auth.redis.smembers(indexKey);
 
     const cores = await Promise.all(
       roomIds.map(async (roomId) => {
@@ -89,10 +91,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }),
     );
 
-    const rooms = cores.filter(
-      (r): r is RoomCoreWithId =>
-        r !== null && r.status === "decided_pending_action",
-    );
+    const rooms = cores
+      .filter(
+        (r): r is RoomCoreWithId =>
+          r !== null && r.status === "decided_pending_action",
+      )
+      // Newest-first by opened_at (descending). opened_at is an ISO
+      // 8601 string with a consistent timezone, so lex sort gives
+      // chronological order. Stable on ties via roomId.
+      .sort((a, b) => {
+        if (b.opened_at !== a.opened_at) return b.opened_at < a.opened_at ? -1 : 1;
+        return a.roomId < b.roomId ? -1 : 1;
+      })
+      .slice(0, limit);
 
     return NextResponse.json({ rooms, count: rooms.length }, { status: 200 });
   } catch (error) {

--- a/web/src/app/api/rooms/decided-pending-ready/route.ts
+++ b/web/src/app/api/rooms/decided-pending-ready/route.ts
@@ -1,0 +1,111 @@
+/**
+ * GET /api/rooms/decided-pending-ready — list rooms in
+ * `decided_pending_action` ready for the local queen's tick-N+1
+ * confirm-merge call (RFC G27).
+ *
+ * Capability: `rooms.synthesize` (same as synthesis-ready — local
+ * queen polls both endpoints).
+ *
+ * # What "ready" means
+ *
+ * Per the RFC, a room is confirm-merge-ready when:
+ *   - status = `decided_pending_action`
+ *   - sealed at tick N ≥60s ago (G13 operator-override window
+ *     elapsed)
+ *   - sealed at tick N ≤15min ago (G4 TTL — older rooms are the
+ *     reconciler's job, G32)
+ *
+ * **PR 3c slice (this commit) returns the status filter only** —
+ * the ≥60s and ≤15min checks are applied by the local queen's
+ * confirm-merge call site (it knows the seal timestamp from its
+ * audit row) and by the reconciler (G32). Server-side enforcement
+ * here would require reading a per-room timestamp, which is fine
+ * but better folded into the confirm-merge endpoint's invariant
+ * check rather than duplicated in this list endpoint.
+ *
+ * **Today this endpoint always returns an empty list** because no
+ * code path SADDs to the `decided_pending_action` status index yet.
+ * The PR-3c slice that ships seal-decision will add the index
+ * write. This endpoint exists now to:
+ *   - establish the route surface area + capability gating
+ *   - let PR 4's hive queen plugin compile against the right
+ *     interface
+ *   - get the auth contract reviewed in isolation
+ *
+ * Response shape:
+ *   { rooms: RoomCoreWithId[], count: number }
+ *
+ * Errors:
+ *   - 401 not_authenticated — missing / invalid bearer
+ *   - 403 capability_denied — bearer lacks `rooms.synthesize`
+ *   - 500 storage_failure
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  statusIndexKey,
+  type RoomCoreWithId,
+} from "@hivemoot/war-room";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.synthesize",
+  });
+  if (!auth.ok) return auth.response;
+
+  const url = new URL(request.url);
+  const rawLimit = url.searchParams.get("limit");
+  let limit = DEFAULT_LIMIT;
+  if (rawLimit !== null) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (Number.isFinite(parsed)) {
+      limit = Math.min(MAX_LIMIT, Math.max(1, parsed));
+    }
+  }
+
+  try {
+    const indexKey = statusIndexKey(auth.installationId, "decided_pending_action");
+    const roomIds = await auth.redis.zrange<string[]>(indexKey, 0, limit - 1, {
+      rev: true,
+    });
+
+    const cores = await Promise.all(
+      roomIds.map(async (roomId) => {
+        try {
+          const core = await getRoomCore({
+            installationId: auth.installationId,
+            roomId,
+            redis: auth.redis,
+          });
+          return { roomId, ...core } as RoomCoreWithId;
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    const rooms = cores.filter(
+      (r): r is RoomCoreWithId =>
+        r !== null && r.status === "decided_pending_action",
+    );
+
+    return NextResponse.json({ rooms, count: rooms.length }, { status: 200 });
+  } catch (error) {
+    console.error("[rooms.decided-pending-ready] storage failure", {
+      installationId: auth.installationId,
+      error,
+    });
+    return NextResponse.json(
+      {
+        code: "storage_failure",
+        message: "Failed to list decided-pending rooms.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/rooms/synthesis-ready/route.test.ts
+++ b/web/src/app/api/rooms/synthesis-ready/route.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@hivemoot/war-room", async () => {
+  const real = await vi.importActual<typeof import("@hivemoot/war-room")>(
+    "@hivemoot/war-room",
+  );
+  return { ...real, getRoomCore: vi.fn() };
+});
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { getRoomCore } from "@hivemoot/war-room";
+import { GET } from "./route";
+
+const mockedAuth = vi.mocked(authenticateAgentRequestV1);
+const mockedCore = vi.mocked(getRoomCore);
+
+function makeAuthOk(overrides?: { redisZrange?: (...args: unknown[]) => Promise<string[]> }) {
+  return {
+    ok: true as const,
+    installationId: "12345",
+    name: "queen",
+    agent_role: "local_queen",
+    capabilities: ["rooms.synthesize"],
+    redis: {
+      zrange: vi.fn(overrides?.redisZrange ?? (async () => [])),
+    } as never,
+    envelope: { fingerprint: "fp", expiresAt: null } as never,
+  };
+}
+
+function makeRoom(roomId: string, status: string) {
+  return {
+    manager: "bot-queen",
+    subject_type: "pr_review" as const,
+    subject_ref: `owner/repo#${roomId.slice(0, 4)}`,
+    opened_at: "2026-05-09T00:00:00Z",
+    status: status as "awaiting_contributions",
+    timing_config: {
+      max_age_secs: 86400,
+      drop_threshold_secs: 600,
+      quiet_period_secs: 60,
+    },
+    last_transition_at: "2026-05-09T00:00:00Z",
+    last_post_close_drift_count: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/rooms/synthesis-ready", () => {
+  it("delegates 401 on missing bearer", async () => {
+    mockedAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "agent_auth_v1_missing_bearer" }, { status: 401 }),
+    });
+    const res = await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(res.status).toBe(401);
+  });
+
+  it("requires rooms.synthesize capability", async () => {
+    const auth = makeAuthOk();
+    mockedAuth.mockResolvedValue(auth);
+    await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(mockedAuth).toHaveBeenCalledWith(expect.any(NextRequest), {
+      requires: "rooms.synthesize",
+    });
+  });
+
+  it("returns rooms in awaiting_contributions only", async () => {
+    const auth = makeAuthOk({
+      redisZrange: async () => ["rm-1", "rm-2", "rm-3"],
+    });
+    mockedAuth.mockResolvedValue(auth);
+    mockedCore
+      .mockResolvedValueOnce(makeRoom("rm-1", "awaiting_contributions"))
+      .mockResolvedValueOnce(makeRoom("rm-2", "deciding")) // raced
+      .mockResolvedValueOnce(makeRoom("rm-3", "awaiting_contributions"));
+    const res = await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(2);
+    expect(body.rooms.map((r: { roomId: string }) => r.roomId)).toEqual(["rm-1", "rm-3"]);
+  });
+
+  it("filters out rooms whose hash has been concurrently deleted", async () => {
+    const auth = makeAuthOk({
+      redisZrange: async () => ["rm-1", "rm-stale"],
+    });
+    mockedAuth.mockResolvedValue(auth);
+    mockedCore
+      .mockResolvedValueOnce(makeRoom("rm-1", "awaiting_contributions"))
+      .mockRejectedValueOnce(new Error("RoomNotFoundError")); // raced
+    const res = await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(1);
+    expect(body.rooms[0].roomId).toBe("rm-1");
+  });
+
+  it("queries the awaiting_contributions status index, not the global one", async () => {
+    const zrangeSpy = vi.fn(async () => []);
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
+    await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(zrangeSpy).toHaveBeenCalledWith(
+      "hive:v1:idx:room:status:12345:awaiting_contributions",
+      0,
+      49,
+      { rev: true },
+    );
+  });
+
+  it("respects the limit query param", async () => {
+    const zrangeSpy = vi.fn(async () => []);
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
+    await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready?limit=10"),
+    );
+    expect(zrangeSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      0,
+      9,
+      { rev: true },
+    );
+  });
+
+  it("caps limit at 200", async () => {
+    const zrangeSpy = vi.fn(async () => []);
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
+    await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready?limit=99999"),
+    );
+    expect(zrangeSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      0,
+      199,
+      { rev: true },
+    );
+  });
+
+  it("returns 500 on storage error", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk({
+        redisZrange: async () => {
+          throw new Error("redis down");
+        },
+      }),
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ code: "storage_failure" });
+    errSpy.mockRestore();
+  });
+});

--- a/web/src/app/api/rooms/synthesis-ready/route.test.ts
+++ b/web/src/app/api/rooms/synthesis-ready/route.test.ts
@@ -19,7 +19,15 @@ import { GET } from "./route";
 const mockedAuth = vi.mocked(authenticateAgentRequestV1);
 const mockedCore = vi.mocked(getRoomCore);
 
-function makeAuthOk(overrides?: { redisZrange?: (...args: unknown[]) => Promise<string[]> }) {
+// ---------------------------------------------------------------------------
+// Mock Redis with smembers — guard pass-1 G1: statusIndexKey is a
+// SET in war-room (SADD/SREM in war-room.ts:2269-2526), so the
+// route MUST use SMEMBERS (not ZRANGE). Real Redis returns
+// WRONGTYPE for ZRANGE against a SET. .zrange is intentionally
+// undefined on the mock so a future regression to ZRANGE blows
+// up loudly here.
+// ---------------------------------------------------------------------------
+function makeAuthOk(overrides?: { redisSmembers?: () => Promise<string[]> }) {
   return {
     ok: true as const,
     installationId: "12345",
@@ -27,25 +35,25 @@ function makeAuthOk(overrides?: { redisZrange?: (...args: unknown[]) => Promise<
     agent_role: "local_queen",
     capabilities: ["rooms.synthesize"],
     redis: {
-      zrange: vi.fn(overrides?.redisZrange ?? (async () => [])),
+      smembers: vi.fn(overrides?.redisSmembers ?? (async () => [])),
     } as never,
     envelope: { fingerprint: "fp", expiresAt: null } as never,
   };
 }
 
-function makeRoom(roomId: string, status: string) {
+function makeRoom(roomId: string, status: string, openedAt = "2026-05-09T00:00:00Z") {
   return {
     manager: "bot-queen",
     subject_type: "pr_review" as const,
     subject_ref: `owner/repo#${roomId.slice(0, 4)}`,
-    opened_at: "2026-05-09T00:00:00Z",
+    opened_at: openedAt,
     status: status as "awaiting_contributions",
     timing_config: {
       max_age_secs: 86400,
       drop_threshold_secs: 600,
       quiet_period_secs: 60,
     },
-    last_transition_at: "2026-05-09T00:00:00Z",
+    last_transition_at: openedAt,
     last_post_close_drift_count: 0,
   };
 }
@@ -75,7 +83,7 @@ describe("GET /api/rooms/synthesis-ready", () => {
 
   it("returns rooms in awaiting_contributions only", async () => {
     const auth = makeAuthOk({
-      redisZrange: async () => ["rm-1", "rm-2", "rm-3"],
+      redisSmembers: async () => ["rm-1", "rm-2", "rm-3"],
     });
     mockedAuth.mockResolvedValue(auth);
     mockedCore
@@ -86,12 +94,14 @@ describe("GET /api/rooms/synthesis-ready", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.count).toBe(2);
+    // Both rooms have the same opened_at; the tie-breaker is roomId
+    // ascending — rm-1 before rm-3.
     expect(body.rooms.map((r: { roomId: string }) => r.roomId)).toEqual(["rm-1", "rm-3"]);
   });
 
   it("filters out rooms whose hash has been concurrently deleted", async () => {
     const auth = makeAuthOk({
-      redisZrange: async () => ["rm-1", "rm-stale"],
+      redisSmembers: async () => ["rm-1", "rm-stale"],
     });
     mockedAuth.mockResolvedValue(auth);
     mockedCore
@@ -104,50 +114,83 @@ describe("GET /api/rooms/synthesis-ready", () => {
     expect(body.rooms[0].roomId).toBe("rm-1");
   });
 
-  it("queries the awaiting_contributions status index, not the global one", async () => {
-    const zrangeSpy = vi.fn(async () => []);
-    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
-    await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
-    expect(zrangeSpy).toHaveBeenCalledWith(
+  it("sorts the response newest-first by opened_at (post-hoc, since SETs are unordered)", async () => {
+    // SMEMBERS is unordered — the test puts the oldest room first
+    // and expects the response to flip to newest-first.
+    const auth = makeAuthOk({
+      redisSmembers: async () => ["rm-old", "rm-new", "rm-mid"],
+    });
+    mockedAuth.mockResolvedValue(auth);
+    mockedCore.mockImplementation(async ({ roomId }) => {
+      if (roomId === "rm-old") return makeRoom(roomId, "awaiting_contributions", "2026-01-01T00:00:00Z");
+      if (roomId === "rm-mid") return makeRoom(roomId, "awaiting_contributions", "2026-03-01T00:00:00Z");
+      if (roomId === "rm-new") return makeRoom(roomId, "awaiting_contributions", "2026-05-01T00:00:00Z");
+      throw new Error(`unexpected ${roomId}`);
+    });
+    const res = await GET(new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rooms.map((r: { roomId: string }) => r.roomId)).toEqual([
+      "rm-new",
+      "rm-mid",
+      "rm-old",
+    ]);
+  });
+
+  it("uses SMEMBERS (not ZRANGE) against the awaiting_contributions status SET (G1 pin)", async () => {
+    // The mock's `.zrange` is intentionally undefined — if a future
+    // change copies ZRANGE back, this test fails with
+    // "redis.zrange is not a function" inside GET(), pinning the
+    // SMEMBERS contract loudly. statusIndexKey is a SET (SADD/SREM
+    // in war-room.ts:2269-2526), so ZRANGE returns WRONGTYPE in
+    // real Redis.
+    const smembersSpy = vi.fn(async () => []);
+    mockedAuth.mockResolvedValue(makeAuthOk({ redisSmembers: smembersSpy }));
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready"),
+    );
+    expect(res.status).toBe(200);
+    expect(smembersSpy).toHaveBeenCalledWith(
       "hive:v1:idx:room:status:12345:awaiting_contributions",
-      0,
-      49,
-      { rev: true },
     );
   });
 
-  it("respects the limit query param", async () => {
-    const zrangeSpy = vi.fn(async () => []);
-    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
-    await GET(
-      new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready?limit=10"),
+  it("respects the limit query param (slices post-hoc, since SET has no count cap)", async () => {
+    const auth = makeAuthOk({
+      redisSmembers: async () => ["rm-1", "rm-2", "rm-3"],
+    });
+    mockedAuth.mockResolvedValue(auth);
+    mockedCore.mockImplementation(async ({ roomId }) =>
+      makeRoom(roomId, "awaiting_contributions", `2026-05-0${roomId.slice(-1)}T00:00:00Z`),
     );
-    expect(zrangeSpy).toHaveBeenCalledWith(
-      expect.any(String),
-      0,
-      9,
-      { rev: true },
+    const res = await GET(
+      new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready?limit=2"),
     );
+    const body = await res.json();
+    expect(body.count).toBe(2);
+    // Newest two only.
+    expect(body.rooms.map((r: { roomId: string }) => r.roomId)).toEqual(["rm-3", "rm-2"]);
   });
 
   it("caps limit at 200", async () => {
-    const zrangeSpy = vi.fn(async () => []);
-    mockedAuth.mockResolvedValue(makeAuthOk({ redisZrange: zrangeSpy }));
-    await GET(
+    const auth = makeAuthOk({
+      redisSmembers: async () => Array.from({ length: 250 }, (_, i) => `rm-${i}`),
+    });
+    mockedAuth.mockResolvedValue(auth);
+    mockedCore.mockImplementation(async ({ roomId }) =>
+      makeRoom(roomId, "awaiting_contributions"),
+    );
+    const res = await GET(
       new NextRequest("https://www.hivemoot.dev/api/rooms/synthesis-ready?limit=99999"),
     );
-    expect(zrangeSpy).toHaveBeenCalledWith(
-      expect.any(String),
-      0,
-      199,
-      { rev: true },
-    );
+    const body = await res.json();
+    expect(body.count).toBe(200);
   });
 
   it("returns 500 on storage error", async () => {
     mockedAuth.mockResolvedValue(
       makeAuthOk({
-        redisZrange: async () => {
+        redisSmembers: async () => {
           throw new Error("redis down");
         },
       }),

--- a/web/src/app/api/rooms/synthesis-ready/route.ts
+++ b/web/src/app/api/rooms/synthesis-ready/route.ts
@@ -60,14 +60,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   try {
     const indexKey = statusIndexKey(auth.installationId, "awaiting_contributions");
-    // Newest-first across the awaiting_contributions index. The
-    // installation's combined index uses ZADD with score=opened_at;
-    // ZRANGE with REV gives newest first. listRooms paginates the
-    // combined index across statuses, which is wrong here — we want
-    // the awaiting subset only.
-    const roomIds = await auth.redis.zrange<string[]>(indexKey, 0, limit - 1, {
-      rev: true,
-    });
+    // `statusIndexKey` is a Redis SET (SADD/SREM in war-room.ts:
+    // 2269-2526). Reading via SMEMBERS is the only key-type-safe
+    // option; ZRANGE returns WRONGTYPE against a SET in real Redis
+    // (guard pass-1 G1). Newest-first ordering is a property of the
+    // *response*, not the index — we sort the hydrated cores by
+    // `opened_at` post-hoc.
+    const roomIds = await auth.redis.smembers(indexKey);
 
     // Hydrate room cores in parallel. A room can transition out of
     // awaiting_contributions between the index read and the core
@@ -91,9 +90,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }),
     );
 
-    const rooms = cores.filter(
-      (r): r is RoomCoreWithId => r !== null && r.status === "awaiting_contributions",
-    );
+    const rooms = cores
+      .filter(
+        (r): r is RoomCoreWithId =>
+          r !== null && r.status === "awaiting_contributions",
+      )
+      // Newest-first by opened_at (descending). opened_at is an ISO
+      // 8601 string with a consistent timezone, so lex sort gives
+      // chronological order. Stable on ties via roomId.
+      .sort((a, b) => {
+        if (b.opened_at !== a.opened_at) return b.opened_at < a.opened_at ? -1 : 1;
+        return a.roomId < b.roomId ? -1 : 1;
+      })
+      .slice(0, limit);
 
     return NextResponse.json({ rooms, count: rooms.length }, { status: 200 });
   } catch (error) {

--- a/web/src/app/api/rooms/synthesis-ready/route.ts
+++ b/web/src/app/api/rooms/synthesis-ready/route.ts
@@ -1,0 +1,109 @@
+/**
+ * GET /api/rooms/synthesis-ready — list rooms in
+ * `awaiting_contributions` ready for synthesis claim. Required by
+ * the local queen's polling loop (RFC PR 4).
+ *
+ * Capability: `rooms.synthesize` (RFC D14, the cap PR 645 added).
+ * Cross-installation isolation: the bearer's `installationId` is the
+ * canonical scope.
+ *
+ * # What "ready" means
+ *
+ * Per the RFC, a room is synthesis-ready when:
+ *   - status = `awaiting_contributions`
+ *   - all participants are resolved
+ *   - quiet-period gate has elapsed (≥60s since last transition)
+ *
+ * **PR 3c slice (this commit) returns the status filter only** —
+ * eligibility checks (participants resolved, quiet period elapsed)
+ * stay in the local queen's trigger loop where they're already
+ * implemented for the cloud queen-tick. Server-side filtering would
+ * require fan-out reads (participants per room) and the local queen
+ * already does the per-room re-fetch via `claim-synthesis`'s
+ * post-claim re-validation (D5). Adding it here would be redundant.
+ *
+ * Response shape:
+ *   { rooms: RoomCoreWithId[], count: number }
+ *
+ * Errors:
+ *   - 401 not_authenticated — missing / invalid bearer
+ *   - 403 capability_denied — bearer lacks `rooms.synthesize`
+ *   - 500 storage_failure
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getRoomCore,
+  statusIndexKey,
+  type RoomCoreWithId,
+} from "@hivemoot/war-room";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "rooms.synthesize",
+  });
+  if (!auth.ok) return auth.response;
+
+  const url = new URL(request.url);
+  const rawLimit = url.searchParams.get("limit");
+  let limit = DEFAULT_LIMIT;
+  if (rawLimit !== null) {
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (Number.isFinite(parsed)) {
+      limit = Math.min(MAX_LIMIT, Math.max(1, parsed));
+    }
+  }
+
+  try {
+    const indexKey = statusIndexKey(auth.installationId, "awaiting_contributions");
+    // Newest-first across the awaiting_contributions index. The
+    // installation's combined index uses ZADD with score=opened_at;
+    // ZRANGE with REV gives newest first. listRooms paginates the
+    // combined index across statuses, which is wrong here — we want
+    // the awaiting subset only.
+    const roomIds = await auth.redis.zrange<string[]>(indexKey, 0, limit - 1, {
+      rev: true,
+    });
+
+    // Hydrate room cores in parallel. A room can transition out of
+    // awaiting_contributions between the index read and the core
+    // read; the caller's claim-synthesis call re-validates status,
+    // so a stale entry here is harmless (just one wasted attempt).
+    const cores = await Promise.all(
+      roomIds.map(async (roomId) => {
+        try {
+          const core = await getRoomCore({
+            installationId: auth.installationId,
+            roomId,
+            redis: auth.redis,
+          });
+          return { roomId, ...core } as RoomCoreWithId;
+        } catch {
+          // Race: room transitioned (terminate / close) between the
+          // index read and the hash read. Filter out — it'll be
+          // gone from the index by the next request anyway.
+          return null;
+        }
+      }),
+    );
+
+    const rooms = cores.filter(
+      (r): r is RoomCoreWithId => r !== null && r.status === "awaiting_contributions",
+    );
+
+    return NextResponse.json({ rooms, count: rooms.length }, { status: 200 });
+  } catch (error) {
+    console.error("[rooms.synthesis-ready] storage failure", {
+      installationId: auth.installationId,
+      error,
+    });
+    return NextResponse.json(
+      { code: "storage_failure", message: "Failed to list synthesis-ready rooms." },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

PR 3c slice 1. **Stacked on #646** (RoomStatus type addition). Three endpoints for the local queen's polling + claim flow, all gated by \`rooms.synthesize\`.

This slice is intentionally small: NO new state-machine transitions, NO new Lua scripts. The claim-synthesis endpoint reuses the existing \`claimSynthesis\` primitive (same one the cloud queen's \`/decide\` route uses) — only the response shape is new (composite bundle).

## What ships

| Endpoint | Purpose | Today |
|---|---|---|
| \`GET /api/rooms/synthesis-ready\` | Lists rooms in \`awaiting_contributions\` ready for synthesis claim | Returns the awaiting set newest-first |
| \`GET /api/rooms/decided-pending-ready\` | Lists rooms in \`decided_pending_action\` ready for confirm-merge (G27) | Always returns empty — no code path SADDs to that index yet |
| \`POST /api/rooms/:roomId/claim-synthesis\` | Atomic claim + composite \`{claim, room, participants, contributions}\` return (builder pass-9 §2) | Wraps the existing \`claimSynthesis\` primitive; new response shape only |

## Why ship this slice now

- Establishes the route surface area + capability gating + auth contract for PR 4 (hive queen plugin) to compile against
- claim-synthesis kills the 4-roundtrip fan-out tax the local queen would otherwise pay (builder pass-9 §2 ask)
- decided-pending-ready is intentionally a no-op until subsequent slices add the index write — its empty return today pins the "read-only listing layer is correct" contract

## Out of scope (subsequent PR-3c slices)

- \`seal-decision\` endpoint (deciding → decided_pending_action transition + Lua-script work)
- \`confirm-merge\` endpoint (decided_pending_action → closed)
- \`resolve-action\` with reviewed_head_sha drift guard
- \`report-merge-result\` with server-side cross-check (G33)
- G32 server-side reconciler (load-bearing)

## Test plan

- [x] 8 synthesis-ready cases (auth, capability, status filter, race-safe drop, limit clamping, storage error)
- [x] 6 decided-pending-ready cases (auth, today's-empty contract, key-shape pin, race-safe filter)
- [x] 9 claim-synthesis cases (auth, capability, body validation, composite shape, 404 RoomNotFound, 409 claim_already_held with heldByRunner+throughSequence, 409 invalid_status_for_claim, 500 composite-hydration recovery hint)
- [x] Web suite: 1564 passing
- [x] Typecheck + lint clean

Refs RFC PR 3 + D14 + G27 + builder pass-9 §2.