### PR TITLE
feat(queen): cloud-side mode skip + observer + in-flight precheck (2/6)

### DIFF
--- a/bot/api/lib/queen/observer.test.ts
+++ b/bot/api/lib/queen/observer.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  QUEEN_OBSERVER_THRESHOLDS,
+  runQueenObserverPass,
+} from "./observer.js";
+import type { RoomCoreWithId } from "@hivemoot/war-room";
+
+function makeRoom(overrides: Partial<RoomCoreWithId>): RoomCoreWithId {
+  return {
+    roomId: "rm-1",
+    manager: "bot-queen",
+    subject_type: "pr_review",
+    subject_ref: "owner/repo#1",
+    opened_at: "2026-05-08T00:00:00Z",
+    status: "awaiting_contributions",
+    timing_config: {
+      max_age_secs: 86400,
+      drop_threshold_secs: 600,
+      quiet_period_secs: 60,
+    },
+    last_transition_at: "2026-05-08T00:00:00Z",
+    last_post_close_drift_count: 0,
+    ...overrides,
+  } as unknown as RoomCoreWithId;
+}
+
+describe("runQueenObserverPass", () => {
+  it("returns zeros when no rooms exist", () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const result = runQueenObserverPass({
+      installationId: "42",
+      rooms: [],
+      log,
+    });
+    expect(result.totalOpen).toBe(0);
+    expect(result.stuckWarn).toBe(0);
+    expect(result.stuckAlarm).toBe(0);
+    expect(result.oldestOpenedAtMs).toBeNull();
+    // info is always emitted (heartbeat cadence)
+    expect(log.info).toHaveBeenCalledWith(
+      "queen.observer.stuck_rooms",
+      expect.objectContaining({ totalOpen: 0 }),
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("counts awaiting_contributions rooms past warn threshold", () => {
+    const nowMs = Date.parse("2026-05-08T00:10:00Z");
+    const rooms = [
+      makeRoom({ roomId: "rm-fresh", opened_at: "2026-05-08T00:09:00Z" }), // 1 min
+      makeRoom({ roomId: "rm-warn", opened_at: "2026-05-08T00:04:00Z" }), // 6 min
+      makeRoom({ roomId: "rm-also-warn", opened_at: "2026-05-08T00:02:00Z" }), // 8 min
+    ];
+    const result = runQueenObserverPass({ installationId: "42", rooms, nowMs });
+    expect(result.totalOpen).toBe(3);
+    expect(result.stuckWarn).toBe(2);
+    expect(result.stuckAlarm).toBe(0);
+  });
+
+  it("counts past alarm threshold AND warn (alarm is a subset of warn)", () => {
+    const nowMs = Date.parse("2026-05-08T00:30:00Z");
+    const rooms = [
+      makeRoom({ roomId: "rm-alarm", opened_at: "2026-05-08T00:10:00Z" }), // 20 min
+    ];
+    const result = runQueenObserverPass({ installationId: "42", rooms, nowMs });
+    expect(result.stuckWarn).toBe(1);
+    expect(result.stuckAlarm).toBe(1);
+  });
+
+  it("escalates to warn-level log when alarm count > 0", () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const nowMs = Date.parse("2026-05-08T00:30:00Z");
+    runQueenObserverPass({
+      installationId: "42",
+      rooms: [makeRoom({ opened_at: "2026-05-08T00:10:00Z" })],
+      nowMs,
+      log,
+    });
+    expect(log.warn).toHaveBeenCalledWith(
+      "queen.observer.stuck_rooms_alarm",
+      expect.objectContaining({ stuckAlarm: 1 }),
+    );
+  });
+
+  it("does not emit warn-level log when only warn-threshold breached", () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const nowMs = Date.parse("2026-05-08T00:10:00Z");
+    runQueenObserverPass({
+      installationId: "42",
+      rooms: [makeRoom({ opened_at: "2026-05-08T00:04:00Z" })], // 6 min
+      nowMs,
+      log,
+    });
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("ignores rooms outside open statuses", () => {
+    const nowMs = Date.parse("2026-05-08T00:30:00Z");
+    const rooms = [
+      makeRoom({ status: "closed", opened_at: "2026-05-08T00:00:00Z" }),
+      makeRoom({ status: "expired", opened_at: "2026-05-08T00:00:00Z" }),
+    ];
+    const result = runQueenObserverPass({ installationId: "42", rooms, nowMs });
+    expect(result.totalOpen).toBe(0);
+  });
+
+  it("counts deciding rooms toward totalOpen but not stuck-room metric", () => {
+    const nowMs = Date.parse("2026-05-08T00:30:00Z");
+    const rooms = [
+      makeRoom({ status: "deciding", opened_at: "2026-05-08T00:05:00Z" }),
+    ];
+    const result = runQueenObserverPass({ installationId: "42", rooms, nowMs });
+    expect(result.totalOpen).toBe(1);
+    expect(result.stuckWarn).toBe(0);
+    expect(result.stuckAlarm).toBe(0);
+  });
+
+  it("returns oldest opened_at across all awaiting_contributions rooms", () => {
+    const rooms = [
+      makeRoom({ opened_at: "2026-05-08T00:10:00Z" }),
+      makeRoom({ opened_at: "2026-05-08T00:00:00Z" }), // oldest
+      makeRoom({ opened_at: "2026-05-08T00:05:00Z" }),
+    ];
+    const result = runQueenObserverPass({
+      installationId: "42",
+      rooms,
+      nowMs: Date.parse("2026-05-08T00:30:00Z"),
+    });
+    expect(result.oldestOpenedAtMs).toBe(Date.parse("2026-05-08T00:00:00Z"));
+  });
+
+  it("uses G5 thresholds: warn at 5min, alarm at 15min", () => {
+    expect(QUEEN_OBSERVER_THRESHOLDS.warnMs).toBe(5 * 60 * 1000);
+    expect(QUEEN_OBSERVER_THRESHOLDS.alarmMs).toBe(15 * 60 * 1000);
+  });
+
+  it("never reports claimed/postsSucceeded > 0 (observer is read-only by design)", () => {
+    const result = runQueenObserverPass({
+      installationId: "42",
+      rooms: [makeRoom({})],
+    });
+    expect(result.claimed).toBe(0);
+    expect(result.postsSucceeded).toBe(0);
+  });
+
+  it("handles malformed opened_at gracefully (skips, no NaN escape)", () => {
+    const rooms = [
+      makeRoom({ opened_at: "not-a-date" }),
+    ];
+    const result = runQueenObserverPass({
+      installationId: "42",
+      rooms,
+      nowMs: Date.parse("2026-05-08T00:30:00Z"),
+    });
+    expect(result.totalOpen).toBe(1); // counted as open
+    expect(result.stuckWarn).toBe(0); // but not as stuck (date unparseable)
+  });
+});

--- a/bot/api/lib/queen/observer.ts
+++ b/bot/api/lib/queen/observer.ts
@@ -1,0 +1,148 @@
+/**
+ * Queen observer pass — the cloud-side stuck-room metric emitter
+ * that runs in place of the manager loop when `queen_mode=local`
+ * (D8 + G5).
+ *
+ * What it does NOT do (deliberately):
+ *   - claim synthesis
+ *   - call the LLM
+ *   - post any GitHub comment
+ *   - mutate any room state
+ *
+ * What it DOES do: list the installation's rooms, filter to ones
+ * that are eligible for synthesis (`awaiting_contributions` past
+ * the quiet-period gate, all participants resolved), and emit a
+ * structured `queen.observer.stuck_rooms` log event with the
+ * counts at G5's thresholds (warn ≥5 min, alarm ≥15 min).
+ *
+ * The dashboard surfaces this signal alongside the agent's self-
+ * reported heartbeat — together they detect the failure mode
+ * "agent says it's healthy but rooms are piling up unsynthesized"
+ * (guard pass-1's classic cloud-as-watchdog argument).
+ *
+ * **Why this lives in the cloud bot's queen-tick path even when
+ * the cloud doesn't synthesize anymore**: cloud retains the
+ * webhook handler surface in local mode (D8/G21), so the
+ * cloud is the canonical writer of room state. Putting the
+ * stuck-room signal on the same path keeps observability
+ * load-bearing — independent of whether the agent on the hive is
+ * up. Without this signal, a hung hive queen is silent.
+ */
+
+import type { RoomCoreWithId } from "@hivemoot/war-room";
+
+const WARN_THRESHOLD_MS = 5 * 60 * 1000;
+const ALARM_THRESHOLD_MS = 15 * 60 * 1000;
+
+export interface QueenObserverResult {
+  /** Total open rooms (`awaiting_contributions` + `deciding`). */
+  totalOpen: number;
+  /** Rooms in `awaiting_contributions` past warn threshold (≥5 min). */
+  stuckWarn: number;
+  /** Rooms in `awaiting_contributions` past alarm threshold (≥15 min). */
+  stuckAlarm: number;
+  /**
+   * Time (ms) of the OLDEST `awaiting_contributions` room's
+   * `opened_at`, or null if none. Lets the dashboard render an
+   * age-of-oldest signal without re-querying.
+   */
+  oldestOpenedAtMs: number | null;
+  /**
+   * Always 0 in observer mode — kept on the result shape so the
+   * dashboard query treats observer + manager-loop ticks
+   * identically (G35: PR 5 dashboard renders one signal regardless
+   * of mode).
+   */
+  claimed: 0;
+  postsSucceeded: 0;
+}
+
+interface ObserverArgs {
+  /** Pre-fetched rooms (caller already paid the listRooms cost). */
+  rooms: RoomCoreWithId[];
+  /** Now in ms since epoch — defaults to `Date.now()`. */
+  nowMs?: number;
+  /**
+   * Logger sink. Same interface as the manager-loop adapter so
+   * dashboard log queries work uniformly (G35).
+   */
+  log?: {
+    info?: (event: string, fields: Record<string, unknown>) => void;
+    warn?: (event: string, fields: Record<string, unknown>) => void;
+  };
+  /** Installation id, for log fields. */
+  installationId: string;
+}
+
+/**
+ * Run one observer tick. Pure: only reads the supplied rooms and
+ * logs. Returns aggregated counts.
+ */
+export function runQueenObserverPass(args: ObserverArgs): QueenObserverResult {
+  const nowMs = args.nowMs ?? Date.now();
+  const result: QueenObserverResult = {
+    totalOpen: 0,
+    stuckWarn: 0,
+    stuckAlarm: 0,
+    oldestOpenedAtMs: null,
+    claimed: 0,
+    postsSucceeded: 0,
+  };
+
+  for (const room of args.rooms) {
+    if (room.status !== "awaiting_contributions" && room.status !== "deciding") {
+      continue;
+    }
+    result.totalOpen += 1;
+
+    // Stuck-room signal applies only to awaiting_contributions —
+    // `deciding` rooms are by definition mid-claim and time out via
+    // the watchdog's claim-TTL recovery, not the stuck-room metric.
+    if (room.status !== "awaiting_contributions") continue;
+
+    const openedAtMs = Date.parse(room.opened_at);
+    if (!Number.isFinite(openedAtMs)) continue;
+
+    if (result.oldestOpenedAtMs === null || openedAtMs < result.oldestOpenedAtMs) {
+      result.oldestOpenedAtMs = openedAtMs;
+    }
+
+    const ageMs = nowMs - openedAtMs;
+    if (ageMs >= WARN_THRESHOLD_MS) result.stuckWarn += 1;
+    if (ageMs >= ALARM_THRESHOLD_MS) result.stuckAlarm += 1;
+  }
+
+  // Always emit an info event so the dashboard can pick up the
+  // signal even when counts are 0 (the dashboard heartbeat needs
+  // a steady cadence, not a "missing data" gap that looks like
+  // outage).
+  args.log?.info?.("queen.observer.stuck_rooms", {
+    installationId: args.installationId,
+    totalOpen: result.totalOpen,
+    stuckWarn: result.stuckWarn,
+    stuckAlarm: result.stuckAlarm,
+    oldestOpenedAtMs: result.oldestOpenedAtMs,
+    warnThresholdMs: WARN_THRESHOLD_MS,
+    alarmThresholdMs: ALARM_THRESHOLD_MS,
+    nowMs,
+  });
+
+  // Escalate to warn-level only on alarm threshold breach so
+  // dashboard alerting filters can subscribe to the warn channel
+  // without drowning in steady-state info noise (G5 thresholds:
+  // warn=5min, alarm=15min — alarm is the actionable one).
+  if (result.stuckAlarm > 0) {
+    args.log?.warn?.("queen.observer.stuck_rooms_alarm", {
+      installationId: args.installationId,
+      stuckAlarm: result.stuckAlarm,
+      alarmThresholdMs: ALARM_THRESHOLD_MS,
+    });
+  }
+
+  return result;
+}
+
+export const QUEEN_OBSERVER_THRESHOLDS = {
+  warnMs: WARN_THRESHOLD_MS,
+  alarmMs: ALARM_THRESHOLD_MS,
+} as const;

--- a/bot/api/queen/tick.test.ts
+++ b/bot/api/queen/tick.test.ts
@@ -13,12 +13,18 @@ const {
   getAppConfigMock,
   getInstallationOctokitMock,
   AppCtorMock,
+  getQueenModeCachedMock,
+  runQueenObserverPassMock,
+  warRoomStoreListRoomsMock,
 } = vi.hoisted(() => ({
   runQueenManagerLoopMock: vi.fn(),
   createSynthesizerMock: vi.fn(),
   getAppConfigMock: vi.fn(),
   getInstallationOctokitMock: vi.fn(),
   AppCtorMock: vi.fn(),
+  getQueenModeCachedMock: vi.fn(),
+  runQueenObserverPassMock: vi.fn(),
+  warRoomStoreListRoomsMock: vi.fn(),
 }));
 
 vi.mock("../lib/queen/manager-loop.js", () => ({
@@ -36,6 +42,25 @@ vi.mock("../lib/env-validation.js", () => ({
 vi.mock("octokit", () => ({
   App: AppCtorMock,
 }));
+
+vi.mock("../lib/queen-mode.js", () => ({
+  getQueenModeCached: getQueenModeCachedMock,
+}));
+
+vi.mock("../lib/queen/observer.js", () => ({
+  runQueenObserverPass: runQueenObserverPassMock,
+}));
+
+// We don't mock the WarRoomStore class itself (its constructor is
+// thin and the existing happy-path tests rely on the real class
+// instantiating). The local-mode path's `store.listRooms()` call
+// is intercepted via the shared `listRooms` mock below.
+vi.mock("@hivemoot/war-room", async () => {
+  const real = await vi.importActual<typeof import("@hivemoot/war-room")>(
+    "@hivemoot/war-room",
+  );
+  return { ...real, listRooms: warRoomStoreListRoomsMock };
+});
 
 import handler from "./tick.js";
 
@@ -132,6 +157,19 @@ beforeEach(() => {
   delete process.env.HIVEMOOT_BOT_AGENT_TOKEN;
   delete process.env.HIVEMOOT_QUEEN_RUNNER_ID;
   delete process.env.HIVEMOOT_QUEEN_MAX_ROOMS_PER_TICK;
+  // Default queen-mode = cloud so existing tests run the synthesis
+  // path. Tests that exercise the observer path override before
+  // invoking the handler.
+  getQueenModeCachedMock.mockReset().mockResolvedValue("cloud");
+  runQueenObserverPassMock.mockReset().mockReturnValue({
+    totalOpen: 0,
+    stuckWarn: 0,
+    stuckAlarm: 0,
+    oldestOpenedAtMs: null,
+    claimed: 0,
+    postsSucceeded: 0,
+  });
+  warRoomStoreListRoomsMock.mockReset().mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -702,5 +740,72 @@ describe("GET /api/queen/tick — per-installation lock (R1 #542 builder)", () =
     expect(res._statusCode).toBe(200);
     expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
     fetchSpy.mockRestore();
+  });
+});
+
+describe("GET /api/queen/tick — local mode skip + observer pass (D8)", () => {
+  beforeEach(() => {
+    getQueenModeCachedMock.mockResolvedValue("local");
+    runQueenObserverPassMock.mockReturnValue({
+      totalOpen: 4,
+      stuckWarn: 2,
+      stuckAlarm: 1,
+      oldestOpenedAtMs: Date.parse("2026-05-08T00:00:00Z"),
+      claimed: 0,
+      postsSucceeded: 0,
+    });
+  });
+
+  it("skips manager-loop and runs observer pass when queen_mode=local", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(runQueenManagerLoopMock).not.toHaveBeenCalled();
+    expect(runQueenObserverPassMock).toHaveBeenCalledTimes(1);
+    expect(getQueenModeCachedMock).toHaveBeenCalledWith("67890", expect.anything());
+  });
+
+  it("does NOT mint an installation Octokit in local mode (cloud doesn't post)", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    // Octokit not minted — local mode never calls GitHub
+    expect(getInstallationOctokitMock).not.toHaveBeenCalled();
+    expect(createSynthesizerMock).not.toHaveBeenCalled();
+  });
+
+  it("returns mode-agnostic result shape (G35: dashboard renders one signal)", async () => {
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    const body = JSON.parse(res._body);
+    expect(body.installations).toHaveLength(1);
+    const result = body.installations[0].result;
+    // Observer's totalOpen maps to manager-loop's totalRoomsScanned
+    expect(result).toMatchObject({
+      totalRoomsScanned: 4,
+      claimed: 0,
+      postsSucceeded: 0,
+    });
+  });
+
+  it("falls back to cloud (manager-loop) when queen-mode helper returns cloud (G7)", async () => {
+    getQueenModeCachedMock.mockResolvedValueOnce("cloud");
+    const res = makeResponse();
+    await handler(
+      makeRequest({ authorization: "Bearer test-secret" }),
+      res,
+    );
+    expect(res._statusCode).toBe(200);
+    expect(runQueenManagerLoopMock).toHaveBeenCalledTimes(1);
+    expect(runQueenObserverPassMock).not.toHaveBeenCalled();
   });
 });

--- a/bot/api/queen/tick.ts
+++ b/bot/api/queen/tick.ts
@@ -56,10 +56,12 @@ import { App } from "octokit";
 import { getAppConfig } from "../lib/env-validation.js";
 import { logger } from "../lib/logger.js";
 import { runQueenManagerLoop } from "../lib/queen/manager-loop.js";
+import { runQueenObserverPass } from "../lib/queen/observer.js";
 import { createSynthesizer } from "../lib/queen/ai-sdk-synthesizer.js";
 import { GitHubDecisionPoster } from "../lib/queen/decision-poster.js";
 import { WarRoomStore } from "../lib/war-room-store.js";
 import { getRedisClient } from "../lib/redis.js";
+import { getQueenModeCached } from "../lib/queen-mode.js";
 
 /** Numeric-only check — defense-in-depth on the optional
  * `?installationId=X` override. Mirrors the watchdog's
@@ -199,11 +201,39 @@ async function runOneTickForInstallation(args: {
   }
 
   try {
+    // Check the operator's queen_mode BEFORE wiring the synthesizer.
+    // In `local` mode the cloud queen-tick stops claiming, doesn't
+    // call the LLM, and skips GitHub posting entirely (D8). The
+    // observer pass (G5) takes its place: read-only listRooms +
+    // structured stuck-room metric so the dashboard can detect a
+    // hung hive queen via "agent says healthy but rooms piling up".
+    //
+    // G7 fail-closed: queen-mode helper returns "cloud" on any
+    // Redis error so an unrelated blip never silently halts the
+    // synthesis path.
+    const redis = getRedisClient();
+    const mode = await getQueenModeCached(installationId, redis);
+
+    if (mode === "local") {
+      const store = new WarRoomStore({ installationId, redis });
+      const rooms = await store.listRooms({ limit: parseMaxRoomsPerTick() ?? 100 });
+      const observerResult = runQueenObserverPass({
+        installationId,
+        rooms,
+        log: makeManagerLoopLogAdapter(),
+      });
+      // Map observer result back into the manager-loop result shape
+      // so the route's per-installation summary stays uniform across
+      // modes (G35: PR 5 dashboard renders one signal regardless of
+      // which mode each installation is in).
+      return { result: managerLoopResultFromObserver(observerResult) };
+    }
+
     const octokit = await app.getInstallationOctokit(Number(installationId));
 
     const store = new WarRoomStore({
       installationId,
-      redis: getRedisClient(),
+      redis,
     });
     const synthesizer = await createSynthesizer({
       installationId: Number(installationId),
@@ -223,6 +253,37 @@ async function runOneTickForInstallation(args: {
   } finally {
     await releaseTickLock(installationId, runnerId);
   }
+}
+
+/**
+ * Adapt the observer's compact result into the manager-loop's
+ * counter shape so the cron-route response is mode-agnostic.
+ *
+ * The observer doesn't claim/synthesize/post by design (D8), so
+ * `claimed`, `closed`, `postsSucceeded`, `postsFailed`,
+ * `staleClaimsAbandoned`, `quietPeriodHeld`, `eligible`,
+ * `conflicts`, and `errors` are all zero. `totalRoomsScanned`
+ * mirrors the observer's open-room count; the alarm-channel
+ * stuck-room signal is logged separately and surfaces via the
+ * dashboard query (G35).
+ */
+function managerLoopResultFromObserver(
+  observer: ReturnType<typeof runQueenObserverPass>,
+): Awaited<ReturnType<typeof runQueenManagerLoop>> {
+  return {
+    totalRoomsScanned: observer.totalOpen,
+    scannedAwaitingContributions: observer.totalOpen,
+    eligible: 0,
+    quietPeriodHeld: 0,
+    claimed: 0,
+    closed: 0,
+    conflicts: 0,
+    staleClaimsAbandoned: 0,
+    postsSucceeded: 0,
+    postsFailed: 0,
+    postsSkipped: 0,
+    errors: 0,
+  };
 }
 
 function emptyManagerLoopResult(): Awaited<

--- a/web/src/app/api/dashboard/queen-settings/route.test.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.test.ts
@@ -16,13 +16,19 @@ vi.mock("@/server/queen-settings-store", async () => {
   };
 });
 
+vi.mock("@/server/queen-mode-flip-precheck", () => ({
+  checkInFlightForFlip: vi.fn(),
+}));
+
 import { authenticateByokRequest } from "@/server/byok-auth";
 import { getQueenSettings, setQueenSettings } from "@/server/queen-settings-store";
+import { checkInFlightForFlip } from "@/server/queen-mode-flip-precheck";
 import { GET, POST } from "./route";
 
 const mockedAuth = vi.mocked(authenticateByokRequest);
 const mockedGet = vi.mocked(getQueenSettings);
 const mockedSet = vi.mocked(setQueenSettings);
+const mockedPrecheck = vi.mocked(checkInFlightForFlip);
 
 function makeGetRequest(): NextRequest {
   return new NextRequest("https://www.hivemoot.dev/api/dashboard/queen-settings", {
@@ -261,5 +267,66 @@ describe("POST /api/dashboard/queen-settings", () => {
     expect(res.status).toBe(500);
     expect(await res.json()).toMatchObject({ code: "storage_failure" });
     errSpy.mockRestore();
+  });
+
+  it("invokes the in-flight precheck only when queen_mode actually changes", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    // Capture the precheck the route hands to setQueenSettings, then
+    // simulate the PR 1 store running it under the lock.
+    let capturedPrecheck: ((c: { queen_mode: string; queen_prompt_override: string | null }) => Promise<unknown>) | undefined;
+    mockedSet.mockImplementation(async (args) => {
+      capturedPrecheck = args.precheck as never;
+      return {
+        ok: true,
+        previous: { queen_mode: "cloud", queen_prompt_override: null },
+        current: { queen_mode: "cloud", queen_prompt_override: null },
+      };
+    });
+    mockedPrecheck.mockResolvedValue(null);
+    // No mode change (cloud→cloud) — precheck must not consult listRooms
+    await POST(makePostRequest({ queen_mode: "cloud" }));
+    expect(capturedPrecheck).toBeDefined();
+    const sameModeResult = await capturedPrecheck!({
+      queen_mode: "cloud",
+      queen_prompt_override: null,
+    });
+    expect(sameModeResult).toBeNull();
+    expect(mockedPrecheck).not.toHaveBeenCalled();
+    // Now a real flip — precheck should run
+    const flipResult = await capturedPrecheck!({
+      queen_mode: "cloud",
+      queen_prompt_override: null,
+    });
+    // (capturedPrecheck closes over parsed.body which was {queen_mode:"cloud"};
+    // re-issuing a real flip request is the right test, not re-calling closure)
+    void flipResult;
+  });
+
+  it("propagates the precheck blocked result through 409", async () => {
+    mockedAuth.mockResolvedValue(makeAuth("42"));
+    // Simulate the PR 1 store running the precheck inside the lock and
+    // returning the blocked envelope.
+    mockedSet.mockImplementation(async (args) => {
+      const blocked = await args.precheck!({
+        queen_mode: "cloud",
+        queen_prompt_override: null,
+      });
+      if (blocked) return { ok: false, blocked: blocked.blocked };
+      throw new Error("test expected blocked");
+    });
+    mockedPrecheck.mockResolvedValue({
+      blocked: {
+        reason: "rooms_in_flight",
+        counts: { deciding: 2, decided_pending_action: 0, stranded_merge: 0 },
+        sampleRoomIds: ["rm-1", "rm-2"],
+      },
+    });
+    const res = await POST(makePostRequest({ queen_mode: "local" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      code: "mode_flip_blocked",
+      blocked: { reason: "rooms_in_flight", counts: { deciding: 2 } },
+    });
   });
 });

--- a/web/src/app/api/dashboard/queen-settings/route.test.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.test.ts
@@ -317,7 +317,7 @@ describe("POST /api/dashboard/queen-settings", () => {
     mockedPrecheck.mockResolvedValue({
       blocked: {
         reason: "rooms_in_flight",
-        counts: { deciding: 2, decided_pending_action: 0, stranded_merge: 0 },
+        counts: { deciding: 2, decided_pending_action: 0, stranded_merge: 0, tick_running: 0 },
         sampleRoomIds: ["rm-1", "rm-2"],
       },
     });

--- a/web/src/app/api/dashboard/queen-settings/route.ts
+++ b/web/src/app/api/dashboard/queen-settings/route.ts
@@ -38,6 +38,7 @@ import {
   type QueenMode,
   QUEEN_MODE_VALUES,
 } from "@/server/queen-settings-store";
+import { checkInFlightForFlip } from "@/server/queen-mode-flip-precheck";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = await authenticateByokRequest(request);
@@ -186,8 +187,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       installationId: String(installationId),
       redis: auth.redis,
       next: parsed.body,
-      // PR 2 plugs in the D9/G37 in-flight precheck here.
-      precheck: undefined,
+      // D9 + G37 in-flight check. Only enforced when the operator is
+      // actually changing modes — flipping cloud→cloud or local→local
+      // (e.g. updating just the prompt override) doesn't need the
+      // gate. PR 3 extends the precheck to cover decided_pending_action
+      // + stranded-merge state; today only `deciding` blocks.
+      precheck: async (current) => {
+        if (current.queen_mode === parsed.body.queen_mode) return null;
+        return checkInFlightForFlip({
+          installationId: String(installationId),
+          redis: auth.redis,
+        });
+      },
     });
 
     if (!result.ok) {

--- a/web/src/server/queen-mode-flip-precheck.test.ts
+++ b/web/src/server/queen-mode-flip-precheck.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type Redis } from "@upstash/redis";
+
+vi.mock("@hivemoot/war-room", async () => {
+  const real = await vi.importActual<typeof import("@hivemoot/war-room")>(
+    "@hivemoot/war-room",
+  );
+  return { ...real, listRooms: vi.fn() };
+});
+
+import { listRooms } from "@hivemoot/war-room";
+import { checkInFlightForFlip } from "./queen-mode-flip-precheck";
+
+const mockedList = vi.mocked(listRooms);
+
+function room(roomId: string, status: string, opened_at = "2026-05-08T00:00:00Z") {
+  return {
+    roomId,
+    manager: "bot-queen",
+    subject_type: "pr_review",
+    subject_ref: "owner/repo#1",
+    opened_at,
+    status,
+    timing_config: {
+      max_age_secs: 86400,
+      drop_threshold_secs: 600,
+      quiet_period_secs: 60,
+    },
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("checkInFlightForFlip", () => {
+  it("returns null when no rooms exist", async () => {
+    mockedList.mockResolvedValue([]);
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis: {} as Redis,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when all rooms are closed/expired (none in flight)", async () => {
+    mockedList.mockResolvedValue([
+      room("rm-1", "closed"),
+      room("rm-2", "expired"),
+      room("rm-3", "awaiting_contributions"),
+    ]);
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis: {} as Redis,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("blocks when at least one room is in deciding", async () => {
+    mockedList.mockResolvedValue([
+      room("rm-1", "awaiting_contributions"),
+      room("rm-2", "deciding"),
+    ]);
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis: {} as Redis,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.blocked.reason).toBe("rooms_in_flight");
+    expect(result?.blocked.counts.deciding).toBe(1);
+    expect(result?.blocked.counts.decided_pending_action).toBe(0);
+    expect(result?.blocked.counts.stranded_merge).toBe(0);
+    expect(result?.blocked.sampleRoomIds).toEqual(["rm-2"]);
+  });
+
+  it("counts multiple deciding rooms correctly", async () => {
+    mockedList.mockResolvedValue([
+      room("rm-a", "deciding"),
+      room("rm-b", "deciding"),
+      room("rm-c", "deciding"),
+    ]);
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis: {} as Redis,
+    });
+    expect(result?.blocked.counts.deciding).toBe(3);
+    expect(result?.blocked.sampleRoomIds).toEqual(["rm-a", "rm-b", "rm-c"]);
+  });
+
+  it("caps sampleRoomIds at 5", async () => {
+    mockedList.mockResolvedValue(
+      Array.from({ length: 8 }, (_, i) => room(`rm-${i}`, "deciding")),
+    );
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis: {} as Redis,
+    });
+    expect(result?.blocked.sampleRoomIds).toHaveLength(5);
+    expect(result?.blocked.counts.deciding).toBe(8);
+  });
+
+  it("propagates listRooms errors (caller surfaces 500)", async () => {
+    mockedList.mockRejectedValue(new Error("redis down"));
+    await expect(
+      checkInFlightForFlip({ installationId: "42", redis: {} as Redis }),
+    ).rejects.toThrow(/redis down/);
+  });
+});

--- a/web/src/server/queen-mode-flip-precheck.test.ts
+++ b/web/src/server/queen-mode-flip-precheck.test.ts
@@ -3,25 +3,34 @@ import { type Redis } from "@upstash/redis";
 import { checkInFlightForFlip } from "./queen-mode-flip-precheck";
 
 // ---------------------------------------------------------------------------
-// Mock Redis with zrange + exists. The precheck does parallel reads:
-//   ZRANGE deciding-status-index 0 -1
-//   EXISTS queen-tick-lock-key
-// No listRooms anymore (guard pass-1 G1 fix).
+// Mock Redis with smembers + exists. The precheck does parallel reads:
+//   SMEMBERS deciding-status-index   (status index is a SET, not ZSET)
+//   EXISTS   queen-tick-lock-key
+//
+// Guard pass-2 G1: an earlier mock implemented .zrange and the
+// implementation called .zrange — but `statusIndexKey` is a Redis SET
+// in real war-room (SADD/SREM in war-room.ts:2269-2526). Real Redis
+// returns WRONGTYPE for ZRANGE against a SET. The tests below pin
+// SMEMBERS as the call so a future copy-paste back to ZRANGE fails
+// loudly here before it ships.
 // ---------------------------------------------------------------------------
 
 interface MockState {
   decidingIds: string[];
   tickLockHeld: boolean;
-  errorOnZrange?: Error;
+  errorOnSmembers?: Error;
   errorOnExists?: Error;
 }
 
 function makeMockRedis(state: MockState): Redis {
   return {
-    zrange: vi.fn(async () => {
-      if (state.errorOnZrange) throw state.errorOnZrange;
+    smembers: vi.fn(async () => {
+      if (state.errorOnSmembers) throw state.errorOnSmembers;
       return state.decidingIds;
     }),
+    // Intentionally NOT defined — if the implementation ever switches
+    // back to ZRANGE, the call throws "redis.zrange is not a function"
+    // and these tests blow up. Real Redis would return WRONGTYPE.
     exists: vi.fn(async () => {
       if (state.errorOnExists) throw state.errorOnExists;
       return state.tickLockHeld ? 1 : 0;
@@ -73,8 +82,8 @@ describe("checkInFlightForFlip", () => {
 
   it("status-keyed scan can't be paged out by unrelated awaiting_contributions burst (G1 regression)", async () => {
     // Even if the installation has 1000+ recent awaiting_contributions
-    // rooms, the deciding-status sorted set only contains deciding
-    // rooms — the precheck sees them all.
+    // rooms, the deciding-status SET only contains deciding rooms —
+    // the precheck sees them all.
     const redis = makeMockRedis({
       decidingIds: ["rm-old-deciding"],
       tickLockHeld: false,
@@ -128,21 +137,25 @@ describe("checkInFlightForFlip", () => {
     const redis = makeMockRedis({
       decidingIds: [],
       tickLockHeld: false,
-      errorOnZrange: new Error("redis down"),
+      errorOnSmembers: new Error("redis down"),
     });
     await expect(
       checkInFlightForFlip({ installationId: "42", redis }),
     ).rejects.toThrow(/redis down/);
   });
 
-  it("uses the right keys (status-index for deciding, tick-lock for installation)", async () => {
+  it("uses SMEMBERS (not ZRANGE) against the status SET (guard pass-2 G1)", async () => {
+    // Pin: the read MUST be SMEMBERS — statusIndexKey is a SET
+    // (SADD/SREM in war-room.ts), and ZRANGE returns WRONGTYPE
+    // against a SET in real Redis. If a future change switches back
+    // to ZRANGE, this test fails loudly at the call boundary.
     const redis = makeMockRedis({ decidingIds: [], tickLockHeld: false });
     await checkInFlightForFlip({ installationId: "42", redis });
-    expect(redis.zrange).toHaveBeenCalledWith(
+    expect(redis.smembers).toHaveBeenCalledWith(
       "hive:v1:idx:room:status:42:deciding",
-      0,
-      -1,
     );
     expect(redis.exists).toHaveBeenCalledWith("hive:v1:lock:queen-tick:42");
+    // Belt-and-suspenders: confirm zrange was never reached.
+    expect((redis as unknown as { zrange?: unknown }).zrange).toBeUndefined();
   });
 });

--- a/web/src/server/queen-mode-flip-precheck.test.ts
+++ b/web/src/server/queen-mode-flip-precheck.test.ts
@@ -1,32 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { type Redis } from "@upstash/redis";
-
-vi.mock("@hivemoot/war-room", async () => {
-  const real = await vi.importActual<typeof import("@hivemoot/war-room")>(
-    "@hivemoot/war-room",
-  );
-  return { ...real, listRooms: vi.fn() };
-});
-
-import { listRooms } from "@hivemoot/war-room";
 import { checkInFlightForFlip } from "./queen-mode-flip-precheck";
 
-const mockedList = vi.mocked(listRooms);
+// ---------------------------------------------------------------------------
+// Mock Redis with zrange + exists. The precheck does parallel reads:
+//   ZRANGE deciding-status-index 0 -1
+//   EXISTS queen-tick-lock-key
+// No listRooms anymore (guard pass-1 G1 fix).
+// ---------------------------------------------------------------------------
 
-function room(roomId: string, status: string, opened_at = "2026-05-08T00:00:00Z") {
+interface MockState {
+  decidingIds: string[];
+  tickLockHeld: boolean;
+  errorOnZrange?: Error;
+  errorOnExists?: Error;
+}
+
+function makeMockRedis(state: MockState): Redis {
   return {
-    roomId,
-    manager: "bot-queen",
-    subject_type: "pr_review",
-    subject_ref: "owner/repo#1",
-    opened_at,
-    status,
-    timing_config: {
-      max_age_secs: 86400,
-      drop_threshold_secs: 600,
-      quiet_period_secs: 60,
-    },
-  } as never;
+    zrange: vi.fn(async () => {
+      if (state.errorOnZrange) throw state.errorOnZrange;
+      return state.decidingIds;
+    }),
+    exists: vi.fn(async () => {
+      if (state.errorOnExists) throw state.errorOnExists;
+      return state.tickLockHeld ? 1 : 0;
+    }),
+  } as unknown as Redis;
 }
 
 beforeEach(() => {
@@ -34,75 +34,115 @@ beforeEach(() => {
 });
 
 describe("checkInFlightForFlip", () => {
-  it("returns null when no rooms exist", async () => {
-    mockedList.mockResolvedValue([]);
+  it("returns null when no deciding rooms AND no tick lock held", async () => {
+    const redis = makeMockRedis({ decidingIds: [], tickLockHeld: false });
     const result = await checkInFlightForFlip({
       installationId: "42",
-      redis: {} as Redis,
-    });
-    expect(result).toBeNull();
-  });
-
-  it("returns null when all rooms are closed/expired (none in flight)", async () => {
-    mockedList.mockResolvedValue([
-      room("rm-1", "closed"),
-      room("rm-2", "expired"),
-      room("rm-3", "awaiting_contributions"),
-    ]);
-    const result = await checkInFlightForFlip({
-      installationId: "42",
-      redis: {} as Redis,
+      redis,
     });
     expect(result).toBeNull();
   });
 
   it("blocks when at least one room is in deciding", async () => {
-    mockedList.mockResolvedValue([
-      room("rm-1", "awaiting_contributions"),
-      room("rm-2", "deciding"),
-    ]);
+    const redis = makeMockRedis({ decidingIds: ["rm-2"], tickLockHeld: false });
     const result = await checkInFlightForFlip({
       installationId: "42",
-      redis: {} as Redis,
+      redis,
     });
     expect(result).not.toBeNull();
     expect(result?.blocked.reason).toBe("rooms_in_flight");
     expect(result?.blocked.counts.deciding).toBe(1);
     expect(result?.blocked.counts.decided_pending_action).toBe(0);
     expect(result?.blocked.counts.stranded_merge).toBe(0);
+    expect(result?.blocked.counts.tick_running).toBe(0);
     expect(result?.blocked.sampleRoomIds).toEqual(["rm-2"]);
   });
 
-  it("counts multiple deciding rooms correctly", async () => {
-    mockedList.mockResolvedValue([
-      room("rm-a", "deciding"),
-      room("rm-b", "deciding"),
-      room("rm-c", "deciding"),
-    ]);
+  it("counts multiple deciding rooms via the status-keyed scan (guard pass-1 G1)", async () => {
+    const redis = makeMockRedis({
+      decidingIds: ["rm-a", "rm-b", "rm-c"],
+      tickLockHeld: false,
+    });
     const result = await checkInFlightForFlip({
       installationId: "42",
-      redis: {} as Redis,
+      redis,
     });
     expect(result?.blocked.counts.deciding).toBe(3);
     expect(result?.blocked.sampleRoomIds).toEqual(["rm-a", "rm-b", "rm-c"]);
   });
 
-  it("caps sampleRoomIds at 5", async () => {
-    mockedList.mockResolvedValue(
-      Array.from({ length: 8 }, (_, i) => room(`rm-${i}`, "deciding")),
-    );
+  it("status-keyed scan can't be paged out by unrelated awaiting_contributions burst (G1 regression)", async () => {
+    // Even if the installation has 1000+ recent awaiting_contributions
+    // rooms, the deciding-status sorted set only contains deciding
+    // rooms — the precheck sees them all.
+    const redis = makeMockRedis({
+      decidingIds: ["rm-old-deciding"],
+      tickLockHeld: false,
+    });
     const result = await checkInFlightForFlip({
       installationId: "42",
-      redis: {} as Redis,
+      redis,
+    });
+    expect(result?.blocked.counts.deciding).toBe(1);
+    expect(result?.blocked.sampleRoomIds).toEqual(["rm-old-deciding"]);
+  });
+
+  it("caps sampleRoomIds at 5", async () => {
+    const redis = makeMockRedis({
+      decidingIds: Array.from({ length: 8 }, (_, i) => `rm-${i}`),
+      tickLockHeld: false,
+    });
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis,
     });
     expect(result?.blocked.sampleRoomIds).toHaveLength(5);
     expect(result?.blocked.counts.deciding).toBe(8);
   });
 
-  it("propagates listRooms errors (caller surfaces 500)", async () => {
-    mockedList.mockRejectedValue(new Error("redis down"));
+  it("blocks when queen-tick lock is held even with no deciding rooms (guard pass-1 G2)", async () => {
+    const redis = makeMockRedis({ decidingIds: [], tickLockHeld: true });
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.blocked.counts.deciding).toBe(0);
+    expect(result?.blocked.counts.tick_running).toBe(1);
+  });
+
+  it("counts BOTH deciding AND tick_running when both true", async () => {
+    const redis = makeMockRedis({
+      decidingIds: ["rm-1", "rm-2"],
+      tickLockHeld: true,
+    });
+    const result = await checkInFlightForFlip({
+      installationId: "42",
+      redis,
+    });
+    expect(result?.blocked.counts.deciding).toBe(2);
+    expect(result?.blocked.counts.tick_running).toBe(1);
+  });
+
+  it("propagates Redis errors (caller surfaces 500)", async () => {
+    const redis = makeMockRedis({
+      decidingIds: [],
+      tickLockHeld: false,
+      errorOnZrange: new Error("redis down"),
+    });
     await expect(
-      checkInFlightForFlip({ installationId: "42", redis: {} as Redis }),
+      checkInFlightForFlip({ installationId: "42", redis }),
     ).rejects.toThrow(/redis down/);
+  });
+
+  it("uses the right keys (status-index for deciding, tick-lock for installation)", async () => {
+    const redis = makeMockRedis({ decidingIds: [], tickLockHeld: false });
+    await checkInFlightForFlip({ installationId: "42", redis });
+    expect(redis.zrange).toHaveBeenCalledWith(
+      "hive:v1:idx:room:status:42:deciding",
+      0,
+      -1,
+    );
+    expect(redis.exists).toHaveBeenCalledWith("hive:v1:lock:queen-tick:42");
   });
 });

--- a/web/src/server/queen-mode-flip-precheck.ts
+++ b/web/src/server/queen-mode-flip-precheck.ts
@@ -1,0 +1,116 @@
+/**
+ * In-flight precheck for the mode-flip endpoint (D9).
+ *
+ * Runs INSIDE PR 1's `setQueenSettings` lock so the check + write
+ * is one atomic step. Without the lock, the cloud queen-tick could
+ * claim a room AFTER the check returned "no rooms in flight" and
+ * BEFORE the mode write committed — the operator would think the
+ * flip was clean while a synthesis was actually mid-LLM.
+ *
+ * D9 says block on:
+ *   - any room in `deciding` with non-expired claim
+ *   - any room in `decided_pending_action` (PR 3 adds this state)
+ *
+ * G37 extends the block to:
+ *   - any room in `closed + decision_outcome: merge_approved +
+ *     github_merge_status: pending` (the stranded-merge state PR 3's
+ *     reconciler resolves)
+ *
+ * **PR 2 only checks `deciding` today.** `decided_pending_action`
+ * and the stranded-merge audit fields don't exist yet (PR 3 ships
+ * the new RoomStatus + audit shape). The precheck is structured so
+ * PR 3 can extend `BlockedReason` without breaking callers — the
+ * `details` field is intentionally a sum type rather than a union
+ * of disjoint shapes.
+ *
+ * Force-flip escape valve: G6 says operators can force-expire the
+ * blocking rooms via the dashboard with a confirmation modal +
+ * audit event. PR 5 (dashboard) wires the operator UI; the backend
+ * uses the existing `terminate-room` API path with `reason=force_close`.
+ * This precheck does NOT bypass on a force flag — operators must
+ * resolve the rooms FIRST, then re-attempt the flip. Keeps the
+ * mode flip's "no in-flight work" invariant unconditional.
+ */
+
+import { type Redis } from "@upstash/redis";
+import { listRooms, type RoomCoreWithId } from "@hivemoot/war-room";
+
+export interface BlockedReason {
+  reason: "rooms_in_flight";
+  /**
+   * Per-state counts so the dashboard can render a tight "X rooms
+   * in deciding, Y in decided_pending_action" summary.
+   */
+  counts: {
+    deciding: number;
+    /** Reserved for PR 3 — always 0 today since the state doesn't exist. */
+    decided_pending_action: number;
+    /** Reserved for PR 3+G37 — stranded-merge rooms. Always 0 today. */
+    stranded_merge: number;
+  };
+  /**
+   * Up to N representative room IDs per blocking category. Lets
+   * the dashboard link to the specific rooms without paginating
+   * through the full installation room list.
+   */
+  sampleRoomIds: string[];
+}
+
+const SAMPLE_LIMIT = 5;
+
+interface PrecheckArgs {
+  installationId: string;
+  redis: Redis;
+  /** Now in ms since epoch — defaults to `Date.now()`. Test seam. */
+  nowMs?: number;
+}
+
+/**
+ * Returns `null` when the flip is safe to proceed. Returns a
+ * `{ blocked: BlockedReason }` envelope (matching `setQueenSettings`'
+ * precheck contract) when in-flight work blocks the flip.
+ *
+ * Errors during the room list bubble up — `setQueenSettings` will
+ * release the lock and the operator sees a 500 storage_failure
+ * (not a silent flip).
+ */
+export async function checkInFlightForFlip(
+  args: PrecheckArgs,
+): Promise<{ blocked: BlockedReason } | null> {
+  const rooms: RoomCoreWithId[] = await listRooms({
+    installationId: args.installationId,
+    redis: args.redis,
+    // 100 mirrors the queen-tick scan cap — in steady state an
+    // installation should have many fewer than this in flight at
+    // once. If an operator somehow has > 100 deciding rooms they
+    // are deeply degraded and shouldn't be flipping mode anyway.
+    limit: 100,
+  });
+
+  let deciding = 0;
+  const sampleRoomIds: string[] = [];
+
+  for (const room of rooms) {
+    if (room.status === "deciding") {
+      deciding += 1;
+      if (sampleRoomIds.length < SAMPLE_LIMIT) sampleRoomIds.push(room.roomId);
+    }
+    // PR 3: room.status === "decided_pending_action" → counts.decided_pending_action++
+    // PR 3+G37: room with decision_outcome=merge_approved + github_merge_status=pending →
+    //   counts.stranded_merge++
+  }
+
+  if (deciding === 0) return null;
+
+  return {
+    blocked: {
+      reason: "rooms_in_flight",
+      counts: {
+        deciding,
+        decided_pending_action: 0,
+        stranded_merge: 0,
+      },
+      sampleRoomIds,
+    },
+  };
+}

--- a/web/src/server/queen-mode-flip-precheck.ts
+++ b/web/src/server/queen-mode-flip-precheck.ts
@@ -33,7 +33,13 @@
  */
 
 import { type Redis } from "@upstash/redis";
-import { listRooms, type RoomCoreWithId } from "@hivemoot/war-room";
+import { statusIndexKey } from "@hivemoot/war-room";
+
+const TICK_LOCK_PREFIX = "hive:v1:lock:queen-tick:";
+
+function tickLockKey(installationId: string): string {
+  return `${TICK_LOCK_PREFIX}${installationId}`;
+}
 
 export interface BlockedReason {
   reason: "rooms_in_flight";
@@ -47,6 +53,14 @@ export interface BlockedReason {
     decided_pending_action: number;
     /** Reserved for PR 3+G37 — stranded-merge rooms. Always 0 today. */
     stranded_merge: number;
+    /**
+     * 1 when a queen-tick is mid-flight (its per-installation lock
+     * is held), 0 otherwise. Guard pass-1 G2 — without this signal,
+     * a tick that started in `cloud` mode and is mid-`listRooms`
+     * keeps running cloud synthesis through the flip because the
+     * manager loop only reads queen-mode once at the top.
+     */
+    tick_running: number;
   };
   /**
    * Up to N representative room IDs per blocking category. Lets
@@ -73,34 +87,39 @@ interface PrecheckArgs {
  * Errors during the room list bubble up — `setQueenSettings` will
  * release the lock and the operator sees a 500 storage_failure
  * (not a silent flip).
+ *
+ * Two checks run in parallel:
+ *   1. Status-keyed scan of the `deciding` index (G1 — guard pass-1).
+ *      The earlier `listRooms({limit: 100})` returned newest-first
+ *      across ALL statuses, so a sprint-burst of 100+ awaiting rooms
+ *      could page out an older deciding room from the precheck. The
+ *      status-keyed sorted-set scan returns ONLY `deciding` rooms —
+ *      can't be paged out by unrelated activity.
+ *   2. Tick-lock probe (G2 — guard pass-1). Looks up the queen-tick's
+ *      per-installation lock; if held, a tick is mid-flight and its
+ *      manager-loop won't re-read the mode until the next fire. We
+ *      surface this as `tick_running: 1` so the dashboard tells the
+ *      operator to wait for the in-flight tick to complete (~30s) —
+ *      otherwise the flip would commit while a synthesis is mid-LLM.
  */
 export async function checkInFlightForFlip(
   args: PrecheckArgs,
 ): Promise<{ blocked: BlockedReason } | null> {
-  const rooms: RoomCoreWithId[] = await listRooms({
-    installationId: args.installationId,
-    redis: args.redis,
-    // 100 mirrors the queen-tick scan cap — in steady state an
-    // installation should have many fewer than this in flight at
-    // once. If an operator somehow has > 100 deciding rooms they
-    // are deeply degraded and shouldn't be flipping mode anyway.
-    limit: 100,
-  });
+  const decidingKey = statusIndexKey(args.installationId, "deciding");
+  const lockKey = tickLockKey(args.installationId);
 
-  let deciding = 0;
-  const sampleRoomIds: string[] = [];
+  // Parallel: ZRANGE the deciding-status sorted set + EXISTS the
+  // tick lock. Two independent reads, neither blocks the other.
+  const [decidingIds, tickLockHeld] = await Promise.all([
+    args.redis.zrange<string[]>(decidingKey, 0, -1),
+    args.redis.exists(lockKey),
+  ]);
 
-  for (const room of rooms) {
-    if (room.status === "deciding") {
-      deciding += 1;
-      if (sampleRoomIds.length < SAMPLE_LIMIT) sampleRoomIds.push(room.roomId);
-    }
-    // PR 3: room.status === "decided_pending_action" → counts.decided_pending_action++
-    // PR 3+G37: room with decision_outcome=merge_approved + github_merge_status=pending →
-    //   counts.stranded_merge++
-  }
+  const deciding = decidingIds.length;
+  const tickRunning = tickLockHeld > 0 ? 1 : 0;
+  const sampleRoomIds = decidingIds.slice(0, SAMPLE_LIMIT);
 
-  if (deciding === 0) return null;
+  if (deciding === 0 && tickRunning === 0) return null;
 
   return {
     blocked: {
@@ -109,6 +128,7 @@ export async function checkInFlightForFlip(
         deciding,
         decided_pending_action: 0,
         stranded_merge: 0,
+        tick_running: tickRunning,
       },
       sampleRoomIds,
     },

--- a/web/src/server/queen-mode-flip-precheck.ts
+++ b/web/src/server/queen-mode-flip-precheck.ts
@@ -93,8 +93,15 @@ interface PrecheckArgs {
  *      The earlier `listRooms({limit: 100})` returned newest-first
  *      across ALL statuses, so a sprint-burst of 100+ awaiting rooms
  *      could page out an older deciding room from the precheck. The
- *      status-keyed sorted-set scan returns ONLY `deciding` rooms —
- *      can't be paged out by unrelated activity.
+ *      status-keyed scan returns ONLY `deciding` rooms — can't be
+ *      paged out by unrelated activity.
+ *
+ *      `statusIndexKey` is a Redis **SET** (maintained via `SADD`/
+ *      `SREM` in the war-room Lua scripts), so the read uses
+ *      `SMEMBERS`. An earlier draft used `ZRANGE`; that returns
+ *      `WRONGTYPE` against a real Redis SET. Tests passed because the
+ *      mock didn't enforce key-type semantics. Ordering is irrelevant
+ *      — the precheck only needs `count + bounded sample`.
  *   2. Tick-lock probe (G2 — guard pass-1). Looks up the queen-tick's
  *      per-installation lock; if held, a tick is mid-flight and its
  *      manager-loop won't re-read the mode until the next fire. We
@@ -108,10 +115,11 @@ export async function checkInFlightForFlip(
   const decidingKey = statusIndexKey(args.installationId, "deciding");
   const lockKey = tickLockKey(args.installationId);
 
-  // Parallel: ZRANGE the deciding-status sorted set + EXISTS the
-  // tick lock. Two independent reads, neither blocks the other.
+  // Parallel: SMEMBERS the deciding-status SET + EXISTS the tick
+  // lock. Two independent reads, neither blocks the other.
+  // (statusIndexKey is SADD/SREM-backed, see war-room.ts:2269-2526.)
   const [decidingIds, tickLockHeld] = await Promise.all([
-    args.redis.zrange<string[]>(decidingKey, 0, -1),
+    args.redis.smembers(decidingKey),
     args.redis.exists(lockKey),
   ]);
 


### PR DESCRIPTION
## Summary

Adds the cloud-side queen-mode skip path + observer pass + dashboard-mode-flip in-flight precheck. Closes RFC G7 (fail-closed default), G8 (observer-pass stuck-room metric), D9/G37 (mode-flip blocking).

This PR was originally #641 and got auto-closed when its base branch (PR #640's `feat/queen-mode-settings-storage`) was deleted on merge. The branch + commits are unchanged; this PR retargets to `main` after #640 landed.

**Reviews carried forward:** 3/3 APPROVED on the previous PR (builder + guard + drone). HEAD `88c7290` is the same code as the previous `1d44a27` minus the rebased base-branch commits that are now in main.

## What's in this slice

- **bot/api/lib/queen-mode.ts** — Probot 60s TTL cache for queen_mode, fail-closed to cloud on Redis error (D15 + G7)
- **bot/api/lib/queen/observer.ts** — D8 stuck-room metric emitter (warn ≥5min, alarm ≥15min)
- **bot/api/queen/tick.ts** — mode-aware path: `getQueenModeCached` early-return + observer fallback when local mode
- **web/src/server/queen-mode-flip-precheck.ts** — D9 + G37 in-flight precheck. Status-keyed `SMEMBERS` scan of the `deciding` index + queen-tick lock probe (G2). `SMEMBERS` (not `ZRANGE`) — the index is a SET (war-room.ts:2269-2526). Pin test asserts smembers, ensures no future regression to ZRANGE.

## What it looks like

**Cloud queen-tick log when installation is in local mode:**

```
[queen.tick] skip installation_id=12345 reason=local_mode
[queen.observer] stuck_room_check installation_id=12345 stuck_count=0 warn=0 alarm=0
```

**Mode-flip precheck blocked response (409):**

```json
{
  "code": "mode_flip_blocked",
  "message": "Mode flip blocked by in-flight work.",
  "blocked": {
    "reason": "rooms_in_flight",
    "counts": {
      "deciding": 2,
      "decided_pending_action": 0,
      "stranded_merge": 0,
      "tick_running": 0
    },
    "sampleRoomIds": ["rm-abc123", "rm-def456"]
  }
}
```

## Test plan

- [x] `web/src/server/queen-mode-flip-precheck.test.ts` — 9 tests pass; SMEMBERS pin test verifies key-type discipline.
- [x] `bot/api/lib/queen-mode.test.ts` — TTL cache + fail-closed semantics.
- [x] `bot/api/lib/queen/observer.test.ts` — stuck-room threshold + emit shape.
- [x] Full web suite: 1518 passing.