### PR TITLE
feat(audit): queen.verdict_floor_override + queen.action_downgrade events (3c slice 2c-a)

### DIFF
--- a/web/src/server/agent-token-v1-audit.ts
+++ b/web/src/server/agent-token-v1-audit.ts
@@ -218,7 +218,18 @@ export function buildAuditEntryJson(entry: AuditEntry): string {
   return JSON.stringify(entry);
 }
 
-function isMutationAction(action: string): action is AuditMutationAction {
+/**
+ * Classifier used by `auditAppend` to route entries to the
+ * `:audit` (mutations) or `:auth` stream.
+ *
+ * Exported (slice 2c-a builder pass-1): the queen-audit module
+ * extended `AuditMutationAction` with `queen.*` events, and the
+ * stream routing depends on this classifier accepting them at
+ * runtime. The TypeScript narrowing on the enum alone doesn't
+ * pin the JS branch; consumers (queen-audit.test.ts) call this
+ * directly to assert the new actions are mutation-class.
+ */
+export function isMutationAction(action: string): action is AuditMutationAction {
   return (
     action === "issue" ||
     action === "revoke" ||

--- a/web/src/server/agent-token-v1-audit.ts
+++ b/web/src/server/agent-token-v1-audit.ts
@@ -80,13 +80,25 @@ export function authStreamKey(installationId: string): string {
 // Entry shapes
 // ---------------------------------------------------------------------------
 
-/** Event classes that emit to the `:audit` (mutations) stream. */
+/**
+ * Event classes that emit to the `:audit` (mutations) stream.
+ *
+ * The `queen.*` prefix is for queen-runtime events emitted by
+ * `resolve-action`, `seal-decision`, `confirm-merge`, etc. — see
+ * `queen-audit.ts` for the typed wrappers + payload schemas. They
+ * reuse the agent-token mutations stream rather than introducing
+ * a new one (same retention math, single grep target for
+ * operators forensic-correlating queen events with token
+ * mutations).
+ */
 export type AuditMutationAction =
   | "issue"
   | "revoke"
   | "set_capabilities"
   | "rotate"
-  | "bootstrap";
+  | "bootstrap"
+  | "queen.verdict_floor_override"
+  | "queen.action_downgrade";
 
 /** Event classes that emit to the `:auth` (auth events) stream. */
 export type AuditAuthAction = "auth.success" | "auth.failure";
@@ -212,6 +224,8 @@ function isMutationAction(action: string): action is AuditMutationAction {
     action === "revoke" ||
     action === "set_capabilities" ||
     action === "rotate" ||
-    action === "bootstrap"
+    action === "bootstrap" ||
+    action === "queen.verdict_floor_override" ||
+    action === "queen.action_downgrade"
   );
 }

--- a/web/src/server/queen-audit.test.ts
+++ b/web/src/server/queen-audit.test.ts
@@ -103,11 +103,16 @@ describe("emitQueenVerdictFloorOverride", () => {
     expect(Number.isFinite(Date.parse(ts))).toBe(true);
   });
 
-  it("does not throw when auditAppend itself rejects (fire-and-forget by design)", async () => {
-    // The underlying auditAppend swallows errors; the wrapper
-    // should also be safe to await without try/catch in the
-    // route handler.
+  it("does not throw when auditAppend rejects (pass-1 fix — wrapper exports stronger 'never throws' contract for resolve-action call sites)", async () => {
+    // Builder pass-1: the module header + emitter docstrings
+    // promise fire-and-forget semantics. The underlying auditAppend
+    // catches internally, but the wrapper now also catches
+    // explicitly so a future change to auditAppend can't surprise
+    // resolve-action call sites — they MUST be able to safely
+    // await these emitters without duplicating audit failure
+    // handling at every call site.
     mockedAuditAppend.mockRejectedValueOnce(new Error("redis down"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     await expect(
       emitQueenVerdictFloorOverride({
         ...CALLER,
@@ -119,14 +124,31 @@ describe("emitQueenVerdictFloorOverride", () => {
           clamped_verdict: "COMMENT",
         },
       }),
-    ).rejects.toThrow();
-    // NOTE: the wrapper currently re-throws because we await
-    // auditAppend directly. The CALL SITE in the route handler
-    // is responsible for not propagating audit failures (since
-    // the room state hasn't mutated — emit failure shouldn't
-    // wedge resolve-action). This test pins the current behavior
-    // so a future change "auditAppend never throws" is observed
-    // here too.
+    ).resolves.toBeUndefined();
+    // Failure logged via console.warn for ops visibility.
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("emitQueenActionDowngrade also swallows underlying audit failures (same contract)", async () => {
+    mockedAuditAppend.mockRejectedValueOnce(new Error("redis down"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      emitQueenActionDowngrade({
+        ...CALLER,
+        detail: {
+          room_id: "rm-down",
+          subject_ref: "hivemoot/colony#1",
+          recommended_action: "squash-merge",
+          permitted_action: "comment",
+          downgrade_reason: "ci_failure",
+          clamped_verdict: "APPROVE",
+          reviewed_head_sha: "deadbeef",
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });
 
@@ -213,34 +235,42 @@ describe("emitQueenActionDowngrade", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Stream routing — queen events go to the :audit (mutations) stream
+// Runtime stream routing — queen events go to the :audit (mutations) stream
 // ---------------------------------------------------------------------------
+//
+// Builder pass-1 follow-up: the prior version was a type-only pin
+// (TypeScript narrowing on the AuditMutationAction union). The
+// stream-routing decision happens at RUNTIME via the
+// `isMutationAction` classifier inside agent-token-v1-audit.ts.
+// We export the classifier and test it directly here — confirms
+// the new queen actions are wired into the runtime branch, not
+// just the type-level union.
 
-describe("queen audit stream routing", () => {
-  it("queen.verdict_floor_override emits an entry that the agent-token audit emitter classifies as a mutation", async () => {
-    // The agent-token emitter inspects the action via
-    // isMutationAction to choose `:audit` vs `:auth` stream.
-    // Pin that the queen action enum extension is wired into
-    // that classifier.
-    const real = await vi.importActual<typeof import("./agent-token-v1-audit")>(
-      "./agent-token-v1-audit",
-    );
-    expect(real.auditStreamKey).toBeDefined();
-    expect(real.authStreamKey).toBeDefined();
-    // The classifier is intentionally not exported (it's a
-    // private helper inside the module); the public surface
-    // pinned here is the AuditMutationAction enum, which queen
-    // events ARE part of post-slice 2c-a.
-    type _Check = "queen.verdict_floor_override" extends import("./agent-token-v1-audit").AuditMutationAction
-      ? true
-      : false;
-    const isMutationActionType: _Check = true;
-    expect(isMutationActionType).toBe(true);
+import { isMutationAction } from "./agent-token-v1-audit";
 
-    type _Check2 = "queen.action_downgrade" extends import("./agent-token-v1-audit").AuditMutationAction
-      ? true
-      : false;
-    const isMutationActionType2: _Check2 = true;
-    expect(isMutationActionType2).toBe(true);
+describe("isMutationAction runtime classifier (builder pass-1 follow-up)", () => {
+  it("accepts queen.verdict_floor_override → routes to :audit (mutations) stream", () => {
+    expect(isMutationAction("queen.verdict_floor_override")).toBe(true);
+  });
+
+  it("accepts queen.action_downgrade → routes to :audit (mutations) stream", () => {
+    expect(isMutationAction("queen.action_downgrade")).toBe(true);
+  });
+
+  it("still accepts existing mutation actions (no regression)", () => {
+    for (const a of ["issue", "revoke", "set_capabilities", "rotate", "bootstrap"]) {
+      expect(isMutationAction(a), a).toBe(true);
+    }
+  });
+
+  it("rejects auth actions (still routed to :auth stream)", () => {
+    expect(isMutationAction("auth.success")).toBe(false);
+    expect(isMutationAction("auth.failure")).toBe(false);
+  });
+
+  it("rejects unknown actions (defensive — future enum additions need explicit wiring)", () => {
+    expect(isMutationAction("queen.unknown_event")).toBe(false);
+    expect(isMutationAction("rogue")).toBe(false);
+    expect(isMutationAction("")).toBe(false);
   });
 });

--- a/web/src/server/queen-audit.test.ts
+++ b/web/src/server/queen-audit.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock auditAppend before the queen-audit module imports it.
+vi.mock("./agent-token-v1-audit", async () => {
+  const real = await vi.importActual<typeof import("./agent-token-v1-audit")>(
+    "./agent-token-v1-audit",
+  );
+  return { ...real, auditAppend: vi.fn(async () => undefined) };
+});
+
+import { auditAppend } from "./agent-token-v1-audit";
+import {
+  emitQueenVerdictFloorOverride,
+  emitQueenActionDowngrade,
+} from "./queen-audit";
+
+const mockedAuditAppend = vi.mocked(auditAppend);
+
+beforeEach(() => {
+  mockedAuditAppend.mockReset();
+  mockedAuditAppend.mockResolvedValue(undefined);
+});
+
+const CALLER = {
+  installationId: "12345",
+  redis: {} as never,
+  name: "queen-hive-1",
+  fingerprint: "abcd1234",
+};
+
+// ---------------------------------------------------------------------------
+// emitQueenVerdictFloorOverride
+// ---------------------------------------------------------------------------
+
+describe("emitQueenVerdictFloorOverride", () => {
+  it("delegates to auditAppend with the queen.verdict_floor_override action", async () => {
+    await emitQueenVerdictFloorOverride({
+      ...CALLER,
+      detail: {
+        room_id: "rm-abc",
+        subject_ref: "hivemoot/colony#42",
+        submitted_verdict: "APPROVE",
+        floor_verdict: "CONCERNS",
+        clamped_verdict: "CONCERNS",
+      },
+    });
+
+    expect(mockedAuditAppend).toHaveBeenCalledTimes(1);
+    const call = mockedAuditAppend.mock.calls[0][0];
+    expect(call.installationId).toBe("12345");
+    expect(call.entry.action).toBe("queen.verdict_floor_override");
+  });
+
+  it("carries fingerprint + name from caller context onto the entry (correlation)", async () => {
+    await emitQueenVerdictFloorOverride({
+      ...CALLER,
+      detail: {
+        room_id: "rm-abc",
+        subject_ref: "hivemoot/colony#42",
+        submitted_verdict: "APPROVE",
+        floor_verdict: "COMMENT",
+        clamped_verdict: "COMMENT",
+      },
+    });
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    expect(entry.fingerprint).toBe("abcd1234");
+    expect(entry.name).toBe("queen-hive-1");
+    // Mutation entries also have an `actor` field — for queen
+    // events that's the bearer's name (the queen runner identity).
+    if (entry.action === "queen.verdict_floor_override") {
+      expect(entry.actor).toBe("queen-hive-1");
+    }
+  });
+
+  it("puts detail payload on entry.detail verbatim (room_id, subject_ref, verdicts)", async () => {
+    const detail = {
+      room_id: "rm-abc-123",
+      subject_ref: "hivemoot/colony#7",
+      submitted_verdict: "APPROVE" as const,
+      floor_verdict: "REQUEST_CHANGES" as const,
+      clamped_verdict: "REQUEST_CHANGES" as const,
+    };
+    await emitQueenVerdictFloorOverride({ ...CALLER, detail });
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    if (entry.action === "queen.verdict_floor_override") {
+      expect(entry.detail).toEqual(detail);
+    }
+  });
+
+  it("sets ts to a parseable ISO 8601 string", async () => {
+    await emitQueenVerdictFloorOverride({
+      ...CALLER,
+      detail: {
+        room_id: "rm-abc",
+        subject_ref: "hivemoot/colony#42",
+        submitted_verdict: "APPROVE",
+        floor_verdict: "COMMENT",
+        clamped_verdict: "COMMENT",
+      },
+    });
+    const ts = mockedAuditAppend.mock.calls[0][0].entry.ts;
+    expect(typeof ts).toBe("string");
+    expect(Number.isFinite(Date.parse(ts))).toBe(true);
+  });
+
+  it("does not throw when auditAppend itself rejects (fire-and-forget by design)", async () => {
+    // The underlying auditAppend swallows errors; the wrapper
+    // should also be safe to await without try/catch in the
+    // route handler.
+    mockedAuditAppend.mockRejectedValueOnce(new Error("redis down"));
+    await expect(
+      emitQueenVerdictFloorOverride({
+        ...CALLER,
+        detail: {
+          room_id: "rm-abc",
+          subject_ref: "hivemoot/colony#42",
+          submitted_verdict: "APPROVE",
+          floor_verdict: "COMMENT",
+          clamped_verdict: "COMMENT",
+        },
+      }),
+    ).rejects.toThrow();
+    // NOTE: the wrapper currently re-throws because we await
+    // auditAppend directly. The CALL SITE in the route handler
+    // is responsible for not propagating audit failures (since
+    // the room state hasn't mutated — emit failure shouldn't
+    // wedge resolve-action). This test pins the current behavior
+    // so a future change "auditAppend never throws" is observed
+    // here too.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emitQueenActionDowngrade
+// ---------------------------------------------------------------------------
+
+describe("emitQueenActionDowngrade", () => {
+  it("delegates to auditAppend with the queen.action_downgrade action", async () => {
+    await emitQueenActionDowngrade({
+      ...CALLER,
+      detail: {
+        room_id: "rm-xyz",
+        subject_ref: "hivemoot/colony#99",
+        recommended_action: "squash-merge",
+        permitted_action: "comment",
+        downgrade_reason: "label_missing",
+        clamped_verdict: "APPROVE",
+        reviewed_head_sha: "deadbeef",
+      },
+    });
+    const call = mockedAuditAppend.mock.calls[0][0];
+    expect(call.entry.action).toBe("queen.action_downgrade");
+  });
+
+  it("carries downgrade_reason verbatim — operators grep by reason class", async () => {
+    // The downgrade_reason is the actionable field for operators
+    // ('we keep seeing ci_pending — is CI slow today?'). Pin the
+    // verbatim shape so a future enum rename doesn't break grep
+    // queries silently.
+    for (const reason of [
+      "verdict_not_approve",
+      "label_missing",
+      "ci_truncated",
+      "ci_failure",
+      "ci_pending",
+      "head_sha_drift",
+      "post_close_drift",
+    ] as const) {
+      mockedAuditAppend.mockClear();
+      await emitQueenActionDowngrade({
+        ...CALLER,
+        detail: {
+          room_id: "rm-x",
+          subject_ref: "hivemoot/colony#1",
+          recommended_action: "squash-merge",
+          permitted_action: "comment",
+          downgrade_reason: reason,
+          clamped_verdict: "APPROVE",
+          reviewed_head_sha: "deadbeef",
+        },
+      });
+      const entry = mockedAuditAppend.mock.calls[0][0].entry;
+      if (entry.action === "queen.action_downgrade") {
+        expect((entry.detail as { downgrade_reason: string }).downgrade_reason).toBe(reason);
+      }
+    }
+  });
+
+  it("carries reviewed_head_sha for head_sha_drift diagnostics", async () => {
+    // When downgrade_reason='head_sha_drift', an operator looking
+    // at the audit row needs both the SHA the queen synthesized
+    // against (reviewed_head_sha) and the time (entry.ts) so they
+    // can correlate with the PR's push history.
+    await emitQueenActionDowngrade({
+      ...CALLER,
+      detail: {
+        room_id: "rm-drift",
+        subject_ref: "hivemoot/colony#5",
+        recommended_action: "squash-merge",
+        permitted_action: "comment",
+        downgrade_reason: "head_sha_drift",
+        clamped_verdict: "APPROVE",
+        reviewed_head_sha: "feedfacefeedface",
+      },
+    });
+    const entry = mockedAuditAppend.mock.calls[0][0].entry;
+    if (entry.action === "queen.action_downgrade") {
+      expect((entry.detail as { reviewed_head_sha: string }).reviewed_head_sha).toBe(
+        "feedfacefeedface",
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream routing — queen events go to the :audit (mutations) stream
+// ---------------------------------------------------------------------------
+
+describe("queen audit stream routing", () => {
+  it("queen.verdict_floor_override emits an entry that the agent-token audit emitter classifies as a mutation", async () => {
+    // The agent-token emitter inspects the action via
+    // isMutationAction to choose `:audit` vs `:auth` stream.
+    // Pin that the queen action enum extension is wired into
+    // that classifier.
+    const real = await vi.importActual<typeof import("./agent-token-v1-audit")>(
+      "./agent-token-v1-audit",
+    );
+    expect(real.auditStreamKey).toBeDefined();
+    expect(real.authStreamKey).toBeDefined();
+    // The classifier is intentionally not exported (it's a
+    // private helper inside the module); the public surface
+    // pinned here is the AuditMutationAction enum, which queen
+    // events ARE part of post-slice 2c-a.
+    type _Check = "queen.verdict_floor_override" extends import("./agent-token-v1-audit").AuditMutationAction
+      ? true
+      : false;
+    const isMutationActionType: _Check = true;
+    expect(isMutationActionType).toBe(true);
+
+    type _Check2 = "queen.action_downgrade" extends import("./agent-token-v1-audit").AuditMutationAction
+      ? true
+      : false;
+    const isMutationActionType2: _Check2 = true;
+    expect(isMutationActionType2).toBe(true);
+  });
+});

--- a/web/src/server/queen-audit.ts
+++ b/web/src/server/queen-audit.ts
@@ -145,18 +145,30 @@ export async function emitQueenVerdictFloorOverride(
     detail: QueenVerdictFloorOverrideDetail;
   },
 ): Promise<void> {
-  await auditAppend({
-    redis: args.redis,
-    installationId: args.installationId,
-    entry: {
-      ts: new Date().toISOString(),
-      fingerprint: args.fingerprint,
-      name: args.name,
-      action: "queen.verdict_floor_override",
-      actor: args.name,
-      detail: args.detail as unknown as Record<string, unknown>,
-    },
-  });
+  try {
+    await auditAppend({
+      redis: args.redis,
+      installationId: args.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: args.fingerprint,
+        name: args.name,
+        action: "queen.verdict_floor_override",
+        actor: args.name,
+        detail: args.detail as unknown as Record<string, unknown>,
+      },
+    });
+  } catch (err) {
+    // Defense-in-depth: the underlying auditAppend already
+    // catches internally, but the queen-audit module exports the
+    // stronger "never throws" contract that the resolve-action
+    // endpoint (slice 2c-b) will rely on. Wrap explicitly so a
+    // future change to auditAppend can't surprise callers.
+    console.warn(
+      `[queen-audit] emitQueenVerdictFloorOverride failed for installation=${args.installationId} room=${args.detail.room_id}`,
+      err,
+    );
+  }
 }
 
 /**
@@ -170,16 +182,23 @@ export async function emitQueenActionDowngrade(
     detail: QueenActionDowngradeDetail;
   },
 ): Promise<void> {
-  await auditAppend({
-    redis: args.redis,
-    installationId: args.installationId,
-    entry: {
-      ts: new Date().toISOString(),
-      fingerprint: args.fingerprint,
-      name: args.name,
-      action: "queen.action_downgrade",
-      actor: args.name,
-      detail: args.detail as unknown as Record<string, unknown>,
-    },
-  });
+  try {
+    await auditAppend({
+      redis: args.redis,
+      installationId: args.installationId,
+      entry: {
+        ts: new Date().toISOString(),
+        fingerprint: args.fingerprint,
+        name: args.name,
+        action: "queen.action_downgrade",
+        actor: args.name,
+        detail: args.detail as unknown as Record<string, unknown>,
+      },
+    });
+  } catch (err) {
+    console.warn(
+      `[queen-audit] emitQueenActionDowngrade failed for installation=${args.installationId} room=${args.detail.room_id}`,
+      err,
+    );
+  }
 }

--- a/web/src/server/queen-audit.ts
+++ b/web/src/server/queen-audit.ts
@@ -1,0 +1,185 @@
+/**
+ * Queen-audit emit primitives for the local-queen runtime
+ * (RFC PR 3c slice 2c-a foundation).
+ *
+ * Per the RFC, the queen's `resolve-action` endpoint emits two
+ * audit event classes when the queen's submitted verdict / action
+ * is overridden by server-side policy:
+ *
+ *   - G1 `queen.verdict_floor_override` — emitted when
+ *     `applyDowngradeOnlyFloor` clamps the queen's submitted
+ *     verdict (any worker contribution carries a structured
+ *     `body.verdict` that's more conservative than the queen's
+ *     LLM-derived verdict). This is the structural defense against
+ *     prompt-injection-shaped queen verdicts.
+ *
+ *   - G2 `queen.action_downgrade` — emitted when the D1 invariant
+ *     check forces `permittedAction: "comment"` despite the queen's
+ *     `recommendedAction: "squash-merge"`. The `downgrade_reason`
+ *     field is the first failed D1 invariant (see
+ *     `resolve-action-policy.ts` for the order).
+ *
+ * # Stream choice
+ *
+ * Reuses the existing per-installation `:audit` stream
+ * (`hive:v1:agent-token:{installationId}:audit`) rather than
+ * introducing a new stream. Rationale:
+ *
+ *   - Storage rent is amortized across the agent-token audit
+ *     events already there. Same retention math (MAXLEN ~10000),
+ *     same per-installation isolation.
+ *   - Operators forensic-grep the audit stream by installation +
+ *     date range; having queen events in the same stream means a
+ *     single jq pipeline covers both token mutations and queen
+ *     actions.
+ *   - The action enum's `queen.*` prefix keeps the two event
+ *     classes filterable without a stream split.
+ *
+ * The agent-token audit emitter (`auditAppend` in
+ * `agent-token-v1-audit.ts`) is the underlying primitive — this
+ * module is a thin typed wrapper that constructs the
+ * `AuditMutationEntry` payload with the queen-specific `detail`
+ * shape, then delegates to `auditAppend`.
+ *
+ * # Best-effort emission
+ *
+ * Inherits the underlying `auditAppend` semantics: emission
+ * failures are logged but do not throw. A Redis hiccup at audit
+ * emission time MUST NOT fail the operator's resolve-action call —
+ * the room state hasn't mutated (resolve-action is advisory) so
+ * the worst case is a missing audit row, not a wedged room.
+ */
+
+import { type Redis } from "@upstash/redis";
+import { auditAppend } from "./agent-token-v1-audit";
+import type { WorkerVerdict } from "@hivemoot/war-room";
+import type { DowngradeReason } from "./resolve-action-policy";
+
+// ---------------------------------------------------------------------------
+// Detail payload shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * `detail` payload for `queen.verdict_floor_override` (G1).
+ *
+ * The queen submitted `submittedVerdict` from its LLM derivation.
+ * The structural floor (`aggregateWorkerVerdicts` over structured
+ * worker contributions) computed `floorVerdict`. `applyDowngradeOnlyFloor`
+ * returned `clampedVerdict` = `mostConservative(submittedVerdict, floorVerdict)`.
+ * This event fires whenever `submittedVerdict !== clampedVerdict`.
+ *
+ * Operators audit this stream to detect:
+ *   - Queen submitting non-conservative verdicts despite worker
+ *     contributions saying otherwise (signal: worker is more
+ *     careful than the queen on this room).
+ *   - Prompt-injection shaped queen output that the floor caught.
+ */
+export interface QueenVerdictFloorOverrideDetail {
+  room_id: string;
+  /** Room's `subject_ref` for human-readable correlation. */
+  subject_ref: string;
+  /** What the queen submitted (LLM output). */
+  submitted_verdict: WorkerVerdict;
+  /** What the structural floor computed (from worker contributions). */
+  floor_verdict: WorkerVerdict;
+  /** What the endpoint will USE (most conservative of the two). */
+  clamped_verdict: WorkerVerdict;
+}
+
+/**
+ * `detail` payload for `queen.action_downgrade` (G2).
+ *
+ * The queen submitted `recommendedAction` (typically `"squash-merge"`).
+ * The D1 invariant check found one failed invariant and forced
+ * `permittedAction: "comment"`. `downgrade_reason` is the FIRST
+ * failed invariant in the policy evaluation order (see
+ * `resolve-action-policy.ts:evaluateResolveActionPolicy` for the
+ * order pin).
+ */
+export interface QueenActionDowngradeDetail {
+  room_id: string;
+  subject_ref: string;
+  /** What the queen wanted to do. */
+  recommended_action: "comment" | "squash-merge";
+  /** What the endpoint permitted (always `"comment"` when this
+   * event fires — squash-merge events aren't downgrades). */
+  permitted_action: "comment";
+  /** First failed D1 invariant. */
+  downgrade_reason: DowngradeReason;
+  /** Clamped verdict at time of decision (for cross-correlation
+   * with `queen.verdict_floor_override` events on the same room). */
+  clamped_verdict: WorkerVerdict;
+  /** Queen-submitted `reviewed_head_sha` (the SHA the queen
+   * synthesized against). Useful for diagnostics when downgrade
+   * is `head_sha_drift`. */
+  reviewed_head_sha: string;
+}
+
+// ---------------------------------------------------------------------------
+// Emitters
+// ---------------------------------------------------------------------------
+
+/**
+ * Common bearer-identity arguments. Carried on the audit entry's
+ * `BaseAuditEntry` fields. Match what the agent-token audit
+ * emitter writes for caller correlation.
+ */
+export interface QueenAuditCallerContext {
+  installationId: string;
+  redis: Redis;
+  /** Bearer's name (e.g. `"queen"` for the local-queen runner). */
+  name: string;
+  /** First 8 hex chars of SHA-256(bearer). */
+  fingerprint: string;
+}
+
+/**
+ * Emit G1 `queen.verdict_floor_override` audit event.
+ *
+ * Fire-and-forget — never throws. Always pair with the route's
+ * response: emit BEFORE returning the policy decision so a Redis
+ * hiccup doesn't lose the audit context.
+ */
+export async function emitQueenVerdictFloorOverride(
+  args: QueenAuditCallerContext & {
+    detail: QueenVerdictFloorOverrideDetail;
+  },
+): Promise<void> {
+  await auditAppend({
+    redis: args.redis,
+    installationId: args.installationId,
+    entry: {
+      ts: new Date().toISOString(),
+      fingerprint: args.fingerprint,
+      name: args.name,
+      action: "queen.verdict_floor_override",
+      actor: args.name,
+      detail: args.detail as unknown as Record<string, unknown>,
+    },
+  });
+}
+
+/**
+ * Emit G2 `queen.action_downgrade` audit event.
+ *
+ * Same semantics as the G1 emitter — fire-and-forget, always pair
+ * with the response, never throws.
+ */
+export async function emitQueenActionDowngrade(
+  args: QueenAuditCallerContext & {
+    detail: QueenActionDowngradeDetail;
+  },
+): Promise<void> {
+  await auditAppend({
+    redis: args.redis,
+    installationId: args.installationId,
+    entry: {
+      ts: new Date().toISOString(),
+      fingerprint: args.fingerprint,
+      name: args.name,
+      action: "queen.action_downgrade",
+      actor: args.name,
+      detail: args.detail as unknown as Record<string, unknown>,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Audit emit primitives for the upcoming `resolve-action` endpoint (slice 2c-b). Two new audit event classes for queen-runtime events.

Originally #657 — auto-closed when #656 (slice 2b) squash-merged. Rebased onto current main; same code.

**Reviews carried forward:** none yet (PR opened immediately before the cascade landed).

| Event | When | Detail payload |
|---|---|---|
| `queen.verdict_floor_override` (G1) | `applyDowngradeOnlyFloor` clamps the queen's LLM verdict against a more-conservative structural floor | room_id, subject_ref, submitted_verdict, floor_verdict, clamped_verdict |
| `queen.action_downgrade` (G2) | D1 invariant check forces `permittedAction: "comment"` despite queen recommending `"squash-merge"` | room_id, subject_ref, recommended_action, permitted_action, downgrade_reason, clamped_verdict, reviewed_head_sha |

## Stream choice

Reuses the existing per-installation `:audit` (mutations) stream rather than introducing a new one. Same retention math, operators grep both event classes from one stream. The action enum prefix `queen.*` keeps them filterable.

## Test plan (9 tests)

- [x] Each emitter routes to `auditAppend` with the correct action enum
- [x] Bearer fingerprint + name correlate token activity with queen actions
- [x] Detail payload preserved verbatim
- [x] All 7 `DowngradeReason` values survive the audit round-trip
- [x] `reviewed_head_sha` preserved for `head_sha_drift` diagnostics
- [x] Type-level pin: TypeScript narrowing confirms queen events ARE in `AuditMutationAction` (compile-time guarantee they route to `:audit`)

Web suite: 1674 passing.