### PR TITLE
feat(github): web-side PR state reader for resolve-action (3c slice 2a foundation)

### DIFF
--- a/web/src/server/github-pr-state.test.ts
+++ b/web/src/server/github-pr-state.test.ts
@@ -146,6 +146,31 @@ describe("deriveCiState", () => {
     ).toBe("failure");
   });
 
+  it("legacy status: 'error' is treated as failure (builder pass-1 fix — GitHub's combined-status enum includes 'error', and bot's isCIPassing blocks anything != 'success')", () => {
+    // Pre-fix, the reducer only branched on literal 'failure', so
+    // green check-runs + legacy 'error' fell through to 'success',
+    // letting resolve-action merge a PR with a broken external check.
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "success" }],
+        truncated: false,
+        status: { state: "error", total_count: 1 },
+      }),
+    ).toBe("failure");
+  });
+
+  it("legacy status: unknown value (defensive against GitHub enum expansion) → failure", () => {
+    // If GitHub ever adds a new state value, we want fail-closed
+    // behavior, not silent merge-eligible.
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "success" }],
+        truncated: false,
+        status: { state: "neutral_future_value", total_count: 1 },
+      }),
+    ).toBe("failure");
+  });
+
   it("legacy status: 'pending' counts as pending even when check-runs all succeeded", () => {
     expect(
       deriveCiState({

--- a/web/src/server/github-pr-state.test.ts
+++ b/web/src/server/github-pr-state.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  getPullRequestState,
+  deriveCiState,
+  PullRequestNotFoundError,
+  GitHubAPIError,
+  type CiState,
+} from "./github-pr-state";
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+interface MockEndpoint {
+  /** URL substring to match. */
+  match: string;
+  /** Response body (JSON-stringified by the helper). */
+  body: unknown;
+  /** Status code. Defaults to 200. */
+  status?: number;
+}
+
+function makeFetchMock(endpoints: MockEndpoint[]): typeof fetch {
+  return vi.fn(async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const match = endpoints.find((e) => url.includes(e.match));
+    if (!match) {
+      throw new Error(`Unmocked fetch URL: ${url}`);
+    }
+    return {
+      ok: (match.status ?? 200) >= 200 && (match.status ?? 200) < 300,
+      status: match.status ?? 200,
+      json: async () => match.body,
+      text: async () =>
+        typeof match.body === "string" ? match.body : JSON.stringify(match.body),
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+function prPayload(overrides: {
+  sha?: string;
+  labels?: string[];
+  mergeable_state?: string | null;
+} = {}) {
+  return {
+    head: { sha: overrides.sha ?? "abc123" },
+    labels: (overrides.labels ?? []).map((name) => ({ name })),
+    // Use `in` instead of `??` so `null` passes through (vs. being
+    // coerced to the "clean" default — the GitHub API returns null
+    // while it computes mergeable_state, and we want that path
+    // exercised by the test).
+    mergeable_state:
+      "mergeable_state" in overrides ? overrides.mergeable_state : "clean",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// deriveCiState — unit tests on the normalization helper
+// ---------------------------------------------------------------------------
+
+describe("deriveCiState", () => {
+  const emptyStatus = { state: "pending", total_count: 0 };
+
+  it("'no_checks' when no check-runs and no legacy statuses (CI not configured)", () => {
+    expect(
+      deriveCiState({ checkRuns: [], truncated: false, status: emptyStatus }),
+    ).toBe("no_checks" satisfies CiState);
+  });
+
+  it("'truncated' when GitHub returned more check-runs than fit in one page (>100)", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "success" }],
+        truncated: true,
+        status: emptyStatus,
+      }),
+    ).toBe("truncated");
+  });
+
+  it("'success' when all check-runs completed with passing conclusions and no failing legacy status", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [
+          { status: "completed", conclusion: "success" },
+          { status: "completed", conclusion: "neutral" },
+          { status: "completed", conclusion: "skipped" },
+        ],
+        truncated: false,
+        status: emptyStatus,
+      }),
+    ).toBe("success");
+  });
+
+  it("'failure' on any failing check-run conclusion (failure, cancelled, timed_out, action_required, stale)", () => {
+    for (const conclusion of [
+      "failure",
+      "cancelled",
+      "timed_out",
+      "action_required",
+      "stale",
+    ]) {
+      expect(
+        deriveCiState({
+          checkRuns: [{ status: "completed", conclusion }],
+          truncated: false,
+          status: emptyStatus,
+        }),
+      ).toBe("failure");
+    }
+  });
+
+  it("'failure' on completed check-run with null conclusion (defensive — should not happen in practice)", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: null }],
+        truncated: false,
+        status: emptyStatus,
+      }),
+    ).toBe("failure");
+  });
+
+  it("'pending' on queued/in-progress check-runs (no failures yet)", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "queued", conclusion: null }],
+        truncated: false,
+        status: emptyStatus,
+      }),
+    ).toBe("pending");
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "in_progress", conclusion: null }],
+        truncated: false,
+        status: emptyStatus,
+      }),
+    ).toBe("pending");
+  });
+
+  it("legacy status: 'failure' overrides 'success' from check-runs", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "success" }],
+        truncated: false,
+        status: { state: "failure", total_count: 1 },
+      }),
+    ).toBe("failure");
+  });
+
+  it("legacy status: 'pending' counts as pending even when check-runs all succeeded", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "success" }],
+        truncated: false,
+        status: { state: "pending", total_count: 1 },
+      }),
+    ).toBe("pending");
+  });
+
+  it("legacy status: 'success' alone (no check-runs) → 'success'", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [],
+        truncated: false,
+        status: { state: "success", total_count: 1 },
+      }),
+    ).toBe("success");
+  });
+
+  it("legacy status with total_count=0 is ignored regardless of `state`", () => {
+    // GitHub returns `state: "pending"` with total_count=0 when no
+    // statuses are configured. That must NOT mark the PR as pending.
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "success" }],
+        truncated: false,
+        status: { state: "pending", total_count: 0 },
+      }),
+    ).toBe("success");
+  });
+
+  it("check-run failure overrides legacy success (failure dominates)", () => {
+    expect(
+      deriveCiState({
+        checkRuns: [{ status: "completed", conclusion: "failure" }],
+        truncated: false,
+        status: { state: "success", total_count: 1 },
+      }),
+    ).toBe("failure");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPullRequestState — integration through the fetch mock
+// ---------------------------------------------------------------------------
+
+describe("getPullRequestState", () => {
+  it("returns labels + headSha + mergeableState + ciState=success on the happy path", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/42", body: prPayload({ sha: "deadbeef", labels: ["hivemoot:automerge", "ready"] }) },
+      {
+        match: "/commits/deadbeef/check-runs",
+        body: {
+          total_count: 1,
+          check_runs: [{ status: "completed", conclusion: "success" }],
+        },
+      },
+      { match: "/commits/deadbeef/status", body: { state: "success", total_count: 0 } },
+    ]);
+
+    const result = await getPullRequestState({
+      token: "ghs_test",
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      headSha: "deadbeef",
+      labels: ["hivemoot:automerge", "ready"],
+      ciState: "success",
+      mergeableState: "clean",
+    });
+  });
+
+  it("throws PullRequestNotFoundError on 404 from /pulls", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/99", body: { message: "Not Found" }, status: 404 },
+    ]);
+
+    await expect(
+      getPullRequestState({
+        token: "ghs_test",
+        owner: "hivemoot",
+        repo: "hivemoot",
+        prNumber: 99,
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(PullRequestNotFoundError);
+  });
+
+  it("throws GitHubAPIError on non-404, non-2xx response", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/", body: "rate-limited", status: 403 },
+    ]);
+
+    await expect(
+      getPullRequestState({
+        token: "ghs_test",
+        owner: "hivemoot",
+        repo: "hivemoot",
+        prNumber: 42,
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(GitHubAPIError);
+  });
+
+  it("throws GitHubAPIError if check-runs call fails (PR succeeds, CI lookup explodes)", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/42", body: prPayload() },
+      { match: "/check-runs", body: "internal error", status: 500 },
+      { match: "/status", body: { state: "success", total_count: 0 } },
+    ]);
+
+    await expect(
+      getPullRequestState({
+        token: "ghs_test",
+        owner: "hivemoot",
+        repo: "hivemoot",
+        prNumber: 42,
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(GitHubAPIError);
+  });
+
+  it("returns ciState='truncated' when GitHub reports more check-runs than fit (>100)", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/42", body: prPayload() },
+      {
+        match: "/check-runs",
+        body: {
+          total_count: 250,
+          check_runs: Array.from({ length: 100 }, () => ({
+            status: "completed",
+            conclusion: "success",
+          })),
+        },
+      },
+      { match: "/status", body: { state: "success", total_count: 0 } },
+    ]);
+
+    const result = await getPullRequestState({
+      token: "ghs_test",
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      fetchImpl,
+    });
+    expect(result.ciState).toBe("truncated");
+  });
+
+  it("returns mergeableState=null when GitHub is still computing it", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/42", body: prPayload({ mergeable_state: null }) },
+      { match: "/check-runs", body: { total_count: 0, check_runs: [] } },
+      { match: "/status", body: { state: "pending", total_count: 0 } },
+    ]);
+
+    const result = await getPullRequestState({
+      token: "ghs_test",
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      fetchImpl,
+    });
+    expect(result.mergeableState).toBeNull();
+  });
+
+  it("returns labels=[] when PR has no labels (not undefined / null)", async () => {
+    const fetchImpl = makeFetchMock([
+      { match: "/pulls/42", body: prPayload({ labels: [] }) },
+      { match: "/check-runs", body: { total_count: 0, check_runs: [] } },
+      { match: "/status", body: { state: "pending", total_count: 0 } },
+    ]);
+
+    const result = await getPullRequestState({
+      token: "ghs_test",
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      fetchImpl,
+    });
+    expect(result.labels).toEqual([]);
+  });
+
+  it("sends the bearer token + GitHub API version on every call", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input.toString();
+      const headers = init?.headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBe("Bearer ghs_my_token");
+      expect(headers?.["X-GitHub-Api-Version"]).toBe("2022-11-28");
+      expect(headers?.Accept).toBe("application/vnd.github+json");
+
+      if (url.includes("/pulls/")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => prPayload(),
+          text: async () => "",
+        } as Response;
+      }
+      if (url.includes("/check-runs")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ total_count: 0, check_runs: [] }),
+          text: async () => "",
+        } as Response;
+      }
+      // /status
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ state: "pending", total_count: 0 }),
+        text: async () => "",
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    await getPullRequestState({
+      token: "ghs_my_token",
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("hits the PR endpoint first, then check-runs + status in parallel against the resolved head SHA", async () => {
+    // Pin the dependency: PR fetch must complete before CI fetches
+    // fire (they need head_sha). The two CI calls are parallel.
+    const callOrder: string[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = input.toString();
+      if (url.includes("/pulls/")) {
+        callOrder.push("pr");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => prPayload({ sha: "feedface" }),
+          text: async () => "",
+        } as Response;
+      }
+      if (url.includes("/commits/feedface/check-runs")) {
+        callOrder.push("checks");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ total_count: 0, check_runs: [] }),
+          text: async () => "",
+        } as Response;
+      }
+      if (url.includes("/commits/feedface/status")) {
+        callOrder.push("status");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ state: "pending", total_count: 0 }),
+          text: async () => "",
+        } as Response;
+      }
+      throw new Error(`unexpected ${url}`);
+    }) as unknown as typeof fetch;
+
+    await getPullRequestState({
+      token: "ghs_test",
+      owner: "hivemoot",
+      repo: "hivemoot",
+      prNumber: 42,
+      fetchImpl,
+    });
+
+    // PR is first; checks + status follow in either order.
+    expect(callOrder[0]).toBe("pr");
+    expect(callOrder.slice(1).sort()).toEqual(["checks", "status"]);
+  });
+});

