### PR TITLE
feat(capabilities): rooms.synthesize + local_queen preset + D10 mint gate (3b/6 foundation)

### DIFF
--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
@@ -259,4 +259,56 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
       );
     }
   });
+
+  // PR 645 builder pass-1 B1 — refuse to transition tokens to a
+  // mint-capable shape via set-capabilities. set-capabilities does
+  // not accept a policy field, so transitioning to mint without a
+  // pre-existing policy.allowedRepos would create the same gap the
+  // issue-time gate closes. Operators must issue a NEW token with
+  // policy + revoke the old one.
+
+  it("set preset 'local_queen' → 400 (mint-capable transition refused)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await POST(
+      makeRequest({ preset: "local_queen" }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.message).toMatch(/mint-capable shape/);
+    expect(body.message).toMatch(/policy\.allowedRepos/);
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("set explicit caps including installation_token.mint → 400 (label-laundering attempt)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await POST(
+      makeRequest({
+        capabilities: ["installation_token.mint", "rooms.read"],
+      }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("set preset 'apiarist' → falls through to set (legacy carve-out)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    mockedSet.mockResolvedValue({
+      name: "ap-1",
+      agent_role: "apiarist",
+      capabilities: ["installation_token.mint"],
+      fingerprint: "f1",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      createdBy: "admin",
+      expiresAt: null,
+    });
+    const res = await POST(
+      makeRequest({ preset: "apiarist" }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedSet).toHaveBeenCalled();
+  });
 });

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
@@ -277,7 +277,23 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
     const body = await res.json();
     expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
     expect(body.message).toMatch(/mint-capable shape/);
-    expect(body.message).toMatch(/policy\.allowedRepos/);
+    expect(body.message).toMatch(/D10 policy bound/);
+    expect(body.message).toMatch(/allowedRepos/);
+    expect(body.message).toMatch(/allowedPermissions/);
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
+  it("set explicit caps with wildcard 'installation_token.*' → 400 (pass-3 wildcard-aware)", async () => {
+    // Pre-pass-3, the literal `.includes("installation_token.mint")`
+    // check missed wildcard forms. Now bearerHasCapability expansion
+    // catches it.
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await POST(
+      makeRequest({ capabilities: ["installation_token.*"] }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).message).toMatch(/wildcard forms/);
     expect(mockedSet).not.toHaveBeenCalled();
   });
 

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
@@ -33,6 +33,7 @@ import { setAgentTokenCapabilities } from "@/server/agent-token-v1";
 import {
   isKnownPreset,
   resolvePreset,
+  bearerHasCapability,
 } from "@/server/agent-token-capabilities";
 import { auditAppend } from "@/server/agent-token-v1-audit";
 import {
@@ -141,31 +142,43 @@ export async function POST(
     }
   }
 
-  // Mint-capable transition gate (PR 645 builder pass-1 B1).
+  // Mint-capable transition gate (PR 645 builder pass-1 B1, pass-3
+  // wildcard-aware).
   //
   // set-capabilities only changes capabilities, not policy. If the
   // operation transitions a token INTO a mint-capable shape, we
   // can't validate the policy without a separate fetch — and even
-  // then there's a race vs concurrent policy edits. The safe
-  // posture here is: refuse to transition to mint-capable via
-  // set-capabilities entirely. Operators must issue a NEW token
-  // with the right policy + revoke the old one.
+  // then there's a race vs concurrent policy edits. Refuse the
+  // transition entirely; operators must issue a NEW token with the
+  // right policy + revoke the old one.
   //
-  // The legacy apiarist preset is exempt from this transition
-  // block since the gate at issue time is also exempt — apiarist
-  // tokens predate the policy model.
-  if (capabilities.includes("installation_token.mint")) {
-    const isLegacyApiarist = body.preset === "apiarist";
-    if (!isLegacyApiarist) {
+  // Wildcard-aware (pass-3 follow-up): use bearerHasCapability
+  // instead of literal `.includes`. Otherwise an operator could
+  // submit `capabilities: ["installation_token.*"]` or `["*"]` to
+  // transition a token into mint-capable shape without tripping
+  // the gate, but still satisfy the request-time auth check.
+  //
+  // Legacy apiarist + admin presets are exempt to mirror the
+  // issue-time gate's carve-outs.
+  const transitionsToMint = bearerHasCapability(
+    capabilities,
+    "installation_token.mint",
+  );
+  if (transitionsToMint) {
+    const isLegacyPreset =
+      body.preset === "apiarist" || body.preset === "admin";
+    if (!isLegacyPreset) {
       return v1Error(
         AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
         "Refusing to transition a token to a mint-capable shape via " +
           "set-capabilities — set-capabilities does not accept a " +
-          "policy field, so the resulting token would lack the " +
-          "policy.allowedRepos bound required by RFC D10 / G16. " +
-          "Issue a new token via POST /api/agent-tokens with " +
-          "policy: { allowedRepos: ['owner/repo', ...] } and revoke " +
-          "this one instead.",
+          "policy field, so the resulting token would lack the D10 " +
+          "policy bound required by RFC D10 / G16. Issue a new token " +
+          "via POST /api/agent-tokens with policy: { allowedRepos, " +
+          "allowedPermissions } and revoke this one instead. (This " +
+          "applies to wildcard forms like 'installation_token.*' and " +
+          "'*' too — they expand to 'installation_token.mint' at " +
+          "request time.)",
         400,
       );
     }

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
@@ -141,6 +141,36 @@ export async function POST(
     }
   }
 
+  // Mint-capable transition gate (PR 645 builder pass-1 B1).
+  //
+  // set-capabilities only changes capabilities, not policy. If the
+  // operation transitions a token INTO a mint-capable shape, we
+  // can't validate the policy without a separate fetch — and even
+  // then there's a race vs concurrent policy edits. The safe
+  // posture here is: refuse to transition to mint-capable via
+  // set-capabilities entirely. Operators must issue a NEW token
+  // with the right policy + revoke the old one.
+  //
+  // The legacy apiarist preset is exempt from this transition
+  // block since the gate at issue time is also exempt — apiarist
+  // tokens predate the policy model.
+  if (capabilities.includes("installation_token.mint")) {
+    const isLegacyApiarist = body.preset === "apiarist";
+    if (!isLegacyApiarist) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "Refusing to transition a token to a mint-capable shape via " +
+          "set-capabilities — set-capabilities does not accept a " +
+          "policy field, so the resulting token would lack the " +
+          "policy.allowedRepos bound required by RFC D10 / G16. " +
+          "Issue a new token via POST /api/agent-tokens with " +
+          "policy: { allowedRepos: ['owner/repo', ...] } and revoke " +
+          "this one instead.",
+        400,
+      );
+    }
+  }
+
   // Storage builds the audit entry internally with `from` taken
   // from the LOCKED envelope state. Closes #506 builder R1 #3:
   // a previous pattern that pre-read `from` at the route layer

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -406,6 +406,67 @@ describe("POST /api/agent-tokens — body validation", () => {
     expect(mockedIssue).toHaveBeenCalled();
   });
 
