### PR TITLE
feat(rooms): D1 invariant evaluator + subject_ref parser (3c slice 2b)

### DIFF
--- a/web/src/server/resolve-action-policy.test.ts
+++ b/web/src/server/resolve-action-policy.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateResolveActionPolicy,
+  parsePullRequestSubjectRef,
+  type DowngradeReason,
+} from "./resolve-action-policy";
+import type { PullRequestState } from "./github-pr-state";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const HEAD_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+function makePrState(overrides: Partial<PullRequestState> = {}): PullRequestState {
+  return {
+    headSha: HEAD_SHA,
+    labels: ["hivemoot:automerge"],
+    ciState: "success",
+    mergeableState: "clean",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// evaluateResolveActionPolicy — the all-pass happy path
+// ---------------------------------------------------------------------------
+
+describe("evaluateResolveActionPolicy — happy path", () => {
+  it("all invariants pass → squash-merge", () => {
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState(),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result).toEqual({
+      permittedAction: "squash-merge",
+      downgradeReason: null,
+    });
+  });
+
+  it("all invariants pass with `no_checks` CI state (repo has no CI configured)", () => {
+    // `no_checks` mirrors `bot/api/lib/merge-readiness.ts:isCIPassing`
+    // — treated as passing for merge eligibility.
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState({ ciState: "no_checks" }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result.permittedAction).toBe("squash-merge");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateResolveActionPolicy — each downgrade path
+// ---------------------------------------------------------------------------
+
+describe("evaluateResolveActionPolicy — downgrade reasons", () => {
+  const baseInputs = {
+    clampedVerdict: "APPROVE" as const,
+    prState: makePrState(),
+    reviewedHeadSha: HEAD_SHA,
+    lastPostCloseDriftAt: null as string | null,
+  };
+
+  it("verdict_not_approve: COMMENT verdict downgrades", () => {
+    for (const v of ["COMMENT", "CONCERNS", "REQUEST_CHANGES"] as const) {
+      const result = evaluateResolveActionPolicy({
+        ...baseInputs,
+        clampedVerdict: v,
+      });
+      expect(result.downgradeReason, `verdict=${v}`).toBe("verdict_not_approve");
+      expect(result.permittedAction).toBe("comment");
+    }
+  });
+
+  it("ci_truncated: GitHub returned >100 check-runs, fail closed", () => {
+    const result = evaluateResolveActionPolicy({
+      ...baseInputs,
+      prState: makePrState({ ciState: "truncated" }),
+    });
+    expect(result.downgradeReason).toBe("ci_truncated");
+  });
+
+  it("label_missing: no `hivemoot:automerge` label", () => {
+    const result = evaluateResolveActionPolicy({
+      ...baseInputs,
+      prState: makePrState({ labels: ["ready", "documentation"] }),
+    });
+    expect(result.downgradeReason).toBe("label_missing");
+  });
+
+  it("ci_failure: any failing check-run", () => {
+    const result = evaluateResolveActionPolicy({
+      ...baseInputs,
+      prState: makePrState({ ciState: "failure" }),
+    });
+    expect(result.downgradeReason).toBe("ci_failure");
+  });
+
+  it("ci_pending: check-runs still in-progress", () => {
+    const result = evaluateResolveActionPolicy({
+      ...baseInputs,
+      prState: makePrState({ ciState: "pending" }),
+    });
+    expect(result.downgradeReason).toBe("ci_pending");
+  });
+
+  it("head_sha_drift: current GitHub head differs from queen's reviewed_head_sha", () => {
+    const result = evaluateResolveActionPolicy({
+      ...baseInputs,
+      prState: makePrState({ headSha: "0000000000000000000000000000000000000000" }),
+    });
+    expect(result.downgradeReason).toBe("head_sha_drift");
+  });
+
+  it("post_close_drift: room has last_post_close_drift_at set", () => {
+    const result = evaluateResolveActionPolicy({
+      ...baseInputs,
+      lastPostCloseDriftAt: "2026-05-10T00:00:00Z",
+    });
+    expect(result.downgradeReason).toBe("post_close_drift");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evaluation order — first failure wins
+// ---------------------------------------------------------------------------
+
+describe("evaluateResolveActionPolicy — first failure wins", () => {
+  // The order pin lets the queen see which invariant to fix first
+  // when multiple fail. Tests below set TWO failures simultaneously
+  // and assert that the earlier-in-the-order one surfaces.
+
+  it("verdict_not_approve dominates ci_truncated", () => {
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "REQUEST_CHANGES",
+      prState: makePrState({ ciState: "truncated", labels: [] }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result.downgradeReason).toBe("verdict_not_approve");
+  });
+
+  it("ci_truncated dominates label_missing", () => {
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState({ ciState: "truncated", labels: [] }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result.downgradeReason).toBe("ci_truncated");
+  });
+
+  it("label_missing dominates ci_failure", () => {
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState({ ciState: "failure", labels: [] }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result.downgradeReason).toBe("label_missing");
+  });
+
+  it("ci_failure dominates ci_pending (the failure already happened)", () => {
+    // Can't actually have both at the same time per CiState, but
+    // pin the order between failure and pending here in case the
+    // CI normalization layer changes.
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState({ ciState: "failure" }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result.downgradeReason).toBe("ci_failure");
+  });
+
+  it("ci_pending dominates head_sha_drift", () => {
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState({
+        ciState: "pending",
+        headSha: "0000000000000000000000000000000000000000",
+      }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: null,
+    });
+    expect(result.downgradeReason).toBe("ci_pending");
+  });
+
+  it("head_sha_drift dominates post_close_drift", () => {
+    const result = evaluateResolveActionPolicy({
+      clampedVerdict: "APPROVE",
+      prState: makePrState({ headSha: "0000000000000000000000000000000000000000" }),
+      reviewedHeadSha: HEAD_SHA,
+      lastPostCloseDriftAt: "2026-05-10T00:00:00Z",
+    });
+    expect(result.downgradeReason).toBe("head_sha_drift");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pair invariant: comment <-> downgradeReason
+// ---------------------------------------------------------------------------
+
+describe("evaluateResolveActionPolicy — response shape invariant", () => {
+  it("permittedAction='squash-merge' iff downgradeReason===null", () => {
+    // Generate all (verdict × ciState × label-presence × head-match
+    // × drift) combinations and check the pair invariant. Cheap
+    // exhaustive coverage.
+    const verdicts = ["APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"] as const;
+    const ciStates = ["success", "failure", "pending", "no_checks", "truncated"] as const;
+    const labelSets = [["hivemoot:automerge"], []];
+    const driftStates = [null, "2026-05-10T00:00:00Z"];
+
+    for (const v of verdicts) {
+      for (const ci of ciStates) {
+        for (const labels of labelSets) {
+          for (const drift of driftStates) {
+            const result = evaluateResolveActionPolicy({
+              clampedVerdict: v,
+              prState: makePrState({ ciState: ci, labels }),
+              reviewedHeadSha: HEAD_SHA,
+              lastPostCloseDriftAt: drift,
+            });
+            const isMerge = result.permittedAction === "squash-merge";
+            const hasReason = result.downgradeReason !== null;
+            // squash-merge → reason MUST be null;
+            // comment → reason MUST be non-null.
+            expect(
+              isMerge === !hasReason,
+              `verdict=${v} ci=${ci} labels=${JSON.stringify(labels)} drift=${drift} permitted=${result.permittedAction} reason=${result.downgradeReason}`,
+            ).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("all DowngradeReason values are reachable from at least one input combination", () => {
+    // Catch dead-code reasons (e.g. enum value added but no branch
+    // emits it). Each reason MUST be produced by at least one input.
+    const required: DowngradeReason[] = [
+      "verdict_not_approve",
+      "label_missing",
+      "ci_truncated",
+      "ci_failure",
+      "ci_pending",
+      "head_sha_drift",
+      "post_close_drift",
+    ];
+    const observed = new Set<DowngradeReason>();
+
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "COMMENT",
+        prState: makePrState(),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: null,
+      }).downgradeReason as DowngradeReason,
+    );
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "APPROVE",
+        prState: makePrState({ ciState: "truncated" }),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: null,
+      }).downgradeReason as DowngradeReason,
+    );
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "APPROVE",
+        prState: makePrState({ labels: [] }),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: null,
+      }).downgradeReason as DowngradeReason,
+    );
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "APPROVE",
+        prState: makePrState({ ciState: "failure" }),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: null,
+      }).downgradeReason as DowngradeReason,
+    );
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "APPROVE",
+        prState: makePrState({ ciState: "pending" }),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: null,
+      }).downgradeReason as DowngradeReason,
+    );
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "APPROVE",
+        prState: makePrState({ headSha: "0".repeat(40) }),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: null,
+      }).downgradeReason as DowngradeReason,
+    );
+    observed.add(
+      evaluateResolveActionPolicy({
+        clampedVerdict: "APPROVE",
+        prState: makePrState(),
+        reviewedHeadSha: HEAD_SHA,
+        lastPostCloseDriftAt: "2026-05-10T00:00:00Z",
+      }).downgradeReason as DowngradeReason,
+    );
+
+    for (const r of required) {
+      expect(observed.has(r), `${r} unreachable`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePullRequestSubjectRef
+// ---------------------------------------------------------------------------
+
+describe("parsePullRequestSubjectRef", () => {
+  it("parses canonical `<owner>/<repo>#<number>` shape", () => {
+    const result = parsePullRequestSubjectRef("hivemoot/colony#42");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ref).toEqual({ owner: "hivemoot", repo: "colony", prNumber: 42 });
+    }
+  });
+
+  it("preserves owner/repo casing (GitHub canonical casing matters at API call time)", () => {
+    const result = parsePullRequestSubjectRef("HiveMoot/Colony#1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ref.owner).toBe("HiveMoot");
+      expect(result.ref.repo).toBe("Colony");
+    }
+  });
+
+  it("rejects missing `#` separator", () => {
+    const result = parsePullRequestSubjectRef("hivemoot/colony");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-numeric PR number", () => {
+    const result = parsePullRequestSubjectRef("hivemoot/colony#abc");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects PR number = 0 (positive integer required)", () => {
+    const result = parsePullRequestSubjectRef("hivemoot/colony#0");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects empty owner or repo", () => {
+    expect(parsePullRequestSubjectRef("/colony#1").ok).toBe(false);
+    expect(parsePullRequestSubjectRef("hivemoot/#1").ok).toBe(false);
+  });
+
+  it("rejects extra path segments (`<owner>/<repo>/<extra>#<n>`)", () => {
+    const result = parsePullRequestSubjectRef("hivemoot/colony/src#1");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects `#` inside repo name", () => {
+    // Defensive: GitHub repo names can't contain `#`, but the
+    // regex should reject this explicitly.
+    const result = parsePullRequestSubjectRef("hivemoot/colo#ny#1");
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts repo names with hyphens, underscores, dots", () => {
+    expect(parsePullRequestSubjectRef("hivemoot/my-repo#1").ok).toBe(true);
+    expect(parsePullRequestSubjectRef("hivemoot/my_repo#1").ok).toBe(true);
+    expect(parsePullRequestSubjectRef("hivemoot/repo.name#1").ok).toBe(true);
+  });
+
+  it("accepts large PR numbers (e.g. 99999)", () => {
+    const result = parsePullRequestSubjectRef("hivemoot/colony#99999");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.ref.prNumber).toBe(99999);
+  });
+});

--- a/web/src/server/resolve-action-policy.ts
+++ b/web/src/server/resolve-action-policy.ts
@@ -1,0 +1,187 @@
+/**
+ * Pure D1-invariant evaluator + subject_ref parser for the local-queen
+ * `resolve-action` endpoint (RFC PR 3c slice 2c).
+ *
+ * Per RFC D1, the resolve-action endpoint computes a `permittedAction`
+ * given the queen's submitted verdict + the PR's current GitHub state.
+ * The invariants (all must hold for `squash-merge`):
+ *
+ *   1. Clamped verdict (post-`applyDowngradeOnlyFloor`) == APPROVE
+ *   2. `hivemoot:automerge` label present
+ *   3. CI green (Check Runs + legacy Status both passing)
+ *   4. Head SHA stable (reviewed_head_sha matches current GitHub head)
+ *   5. No prior post-close drift recorded on the room
+ *      (`last_post_close_drift_at` unset — set by a different flow
+ *      after a confirmed merge sees post-close events arrive,
+ *      indicating the room shouldn't be re-merged)
+ *
+ * Failing ANY invariant returns `permittedAction: "comment"` with a
+ * typed `downgradeReason`. The endpoint emits a G2
+ * `queen.action_downgrade` audit event using this reason (whenever
+ * the queen's recommendation differs from the permitted action).
+ *
+ * This module is pure: no Redis, no GitHub, no audit. It takes the
+ * inputs the endpoint has already loaded and returns the decision.
+ * The endpoint (slice 2c) is responsible for:
+ *   - Loading the room core (for `last_post_close_drift_at`)
+ *   - Loading contributions + computing the clamped verdict via
+ *     `applyDowngradeOnlyFloor`
+ *   - Calling `getPullRequestState` (slice 2a)
+ *   - Emitting audit events
+ *   - Returning the response envelope
+ *
+ * Splitting the policy out makes the invariant logic testable in
+ * isolation and visibly co-located with the RFC spec.
+ */
+
+import type { WorkerVerdict } from "@hivemoot/war-room";
+import type { PullRequestState } from "./github-pr-state";
+
+/**
+ * Why `permittedAction` was forced to `"comment"` instead of the
+ * queen's recommended `"squash-merge"`. One reason per failed
+ * invariant, evaluated in the order below — the FIRST failure wins
+ * (so e.g. `verdict_not_approve` shadows downstream checks rather
+ * than the queen guessing which to fix first).
+ *
+ * Audit events emit this reason verbatim as the `downgrade_reason`
+ * field of `queen.action_downgrade`.
+ */
+export type DowngradeReason =
+  /** Clamped verdict (post-floor) was not APPROVE. */
+  | "verdict_not_approve"
+  /** `hivemoot:automerge` label not present on the PR. */
+  | "label_missing"
+  /** GitHub returned `total_count > 100` check-runs — unseen checks
+   * could be failing, so fail closed. */
+  | "ci_truncated"
+  /** Any check-run conclusion is failing OR legacy combined-status
+   * is `failure`. */
+  | "ci_failure"
+  /** Check-runs queued/in-progress OR legacy combined-status is
+   * `pending` (no failures yet, but not green either). */
+  | "ci_pending"
+  /** Current GitHub head SHA differs from the queen's submitted
+   * `reviewed_head_sha` (PR was pushed during synthesis). */
+  | "head_sha_drift"
+  /** Room has `last_post_close_drift_at` set — a prior merge attempt
+   * saw post-close events, marking it ineligible for re-merge. */
+  | "post_close_drift";
+
+export interface PolicyDecision {
+  permittedAction: "comment" | "squash-merge";
+  /**
+   * Set when `permittedAction === "comment"` and at least one D1
+   * invariant failed. `null` when `permittedAction === "squash-merge"`
+   * (all invariants passed). The pair is mutually constrained — a
+   * "comment" with no downgrade reason would be a logic bug.
+   */
+  downgradeReason: DowngradeReason | null;
+}
+
+/**
+ * Evaluate the D1 invariants. Pure function: no I/O, no side effects.
+ *
+ * Evaluation order is significant — the first failed invariant wins
+ * (see `DowngradeReason` doc). Order:
+ *   1. verdict_not_approve
+ *   2. ci_truncated (defense before label — truncated means we can't
+ *      verify any CI signal, so we want to surface this distinctly
+ *      from a label-only failure)
+ *   3. label_missing
+ *   4. ci_failure
+ *   5. ci_pending
+ *   6. head_sha_drift
+ *   7. post_close_drift
+ *
+ * All-pass returns `{ permittedAction: "squash-merge", downgradeReason: null }`.
+ */
+export function evaluateResolveActionPolicy(args: {
+  clampedVerdict: WorkerVerdict;
+  prState: PullRequestState;
+  /** From the queen's request body. Compared to `prState.headSha`. */
+  reviewedHeadSha: string;
+  /** From the room core. ISO 8601 or null. */
+  lastPostCloseDriftAt: string | null;
+}): PolicyDecision {
+  if (args.clampedVerdict !== "APPROVE") {
+    return {
+      permittedAction: "comment",
+      downgradeReason: "verdict_not_approve",
+    };
+  }
+  if (args.prState.ciState === "truncated") {
+    return { permittedAction: "comment", downgradeReason: "ci_truncated" };
+  }
+  if (!args.prState.labels.includes("hivemoot:automerge")) {
+    return { permittedAction: "comment", downgradeReason: "label_missing" };
+  }
+  if (args.prState.ciState === "failure") {
+    return { permittedAction: "comment", downgradeReason: "ci_failure" };
+  }
+  if (args.prState.ciState === "pending") {
+    return { permittedAction: "comment", downgradeReason: "ci_pending" };
+  }
+  if (args.prState.headSha !== args.reviewedHeadSha) {
+    return { permittedAction: "comment", downgradeReason: "head_sha_drift" };
+  }
+  if (args.lastPostCloseDriftAt !== null) {
+    return { permittedAction: "comment", downgradeReason: "post_close_drift" };
+  }
+  return { permittedAction: "squash-merge", downgradeReason: null };
+}
+
+// ---------------------------------------------------------------------------
+// subject_ref parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Room `subject_ref` shape for `subject_type: "pr_review"` is
+ * `<owner>/<repo>#<number>` per the war-room storage convention.
+ * The resolve-action endpoint needs to split this into the three
+ * parts to pass to `getPullRequestState`.
+ *
+ * Strict parser — returns `{ ok: false }` on:
+ *   - missing `#` separator
+ *   - non-numeric PR number
+ *   - empty owner or repo
+ *   - extra path segments (we expect exactly one `/`)
+ *
+ * Owner + repo names are NOT case-normalized — GitHub is
+ * case-insensitive on owner/repo but the canonical casing on the
+ * API call should match what the webhook delivered (preserved on
+ * the room core).
+ */
+export interface ParsedPullRequestSubjectRef {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}
+
+const PR_SUBJECT_REF_REGEX = /^([^/]+)\/([^/#]+)#(\d+)$/;
+
+export function parsePullRequestSubjectRef(
+  subjectRef: string,
+):
+  | { ok: true; ref: ParsedPullRequestSubjectRef }
+  | { ok: false; reason: string } {
+  const match = subjectRef.match(PR_SUBJECT_REF_REGEX);
+  if (!match) {
+    return {
+      ok: false,
+      reason: `subject_ref ${JSON.stringify(subjectRef)} does not match the canonical pr_review shape \`<owner>/<repo>#<number>\``,
+    };
+  }
+  const [, owner, repo, prNumberStr] = match;
+  if (owner.length === 0 || repo.length === 0) {
+    return { ok: false, reason: "owner and repo must both be non-empty" };
+  }
+  const prNumber = Number.parseInt(prNumberStr, 10);
+  if (!Number.isFinite(prNumber) || prNumber <= 0) {
+    return {
+      ok: false,
+      reason: `PR number ${JSON.stringify(prNumberStr)} is not a positive integer`,
+    };
+  }
+  return { ok: true, ref: { owner, repo, prNumber } };
+}


### PR DESCRIPTION
## Summary

Pure-logic foundation for the upcoming `POST /api/rooms/:roomId/resolve-action` endpoint (slice 2c). Splits the D1 invariant evaluation out of the endpoint so the policy decision is testable in isolation without any I/O.

This PR was originally #655 and got auto-closed when its base branch (#654's slice 2a) was deleted on merge. Branch + commits are unchanged; this PR retargets to `main` after #654 landed.

## Public surface

```ts
export function evaluateResolveActionPolicy({
  clampedVerdict: WorkerVerdict,
  prState: PullRequestState,
  reviewedHeadSha: string,
  lastPostCloseDriftAt: string | null,
}): {
  permittedAction: "comment" | "squash-merge",
  downgradeReason: DowngradeReason | null,
}

export function parsePullRequestSubjectRef(subjectRef: string):
  | { ok: true; ref: { owner, repo, prNumber } }
  | { ok: false; reason: string }
```

## D1 invariant evaluation order (pinned)

The first failed invariant wins — the queen sees what to fix first:

| Order | Invariant | DowngradeReason |
|---|---|---|
| 1 | clamped verdict === APPROVE | `verdict_not_approve` |
| 2 | CI not truncated (>100 check-runs) | `ci_truncated` |
| 3 | `hivemoot:automerge` label present | `label_missing` |
| 4 | CI no failures | `ci_failure` |
| 5 | CI not pending | `ci_pending` |
| 6 | head SHA stable (no drift) | `head_sha_drift` |
| 7 | no prior post-close drift | `post_close_drift` |

All-pass → `{ permittedAction: "squash-merge", downgradeReason: null }`.

## Test plan

- [x] 2 happy-path tests (success + no_checks both valid)
- [x] 7 downgrade-reason coverage (one per DowngradeReason)
- [x] 6 evaluation-order pin tests
- [x] 2 response-shape invariants — `squash-merge ⟺ downgradeReason === null` via cross-product enumeration; every DowngradeReason value reachable from some input
- [x] 10 subject_ref parser tests covering canonical shape + edge cases
- 27 tests total, web suite 1663 passing

## What this slice does NOT do

No endpoint surface yet — slice 2c wires this into `POST /api/rooms/:roomId/resolve-action` with claim verification, contribution-read for `applyDowngradeOnlyFloor`, installation token minting (calls the merged #654 `getPullRequestState`), and audit emission (G1 + G2 events).