--- a/web/src/server/github-pr-state.ts
+++ b/web/src/server/github-pr-state.ts
@@ -1,0 +1,291 @@
+/**
+ * GitHub PR state reader for the Queen Execution Mode local-queen
+ * resolve-action endpoint (RFC PR 3c slice 2b).
+ *
+ * The local queen's resolve-action endpoint evaluates D1's merge
+ * invariants server-side:
+ *   1. Verdict == APPROVE (computed elsewhere via applyDowngradeOnlyFloor)
+ *   2. `hivemoot:automerge` label present
+ *   3. CI green (Check Runs + legacy Status API both passing)
+ *   4. Head SHA stable (reviewed_head_sha in request body matches current)
+ *
+ * Items 2-4 require a live GitHub read. This module wraps the three
+ * REST calls that pull them in one shot:
+ *   - GET /repos/{owner}/{repo}/pulls/{pull_number}
+ *     → labels + head.sha + mergeable_state
+ *   - GET /repos/{owner}/{repo}/commits/{head_sha}/check-runs?per_page=100
+ *     → GitHub Actions check runs
+ *   - GET /repos/{owner}/{repo}/commits/{head_sha}/status
+ *     → legacy combined status (external CI like Jenkins)
+ *
+ * CI semantics mirror `bot/api/lib/merge-readiness.ts:isCIPassing`:
+ * BOTH check-runs AND legacy statuses must pass. Truncated check-runs
+ * (>100) fail closed — we can't verify unseen checks. Zero
+ * checks/statuses = passing (repo has no CI configured, also matching
+ * bot semantics).
+ *
+ * Pattern matches `github-contents.ts`: `fetch` + Bearer token, no
+ * `@octokit/rest` dep. Caller supplies the installation access token
+ * (mint via `generateInstallationToken` in `github-auth.ts` or via
+ * the `/api/github/installation-tokens` endpoint).
+ */
+
+const GH_API = "https://api.github.com";
+
+function ghHeaders(token: string): HeadersInit {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * CI state for the PR's current head commit, normalized to a small
+ * enum the resolve-action endpoint can branch on.
+ *
+ * - `success`: both check-runs and legacy statuses pass (and ≥1 check
+ *   or status exists — see `no_checks`).
+ * - `failure`: any check-run or legacy status is in a failing state.
+ * - `pending`: no failures, but at least one check-run is queued/
+ *   in_progress OR the combined status is `pending`.
+ * - `no_checks`: zero check-runs AND zero legacy statuses. The repo
+ *   has no CI configured. Mirrors `bot/api/lib/merge-readiness.ts`
+ *   isCIPassing semantics: treated as passing for merge eligibility.
+ * - `truncated`: GitHub returned `total_count > 100` for check-runs.
+ *   We can't verify unseen checks. Fail closed at the call site.
+ */
+export type CiState =
+  | "success"
+  | "failure"
+  | "pending"
+  | "no_checks"
+  | "truncated";
+
+export interface PullRequestState {
+  /** Current head commit SHA. Compare to bearer's `reviewed_head_sha`
+   * for D1 invariant #4 (head SHA stable). */
+  headSha: string;
+  /** Lowercase label names. Check `labels.includes("hivemoot:automerge")`
+   * for D1 invariant #2. Label matching is case-sensitive on GitHub. */
+  labels: string[];
+  /** Normalized CI signal. Resolve-action treats `success` and
+   * `no_checks` as passing for D1 invariant #3; anything else
+   * downgrades to comment-only. */
+  ciState: CiState;
+  /**
+   * GitHub's `mergeable_state` enum value (`clean`, `dirty`,
+   * `behind`, `blocked`, `unknown`, etc.). Surfaced for diagnostic
+   * use in audit events; resolve-action's invariant check uses
+   * `ciState` + `headSha` directly, not this field. May be `null`
+   * if GitHub is still computing the merge state.
+   */
+  mergeableState: string | null;
+}
+
+/**
+ * Thrown when GitHub returns 404 for the PR (deleted / wrong repo).
+ * Resolve-action surfaces this as 404 to the caller — the room core
+ * has the subject_ref but GitHub no longer has the PR open.
+ */
+export class PullRequestNotFoundError extends Error {
+  public readonly owner: string;
+  public readonly repo: string;
+  public readonly prNumber: number;
+  constructor(owner: string, repo: string, prNumber: number) {
+    super(`Pull request ${owner}/${repo}#${prNumber} not found.`);
+    this.name = "PullRequestNotFoundError";
+    this.owner = owner;
+    this.repo = repo;
+    this.prNumber = prNumber;
+  }
+}
+
+/**
+ * Thrown for any non-200, non-404 GitHub response. Caller surfaces
+ * as 502 bad_gateway — the GitHub-side check failed for reasons
+ * unrelated to PR existence.
+ */
+export class GitHubAPIError extends Error {
+  public readonly status: number;
+  public readonly endpoint: string;
+  public readonly body: string;
+  constructor(endpoint: string, status: number, body: string) {
+    super(`GitHub API ${endpoint} returned ${status}: ${body.slice(0, 200)}`);
+    this.name = "GitHubAPIError";
+    this.status = status;
+    this.endpoint = endpoint;
+    this.body = body;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CI normalization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check-run conclusions that count as "passing" for merge eligibility.
+ * Same set as `bot/api/lib/merge-readiness.ts:PASSING_CHECK_CONCLUSIONS`.
+ * `neutral` and `skipped` are non-failing terminal states; `success`
+ * is the obvious pass. Anything else (failure, cancelled, timed_out,
+ * action_required, stale) blocks merge.
+ */
+const PASSING_CHECK_CONCLUSIONS = new Set<string>([
+  "success",
+  "neutral",
+  "skipped",
+]);
+
+interface CheckRun {
+  status: string; // queued | in_progress | completed
+  conclusion: string | null;
+}
+
+interface CombinedStatusResponse {
+  state: string; // success | pending | failure
+  total_count: number;
+}
+
+/**
+ * Combine GitHub's two CI surfaces into one `CiState` enum.
+ *
+ * @param checkRuns parsed check-runs response (truncation already detected by caller)
+ * @param truncated true when GitHub returned `total_count > checkRuns.length`
+ * @param status parsed combined-status response (legacy / external CI)
+ */
+export function deriveCiState(args: {
+  checkRuns: CheckRun[];
+  truncated: boolean;
+  status: CombinedStatusResponse;
+}): CiState {
+  if (args.truncated) return "truncated";
+
+  // Check-runs evaluation: any failure → "failure"; any in-flight → mark pending
+  let anyCheckPending = false;
+  for (const cr of args.checkRuns) {
+    if (cr.status !== "completed") {
+      anyCheckPending = true;
+      continue;
+    }
+    if (!cr.conclusion || !PASSING_CHECK_CONCLUSIONS.has(cr.conclusion)) {
+      return "failure";
+    }
+  }
+
+  // Legacy status evaluation
+  const legacyHasStatuses = args.status.total_count > 0;
+  if (legacyHasStatuses) {
+    if (args.status.state === "failure") return "failure";
+    if (args.status.state === "pending") anyCheckPending = true;
+  }
+
+  if (anyCheckPending) return "pending";
+
+  // No failures, no pendings. Either there's signal (success) or none.
+  const hasAnySignal = args.checkRuns.length > 0 || legacyHasStatuses;
+  return hasAnySignal ? "success" : "no_checks";
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+interface GetPullRequestStateArgs {
+  /** Installation access token. Mint via `generateInstallationToken`. */
+  token: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  /** Test seam — defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Read the PR's labels, head SHA, mergeable state, and normalized CI
+ * status in (at minimum) two round-trips: the pulls fetch first to
+ * learn the head SHA, then the two CI calls in parallel against that
+ * SHA.
+ *
+ * The PR fetch is sequential because the CI calls need `head.sha`.
+ * Bot's `automerge.ts` accepts a pre-fetched labels array from the
+ * webhook payload to avoid the first fetch; the resolve-action
+ * endpoint doesn't have that — it's a queen-initiated request, not a
+ * webhook receiver, so it must read PR state fresh.
+ *
+ * Failure modes:
+ *   - PR returns 404 → throws `PullRequestNotFoundError`
+ *   - Any call returns non-2xx (non-404) → throws `GitHubAPIError`
+ *   - check-runs `total_count > 100` → returned `ciState: "truncated"`,
+ *     no error (caller fail-closes at the policy boundary)
+ */
+export async function getPullRequestState(
+  args: GetPullRequestStateArgs,
+): Promise<PullRequestState> {
+  const doFetch = args.fetchImpl ?? fetch;
+  const baseRef = `${args.owner}/${args.repo}#${args.prNumber}`;
+
+  // ----- 1. PR core (labels + head.sha + mergeable_state) -----
+  const prEndpoint = `${GH_API}/repos/${args.owner}/${args.repo}/pulls/${args.prNumber}`;
+  const prRes = await doFetch(prEndpoint, { headers: ghHeaders(args.token) });
+  if (prRes.status === 404) {
+    throw new PullRequestNotFoundError(args.owner, args.repo, args.prNumber);
+  }
+  if (!prRes.ok) {
+    throw new GitHubAPIError(
+      `GET /repos/{owner}/{repo}/pulls/{pull_number} (${baseRef})`,
+      prRes.status,
+      await prRes.text(),
+    );
+  }
+  const prBody = (await prRes.json()) as {
+    head: { sha: string };
+    labels: Array<{ name: string }>;
+    mergeable_state: string | null;
+  };
+  const headSha = prBody.head.sha;
+  const labels = prBody.labels.map((l) => l.name);
+  const mergeableState = prBody.mergeable_state ?? null;
+
+  // ----- 2. CI signals (parallel) -----
+  const checksEndpoint = `${GH_API}/repos/${args.owner}/${args.repo}/commits/${headSha}/check-runs?per_page=100`;
+  const statusEndpoint = `${GH_API}/repos/${args.owner}/${args.repo}/commits/${headSha}/status`;
+
+  const [checksRes, statusRes] = await Promise.all([
+    doFetch(checksEndpoint, { headers: ghHeaders(args.token) }),
+    doFetch(statusEndpoint, { headers: ghHeaders(args.token) }),
+  ]);
+
+  if (!checksRes.ok) {
+    throw new GitHubAPIError(
+      `GET /repos/{owner}/{repo}/commits/{ref}/check-runs (${baseRef} @ ${headSha.slice(0, 8)})`,
+      checksRes.status,
+      await checksRes.text(),
+    );
+  }
+  if (!statusRes.ok) {
+    throw new GitHubAPIError(
+      `GET /repos/{owner}/{repo}/commits/{ref}/status (${baseRef} @ ${headSha.slice(0, 8)})`,
+      statusRes.status,
+      await statusRes.text(),
+    );
+  }
+
+  const checksBody = (await checksRes.json()) as {
+    total_count: number;
+    check_runs: CheckRun[];
+  };
+  const statusBody = (await statusRes.json()) as CombinedStatusResponse;
+
+  const truncated = checksBody.total_count > checksBody.check_runs.length;
+  const ciState = deriveCiState({
+    checkRuns: checksBody.check_runs,
+    truncated,
+    status: statusBody,
+  });
+
+  return { headSha, labels, ciState, mergeableState };
+}

--- a/web/src/server/github-pr-state.ts
+++ b/web/src/server/github-pr-state.ts
@@ -176,11 +176,26 @@ export function deriveCiState(args: {
     }
   }
 
-  // Legacy status evaluation
+  // Legacy status evaluation. GitHub's combined-status `state` is
+  // one of: success | pending | failure | error. The bot's
+  // isCIPassing treats anything except `success` as blocking when
+  // `total_count > 0`; we mirror that exactly. Builder pass-1 fix:
+  // a prior version handled `failure` + `pending` explicitly but
+  // fell through `error` to the no-failure branch — green
+  // check-runs + legacy `error` would have been reported as
+  // `success`, letting resolve-action merge a PR with a broken
+  // external check.
   const legacyHasStatuses = args.status.total_count > 0;
   if (legacyHasStatuses) {
-    if (args.status.state === "failure") return "failure";
-    if (args.status.state === "pending") anyCheckPending = true;
+    if (args.status.state === "success") {
+      // Pass; fall through to the combined evaluation below.
+    } else if (args.status.state === "pending") {
+      anyCheckPending = true;
+    } else {
+      // `failure`, `error`, or any other non-success non-pending
+      // value (defensive against future GitHub enum expansion).
+      return "failure";
+    }
   }
 
   if (anyCheckPending) return "pending";


### PR DESCRIPTION
## Summary

Foundation for the local-queen `resolve-action` endpoint (slice 2b). Adds `web/src/server/github-pr-state.ts` — the live-GitHub read layer that resolve-action's D1 invariant check will consume.

The RFC's D1 invariants:
1. Verdict == APPROVE (computed via `applyDowngradeOnlyFloor`, already in shared)
2. `hivemoot:automerge` label present ← **live read**
3. CI green (Check Runs + legacy Status both passing) ← **live read**
4. Head SHA stable (`reviewed_head_sha` matches current) ← **live read**

Items 2-4 require GitHub API calls — none are cached on the room hash today. This module wraps those calls and normalizes them into a small typed envelope.

## Public surface

```ts
async function getPullRequestState({
  token: string,         // installation access token
  owner: string,
  repo: string,
  prNumber: number,
}): Promise<{
  headSha: string,
  labels: string[],      // for `labels.includes("hivemoot:automerge")` check
  ciState: "success" | "failure" | "pending" | "no_checks" | "truncated",
  mergeableState: string | null,   // GitHub enum, surfaced for audit diagnostics
}>
```

Plus `PullRequestNotFoundError` (404 surface) and `GitHubAPIError` (any other non-2xx).

## CI semantics — mirrors `bot/api/lib/merge-readiness.ts:isCIPassing`

| Scenario | `ciState` |
|---|---|
| All check-runs `success/neutral/skipped` + no legacy failures | `success` |
| Any check-run conclusion is `failure/cancelled/timed_out/action_required/stale` | `failure` |
| Any check-run still queued/in-progress (no failures yet) | `pending` |
| Legacy status `failure` (even with passing check-runs) | `failure` |
| 0 check-runs AND 0 legacy statuses | `no_checks` (treated as passing — repo has no CI) |
| `total_count > 100` check-runs (page-size limit hit) | `truncated` (caller MUST fail closed) |

Implementation pattern matches `github-contents.ts`: `fetch` + Bearer token, no `@octokit/rest` dep. Three calls: PR first (need `head.sha`), then check-runs + combined status in parallel.

## Test plan

- [x] 11 unit tests on `deriveCiState` covering each conclusion class + truncation + the legacy-status `total_count=0` edge case (GitHub returns `state: "pending"` when no statuses configured — must NOT be treated as pending)
- [x] 9 integration tests on `getPullRequestState` via fetch mock: happy path, 404 → `PullRequestNotFoundError`, non-404 5xx → `GitHubAPIError`, check-runs failure surfaces, truncation, `mergeable_state=null` passthrough, empty labels, headers correctness, call ordering pin (PR first, then parallel CI)
- [x] Web suite green

## What this slice does NOT do

No endpoint surface yet — `resolve-action` lands in slice 2b alongside the D1 invariant evaluation that consumes this reader. This PR is pure plumbing reviewable in isolation.

## Stack position

- ✅ #640 settings storage / ✅ #648 observer / ✅ #649 verdict primitives / ✅ #651 caps+D10 / ✅ #652 RoomStatus / ✅ #653 read-only endpoints / ✅ #650 dashboard
- 🔄 **This PR (slice 2a)** — web GitHub-client foundation
- ⏳ slice 2b — `resolve-action` endpoint
- ⏳ slice 2c — `seal-decision` endpoint + Lua
- ⏳ slice 2d — `confirm-merge` + `report-merge-result`
- ⏳ slice 2e — G32 server-side reconciler