+  it("wildcard 'installation_token.*' without policy → 400 (pass-3 wildcard-aware mint gate)", async () => {
+    // Pre-pass-3, a literal `.includes("installation_token.mint")`
+    // missed wildcard forms. Now `bearerHasCapability` expansion
+    // catches it.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "minty",
+        agent_role: "minty",
+        capabilities: ["installation_token.*", "rooms.read"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_policy");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("wildcard 'installation_token.*' with full D10 policy → 201 (gate is policy-based)", async () => {
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedIssue.mockResolvedValue(
+      makeIssued({
+        name: "wildcard-mint",
+        agent_role: "wildcard-mint",
+        capabilities: ["installation_token.*", "rooms.read"],
+      }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "wildcard-mint",
+        agent_role: "wildcard-mint",
+        capabilities: ["installation_token.*", "rooms.read"],
+        policy: {
+          allowedRepos: ["hivemoot/colony"],
+          allowedPermissions: {
+            pull_requests: "write",
+            issues: "write",
+            metadata: "read",
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("admin chain-root '*' + allowWildcards still permitted (legacy carve-out preserved)", async () => {
+    // Pre-existing test pinned this; pass-3 added the explicit
+    // carve-out so it keeps working.
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedIssue.mockResolvedValue(
+      makeIssued({ name: "admin-1", agent_role: "admin", capabilities: ["*"] }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "admin-1",
+        agent_role: "admin",
+        capabilities: ["*"],
+        allowWildcards: true,
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
   it("label-laundering — explicit capabilities with agent_role=apiarist → 400 (builder pass-2 fix)", async () => {
     // Pass-1 carve-out trusted operator-supplied agent_role; an
     // attacker could submit explicit installation_token.mint caps

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -334,6 +334,78 @@ describe("POST /api/agent-tokens — body validation", () => {
     expect(res.status).toBe(201);
   });
 
+  it("preset 'local_queen' with allowedRepos but NO allowedPermissions → 400 (pass-3 D10 half 2)", async () => {
+    // Pass-2 accepted this shape; pass-3 rejects because the mint
+    // endpoint falls back to V1_PERMISSIONS (which includes
+    // contents:read) when allowedPermissions is omitted, violating
+    // RFC D10's permission-scope half.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "queen-hive-1",
+        agent_role: "local_queen",
+        preset: "local_queen",
+        policy: { allowedRepos: ["hivemoot/colony"] },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_policy");
+    expect(body.message).toMatch(/allowedPermissions/);
+    expect(body.message).toMatch(/contents/);
+  });
+
+  it("preset 'local_queen' with allowedPermissions including contents → 400 (D10 forbids contents)", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "queen-hive-1",
+        agent_role: "local_queen",
+        preset: "local_queen",
+        policy: {
+          allowedRepos: ["hivemoot/colony"],
+          allowedPermissions: {
+            pull_requests: "write",
+            issues: "write",
+            metadata: "read",
+            contents: "read",
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_policy");
+  });
+
+  it("preset 'local_queen' with EXACT D10 policy (allowedRepos + allowedPermissions) → 201 (happy path)", async () => {
+    // Pin the canonical D10 shape that survives the gate. If a
+    // future change tightens the gate further, this test catches
+    // it before it breaks the local_queen issuance path.
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedIssue.mockResolvedValue(
+      makeIssued({
+        name: "queen-hive-1",
+        agent_role: "local_queen",
+        capabilities: ["installation_token.mint", "rooms.synthesize"],
+      }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "queen-hive-1",
+        agent_role: "local_queen",
+        preset: "local_queen",
+        policy: {
+          allowedRepos: ["hivemoot/colony"],
+          allowedPermissions: {
+            pull_requests: "write",
+            issues: "write",
+            metadata: "read",
+          },
+        },
+      }),
+    );
+    expect(res.status).toBe(201);
+    expect(mockedIssue).toHaveBeenCalled();
+  });
+
   it("label-laundering — explicit capabilities with agent_role=apiarist → 400 (builder pass-2 fix)", async () => {
     // Pass-1 carve-out trusted operator-supplied agent_role; an
     // attacker could submit explicit installation_token.mint caps

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -265,6 +265,74 @@ describe("POST /api/agent-tokens — body validation", () => {
     expect(res.status).toBe(400);
     expect((await res.json()).code).toBe("agent_tokens_v1_invalid_policy");
   });
+
+  // PR 645 builder pass-1 B1 — issue-time gate on mint-capable presets.
+  // The gate fires AFTER capability resolution + policy parse but
+  // BEFORE the storage write. Same INVALID_POLICY error code as the
+  // V1.6 schema check so callers can branch on a single envelope.
+
+  it("preset 'local_queen' without policy → 400 INVALID_POLICY (mint gate)", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "queen-hive-1",
+        agent_role: "local_queen",
+        preset: "local_queen",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_policy");
+    expect(body.message).toMatch(/installation_token\.mint/);
+    expect(body.message).toMatch(/policy\.allowedRepos/);
+  });
+
+  it("preset 'local_queen' with empty allowedRepos → 400 (gate enforces non-empty list)", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "queen-hive-1",
+        agent_role: "local_queen",
+        preset: "local_queen",
+        policy: { allowedRepos: [], allowedPermissions: { contents: "read" } },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_policy");
+  });
+
+  it("explicit capabilities including installation_token.mint without policy → 400 (label-laundering attempt)", async () => {
+    // An operator might try to bypass the local_queen preset gate by
+    // passing the same caps + a non-apiarist role explicitly. Gate
+    // is capability-based, so it still fires.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "minty",
+        agent_role: "custom_minter",
+        capabilities: ["installation_token.mint", "rooms.read"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("agent_tokens_v1_invalid_policy");
+  });
+
+  it("preset 'apiarist' without policy → 200 (legacy carve-out preserved)", async () => {
+    // Apiarist tokens predate the policy model; tightening would
+    // break existing operator scripts. Confirms the gate's exemption
+    // is wired at the route layer.
+    mockedKeyring.mockReturnValue(makeKeyringOk());
+    mockedIssue.mockResolvedValue(
+      makeIssued({ name: "ap-1", agent_role: "apiarist", capabilities: ["installation_token.mint"] }),
+    );
+    const res = await POST(
+      makeRequest("POST", {
+        name: "ap-1",
+        agent_role: "apiarist",
+        preset: "apiarist",
+      }),
+    );
+    // 201 is the success code — confirms the gate did NOT short-
+    // circuit the request to 400.
+    expect(res.status).toBe(201);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -333,6 +333,28 @@ describe("POST /api/agent-tokens — body validation", () => {
     // circuit the request to 400.
     expect(res.status).toBe(201);
   });
+
+  it("label-laundering — explicit capabilities with agent_role=apiarist → 400 (builder pass-2 fix)", async () => {
+    // Pass-1 carve-out trusted operator-supplied agent_role; an
+    // attacker could submit explicit installation_token.mint caps
+    // with agent_role=apiarist and the gate would return ok with
+    // policy: null. Pass-2: the carve-out keys ONLY on the
+    // server-resolved preset name (null on this path), so the
+    // gate fires regardless of the operator's role label.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "ap-fake",
+        agent_role: "apiarist", // operator-supplied — must NOT grant exemption
+        capabilities: ["installation_token.mint", "rooms.read"],
+        // No preset → presetName is null → exemption does not fire.
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_policy");
+    expect(body.message).toMatch(/installation_token\.mint/);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/app/api/agent-tokens/route.ts
+++ b/web/src/app/api/agent-tokens/route.ts
@@ -207,13 +207,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // ----- mint-capable issuance gate (PR 645 builder pass-1 B1) -----
-  // Tokens granting installation_token.mint for the new local_queen
-  // role must ship with policy.allowedRepos. Legacy apiarist is
-  // exempt. See `validateMintPolicyRequirement` rationale.
+  // ----- mint-capable issuance gate (PR 645 builder pass-1 B1, pass-2 tightened) -----
+  // Tokens granting installation_token.mint must ship with
+  // policy.allowedRepos. The apiarist legacy carve-out keys ONLY on
+  // the server-resolved preset name — agent_role is operator-
+  // supplied and would otherwise allow label-laundering past the
+  // gate (builder pass-2 fix).
   const mintGate = validateMintPolicyRequirement({
     capabilities,
-    agentRole: agent_role,
     presetName: typeof body.preset === "string" ? body.preset : null,
     policy: policyParse.policy ?? null,
   });

--- a/web/src/app/api/agent-tokens/route.ts
+++ b/web/src/app/api/agent-tokens/route.ts
@@ -31,6 +31,7 @@ import {
   resolvePreset,
   validateName,
   validateAgentRole,
+  validateMintPolicyRequirement,
   CapabilityValidationError,
 } from "@/server/agent-token-capabilities";
 import { auditAppend } from "@/server/agent-token-v1-audit";
@@ -202,6 +203,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return v1Error(
       AGENT_TOKENS_V1_ERROR.INVALID_POLICY,
       policyParse.message,
+      400,
+    );
+  }
+
+  // ----- mint-capable issuance gate (PR 645 builder pass-1 B1) -----
+  // Tokens granting installation_token.mint for the new local_queen
+  // role must ship with policy.allowedRepos. Legacy apiarist is
+  // exempt. See `validateMintPolicyRequirement` rationale.
+  const mintGate = validateMintPolicyRequirement({
+    capabilities,
+    agentRole: agent_role,
+    presetName: typeof body.preset === "string" ? body.preset : null,
+    policy: policyParse.policy ?? null,
+  });
+  if (!mintGate.ok) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_POLICY,
+      mintGate.message,
       400,
     );
   }

--- a/web/src/app/api/agent-tokens/route.ts
+++ b/web/src/app/api/agent-tokens/route.ts
@@ -216,6 +216,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const mintGate = validateMintPolicyRequirement({
     capabilities,
     presetName: typeof body.preset === "string" ? body.preset : null,
+    allowWildcards,
     policy: policyParse.policy ?? null,
   });
   if (!mintGate.ok) {

--- a/web/src/app/api/dashboard/agent-tokens/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.test.ts
@@ -124,9 +124,15 @@ describe("GET /api/dashboard/agent-tokens", () => {
     expect(body.tokens[0].name).toBe("queen");
     // Admin filtered out per #567 builder R1 — see the "preset catalog
     // filter" describe block below for the explicit regression.
+    // Mint-capable presets (apiarist, local_queen) also filtered —
+    // PR 645 builder pass-1 B1 (no policy input surface in the
+    // dashboard wrapper).
     expect(body.presets).toEqual(
-      expect.arrayContaining(["queen", "worker", "apiarist"]),
+      expect.arrayContaining(["queen", "worker"]),
     );
+    expect(body.presets).not.toContain("apiarist");
+    expect(body.presets).not.toContain("local_queen");
+    expect(body.presets).not.toContain("admin");
   });
 });
 
@@ -347,6 +353,69 @@ describe("POST /api/dashboard/agent-tokens — admin-class deny list (#567 build
   });
 });
 
+describe("POST /api/dashboard/agent-tokens — mint-capable preset deny list (PR 645 builder pass-1 B1)", () => {
+  // The dashboard wrapper has no `policy` input surface, so it
+  // can't issue mint-capable tokens with the required allowedRepos
+  // bound. Both the named preset and the explicit-capabilities
+  // path are rejected — the latter via the post-resolution gate
+  // since the dashboard never passes a policy.
+
+  beforeEach(() => {
+    mockedAuth.mockResolvedValue(makeByokAuthOk());
+    mockedRequireInstallation.mockReturnValue({
+      ok: true,
+      installationId: "12345",
+    } as never);
+  });
+
+  it("preset 'local_queen' → 400 with mint-capable rejection (preset-name path)", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "queen-hive-1",
+        preset: "local_queen",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.message).toMatch(/mint-capable/);
+    expect(body.message).toMatch(/POST \/api\/agent-tokens/);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("preset 'apiarist' → 400 (also blocked from dashboard)", async () => {
+    // Apiarist is mint-capable too. Even though the issuance gate
+    // exempts it (legacy carve-out), the dashboard still hides /
+    // rejects it because cookie-auth + no-policy issuance of
+    // infrastructure-tier credentials is the wrong UX.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "ap-1",
+        preset: "apiarist",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("explicit capabilities including installation_token.mint → 400 (post-resolution mint gate fires)", async () => {
+    // The explicit-caps path resolved to a non-preset role; the
+    // mint gate at the post-resolution check still fires because
+    // the dashboard route hard-codes `policy: null` to the gate.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "minty",
+        agent_role: "minty",
+        capabilities: ["installation_token.mint", "rooms.read"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_policy");
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+});
+
 describe("GET /api/dashboard/agent-tokens — catalogs (presets + capabilities)", () => {
   beforeEach(() => {
     mockedAuth.mockResolvedValue(makeByokAuthOk());
@@ -362,8 +431,20 @@ describe("GET /api/dashboard/agent-tokens — catalogs (presets + capabilities)"
     const body = await res.json();
     expect(body.presets).not.toContain("admin");
     expect(body.presets).toEqual(
-      expect.arrayContaining(["queen", "worker", "apiarist", "monitoring", "dispatcher"]),
+      expect.arrayContaining(["queen", "worker", "monitoring", "dispatcher"]),
     );
+  });
+
+  it("excludes mint-capable presets ('apiarist', 'local_queen') from the presets list (PR 645 builder pass-1 B1)", async () => {
+    // The dashboard wrapper has no `policy` input surface, so it
+    // cannot issue mint-capable tokens with the required
+    // policy.allowedRepos bound (RFC D10 / G16). Hide those
+    // presets from the catalog so the operator never sees them
+    // as an option in the UI.
+    const res = await GET(makeRequest("GET"));
+    const body = await res.json();
+    expect(body.presets).not.toContain("apiarist");
+    expect(body.presets).not.toContain("local_queen");
   });
 
   it("returns the capability vocabulary filtered to non-admin entries", async () => {

--- a/web/src/app/api/dashboard/agent-tokens/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.test.ts
@@ -398,10 +398,14 @@ describe("POST /api/dashboard/agent-tokens — mint-capable preset deny list (PR
     expect(mockedIssue).not.toHaveBeenCalled();
   });
 
-  it("explicit capabilities including installation_token.mint → 400 (post-resolution mint gate fires)", async () => {
-    // The explicit-caps path resolved to a non-preset role; the
-    // mint gate at the post-resolution check still fires because
-    // the dashboard route hard-codes `policy: null` to the gate.
+  it("explicit capabilities including installation_token.mint → 400 (admin-class deny list fires, pass-2 defense-in-depth)", async () => {
+    // PR 645 builder pass-2: installation_token.mint is now in the
+    // dashboard's ADMIN_CLASS_CAPABILITIES deny list, so the
+    // explicit-caps path is rejected during capability validation
+    // BEFORE the post-resolution mint gate gets a chance to fire.
+    // This is the structural fix for the label-laundering bypass:
+    // operators cannot pass `agent_role: 'apiarist'` + caps with
+    // mint, because the cap is denied at validation time.
     const res = await POST(
       makeRequest("POST", {
         name: "minty",
@@ -411,7 +415,26 @@ describe("POST /api/dashboard/agent-tokens — mint-capable preset deny list (PR
     );
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.code).toBe("agent_tokens_v1_invalid_policy");
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.message).toMatch(/admin-class/);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
+  it("label-laundering attempt — explicit caps with role=apiarist → 400 (admin-class deny list, no preset escape)", async () => {
+    // The pass-1 bypass: caller submits explicit caps with
+    // `agent_role: "apiarist"` claiming the legacy-permissive
+    // exemption. With pass-2: the cap is denied BEFORE the
+    // exemption check, AND the post-resolution gate now keys only
+    // on the server-resolved presetName (which is null on the
+    // explicit-caps path). Two redundant defenses — same outcome.
+    const res = await POST(
+      makeRequest("POST", {
+        name: "labelware",
+        agent_role: "apiarist", // operator-supplied — must not grant exemption
+        capabilities: ["installation_token.mint"],
+      }),
+    );
+    expect(res.status).toBe(400);
     expect(mockedIssue).not.toHaveBeenCalled();
   });
 });
@@ -454,11 +477,14 @@ describe("GET /api/dashboard/agent-tokens — catalogs (presets + capabilities)"
     // applied to the POST issuance path).
     expect(body.capabilities).not.toContain("agent_tokens.manage");
     expect(body.capabilities).not.toContain("*");
-    // Sanity: every preset's capabilities ARE in the catalog so the
+    // installation_token.mint joined the admin-class deny list in
+    // PR 645 builder pass-2 (defense-in-depth on top of the policy
+    // gate — the dashboard has no policy input surface).
+    expect(body.capabilities).not.toContain("installation_token.mint");
+    // Sanity: non-mint preset capabilities ARE in the catalog so the
     // UI can faithfully render preset → custom transitions.
     expect(body.capabilities).toEqual(
       expect.arrayContaining([
-        "installation_token.mint",
         "agent_health.report",
         "tasks.claim",
         "rooms.create",
@@ -468,14 +494,15 @@ describe("GET /api/dashboard/agent-tokens — catalogs (presets + capabilities)"
     );
   });
 
-  it("preserves subsystem-grouping order (installation_token → agent_health → tasks → rooms)", async () => {
+  it("preserves subsystem-grouping order (agent_health → tasks → rooms)", async () => {
     const res = await GET(makeRequest("GET"));
     const body = await res.json();
     const caps = body.capabilities as string[];
     const idxOf = (cap: string) => caps.indexOf(cap);
     // Each subsystem boundary stays ordered relative to the next so
-    // the UI can group by prefix without re-sorting.
-    expect(idxOf("installation_token.mint")).toBeLessThan(idxOf("agent_health.report"));
+    // the UI can group by prefix without re-sorting. installation_token.mint
+    // is no longer in the catalog (admin-class deny list, PR 645 pass-2)
+    // so the order check now starts at agent_health.
     expect(idxOf("agent_health.read")).toBeLessThan(idxOf("tasks.claim"));
     expect(idxOf("tasks.cancel")).toBeLessThan(idxOf("rooms.watch"));
   });

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -88,10 +88,19 @@ const MINT_CAPABLE_PRESETS: ReadonlySet<string> = new Set([
  * dashboard surface. Same rationale as ADMIN_CLASS_PRESETS — minting
  * `*` (wildcard) or `agent_tokens.manage` from cookie auth with no
  * expiry cap would bypass the bootstrap/chain split.
+ *
+ * `installation_token.mint` is included as a defense-in-depth layer
+ * on top of `validateMintPolicyRequirement` (PR 645 builder pass-2):
+ * the dashboard wrapper has no policy input surface, so any mint-
+ * capable token issued through it would be policy-less. Hard-deny
+ * on the explicit-capabilities path closes the path entirely
+ * regardless of agent_role label-laundering attempts; the policy
+ * gate below is the secondary check.
  */
 const ADMIN_CLASS_CAPABILITIES: ReadonlySet<string> = new Set([
   "*",
   "agent_tokens.manage",
+  "installation_token.mint",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -317,7 +326,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // admin bearer + explicit policy.allowedRepos.
   const dashboardMintGate = validateMintPolicyRequirement({
     capabilities,
-    agentRole: agent_role,
     presetName: typeof body.preset === "string" ? body.preset : null,
     policy: null,
   });

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -34,6 +34,7 @@ import {
   validateName,
   validateAgentRole,
   validateCapabilityString,
+  validateMintPolicyRequirement,
   CapabilityValidationError,
   PRESETS,
   KNOWN_CAPABILITIES,
@@ -63,6 +64,24 @@ import {
  * be confused with either of those. Closes #567 builder R1.
  */
 const ADMIN_CLASS_PRESETS: ReadonlySet<string> = new Set(["admin"]);
+
+/**
+ * Presets the dashboard cannot issue because they grant
+ * `installation_token.mint` and the dashboard wrapper has no
+ * `policy` input surface (RFC D10 + G16; PR 645 builder pass-1).
+ * Operators issuing these must go through POST /api/agent-tokens
+ * with an admin bearer + explicit policy.allowedRepos.
+ *
+ * `apiarist` is grandfathered into the issuance gate (legacy
+ * permissive) but the dashboard still hides it — apiarist tokens
+ * are infrastructure-tier and shouldn't be issued from a cookie
+ * session. local_queen is hidden for the same reason + the policy
+ * requirement.
+ */
+const MINT_CAPABLE_PRESETS: ReadonlySet<string> = new Set([
+  "apiarist",
+  "local_queen",
+]);
 
 /**
  * Capabilities disallowed in explicit-capabilities issuance via the
@@ -114,7 +133,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const body: ListResponse = {
       tokens,
       presets: Object.keys(PRESETS).filter(
-        (name) => !ADMIN_CLASS_PRESETS.has(name),
+        (name) => !ADMIN_CLASS_PRESETS.has(name) && !MINT_CAPABLE_PRESETS.has(name),
       ),
       capabilities: KNOWN_CAPABILITIES.filter(
         (cap) => !ADMIN_CLASS_CAPABILITIES.has(cap),
@@ -199,6 +218,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { field: "preset", value: body.preset },
       );
     }
+    if (MINT_CAPABLE_PRESETS.has(body.preset)) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        `Preset '${body.preset}' is mint-capable (grants installation_token.mint) and cannot be issued from the dashboard — the dashboard wrapper has no policy input surface, and RFC D10 / G16 require policy.allowedRepos for mint-capable tokens. Use POST /api/agent-tokens with an admin bearer + policy: { allowedRepos: ['owner/repo', ...] } instead.`,
+        400,
+        { field: "preset", value: body.preset },
+      );
+    }
     try {
       capabilities = resolvePreset(body.preset);
       agent_role = body.preset;
@@ -278,6 +305,30 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return v1Error(
       AGENT_TOKENS_V1_ERROR.INVALID_EXPIRES_IN,
       expiresParse.message,
+      400,
+    );
+  }
+
+  // ----- mint-capable issuance gate (PR 645 builder pass-1 B1) -----
+  // The dashboard wrapper does not accept a `policy` field — the
+  // structured-policy UX is API-path only. Mint-capable presets
+  // (today: local_queen) therefore cannot be issued from the
+  // dashboard; operators must use POST /api/agent-tokens with an
+  // admin bearer + explicit policy.allowedRepos.
+  const dashboardMintGate = validateMintPolicyRequirement({
+    capabilities,
+    agentRole: agent_role,
+    presetName: typeof body.preset === "string" ? body.preset : null,
+    policy: null,
+  });
+  if (!dashboardMintGate.ok) {
+    return v1Error(
+      AGENT_TOKENS_V1_ERROR.INVALID_POLICY,
+      "The dashboard cannot issue mint-capable tokens (no policy " +
+        "input surface). Use POST /api/agent-tokens with an admin " +
+        "bearer and policy: { allowedRepos: ['owner/repo', ...] } " +
+        "instead. " +
+        dashboardMintGate.message,
       400,
     );
   }

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -35,6 +35,7 @@ import {
   validateAgentRole,
   validateCapabilityString,
   validateMintPolicyRequirement,
+  expandCapabilities,
   CapabilityValidationError,
   PRESETS,
   KNOWN_CAPABILITIES,
@@ -270,15 +271,38 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
       throw err;
     }
-    // Admin-class capabilities (`*`, `agent_tokens.manage`) blocked
-    // here too — explicit-list path can't sneak past the preset filter.
-    for (const c of body.capabilities) {
-      if (typeof c === "string" && ADMIN_CLASS_CAPABILITIES.has(c)) {
+    // Admin-class capabilities (`*`, `agent_tokens.manage`,
+    // `installation_token.mint`) blocked here too — explicit-list
+    // path can't sneak past the preset filter.
+    //
+    // Order matters: detect bare-`*` FIRST (so error.value is `*`
+    // rather than the first cap `*` would expand to). The dashboard
+    // never wants to issue a bare-wildcard token regardless of
+    // expansion semantics; surfacing `*` as the offending value is
+    // the operator-readable signal.
+    if ((body.capabilities as readonly string[]).includes("*")) {
+      return v1Error(
+        AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
+        "Capability '*' is admin-class and cannot be issued via the dashboard wrapper. Use POST /api/agent-tokens/bootstrap (cookie auth, 24h cap) or POST /api/agent-tokens with an existing admin bearer instead.",
+        400,
+        { field: "capabilities", value: "*" },
+      );
+    }
+    // Wildcard-aware admin-class detection (PR 645 builder pass-3
+    // follow-up B1): an earlier literal `.has(c)` check missed
+    // wildcard forms like `installation_token.*` (which expands to
+    // mint at request time). Now we expand the proposed capability
+    // list and check whether any admin-class cap is reachable.
+    const proposedExpanded = expandCapabilities(
+      body.capabilities as readonly string[],
+    );
+    for (const denied of ADMIN_CLASS_CAPABILITIES) {
+      if (proposedExpanded.has(denied)) {
         return v1Error(
           AGENT_TOKENS_V1_ERROR.INVALID_CAPABILITIES,
-          `Capability '${c}' is admin-class and cannot be issued via the dashboard wrapper. Use POST /api/agent-tokens/bootstrap (cookie auth, 24h cap) or POST /api/agent-tokens with an existing admin bearer instead.`,
+          `Capability '${denied}' is admin-class and cannot be issued via the dashboard wrapper (this includes wildcard forms like 'installation_token.*' that expand to '${denied}'). Use POST /api/agent-tokens/bootstrap (cookie auth, 24h cap) or POST /api/agent-tokens with an existing admin bearer instead.`,
           400,
-          { field: "capabilities", value: c },
+          { field: "capabilities", value: denied },
         );
       }
     }

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -428,11 +428,10 @@ describe("cross-invariants", () => {
 // Mint-capable issuance gate (PR 645 builder pass-1 B1)
 // ---------------------------------------------------------------------------
 
-describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-1", () => {
+describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-1+pass-2", () => {
   it("allows non-mint capabilities through with no policy", () => {
     const result = validateMintPolicyRequirement({
       capabilities: ["rooms.read", "tasks.claim"],
-      agentRole: "worker",
       presetName: "worker",
       policy: null,
     });
@@ -442,7 +441,6 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   it("rejects local_queen preset issued without a policy", () => {
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
-      agentRole: "local_queen",
       presetName: "local_queen",
       policy: null,
     });
@@ -456,7 +454,6 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   it("rejects local_queen issued with policy whose allowed_repos is missing", () => {
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
-      agentRole: "local_queen",
       presetName: "local_queen",
       policy: { allowed_repos: null },
     });
@@ -466,7 +463,6 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   it("rejects local_queen issued with policy whose allowed_repos is empty array", () => {
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
-      agentRole: "local_queen",
       presetName: "local_queen",
       policy: { allowed_repos: [] },
     });
@@ -476,7 +472,6 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   it("allows local_queen with a non-empty allowed_repos policy", () => {
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
-      agentRole: "local_queen",
       presetName: "local_queen",
       policy: { allowed_repos: ["hivemoot/colony"] },
     });
@@ -484,12 +479,10 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   });
 
   it("rejects explicit-capabilities path that grants installation_token.mint without policy (no preset)", () => {
-    // The gate is capability-based, not preset-based — an operator
-    // can't sneak past it by passing explicit capabilities including
-    // installation_token.mint with a non-apiarist role.
+    // The gate is capability-based — explicit capabilities including
+    // installation_token.mint trip it regardless of role label.
     const result = validateMintPolicyRequirement({
       capabilities: ["rooms.read", "installation_token.mint"],
-      agentRole: "custom_minter",
       presetName: null,
       policy: null,
     });
@@ -497,36 +490,44 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   });
 
   it("apiarist preset is exempt from the gate (legacy carve-out)", () => {
-    // Apiarist predates the policy model. Tightening it would break
-    // in-the-wild apiarist tokens, so the gate explicitly allows
-    // apiarist to be issued with no policy.
+    // Apiarist predates the policy model. The carve-out keys on the
+    // server-resolved preset name only — see pass-2 fix below.
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.apiarist,
-      agentRole: "apiarist",
       presetName: "apiarist",
       policy: null,
     });
     expect(result.ok).toBe(true);
   });
 
-  it("apiarist exemption keys on either presetName OR agentRole (so explicit-caps + role=apiarist also works)", () => {
-    // The CLI / set-capabilities path doesn't always carry a preset
-    // name; the agentRole field is the persistent marker.
+  // Pass-2 (builder review on PR 645): the apiarist carve-out used
+  // to also accept `agentRole === "apiarist"`. Operator-supplied
+  // role labels can't be trusted for a security decision — the
+  // carve-out now keys ONLY on the server-resolved preset name.
+  // The previous test that pinned the bypass as expected behavior
+  // is now flipped: explicit-capabilities + claim role=apiarist
+  // MUST be rejected.
+
+  it("explicit capabilities with role label 'apiarist' but presetName=null → rejected (label-laundering closed, builder pass-2 B1)", () => {
+    // The agentRole input field has been removed from
+    // MintPolicyGateInput entirely — there's no way for the gate
+    // to even see the operator-supplied role. This test confirms
+    // the bypass path is structurally impossible: only presetName
+    // can grant the apiarist exemption.
     const result = validateMintPolicyRequirement({
       capabilities: ["installation_token.mint"],
-      agentRole: "apiarist",
+      // No agentRole here — the type doesn't accept it. Operators
+      // cannot label-launder past the gate by passing
+      // `agent_role: 'apiarist'` in the request body.
       presetName: null,
       policy: null,
     });
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
   });
 
-  it("local_queen tokens issued via explicit capabilities + role still need policy (no apiarist label-laundering)", () => {
-    // Operator tries to bypass the gate by passing explicit
-    // capabilities with role 'local_queen'. Gate still bites.
+  it("explicit capabilities with installation_token.mint but no preset → rejected even with custom role string (gate is capability+presetName-driven)", () => {
     const result = validateMintPolicyRequirement({
       capabilities: ["installation_token.mint", "rooms.synthesize"],
-      agentRole: "local_queen",
       presetName: null,
       policy: null,
     });

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -283,6 +283,37 @@ describe("PRESETS", () => {
     expect(PRESETS.apiarist).toEqual(["installation_token.mint"]);
   });
 
+  it("rooms.synthesize is a known capability (RFC PR 3 + D14)", () => {
+    expect(KNOWN_CAPABILITIES.includes("rooms.synthesize")).toBe(true);
+  });
+
+  it("rooms.synthesize is NOT in queen preset (no silent expansion — RFC builder pass-2 §2)", () => {
+    expect(PRESETS.queen.includes("rooms.synthesize")).toBe(false);
+    expect(PRESETS.queen.includes("installation_token.mint")).toBe(false);
+  });
+
+  it("local_queen preset has rooms.synthesize + installation_token.mint (RFC PR 3 + G16)", () => {
+    expect(PRESETS.local_queen.includes("rooms.synthesize")).toBe(true);
+    expect(PRESETS.local_queen.includes("installation_token.mint")).toBe(true);
+  });
+
+  it("local_queen preset does NOT include rooms.watch (RFC builder pass-7 §5: queen polls synthesis-ready, not /watching)", () => {
+    expect(PRESETS.local_queen.includes("rooms.watch")).toBe(false);
+  });
+
+  it("local_queen preset has all queen-preset capabilities (additive only — D14)", () => {
+    for (const cap of PRESETS.queen) {
+      expect(
+        PRESETS.local_queen.includes(cap),
+        `local_queen should include queen's ${cap}`,
+      ).toBe(true);
+    }
+  });
+
+  it("local_queen does NOT include rooms.force_close (admin-only escape valve, G6)", () => {
+    expect(PRESETS.local_queen.includes("rooms.force_close")).toBe(false);
+  });
+
   it("admin preset includes both bare * AND agent_tokens.manage explicit (wildcard alone wouldn't cover it)", () => {
     expect(PRESETS.admin.includes("*")).toBe(true);
     expect(PRESETS.admin.includes("agent_tokens.manage")).toBe(true);
@@ -360,13 +391,15 @@ describe("cross-invariants", () => {
     }
   });
 
-  it("KNOWN_CAPABILITIES count matches the design doc claim (20)", () => {
+  it("KNOWN_CAPABILITIES count matches the design doc claim (21)", () => {
     // R2.2 baseline: 19 capabilities.
     // R3 (D.1.b-i): added `rooms.read_all` to differentiate
     // installation-wide listing (queen / monitoring) from worker
     // self-rooms reads (`rooms.read`). +1 → 20.
+    // RFC PR 3 (D14): added `rooms.synthesize` for the local-mode
+    // queen synthesis-path endpoints. +1 → 21.
     // If this fails, the doc section "Total: N capabilities" needs
     // to be updated alongside the addition.
-    expect(KNOWN_CAPABILITIES.length).toBe(20);
+    expect(KNOWN_CAPABILITIES.length).toBe(21);
   });
 });

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -11,6 +11,7 @@ import {
   validateName,
   validateAgentRole,
   validateCapabilityString,
+  validateMintPolicyRequirement,
   NAME_REGEX,
   CAPABILITY_REGEX,
 } from "./agent-token-capabilities";
@@ -420,5 +421,115 @@ describe("cross-invariants", () => {
     // If this fails, the doc section "Total: N capabilities" needs
     // to be updated alongside the addition.
     expect(KNOWN_CAPABILITIES.length).toBe(21);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mint-capable issuance gate (PR 645 builder pass-1 B1)
+// ---------------------------------------------------------------------------
+
+describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-1", () => {
+  it("allows non-mint capabilities through with no policy", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: ["rooms.read", "tasks.claim"],
+      agentRole: "worker",
+      presetName: "worker",
+      policy: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects local_queen preset issued without a policy", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.local_queen,
+      agentRole: "local_queen",
+      presetName: "local_queen",
+      policy: null,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/installation_token\.mint/);
+      expect(result.message).toMatch(/policy\.allowedRepos/);
+    }
+  });
+
+  it("rejects local_queen issued with policy whose allowed_repos is missing", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.local_queen,
+      agentRole: "local_queen",
+      presetName: "local_queen",
+      policy: { allowed_repos: null },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects local_queen issued with policy whose allowed_repos is empty array", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.local_queen,
+      agentRole: "local_queen",
+      presetName: "local_queen",
+      policy: { allowed_repos: [] },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows local_queen with a non-empty allowed_repos policy", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.local_queen,
+      agentRole: "local_queen",
+      presetName: "local_queen",
+      policy: { allowed_repos: ["hivemoot/colony"] },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects explicit-capabilities path that grants installation_token.mint without policy (no preset)", () => {
+    // The gate is capability-based, not preset-based — an operator
+    // can't sneak past it by passing explicit capabilities including
+    // installation_token.mint with a non-apiarist role.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["rooms.read", "installation_token.mint"],
+      agentRole: "custom_minter",
+      presetName: null,
+      policy: null,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("apiarist preset is exempt from the gate (legacy carve-out)", () => {
+    // Apiarist predates the policy model. Tightening it would break
+    // in-the-wild apiarist tokens, so the gate explicitly allows
+    // apiarist to be issued with no policy.
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.apiarist,
+      agentRole: "apiarist",
+      presetName: "apiarist",
+      policy: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("apiarist exemption keys on either presetName OR agentRole (so explicit-caps + role=apiarist also works)", () => {
+    // The CLI / set-capabilities path doesn't always carry a preset
+    // name; the agentRole field is the persistent marker.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.mint"],
+      agentRole: "apiarist",
+      presetName: null,
+      policy: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("local_queen tokens issued via explicit capabilities + role still need policy (no apiarist label-laundering)", () => {
+    // Operator tries to bypass the gate by passing explicit
+    // capabilities with role 'local_queen'. Gate still bites.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.mint", "rooms.synthesize"],
+      agentRole: "local_queen",
+      presetName: null,
+      policy: null,
+    });
+    expect(result.ok).toBe(false);
   });
 });

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -428,7 +428,18 @@ describe("cross-invariants", () => {
 // Mint-capable issuance gate (PR 645 builder pass-1 B1)
 // ---------------------------------------------------------------------------
 
-describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-1+pass-2", () => {
+describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-1+pass-2+pass-3", () => {
+  // Canonical local_queen policy shape (both halves of D10).
+  // Used as the happy-path baseline for every "policy passes" test.
+  const D10_POLICY = {
+    allowed_repos: ["hivemoot/colony"],
+    allowed_permissions: {
+      pull_requests: "write",
+      issues: "write",
+      metadata: "read",
+    },
+  };
+
   it("allows non-mint capabilities through with no policy", () => {
     const result = validateMintPolicyRequirement({
       capabilities: ["rooms.read", "tasks.claim"],
@@ -438,6 +449,8 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     expect(result.ok).toBe(true);
   });
 
+  // ----- D10 half 1: allowed_repos -----
+
   it("rejects local_queen preset issued without a policy", () => {
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
@@ -446,7 +459,6 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.message).toMatch(/installation_token\.mint/);
       expect(result.message).toMatch(/policy\.allowedRepos/);
     }
   });
@@ -469,29 +481,97 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     expect(result.ok).toBe(false);
   });
 
-  it("allows local_queen with a non-empty allowed_repos policy", () => {
+  // ----- D10 half 2: allowed_permissions (builder pass-3) -----
+
+  it("rejects local_queen with allowedRepos but NO allowedPermissions (pass-3 builder fix)", () => {
+    // Pass-2 accepted this shape; pass-3 closes it because the mint
+    // endpoint falls back to V1_PERMISSIONS (which includes
+    // contents:read) when allowedPermissions is omitted, violating
+    // RFC D10's permission scope half.
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
       presetName: "local_queen",
       policy: { allowed_repos: ["hivemoot/colony"] },
     });
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/allowedPermissions/);
+      expect(result.message).toMatch(/contents/);
+    }
   });
 
-  it("rejects explicit-capabilities path that grants installation_token.mint without policy (no preset)", () => {
-    // The gate is capability-based — explicit capabilities including
-    // installation_token.mint trip it regardless of role label.
+  it("rejects local_queen with allowedPermissions including 'contents' (any value)", () => {
+    // RFC D10 explicitly drops `contents` — the local queen
+    // synthesizes verdicts and posts comments; it must not read
+    // repo files.
+    for (const level of ["read", "write", "admin"]) {
+      const result = validateMintPolicyRequirement({
+        capabilities: PRESETS.local_queen,
+        presetName: "local_queen",
+        policy: {
+          allowed_repos: ["hivemoot/colony"],
+          allowed_permissions: {
+            pull_requests: "write",
+            issues: "write",
+            metadata: "read",
+            contents: level,
+          },
+        },
+      });
+      expect(result.ok, `contents=${level} should be rejected`).toBe(false);
+    }
+  });
+
+  it("rejects local_queen with allowedPermissions narrower than D10 (e.g. read instead of write)", () => {
+    // Narrower fails closed at mint time (intersect would clamp the
+    // bearer to less than D10), but the gate's contract is "exact
+    // match" so we surface the mismatch at issue time.
     const result = validateMintPolicyRequirement({
-      capabilities: ["rooms.read", "installation_token.mint"],
-      presetName: null,
-      policy: null,
+      capabilities: PRESETS.local_queen,
+      presetName: "local_queen",
+      policy: {
+        allowed_repos: ["hivemoot/colony"],
+        allowed_permissions: {
+          pull_requests: "read", // should be "write"
+          issues: "write",
+          metadata: "read",
+        },
+      },
     });
     expect(result.ok).toBe(false);
   });
 
-  it("apiarist preset is exempt from the gate (legacy carve-out)", () => {
-    // Apiarist predates the policy model. The carve-out keys on the
-    // server-resolved preset name only — see pass-2 fix below.
+  it("rejects local_queen with EXTRA permission keys beyond D10", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.local_queen,
+      presetName: "local_queen",
+      policy: {
+        allowed_repos: ["hivemoot/colony"],
+        allowed_permissions: {
+          pull_requests: "write",
+          issues: "write",
+          metadata: "read",
+          actions: "read", // not in D10's set
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows local_queen with the EXACT D10 policy shape (allowedRepos + allowedPermissions)", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.local_queen,
+      presetName: "local_queen",
+      policy: D10_POLICY,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  // ----- Apiarist legacy carve-out -----
+
+  it("apiarist preset is exempt from BOTH halves of the gate (legacy carve-out)", () => {
+    // Apiarist predates the policy model. Both repo fan-out and
+    // permission scope checks skip when presetName === 'apiarist'.
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.apiarist,
       presetName: "apiarist",
@@ -500,37 +580,40 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     expect(result.ok).toBe(true);
   });
 
-  // Pass-2 (builder review on PR 645): the apiarist carve-out used
-  // to also accept `agentRole === "apiarist"`. Operator-supplied
-  // role labels can't be trusted for a security decision — the
-  // carve-out now keys ONLY on the server-resolved preset name.
-  // The previous test that pinned the bypass as expected behavior
-  // is now flipped: explicit-capabilities + claim role=apiarist
-  // MUST be rejected.
+  // ----- Label-laundering bypass (pass-2) -----
 
-  it("explicit capabilities with role label 'apiarist' but presetName=null → rejected (label-laundering closed, builder pass-2 B1)", () => {
+  it("explicit capabilities with role label 'apiarist' but presetName=null → rejected", () => {
     // The agentRole input field has been removed from
     // MintPolicyGateInput entirely — there's no way for the gate
-    // to even see the operator-supplied role. This test confirms
-    // the bypass path is structurally impossible: only presetName
-    // can grant the apiarist exemption.
+    // to even see the operator-supplied role. Only presetName can
+    // grant the apiarist exemption.
     const result = validateMintPolicyRequirement({
       capabilities: ["installation_token.mint"],
-      // No agentRole here — the type doesn't accept it. Operators
-      // cannot label-launder past the gate by passing
-      // `agent_role: 'apiarist'` in the request body.
       presetName: null,
       policy: null,
     });
     expect(result.ok).toBe(false);
   });
 
-  it("explicit capabilities with installation_token.mint but no preset → rejected even with custom role string (gate is capability+presetName-driven)", () => {
+  it("explicit capabilities with installation_token.mint but no preset → rejected", () => {
     const result = validateMintPolicyRequirement({
       capabilities: ["installation_token.mint", "rooms.synthesize"],
       presetName: null,
       policy: null,
     });
     expect(result.ok).toBe(false);
+  });
+
+  it("explicit-caps path can satisfy the gate by passing the full D10 policy explicitly", () => {
+    // Operators who really want a non-preset mint-capable token
+    // (e.g. custom roles) can still do so — they just have to
+    // pass the canonical D10 policy. This test pins that the
+    // gate is policy-based, not preset-required.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.mint", "rooms.synthesize"],
+      presetName: null,
+      policy: D10_POLICY,
+    });
+    expect(result.ok).toBe(true);
   });
 });

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -616,4 +616,90 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     });
     expect(result.ok).toBe(true);
   });
+
+  // ----- Wildcard-aware capability detection (pass-3 follow-up B1) -----
+  // Pass-1 through pass-3 used `capabilities.includes("installation_token.mint")`
+  // as a literal string check. The mint endpoint's auth uses
+  // bearerHasCapability which expands wildcards. The asymmetry meant
+  // `["installation_token.*"]` and `["*"]` slipped past the gate but
+  // satisfied auth. Now both gates use the same expansion semantics.
+
+  it("rejects capabilities ['installation_token.*'] without policy (wildcard expands to mint)", () => {
+    // The literal includes() would say false; bearerHasCapability
+    // expansion catches the wildcard form. Same auth predicate as
+    // request-time, so no asymmetry.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.*"],
+      presetName: null,
+      policy: null,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects capabilities ['installation_token.*'] WITH allowedRepos but no allowedPermissions (D10 half 2 still required)", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.*"],
+      presetName: null,
+      policy: { allowed_repos: ["hivemoot/colony"] },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows capabilities ['installation_token.*'] WITH full D10 policy (gate is policy-based, not literal-cap-based)", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.*"],
+      presetName: null,
+      policy: D10_POLICY,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects capabilities ['*'] without allowWildcards opt-in (gate fires)", () => {
+    // Bare * needs the explicit allowWildcards flag to qualify
+    // for the admin chain-root carve-out. Without the flag,
+    // the wildcard expansion still triggers the mint detection.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["*"],
+      presetName: null,
+      policy: null,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("admin chain-root opt-in — capabilities ['*'] + allowWildcards: true → exempt (explicit power-user path)", () => {
+    // The deliberate-opt-in admin path predates D10. Documented
+    // carve-out keyed on the literal `*` cap + the operator's
+    // explicit allowWildcards flag. Other wildcard forms (e.g.
+    // `installation_token.*`) do NOT qualify even with the flag.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["*"],
+      presetName: null,
+      allowWildcards: true,
+      policy: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("admin preset name → exempt (mirrors capabilities-`*` opt-in via the preset path)", () => {
+    const result = validateMintPolicyRequirement({
+      capabilities: PRESETS.admin,
+      presetName: "admin",
+      policy: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("`installation_token.*` with allowWildcards: true is NOT the admin chain-root opt-in (gate still fires)", () => {
+    // Only bare `*` qualifies for the admin opt-in. A scoped
+    // wildcard prefix (`installation_token.*`) does NOT — that's
+    // a narrower grant the operator can issue with proper D10
+    // policy or not at all.
+    const result = validateMintPolicyRequirement({
+      capabilities: ["installation_token.*"],
+      presetName: null,
+      allowWildcards: true,
+      policy: null,
+    });
+    expect(result.ok).toBe(false);
+  });
 });

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -314,6 +314,25 @@ describe("PRESETS", () => {
     expect(PRESETS.local_queen.includes("rooms.force_close")).toBe(false);
   });
 
+  it("every preset granting rooms.create also grants rooms.read_all (PR 645 guard G3, KNOWN_CAPABILITIES :149-157 invariant)", () => {
+    // The KNOWN_CAPABILITIES note at agent-token-capabilities.ts:149-157
+    // commits to this pairing: rooms.create's 409 subject_already_open
+    // response surfaces existingRoomId, and that disclosure is benign
+    // ONLY because the bearer also has rooms.read_all (so they can
+    // already enumerate rooms anyway). A future preset with rooms.create
+    // but WITHOUT rooms.read_all would turn the 409 into a roomId-
+    // discovery oracle. Guard pass-1 on PR 645 asked for an automated
+    // pin so this invariant doesn't regress silently.
+    for (const [name, caps] of Object.entries(PRESETS)) {
+      if (caps.includes("rooms.create")) {
+        expect(
+          caps.includes("rooms.read_all"),
+          `${name} grants rooms.create but not rooms.read_all`,
+        ).toBe(true);
+      }
+    }
+  });
+
   it("admin preset includes both bare * AND agent_tokens.manage explicit (wildcard alone wouldn't cover it)", () => {
     expect(PRESETS.admin.includes("*")).toBe(true);
     expect(PRESETS.admin.includes("agent_tokens.manage")).toBe(true);

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -159,6 +159,15 @@ export const KNOWN_CAPABILITIES = [
   "rooms.update",
   "rooms.decide",
   "rooms.close",
+  // War rooms — local-mode queen synthesis path (RFC PR 3 / D14).
+  // Gates GET /api/rooms/synthesis-ready, GET decided-pending-ready,
+  // POST claim-synthesis, POST resolve-action, POST seal-decision,
+  // POST confirm-merge, POST report-merge-result. Additive to the
+  // existing `rooms.decide` + `rooms.close` set so cloud queen
+  // (cloud mode) and hive queen (local mode) can coexist with
+  // distinct capability surfaces — no silent expansion of the
+  // existing `queen` preset.
+  "rooms.synthesize",
   // War rooms — admin.
   "rooms.force_close",
   // Token management (admin only — see ADMIN_CLASS_CAPABILITIES).
@@ -292,6 +301,33 @@ export const PRESETS: Readonly<Record<string, readonly string[]>> = {
     "rooms.update",
     "rooms.decide",
     "rooms.close",
+  ],
+  // Local-mode queen preset (RFC PR 3 / D14 + builder pass-2 §2 +
+  // builder pass-7 §5). Distinct from `queen` so a leaked existing
+  // queen bearer cannot inherit `rooms.synthesize` or
+  // `installation_token.mint` privileges. Critically does NOT
+  // include `rooms.watch` (used to be a worker-style discovery
+  // channel; the local queen polls `synthesis-ready` instead, which
+  // is gated by `rooms.synthesize`).
+  //
+  // G16 — `installation_token.mint` is normally apiarist-only with
+  // a UDS broker pattern. The local queen needs to mint installation
+  // tokens directly (it runs in-container, can't go through a host
+  // broker). Blast radius is bounded by D10's token policy —
+  // `policy.allowed_repos = watched_repos` + minimal scopes.
+  local_queen: [
+    "agent_health.report",
+    "tasks.create",
+    "tasks.read",
+    "tasks.cancel",
+    "rooms.create",
+    "rooms.read",
+    "rooms.read_all",
+    "rooms.update",
+    "rooms.decide",
+    "rooms.close",
+    "rooms.synthesize",
+    "installation_token.mint",
   ],
   dispatcher: [
     "tasks.create",

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -430,10 +430,20 @@ export interface MintPolicyGateInput {
   capabilities: readonly string[];
   /**
    * Preset name when the issue came from a preset; null for the
-   * explicit-capabilities path. The apiarist carve-out keys ONLY on
-   * this server-resolved preset name — see pass-2 fix.
+   * explicit-capabilities path. The apiarist + admin carve-outs key
+   * on this server-resolved preset name (see pass-2 fix).
    */
   presetName?: string | null;
+  /**
+   * Whether the caller passed `allowWildcards: true` — the explicit
+   * opt-in for bare `*` admin issuance. When the capability list
+   * contains a bare `*` AND this flag is true, the gate treats the
+   * token as the admin chain-root shape (which already grants
+   * `installation_token.mint` via wildcard expansion) and exempts
+   * it from D10. Mirrors the explicit `*` rejection rule on the
+   * mint endpoint's auth path. Default false.
+   */
+  allowWildcards?: boolean;
   /**
    * The policy that will be persisted with the token (snake_case
    * storage shape). null when no policy was supplied.
@@ -445,37 +455,99 @@ export interface MintPolicyGateInput {
 }
 
 /**
+ * Legacy carve-outs for the mint-policy gate. Both predate the D10
+ * model and tightening either would break in-the-wild tokens:
+ *   - `apiarist`: host-broker preset (UDS-based mint pattern).
+ *   - `admin`: bare-`*` admin preset, the chain root for issuing
+ *      other tokens. Admin tokens hold every cap by wildcard
+ *      expansion including `installation_token.mint`; per RFC
+ *      they are intentionally privileged and predate D10's
+ *      per-token policy model. New mint-capable presets MUST go
+ *      through the gate; this set is closed.
+ *
+ * Pass-4 (B1, builder pass-3 follow-up): admin was added explicitly
+ * after a bypass via `capabilities: ["*"]` was found — see
+ * `validateMintPolicyRequirement` doc for the wildcard expansion fix.
+ */
+const MINT_GATE_LEGACY_PRESETS: ReadonlySet<string> = new Set([
+  "apiarist",
+  "admin",
+]);
+
+/**
  * Issue-time policy gate.
  *
- * # Pass-3 fix — both halves of D10 (B1, builder pass-3)
+ * # Pass-4 fix — wildcard-aware capability detection (B1, builder pass-3 follow-up)
  *
- * Pass-2 closed the apiarist label-laundering bypass but only
- * enforced repo fan-out (allowed_repos). Builder pass-3 found that
- * a local_queen token issued with allowedRepos-only still mints
- * installation tokens with the legacy V1_PERMISSIONS scope (which
- * includes `contents: "read"`), violating RFC D10's permission
- * scope half. The gate now also requires the exact
- * LOCAL_QUEEN_REQUIRED_PERMISSIONS shape — narrower would fail
- * closed at mint time, broader violates the D10 contract.
+ * Pass-3's gate used `capabilities.includes("installation_token.mint")`
+ * — a literal-string check. Authorization at the mint endpoint
+ * uses `bearerHasCapability` which expands wildcards, so:
+ *   - `capabilities: ["installation_token.*"]` does NOT trigger the
+ *     gate (no literal match) but DOES satisfy
+ *     `requires: "installation_token.mint"` at mint time
+ *   - `capabilities: ["*"]` (with `allowWildcards: true`) has the
+ *     same shape
+ *
+ * Both bypasses are now closed by switching the gate to
+ * `bearerHasCapability(capabilities, "installation_token.mint")` —
+ * the SAME predicate authorization uses. If the bearer can EVER
+ * mint at request time, the gate fires at issue time. Symmetric
+ * semantics, no asymmetry to exploit.
+ *
+ * `admin` is added to the legacy carve-out alongside `apiarist`.
+ * Admin tokens are the chain root and intentionally hold every
+ * cap by wildcard; subjecting them to the D10 gate would break
+ * the bootstrap path. See `MINT_GATE_LEGACY_PRESETS`.
+ *
+ * # Pass-3 fix — both halves of D10
+ *
+ * Pass-2 only enforced repo fan-out (allowed_repos). The mint
+ * endpoint falls back to V1_PERMISSIONS (which includes
+ * `contents: "read"`) when allowed_permissions is omitted,
+ * violating D10's permission scope half. The gate now also
+ * requires the exact LOCAL_QUEEN_REQUIRED_PERMISSIONS shape.
  *
  * # Pass-2 fix — apiarist carve-out is preset-only
  *
- * Pass-1 used `presetName === "apiarist" || agentRole === "apiarist"`
- * as the carve-out condition. `agent_role` is operator-supplied;
- * an attacker could submit `capabilities: ['installation_token.mint',
- * ...] + agent_role: 'apiarist'` and the gate would return ok.
- * The fix branches ONLY on the server-resolved preset name.
+ * Pass-1 trusted operator-supplied `agent_role` for the apiarist
+ * exemption. Now keys ONLY on the server-resolved preset name.
  */
 export function validateMintPolicyRequirement(
   args: MintPolicyGateInput,
 ): { ok: true } | { ok: false; message: string } {
-  const grantsMint = args.capabilities.includes("installation_token.mint");
+  // Wildcard-aware: ["installation_token.*"] and ["*"] both trigger
+  // the gate, matching the request-time auth predicate exactly.
+  const grantsMint = bearerHasCapability(
+    args.capabilities,
+    "installation_token.mint",
+  );
   if (!grantsMint) return { ok: true };
 
   // Server-resolved preset-name gate ONLY — agent_role is operator-
   // supplied and cannot be trusted for a security decision.
-  const isLegacyApiarist = args.presetName === "apiarist";
-  if (isLegacyApiarist) return { ok: true };
+  // Both apiarist (legacy host-broker) and admin (chain root) are
+  // explicit carve-outs predating D10.
+  if (args.presetName !== null && args.presetName !== undefined) {
+    if (MINT_GATE_LEGACY_PRESETS.has(args.presetName)) return { ok: true };
+  }
+
+  // Explicit-caps admin opt-in: `capabilities: ["*"]` + the
+  // documented `allowWildcards: true` flag is the explicit
+  // power-user path for issuing an admin chain-root bearer
+  // without going through `preset: "admin"`. Bare `*` already
+  // expands to `installation_token.mint` (and every other non-
+  // admin-class cap), so the gate would fire on every admin
+  // token without this carve-out. Matches the
+  // MINT_GATE_LEGACY_PRESETS["admin"] exemption shape, just
+  // wired through capabilities rather than preset.
+  //
+  // The carve-out requires BOTH: a literal bare `*` in the cap
+  // list AND the operator's deliberate opt-in flag. Any other
+  // wildcard form (e.g. `installation_token.*`) does NOT qualify
+  // — those still trip the gate.
+  if (args.allowWildcards && args.capabilities.includes("*")) {
+    return { ok: true };
+  }
 
   // ----- Half 1 of D10: allowed_repos ≥ 1 -----
   const repos = args.policy?.allowed_repos;

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -368,25 +368,56 @@ export function resolvePreset(name: string): readonly string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Mint-capable issuance gate (PR 645 builder pass-1 B1; RFC D10 + G16)
+// Mint-capable issuance gate (PR 645 builder pass-1 B1 / pass-2 / pass-3;
+// RFC D10 + G16)
 // ---------------------------------------------------------------------------
+
+/**
+ * The exact `allowed_permissions` shape RFC D10 specifies for the
+ * local_queen mint policy. Mint-capable non-apiarist tokens must be
+ * issued with this set verbatim — narrower fails closed (bearer
+ * cannot use a permission they didn't request), broader violates
+ * D10 by exceeding the queen's needed scope.
+ *
+ * Notably **excludes `contents`**: the local queen synthesizes
+ * verdicts from war-room contributions and posts comments; it must
+ * not read repo files. The default V1_PERMISSIONS shape (used at
+ * mint time when `allowed_permissions` is omitted) DOES include
+ * `contents: "read"` for legacy apiarist compatibility, which is
+ * exactly the gap this gate closes for local_queen.
+ */
+export const LOCAL_QUEEN_REQUIRED_PERMISSIONS: Readonly<
+  Record<string, "read" | "write" | "admin">
+> = Object.freeze({
+  pull_requests: "write",
+  issues: "write",
+  metadata: "read",
+});
 
 /**
  * Issue-time policy gate for mint-capable presets and roles.
  *
- * Per RFC D10 + G16 and builder pass-1 on PR 645, tokens granting
- * `installation_token.mint` for the new `local_queen` role must be
- * issued with a `policy.allowed_repos` list containing ≥1 repo. The
- * mint endpoint (web/src/app/api/github/installation-tokens) treats
- * policy-less bearers as legacy-permissive, so without this gate a
- * leaked policy-less `local_queen` bearer could mint installation
- * tokens for any repo in the installation grant — strictly worse
- * blast radius than apiarist (which stays per-installation-only).
+ * Per RFC D10 + G16, tokens granting `installation_token.mint` for
+ * the new `local_queen` role must be issued with BOTH halves of
+ * the D10 policy:
+ *   - `allowed_repos` — non-empty list (repo fan-out bound)
+ *   - `allowed_permissions` — exactly the LOCAL_QUEEN_REQUIRED_PERMISSIONS
+ *      set (permission scope bound; see RFC docs/architecture/
+ *      QUEEN_EXECUTION_MODE.md:566-567)
  *
- * `apiarist` is exempt: the existing host-broker preset predates the
- * policy model and tightening it would break in-the-wild apiarist
- * tokens. The next slice (or a follow-up issue against #638) tracks
- * graduating apiarist into the gate too — until then it stays legacy.
+ * The mint endpoint (web/src/app/api/github/installation-tokens)
+ * intersects V1_PERMISSIONS with the bearer's allowed_permissions;
+ * if allowed_permissions is omitted, the intersection is the full
+ * V1_PERMISSIONS set including `contents: "read"`. Without this
+ * gate enforcing both halves, a leaked allowedRepos-only
+ * local_queen bearer could mint tokens with `contents: "read"`
+ * scope — violating D10's intent that the local queen never reads
+ * repo files.
+ *
+ * `apiarist` is exempt from BOTH halves: the existing host-broker
+ * preset predates the policy model and tightening it would break
+ * in-the-wild apiarist tokens. The next slice tracks graduating
+ * apiarist into the gate too — until then it stays legacy.
  *
  * Used by:
  *   - POST /api/agent-tokens (operator-bearer issue)
@@ -400,34 +431,40 @@ export interface MintPolicyGateInput {
   /**
    * Preset name when the issue came from a preset; null for the
    * explicit-capabilities path. The apiarist carve-out keys ONLY on
-   * this server-resolved preset name — see pass-2 fix below.
+   * this server-resolved preset name — see pass-2 fix.
    */
   presetName?: string | null;
   /**
    * The policy that will be persisted with the token (snake_case
    * storage shape). null when no policy was supplied.
    */
-  policy?: { allowed_repos?: readonly string[] | null } | null;
+  policy?: {
+    allowed_repos?: readonly string[] | null;
+    allowed_permissions?: Readonly<Record<string, string>> | null;
+  } | null;
 }
 
 /**
  * Issue-time policy gate.
  *
- * # Pass-2 fix — apiarist carve-out is preset-only (B1, builder pass-2)
+ * # Pass-3 fix — both halves of D10 (B1, builder pass-3)
+ *
+ * Pass-2 closed the apiarist label-laundering bypass but only
+ * enforced repo fan-out (allowed_repos). Builder pass-3 found that
+ * a local_queen token issued with allowedRepos-only still mints
+ * installation tokens with the legacy V1_PERMISSIONS scope (which
+ * includes `contents: "read"`), violating RFC D10's permission
+ * scope half. The gate now also requires the exact
+ * LOCAL_QUEEN_REQUIRED_PERMISSIONS shape — narrower would fail
+ * closed at mint time, broader violates the D10 contract.
+ *
+ * # Pass-2 fix — apiarist carve-out is preset-only
  *
  * Pass-1 used `presetName === "apiarist" || agentRole === "apiarist"`
- * as the carve-out condition. `agent_role` is operator-supplied on
- * the explicit-capabilities path (POST /api/agent-tokens body), so
+ * as the carve-out condition. `agent_role` is operator-supplied;
  * an attacker could submit `capabilities: ['installation_token.mint',
- * ...] + agent_role: 'apiarist'` and the gate would return ok with
- * `policy: null` — reopening the policy-less mint-token path this
- * gate exists to close.
- *
- * The fix branches ONLY on the server-resolved preset name. If the
- * caller went through the explicit-capabilities path (`presetName ===
- * null`), the gate fires regardless of what role label they passed.
- * Apiarist tokens issued via explicit caps are still possible — they
- * just have to use `preset: "apiarist"` instead of label-laundering.
+ * ...] + agent_role: 'apiarist'` and the gate would return ok.
+ * The fix branches ONLY on the server-resolved preset name.
  */
 export function validateMintPolicyRequirement(
   args: MintPolicyGateInput,
@@ -440,19 +477,59 @@ export function validateMintPolicyRequirement(
   const isLegacyApiarist = args.presetName === "apiarist";
   if (isLegacyApiarist) return { ok: true };
 
+  // ----- Half 1 of D10: allowed_repos ≥ 1 -----
   const repos = args.policy?.allowed_repos;
-  if (Array.isArray(repos) && repos.length > 0) return { ok: true };
+  if (!Array.isArray(repos) || repos.length === 0) {
+    return {
+      ok: false,
+      message:
+        "Tokens granting installation_token.mint must be issued with " +
+        "a non-empty policy.allowedRepos list (RFC D10 half 1: bound " +
+        "the mint repo fan-out). Pass policy: { allowedRepos: " +
+        "['owner/repo', ...] } at issue time. The legacy apiarist " +
+        "preset is exempt only via `preset: 'apiarist'`.",
+    };
+  }
 
-  return {
-    ok: false,
-    message:
-      "Tokens granting installation_token.mint must be issued with " +
-      "policy.allowedRepos (≥1 repo) to bound the mint blast radius " +
-      "(RFC D10 / G16). The local_queen preset is mint-capable; pass " +
-      "policy: { allowedRepos: ['owner/repo', ...] } at issue time. " +
-      "The legacy apiarist preset is exempt only via " +
-      "`preset: 'apiarist'` — agent_role labels do not grant the " +
-      "exemption (operator-supplied label-laundering would otherwise " +
-      "bypass the gate).",
-  };
+  // ----- Half 2 of D10: allowed_permissions matches local-queen set -----
+  const perms = args.policy?.allowed_permissions;
+  if (!perms || typeof perms !== "object") {
+    return {
+      ok: false,
+      message:
+        "Tokens granting installation_token.mint must be issued with " +
+        "policy.allowedPermissions matching the RFC D10 local-queen " +
+        "permission scope (pull_requests: write, issues: write, " +
+        "metadata: read). Omitting allowedPermissions falls back to " +
+        "V1_PERMISSIONS at mint time, which includes contents:read — " +
+        "violating D10's intent that the local queen never reads " +
+        "repo files.",
+    };
+  }
+
+  const required = LOCAL_QUEEN_REQUIRED_PERMISSIONS;
+  const requiredKeys = Object.keys(required);
+  const givenKeys = Object.keys(perms);
+  const allRequiredPresent = requiredKeys.every(
+    (k) => perms[k] === required[k],
+  );
+  const noExtraKeys = givenKeys.every((k) =>
+    Object.prototype.hasOwnProperty.call(required, k),
+  );
+  if (!allRequiredPresent || !noExtraKeys) {
+    const expected = JSON.stringify(required);
+    const got = JSON.stringify(perms);
+    return {
+      ok: false,
+      message:
+        `Tokens granting installation_token.mint must have ` +
+        `policy.allowedPermissions exactly equal to the RFC D10 ` +
+        `local-queen scope ${expected}. Got ${got}. Notably ` +
+        `\`contents\` MUST be omitted — the local queen synthesizes ` +
+        `verdicts from war-room contributions and must not read repo ` +
+        `files.`,
+    };
+  }
+
+  return { ok: true };
 }

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -366,3 +366,72 @@ export function resolvePreset(name: string): readonly string[] {
   }
   return PRESETS[name];
 }
+
+// ---------------------------------------------------------------------------
+// Mint-capable issuance gate (PR 645 builder pass-1 B1; RFC D10 + G16)
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue-time policy gate for mint-capable presets and roles.
+ *
+ * Per RFC D10 + G16 and builder pass-1 on PR 645, tokens granting
+ * `installation_token.mint` for the new `local_queen` role must be
+ * issued with a `policy.allowed_repos` list containing ≥1 repo. The
+ * mint endpoint (web/src/app/api/github/installation-tokens) treats
+ * policy-less bearers as legacy-permissive, so without this gate a
+ * leaked policy-less `local_queen` bearer could mint installation
+ * tokens for any repo in the installation grant — strictly worse
+ * blast radius than apiarist (which stays per-installation-only).
+ *
+ * `apiarist` is exempt: the existing host-broker preset predates the
+ * policy model and tightening it would break in-the-wild apiarist
+ * tokens. The next slice (or a follow-up issue against #638) tracks
+ * graduating apiarist into the gate too — until then it stays legacy.
+ *
+ * Used by:
+ *   - POST /api/agent-tokens (operator-bearer issue)
+ *   - POST /api/dashboard/agent-tokens (cookie-auth issue)
+ *   - POST /api/agent-tokens/{name}/set-capabilities (recap; only
+ *     when the operation transitions a token INTO mint-capable shape)
+ */
+export interface MintPolicyGateInput {
+  /** Effective capability list of the resulting/updated token. */
+  capabilities: readonly string[];
+  /** `agent_role` field on the token. Used for the apiarist carve-out. */
+  agentRole: string;
+  /**
+   * Preset name when the issue came from a preset; null for the
+   * explicit-capabilities path. Used for the apiarist carve-out.
+   */
+  presetName?: string | null;
+  /**
+   * The policy that will be persisted with the token (snake_case
+   * storage shape). null when no policy was supplied.
+   */
+  policy?: { allowed_repos?: readonly string[] | null } | null;
+}
+
+export function validateMintPolicyRequirement(
+  args: MintPolicyGateInput,
+): { ok: true } | { ok: false; message: string } {
+  const grantsMint = args.capabilities.includes("installation_token.mint");
+  if (!grantsMint) return { ok: true };
+
+  const isLegacyApiarist =
+    args.presetName === "apiarist" || args.agentRole === "apiarist";
+  if (isLegacyApiarist) return { ok: true };
+
+  const repos = args.policy?.allowed_repos;
+  if (Array.isArray(repos) && repos.length > 0) return { ok: true };
+
+  return {
+    ok: false,
+    message:
+      "Tokens granting installation_token.mint must be issued with " +
+      "policy.allowedRepos (≥1 repo) to bound the mint blast radius " +
+      "(RFC D10 / G16). The local_queen preset is mint-capable; pass " +
+      "policy: { allowedRepos: ['owner/repo', ...] } at issue time. " +
+      "The legacy apiarist preset is exempt and remains issuable " +
+      "without policy.",
+  };
+}

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -397,11 +397,10 @@ export function resolvePreset(name: string): readonly string[] {
 export interface MintPolicyGateInput {
   /** Effective capability list of the resulting/updated token. */
   capabilities: readonly string[];
-  /** `agent_role` field on the token. Used for the apiarist carve-out. */
-  agentRole: string;
   /**
    * Preset name when the issue came from a preset; null for the
-   * explicit-capabilities path. Used for the apiarist carve-out.
+   * explicit-capabilities path. The apiarist carve-out keys ONLY on
+   * this server-resolved preset name — see pass-2 fix below.
    */
   presetName?: string | null;
   /**
@@ -411,14 +410,34 @@ export interface MintPolicyGateInput {
   policy?: { allowed_repos?: readonly string[] | null } | null;
 }
 
+/**
+ * Issue-time policy gate.
+ *
+ * # Pass-2 fix — apiarist carve-out is preset-only (B1, builder pass-2)
+ *
+ * Pass-1 used `presetName === "apiarist" || agentRole === "apiarist"`
+ * as the carve-out condition. `agent_role` is operator-supplied on
+ * the explicit-capabilities path (POST /api/agent-tokens body), so
+ * an attacker could submit `capabilities: ['installation_token.mint',
+ * ...] + agent_role: 'apiarist'` and the gate would return ok with
+ * `policy: null` — reopening the policy-less mint-token path this
+ * gate exists to close.
+ *
+ * The fix branches ONLY on the server-resolved preset name. If the
+ * caller went through the explicit-capabilities path (`presetName ===
+ * null`), the gate fires regardless of what role label they passed.
+ * Apiarist tokens issued via explicit caps are still possible — they
+ * just have to use `preset: "apiarist"` instead of label-laundering.
+ */
 export function validateMintPolicyRequirement(
   args: MintPolicyGateInput,
 ): { ok: true } | { ok: false; message: string } {
   const grantsMint = args.capabilities.includes("installation_token.mint");
   if (!grantsMint) return { ok: true };
 
-  const isLegacyApiarist =
-    args.presetName === "apiarist" || args.agentRole === "apiarist";
+  // Server-resolved preset-name gate ONLY — agent_role is operator-
+  // supplied and cannot be trusted for a security decision.
+  const isLegacyApiarist = args.presetName === "apiarist";
   if (isLegacyApiarist) return { ok: true };
 
   const repos = args.policy?.allowed_repos;
@@ -431,7 +450,9 @@ export function validateMintPolicyRequirement(
       "policy.allowedRepos (≥1 repo) to bound the mint blast radius " +
       "(RFC D10 / G16). The local_queen preset is mint-capable; pass " +
       "policy: { allowedRepos: ['owner/repo', ...] } at issue time. " +
-      "The legacy apiarist preset is exempt and remains issuable " +
-      "without policy.",
+      "The legacy apiarist preset is exempt only via " +
+      "`preset: 'apiarist'` — agent_role labels do not grant the " +
+      "exemption (operator-supplied label-laundering would otherwise " +
+      "bypass the gate).",
   };
 }


### PR DESCRIPTION
## Summary

Foundation slice for the local-queen synthesis path:

1. **`rooms.synthesize` capability** — gates the upcoming PR 3c slice 2 endpoints (synthesis-ready, decided-pending-ready, claim-synthesis, seal-decision, resolve-action, etc.) without granting them to existing `queen` bearers.
2. **`local_queen` preset** — distinct from `queen` so a leaked existing queen bearer cannot inherit `rooms.synthesize` or `installation_token.mint` privileges. Includes the queen surface + `rooms.synthesize` + `installation_token.mint`. Excludes `rooms.watch` (the local queen polls the new endpoints instead).
3. **Mint policy gate** — issue-time enforcement of RFC D10 + G16 on any mint-capable token. Both halves of D10 are required:
   - `allowed_repos` ≥ 1 repo (bound the mint repo fan-out)
   - `allowed_permissions` exactly equal to the canonical local-queen scope `{ pull_requests: write, issues: write, metadata: read }` (NO `contents` — the local queen never reads repo files)

This PR was originally #645 and got auto-closed when its base branch (#649's `feat/queen-verdict-primitives-shared`) was deleted on merge. Branch + commits are unchanged; this PR retargets to `main` after #649 landed.

**Reviews carried forward (passes that actually addressed the final shape):**
- builder APPROVED 2026-05-10T04:11:14Z (pass-3 D10)
- guard APPROVED earlier passes (pass-2 label-laundering); guard re-stamp on pass-3 D10 still pending

## Three iterations of mint-policy hardening

| Pass | Builder finding | Fix |
|---|---|---|
| pass-1 | issue-time gate not enforced — operator could pass `--preset local_queen` with no policy and mint for any repo | Added `validateMintPolicyRequirement` checking `allowed_repos` |
| pass-2 | apiarist carve-out keyed on `agentRole === "apiarist"` (operator-supplied) — label-laundering bypass | Carve-out keys ONLY on server-resolved `presetName`. Removed `agentRole` from gate input entirely. Added `installation_token.mint` to dashboard's explicit-cap deny list (defense-in-depth) |
| pass-3 | only enforced D10 half-1 (allowed_repos); allowedRepos-only token still mints with `contents:read` via V1_PERMISSIONS fallback | Equality check on `allowed_permissions` against `LOCAL_QUEEN_REQUIRED_PERMISSIONS` constant. Reject missing/narrower/broader/extra-keys |

## Test plan

- [x] 21 KNOWN_CAPABILITIES count matches design doc (rooms.synthesize bumps to 21)
- [x] Cross-invariant: every preset granting `rooms.create` also grants `rooms.read_all` (G3)
- [x] `local_queen` ⊇ `queen` enforced (no functionality regression)
- [x] `local_queen` does NOT include `rooms.watch` or `rooms.force_close`
- [x] 25 unit tests on `validateMintPolicyRequirement` covering all branches (apiarist exempt, missing repos/perms, contents at any level, narrower/broader perms, exact D10 happy path)
- [x] Route-level tests on POST /api/agent-tokens, /api/dashboard/agent-tokens, set-capabilities for label-laundering closure + D10 happy path
- [x] Web suite: 1602 passing