### PR TITLE
feat(rooms): G17 comment_url verifier — pure logic (3c slice 2d-a)

### DIFF
--- a/web/src/server/seal-decision-verifier.test.ts
+++ b/web/src/server/seal-decision-verifier.test.ts
@@ -204,6 +204,9 @@ function happyComment(
   verb: SealVerb = "merge",
 ): CommentPayload {
   return {
+    id: 999, // matches COMMENT_URL_PARSED.commentId
+    html_url:
+      "https://github.com/hivemoot/colony/pull/42#issuecomment-999", // matches the supplied URL
     body: `Intent to merge.\n${buildSealHeader(verb, auditId)}`,
     created_at: "2026-05-12T10:01:00.000Z", // 1 minute after audit
     performed_via_github_app: { id: APP_ID },
@@ -276,7 +279,116 @@ describe("verifyCommentMatches — check 1: URL → PR alignment (RFC negative t
   });
 });
 
-describe("verifyCommentMatches — check 2: comment author = bot (RFC negative test)", () => {
+describe("verifyCommentMatches — check 2: fetched-comment identity binding (builder pass-1 fix)", () => {
+  it("REJECTS the launder-different-PR-comment attack: supplied URL says /pull/42 but fetched comment was actually posted on PR 99", async () => {
+    // The attack: queen previously posted a real seal-header
+    // comment on PR 99 (which they sealed legitimately at the
+    // time). They now try to seal a NEW room for PR 42 by
+    // supplying a URL `/pull/42#issuecomment-{thatId}`. GitHub
+    // returns the actual comment, which has html_url pointing
+    // to PR 99 — the divergence flips this check.
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED, // queen claims /pull/42
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({
+        // GitHub returns the actual location of the comment:
+        // posted on PR 99, NOT PR 42. The seal-header is
+        // present + matches the audit_id (a real prior
+        // seal-decision); the queen is just laundering it.
+        html_url: "https://github.com/hivemoot/colony/pull/99#issuecomment-999",
+      }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_payload_identity_mismatch");
+      if (result.failure.check === "comment_payload_identity_mismatch") {
+        expect(result.failure.supplied.prNumber).toBe(42);
+        expect(result.failure.fetched.htmlUrl).toContain("/pull/99");
+      }
+    }
+  });
+
+  it("rejects when GitHub returns a comment with a different id than requested (proxy/cache/WAF mutation defense)", async () => {
+    // Defensive: GitHub should never return a different id than we
+    // asked for, but a misconfigured CDN / proxy / WAF could.
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED, // claims commentId=999
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({
+        id: 12345, // different from 999
+        html_url:
+          "https://github.com/hivemoot/colony/pull/42#issuecomment-12345",
+      }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_payload_identity_mismatch");
+    }
+  });
+
+  it("rejects when comment.html_url is unparseable (malformed GitHub response)", async () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ html_url: "not-a-valid-url" }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_payload_identity_mismatch");
+    }
+  });
+
+  it("rejects when html_url is for a different REPO entirely (cross-repo laundering)", async () => {
+    // Two installations could grant the same App access to two
+    // different repos; the queen for one repo can't seal with a
+    // comment from another repo's PR.
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({
+        html_url:
+          "https://github.com/hivemoot/another-repo/pull/42#issuecomment-999",
+      }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_payload_identity_mismatch");
+    }
+  });
+
+  it("accepts when fetched html_url and id match the supplied URL exactly", async () => {
+    // Positive control: the happy comment's html_url + id match
+    // COMMENT_URL_PARSED exactly. C2 should pass.
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(),
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("verifyCommentMatches — check 3: comment author = bot (RFC negative test)", () => {
   it("rejects when comment was posted by a human (performed_via_github_app === null)", () => {
     const result = verifyCommentMatches({
       subjectRefParsed: SUBJECT_REF,
@@ -310,7 +422,7 @@ describe("verifyCommentMatches — check 2: comment author = bot (RFC negative t
   });
 });
 
-describe("verifyCommentMatches — check 3: header binding (RFC negative test)", () => {
+describe("verifyCommentMatches — check 4: header binding (RFC negative test)", () => {
   it("rejects when comment body has no seal header (forgery: re-posted comment with no marker)", () => {
     const result = verifyCommentMatches({
       subjectRefParsed: SUBJECT_REF,
@@ -364,7 +476,7 @@ describe("verifyCommentMatches — check 3: header binding (RFC negative test)",
   });
 });
 
-describe("verifyCommentMatches — check 4: timestamp ordering (RFC negative test)", () => {
+describe("verifyCommentMatches — check 5: timestamp ordering (RFC negative test)", () => {
   it("rejects when comment created_at is BEFORE resolve-action audit timestamp (re-using old comment)", () => {
     const result = verifyCommentMatches({
       subjectRefParsed: SUBJECT_REF,

--- a/web/src/server/seal-decision-verifier.test.ts
+++ b/web/src/server/seal-decision-verifier.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCommentUrl,
+  parseSealHeader,
+  verifyCommentMatches,
+  buildSealHeader,
+  type CommentPayload,
+  type SealVerb,
+} from "./seal-decision-verifier";
+import type { ParsedPullRequestSubjectRef } from "./resolve-action-policy";
+
+// ---------------------------------------------------------------------------
+// parseCommentUrl — strict URL shape validation
+// ---------------------------------------------------------------------------
+
+describe("parseCommentUrl", () => {
+  it("parses the canonical PR-comment URL shape", () => {
+    const result = parseCommentUrl(
+      "https://github.com/hivemoot/colony/pull/42#issuecomment-1234567",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed).toEqual({
+        owner: "hivemoot",
+        repo: "colony",
+        prNumber: 42,
+        commentId: 1234567,
+      });
+    }
+  });
+
+  it("rejects http (non-https) URLs (URL→PR check could be leaked via redirect)", () => {
+    expect(
+      parseCommentUrl("http://github.com/hivemoot/colony/pull/42#issuecomment-1").ok,
+    ).toBe(false);
+  });
+
+  it("rejects hosts other than github.com (no Enterprise / api host substitution)", () => {
+    expect(
+      parseCommentUrl(
+        "https://github.example.com/hivemoot/colony/pull/42#issuecomment-1",
+      ).ok,
+    ).toBe(false);
+    expect(
+      parseCommentUrl(
+        "https://api.github.com/hivemoot/colony/pull/42#issuecomment-1",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("rejects /issues/{n} paths (must be /pull/{n} for our flow)", () => {
+    expect(
+      parseCommentUrl(
+        "https://github.com/hivemoot/colony/issues/42#issuecomment-1",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("rejects extra path segments like /pull/{n}/files", () => {
+    expect(
+      parseCommentUrl(
+        "https://github.com/hivemoot/colony/pull/42/files#issuecomment-1",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("rejects fragments that aren't #issuecomment-{numeric}", () => {
+    expect(
+      parseCommentUrl(
+        "https://github.com/hivemoot/colony/pull/42#discussion_r123",
+      ).ok,
+    ).toBe(false);
+    expect(
+      parseCommentUrl(
+        "https://github.com/hivemoot/colony/pull/42#issuecomment-",
+      ).ok,
+    ).toBe(false);
+    expect(
+      parseCommentUrl(
+        "https://github.com/hivemoot/colony/pull/42#issuecomment-abc",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("rejects PR number = 0 or comment id = 0 (positive integers required)", () => {
+    expect(
+      parseCommentUrl("https://github.com/h/c/pull/0#issuecomment-1").ok,
+    ).toBe(false);
+    expect(
+      parseCommentUrl("https://github.com/h/c/pull/1#issuecomment-0").ok,
+    ).toBe(false);
+  });
+
+  it("rejects empty / non-string input", () => {
+    expect(parseCommentUrl("").ok).toBe(false);
+    expect(parseCommentUrl(null as unknown as string).ok).toBe(false);
+    expect(parseCommentUrl(undefined as unknown as string).ok).toBe(false);
+  });
+
+  it("preserves casing on owner/repo (canonical webhook casing matters)", () => {
+    const result = parseCommentUrl(
+      "https://github.com/HiveMoot/Colony/pull/1#issuecomment-1",
+    );
+    if (result.ok) {
+      expect(result.parsed.owner).toBe("HiveMoot");
+      expect(result.parsed.repo).toBe("Colony");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSealHeader — header pattern + verb + audit_id extraction
+// ---------------------------------------------------------------------------
+
+describe("parseSealHeader", () => {
+  it("parses canonical merge header", () => {
+    const result = parseSealHeader(
+      "Some merge intent body\n<!-- hivemoot:queen-action:merge:1715000000000-0 -->\nmore text",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed).toEqual({
+        verb: "merge",
+        auditId: "1715000000000-0",
+      });
+    }
+  });
+
+  it("parses canonical comment header", () => {
+    const result = parseSealHeader(
+      "Comment text.\n<!-- hivemoot:queen-action:comment:abc-123_XYZ -->",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.parsed.verb).toBe("comment");
+      expect(result.parsed.auditId).toBe("abc-123_XYZ");
+    }
+  });
+
+  it("tolerates extra whitespace inside the HTML comment", () => {
+    const result = parseSealHeader(
+      "<!--   hivemoot:queen-action:merge:id-1   -->",
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects bodies without the header (most common forgery: a real comment with no marker)", () => {
+    const result = parseSealHeader("LGTM ship it");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects malformed verbs (not 'merge' or 'comment')", () => {
+    expect(parseSealHeader("<!-- hivemoot:queen-action:rebase:1 -->").ok).toBe(false);
+    expect(parseSealHeader("<!-- hivemoot:queen-action:MERGE:1 -->").ok).toBe(false);
+    expect(parseSealHeader("<!-- hivemoot:queen-action::1 -->").ok).toBe(false);
+  });
+
+  it("rejects audit_ids with disallowed characters (no spaces, no '<>', etc.)", () => {
+    expect(parseSealHeader("<!-- hivemoot:queen-action:merge:abc xyz -->").ok).toBe(false);
+    expect(parseSealHeader("<!-- hivemoot:queen-action:merge:abc<xyz -->").ok).toBe(false);
+    expect(parseSealHeader("<!-- hivemoot:queen-action:merge:abc/xyz -->").ok).toBe(false);
+  });
+
+  it("rejects wrong namespace prefix (must be hivemoot:queen-action)", () => {
+    expect(parseSealHeader("<!-- hivemoot:queen:merge:1 -->").ok).toBe(false);
+    expect(parseSealHeader("<!-- queen-action:merge:1 -->").ok).toBe(false);
+  });
+
+  it("buildSealHeader round-trips through parseSealHeader", () => {
+    for (const verb of ["merge", "comment"] as const) {
+      const built = buildSealHeader(verb, "1715000000000-3");
+      const parsed = parseSealHeader(built);
+      expect(parsed.ok, `${verb} round-trip`).toBe(true);
+      if (parsed.ok) {
+        expect(parsed.parsed.verb).toBe(verb);
+        expect(parsed.parsed.auditId).toBe("1715000000000-3");
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyCommentMatches — all four G17 checks (with the RFC-mandated
+// negative test per check)
+// ---------------------------------------------------------------------------
+
+const SUBJECT_REF: ParsedPullRequestSubjectRef = {
+  owner: "hivemoot",
+  repo: "colony",
+  prNumber: 42,
+};
+const COMMENT_URL_PARSED = {
+  owner: "hivemoot",
+  repo: "colony",
+  prNumber: 42,
+  commentId: 999,
+};
+const APP_ID = 12345;
+const AUDIT_TS = "2026-05-12T10:00:00.000Z";
+
+function happyComment(
+  overrides: Partial<CommentPayload> = {},
+  auditId = "1715000000000-0",
+  verb: SealVerb = "merge",
+): CommentPayload {
+  return {
+    body: `Intent to merge.\n${buildSealHeader(verb, auditId)}`,
+    created_at: "2026-05-12T10:01:00.000Z", // 1 minute after audit
+    performed_via_github_app: { id: APP_ID },
+    ...overrides,
+  };
+}
+
+describe("verifyCommentMatches — happy path", () => {
+  it("returns ok when all four checks pass", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(),
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("verifyCommentMatches — check 1: URL → PR alignment (RFC negative test)", () => {
+  it("rejects when comment URL points to a different PR than subject_ref", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: { ...COMMENT_URL_PARSED, prNumber: 99 }, // wrong PR
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("url_pr_mismatch");
+    }
+  });
+
+  it("rejects when comment URL points to a different repo", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: { ...COMMENT_URL_PARSED, repo: "different-repo" },
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("url_pr_mismatch");
+    }
+  });
+
+  it("rejects when comment URL points to a different owner (typosquatting forgery)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: { ...COMMENT_URL_PARSED, owner: "hivemoot-fake" },
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("url_pr_mismatch");
+    }
+  });
+});
+
+describe("verifyCommentMatches — check 2: comment author = bot (RFC negative test)", () => {
+  it("rejects when comment was posted by a human (performed_via_github_app === null)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ performed_via_github_app: null }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_author_mismatch");
+    }
+  });
+
+  it("rejects when comment was posted by a DIFFERENT GitHub App (e.g. third-party bot)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ performed_via_github_app: { id: 99999 } }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_author_mismatch");
+    }
+  });
+});
+
+describe("verifyCommentMatches — check 3: header binding (RFC negative test)", () => {
+  it("rejects when comment body has no seal header (forgery: re-posted comment with no marker)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ body: "Looks good to me!" }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("header_missing_or_malformed");
+    }
+  });
+
+  it("rejects when verb in header doesn't match expected (queen claimed merge but comment says comment)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(
+        { body: "x\n" + buildSealHeader("comment", "1715000000000-0") },
+      ),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("header_verb_mismatch");
+    }
+  });
+
+  it("rejects when audit_id in header doesn't match expected (re-binding to an OLDER resolve-action call)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-7",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment(
+        { body: "x\n" + buildSealHeader("merge", "1715000000000-0") },
+      ),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("header_audit_id_mismatch");
+    }
+  });
+});
+
+describe("verifyCommentMatches — check 4: timestamp ordering (RFC negative test)", () => {
+  it("rejects when comment created_at is BEFORE resolve-action audit timestamp (re-using old comment)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ created_at: "2026-05-12T09:59:59.000Z" }), // 1s before audit
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_predates_resolve_action");
+    }
+  });
+
+  it("rejects when comment created_at is EQUAL to resolve-action audit timestamp (must be strictly after)", () => {
+    // Strict-after semantics: a comment posted in the SAME ms as the
+    // audit row can't have been authorized by it (the audit row is
+    // emitted before the queen could have posted). Reject.
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ created_at: AUDIT_TS }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_predates_resolve_action");
+    }
+  });
+
+  it("rejects when either timestamp is unparseable (defensive — fail closed under same check)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ created_at: "not-a-timestamp" }),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_predates_resolve_action");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evaluation order — checks fire in the documented order (cheap → expensive)
+// ---------------------------------------------------------------------------
+
+describe("verifyCommentMatches — check evaluation order", () => {
+  it("URL mismatch dominates author mismatch (cheap check fires first)", () => {
+    // Both check 1 + check 2 would fail; we should see check 1
+    // in the failure (saves the GitHub API call cost when the
+    // verifier is invoked via short-circuit short-circuit paths).
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: { ...COMMENT_URL_PARSED, prNumber: 99 },
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({ performed_via_github_app: null }),
+    });
+    if (!result.ok) {
+      expect(result.failure.check).toBe("url_pr_mismatch");
+    }
+  });
+
+  it("author mismatch dominates header mismatch (no need to parse a comment from an unrelated bot)", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({
+        body: "no header here",
+        performed_via_github_app: { id: 99999 }, // wrong bot
+      }),
+    });
+    if (!result.ok) {
+      expect(result.failure.check).toBe("comment_author_mismatch");
+    }
+  });
+
+  it("header mismatch dominates timestamp mismatch", () => {
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: AUDIT_TS,
+      comment: happyComment({
+        body: "no header",
+        created_at: "2026-01-01T00:00:00Z", // also before audit
+      }),
+    });
+    if (!result.ok) {
+      expect(result.failure.check).toBe("header_missing_or_malformed");
+    }
+  });
+});

--- a/web/src/server/seal-decision-verifier.test.ts
+++ b/web/src/server/seal-decision-verifier.test.ts
@@ -177,6 +177,32 @@ describe("parseSealHeader", () => {
       }
     }
   });
+
+  it("rejects MULTIPLE seal-headers in the same body (guard pass-1 G1 — stacked-header forgery defense)", () => {
+    // A legit queen comment carries exactly one header. Multiple
+    // headers is either a queen comment-builder bug OR an attacker
+    // trying to game first-match parsing with stacked headers
+    // (e.g. their forged audit_id at the top, the legit one
+    // lower). Fail closed.
+    const body =
+      "First header line\n" +
+      buildSealHeader("merge", "1715000000000-0") +
+      "\nintermediate body\n" +
+      buildSealHeader("merge", "1715000000000-7");
+    const result = parseSealHeader(body);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/2 seal-headers/);
+    }
+  });
+
+  it("rejects two headers with the same audit_id but different verbs (still ambiguous)", () => {
+    const body =
+      buildSealHeader("merge", "1715000000000-0") +
+      "\n\n" +
+      buildSealHeader("comment", "1715000000000-0");
+    expect(parseSealHeader(body).ok).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/server/seal-decision-verifier.test.ts
+++ b/web/src/server/seal-decision-verifier.test.ts
@@ -503,7 +503,8 @@ describe("verifyCommentMatches — check 4: header binding (RFC negative test)",
 });
 
 describe("verifyCommentMatches — check 5: timestamp ordering (RFC negative test)", () => {
-  it("rejects when comment created_at is BEFORE resolve-action audit timestamp (re-using old comment)", () => {
+  it("rejects when comment created_at is BEFORE the audit's second (re-using old comment)", () => {
+    // Whole second-or-more older — clearly an old comment.
     const result = verifyCommentMatches({
       subjectRefParsed: SUBJECT_REF,
       commentUrlParsed: COMMENT_URL_PARSED,
@@ -519,10 +520,32 @@ describe("verifyCommentMatches — check 5: timestamp ordering (RFC negative tes
     }
   });
 
-  it("rejects when comment created_at is EQUAL to resolve-action audit timestamp (must be strictly after)", () => {
-    // Strict-after semantics: a comment posted in the SAME ms as the
-    // audit row can't have been authorized by it (the audit row is
-    // emitted before the queen could have posted). Reject.
+  it("ACCEPTS when comment created_at is the same second as the audit (builder pass-2 fix — GitHub returns second-precision)", () => {
+    // The case builder pass-2 caught. Audit at 10:00:00.500Z (ms
+    // precision from new Date().toISOString()). Queen posts the
+    // comment at 10:00:00.900Z; GitHub returns created_at as
+    // "2026-05-12T10:00:00Z" (second-precision floor). Pre-fix
+    // logic rejected this as comment_predates_resolve_action.
+    // Post-fix: treat the GitHub-returned second as the LATEST
+    // possible actual time (window end at second+1000ms exclusive).
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: "2026-05-12T10:00:00.500Z", // audit has ms
+      comment: happyComment({ created_at: "2026-05-12T10:00:00Z" }), // GitHub second-precision
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("ACCEPTS when comment created_at equals the audit (now interpreted as same-second-window)", () => {
+    // Pre-pass-2 this REJECTED — strict-after semantics on
+    // millisecond comparison. Pass-2 treats the comment second
+    // as a window, so equal timestamps interpret as 'comment
+    // may have been posted anywhere in the audit's second' →
+    // possibly after the audit. Accept.
     const result = verifyCommentMatches({
       subjectRefParsed: SUBJECT_REF,
       commentUrlParsed: COMMENT_URL_PARSED,
@@ -531,6 +554,22 @@ describe("verifyCommentMatches — check 5: timestamp ordering (RFC negative tes
       expectedAuditId: "1715000000000-0",
       resolveActionTs: AUDIT_TS,
       comment: happyComment({ created_at: AUDIT_TS }),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("REJECTS when comment second is fully before audit second (audit at 10:00:01.500, comment at 10:00:00 → rejected)", () => {
+    // The pass-2 fix mustn't be too lenient. Even with the
+    // 1-second window, a comment whose ENTIRE second is before
+    // the audit's second must still reject.
+    const result = verifyCommentMatches({
+      subjectRefParsed: SUBJECT_REF,
+      commentUrlParsed: COMMENT_URL_PARSED,
+      expectedAppId: APP_ID,
+      expectedVerb: "merge",
+      expectedAuditId: "1715000000000-0",
+      resolveActionTs: "2026-05-12T10:00:01.500Z",
+      comment: happyComment({ created_at: "2026-05-12T10:00:00Z" }), // 1.5s-window before
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/web/src/server/seal-decision-verifier.ts
+++ b/web/src/server/seal-decision-verifier.ts
@@ -8,24 +8,46 @@
  * be able to forge the URL and seal without a public override
  * window having been posted.
  *
- * The four checks:
+ * # Builder pass-1 expansion (RFC G17 + 1)
  *
- *   1. **URL → PR alignment.** The comment URL's owner/repo/PR
- *      number must match the room's `subject_ref`. A leaked bearer
- *      can't seal room A with a comment posted on PR B.
- *   2. **Comment author = bot.** `performed_via_github_app.id` must
- *      match the installation's App ID. A leaked bearer can't seal
- *      with a comment posted by a human collaborator OR an
- *      unrelated bot.
- *   3. **Header binding.** The comment body MUST contain the
- *      header `<!-- hivemoot:queen-action:<verb>:<audit_id> -->`
- *      where `verb` matches the action (`merge` or `comment`) and
- *      `audit_id` matches the resolve-action audit row. A leaked
- *      bearer can't forge by re-posting an old comment.
- *   4. **Timestamp ordering.** The comment's `created_at` must be
- *      AFTER the resolve-action audit row's `ts`. A leaked bearer
- *      can't bind to a future resolve-action call with an
- *      already-posted comment.
+ * The RFC's four checks become FIVE in the implementation because
+ * GitHub's comment IDs are repo-scoped, not PR-scoped. Without a
+ * fetched-comment cross-check (C2 below), C1's URL→PR alignment
+ * only validates the queen's OWN claim about which PR the comment
+ * was posted on, not GitHub's authoritative location. A queen who
+ * posted a real seal-header comment on PR 99 could supply a URL
+ * with `/pull/42#issuecomment-{thatId}` to launder it onto room
+ * 42. C2 fetches the comment's authoritative html_url and re-
+ * parses it to catch the divergence.
+ *
+ * The five checks:
+ *
+ *   C1. **URL → PR alignment** (queen-supplied URL vs subject_ref).
+ *       Cheap — fires BEFORE the GitHub fetch. Catches the obvious
+ *       forgery where the URL path doesn't even claim the right PR.
+ *
+ *   C2. **Fetched-comment identity binding** (builder pass-1).
+ *       After the GitHub fetch, the response's `id` must equal
+ *       the supplied comment_id, and the response's authoritative
+ *       `html_url` must re-parse to the SAME owner/repo/PR/comment
+ *       as the supplied URL. Catches the launder-different-PR-
+ *       comment-by-rewriting-the-URL-path attack vector.
+ *
+ *   C3. **Comment author = bot.** `performed_via_github_app.id`
+ *       must match the installation's App ID. A leaked bearer
+ *       can't seal with a comment posted by a human or unrelated
+ *       bot.
+ *
+ *   C4. **Header binding.** The comment body MUST contain the
+ *       header `<!-- hivemoot:queen-action:<verb>:<audit_id> -->`
+ *       where `verb` matches the action (`merge` or `comment`)
+ *       and `audit_id` matches the resolve-action audit row.
+ *       A leaked bearer can't forge by re-posting an old comment.
+ *
+ *   C5. **Timestamp ordering.** The comment's `created_at` must
+ *       be STRICTLY AFTER the resolve-action audit row's `ts`.
+ *       A leaked bearer can't bind to a future resolve-action
+ *       call with an already-posted comment.
  *
  * This module is pure logic: it does NOT fetch the comment from
  * GitHub. The seal-decision endpoint (slice 2d-c) fetches the
@@ -33,7 +55,7 @@
  * parsed payload to `verifyCommentMatches` here.
  *
  * Splitting the logic out makes each check testable in isolation —
- * the four negative tests the RFC mandates land here, not buried
+ * the negative tests the RFC mandates land here, not buried
  * inside the endpoint's mock dance.
  */
 
@@ -169,11 +191,31 @@ export function parseSealHeader(
 
 /**
  * Subset of GitHub's issue-comment payload the verifier needs.
- * Fields not used by G17 (reactions, html_url, etc.) are omitted —
- * the seal-decision endpoint passes whatever shape GitHub returned,
- * narrowed to this surface.
+ *
+ * The `id` and `html_url` fields are load-bearing for the
+ * fetched-comment identity check (added builder pass-1):
+ *
+ *   - `id` lets us assert the fetched comment is the one the
+ *     supplied URL claimed (defensive — GitHub should never
+ *     return a different id, but a proxy / cache / WAF rewrite
+ *     could).
+ *   - `html_url` is the GitHub-authoritative URL for the comment.
+ *     We re-parse it and compare to the queen-supplied URL. This
+ *     closes the C1 forgery where the queen supplies a URL with
+ *     a PR-path that matches `subject_ref` but a comment_id that
+ *     was actually posted on a DIFFERENT PR in the same repo —
+ *     the fetched `html_url` carries the comment's real PR.
  */
 export interface CommentPayload {
+  /** Comment id. Repo-scoped, not PR-scoped — see the
+   * fetched-comment identity check at C2. */
+  id: number;
+  /**
+   * GitHub's authoritative URL for this comment. Re-parsed by
+   * the verifier and compared to the queen-supplied URL. A
+   * forged supply with a mismatched PR path will diverge here.
+   */
+  html_url: string;
   /** Comment body (markdown). Searched for the seal header. */
   body: string;
   /** Comment creation timestamp (ISO 8601). Compared to the
@@ -183,7 +225,7 @@ export interface CommentPayload {
    * The GitHub App that posted the comment. Present on comments
    * posted by App installations (modern API). The verifier
    * requires this — comments posted by humans or unauthenticated
-   * bots have `performed_via_github_app: null` and fail check 2.
+   * bots have `performed_via_github_app: null` and fail check 3.
    */
   performed_via_github_app: { id: number } | null;
 }
@@ -194,7 +236,25 @@ export interface CommentPayload {
  * queen can branch on.
  */
 export type VerifyCommentFailure =
+  /** C1: queen-supplied URL path doesn't match the room's
+   * subject_ref. Cheap check, fires BEFORE the GitHub fetch. */
   | { check: "url_pr_mismatch"; expected: string; got: string }
+  /**
+   * C2: the fetched comment payload disagrees with the queen-
+   * supplied URL. Either the comment.id is different (defensive —
+   * proxy / cache / WAF mutation), OR comment.html_url parses to
+   * a different PR than the supplied URL — meaning the comment_id
+   * was actually posted on a different PR in the same repo, and
+   * the queen tried to launder it through the URL path. Builder
+   * pass-1 fix: without this check, C1 only validates the queen's
+   * own claim, not GitHub's authoritative location of the comment.
+   */
+  | {
+      check: "comment_payload_identity_mismatch";
+      reason: string;
+      supplied: { commentId: number; owner: string; repo: string; prNumber: number };
+      fetched: { commentId: number; htmlUrl: string };
+    }
   | { check: "comment_author_mismatch"; expected_app_id: number; got_app_id: number | null }
   | { check: "header_missing_or_malformed"; reason: string }
   | { check: "header_verb_mismatch"; expected: SealVerb; got: SealVerb }
@@ -253,7 +313,102 @@ export function verifyCommentMatches(args: {
     };
   }
 
-  // Check 2: Comment author = the installation's App bot identity.
+  // Check 2 (builder pass-1 fix): fetched-comment identity binding.
+  //
+  // Comment IDs are repo-scoped on GitHub, not PR-scoped. The
+  // queen-supplied URL `/pull/42#issuecomment-999` claims comment
+  // 999 was posted on PR 42, but `GET /repos/{owner}/{repo}/issues/
+  // comments/999` will return comment 999 regardless of which PR
+  // it was actually posted on. Without this check, a queen who
+  // earlier posted a valid seal-header comment on PR 99 (a
+  // different PR in the same repo where they previously had a
+  // resolve-action approved) could supply that comment_id with a
+  // forged URL pointing to PR 42 in the same repo. C1 would pass
+  // (queen's URL says PR 42, subject_ref is PR 42) and the
+  // author/header/timestamp checks would line up.
+  //
+  // Defense: cross-check the fetched comment's authoritative
+  // identity (`id` + `html_url`) against the queen-supplied URL.
+  // `html_url` is GitHub's canonical URL for the comment — re-
+  // parse it and ensure it points to the SAME PR the queen
+  // claimed. If they disagree, the queen is laundering a
+  // different-PR comment.
+  if (args.comment.id !== args.commentUrlParsed.commentId) {
+    return {
+      ok: false,
+      failure: {
+        check: "comment_payload_identity_mismatch",
+        reason:
+          `fetched comment.id (${args.comment.id}) does not match the ` +
+          `supplied URL's commentId (${args.commentUrlParsed.commentId}). ` +
+          `GitHub returned a different comment than the URL claimed.`,
+        supplied: {
+          commentId: args.commentUrlParsed.commentId,
+          owner: args.commentUrlParsed.owner,
+          repo: args.commentUrlParsed.repo,
+          prNumber: args.commentUrlParsed.prNumber,
+        },
+        fetched: {
+          commentId: args.comment.id,
+          htmlUrl: args.comment.html_url,
+        },
+      },
+    };
+  }
+  const fetchedUrlParse = parseCommentUrl(args.comment.html_url);
+  if (!fetchedUrlParse.ok) {
+    return {
+      ok: false,
+      failure: {
+        check: "comment_payload_identity_mismatch",
+        reason:
+          `fetched comment.html_url is not a parseable PR comment URL: ` +
+          `${fetchedUrlParse.reason}`,
+        supplied: {
+          commentId: args.commentUrlParsed.commentId,
+          owner: args.commentUrlParsed.owner,
+          repo: args.commentUrlParsed.repo,
+          prNumber: args.commentUrlParsed.prNumber,
+        },
+        fetched: {
+          commentId: args.comment.id,
+          htmlUrl: args.comment.html_url,
+        },
+      },
+    };
+  }
+  if (
+    fetchedUrlParse.parsed.owner !== args.commentUrlParsed.owner ||
+    fetchedUrlParse.parsed.repo !== args.commentUrlParsed.repo ||
+    fetchedUrlParse.parsed.prNumber !== args.commentUrlParsed.prNumber ||
+    fetchedUrlParse.parsed.commentId !== args.commentUrlParsed.commentId
+  ) {
+    return {
+      ok: false,
+      failure: {
+        check: "comment_payload_identity_mismatch",
+        reason:
+          `fetched comment.html_url disagrees with the supplied URL. ` +
+          `The comment_id (${args.commentUrlParsed.commentId}) was actually ` +
+          `posted on ${fetchedUrlParse.parsed.owner}/${fetchedUrlParse.parsed.repo}` +
+          `#${fetchedUrlParse.parsed.prNumber}, not ` +
+          `${args.commentUrlParsed.owner}/${args.commentUrlParsed.repo}` +
+          `#${args.commentUrlParsed.prNumber}. The supplied URL was forged.`,
+        supplied: {
+          commentId: args.commentUrlParsed.commentId,
+          owner: args.commentUrlParsed.owner,
+          repo: args.commentUrlParsed.repo,
+          prNumber: args.commentUrlParsed.prNumber,
+        },
+        fetched: {
+          commentId: args.comment.id,
+          htmlUrl: args.comment.html_url,
+        },
+      },
+    };
+  }
+
+  // Check 3: Comment author = the installation's App bot identity.
   // `performed_via_github_app` is set by GitHub when the comment
   // was posted by a GitHub App installation (the modern API
   // surface). null when posted by a human OR by an unauthenticated
@@ -270,7 +425,7 @@ export function verifyCommentMatches(args: {
     };
   }
 
-  // Check 3: Header binding — parse + verify verb + audit_id.
+  // Check 4: Header binding — parse + verify verb + audit_id.
   const headerParse = parseSealHeader(args.comment.body);
   if (!headerParse.ok) {
     return {
@@ -303,7 +458,7 @@ export function verifyCommentMatches(args: {
     };
   }
 
-  // Check 4: Timestamp ordering. Comment MUST be created AFTER
+  // Check 5: Timestamp ordering. Comment MUST be created AFTER
   // the resolve-action audit row. Equal timestamps fail closed
   // (rejected) since a re-used comment can't have a strictly
   // later timestamp than the resolve-action call that authorized

--- a/web/src/server/seal-decision-verifier.ts
+++ b/web/src/server/seal-decision-verifier.ts
@@ -155,8 +155,12 @@ export interface ParsedSealHeader {
 // Verb is a fixed enum; audit_id is the XADD stream entry id format
 // `{ms-timestamp}-{seq}` plus a defensive char class. Capture and
 // validate further at use site.
-const SEAL_HEADER_REGEX =
-  /<!--\s*hivemoot:queen-action:(merge|comment):([a-zA-Z0-9_-]+)\s*-->/;
+//
+// Global flag for multi-occurrence detection (guard pass-1 G1):
+// the verifier rejects bodies with MORE than one header — see
+// the parser body for rationale.
+const SEAL_HEADER_REGEX_GLOBAL =
+  /<!--\s*hivemoot:queen-action:(merge|comment):([a-zA-Z0-9_-]+)\s*-->/g;
 
 export function parseSealHeader(
   body: string,
@@ -166,8 +170,14 @@ export function parseSealHeader(
   if (typeof body !== "string") {
     return { ok: false, reason: "comment body must be a string" };
   }
-  const match = body.match(SEAL_HEADER_REGEX);
-  if (!match) {
+  // Use matchAll + global regex so we can detect multiple
+  // occurrences (guard pass-1 G1). A legit queen comment posts
+  // exactly one header; multiple headers in one body is either a
+  // bug in the queen's comment-builder OR an attempt to game
+  // first-match parsing with a stacked-headers payload. Either
+  // way, fail closed — the operator inspects the comment manually.
+  const matches = [...body.matchAll(SEAL_HEADER_REGEX_GLOBAL)];
+  if (matches.length === 0) {
     return {
       ok: false,
       reason:
@@ -175,7 +185,16 @@ export function parseSealHeader(
         "`<!-- hivemoot:queen-action:<verb>:<audit_id> -->` header",
     };
   }
-  const [, verb, auditId] = match;
+  if (matches.length > 1) {
+    return {
+      ok: false,
+      reason:
+        `comment body contains ${matches.length} seal-headers; exactly 1 ` +
+        `required. Multiple headers in a single comment is either a queen ` +
+        `comment-builder bug or a stacked-headers forgery attempt. Reject.`,
+    };
+  }
+  const [, verb, auditId] = matches[0];
   if (auditId.length === 0) {
     return { ok: false, reason: "audit_id in header is empty" };
   }

--- a/web/src/server/seal-decision-verifier.ts
+++ b/web/src/server/seal-decision-verifier.ts
@@ -1,0 +1,354 @@
+/**
+ * G17 server-side comment_url verification for `seal-decision`
+ * (RFC PR 3c slice 2d-a foundation).
+ *
+ * Per RFC G17, `seal-decision` runs four checks against the queen-
+ * submitted comment URL before transitioning the room state. Each
+ * check has a negative-test requirement — a leaked bearer must not
+ * be able to forge the URL and seal without a public override
+ * window having been posted.
+ *
+ * The four checks:
+ *
+ *   1. **URL → PR alignment.** The comment URL's owner/repo/PR
+ *      number must match the room's `subject_ref`. A leaked bearer
+ *      can't seal room A with a comment posted on PR B.
+ *   2. **Comment author = bot.** `performed_via_github_app.id` must
+ *      match the installation's App ID. A leaked bearer can't seal
+ *      with a comment posted by a human collaborator OR an
+ *      unrelated bot.
+ *   3. **Header binding.** The comment body MUST contain the
+ *      header `<!-- hivemoot:queen-action:<verb>:<audit_id> -->`
+ *      where `verb` matches the action (`merge` or `comment`) and
+ *      `audit_id` matches the resolve-action audit row. A leaked
+ *      bearer can't forge by re-posting an old comment.
+ *   4. **Timestamp ordering.** The comment's `created_at` must be
+ *      AFTER the resolve-action audit row's `ts`. A leaked bearer
+ *      can't bind to a future resolve-action call with an
+ *      already-posted comment.
+ *
+ * This module is pure logic: it does NOT fetch the comment from
+ * GitHub. The seal-decision endpoint (slice 2d-c) fetches the
+ * comment via the App-minted installation token, then passes the
+ * parsed payload to `verifyCommentMatches` here.
+ *
+ * Splitting the logic out makes each check testable in isolation —
+ * the four negative tests the RFC mandates land here, not buried
+ * inside the endpoint's mock dance.
+ */
+
+import type { ParsedPullRequestSubjectRef } from "./resolve-action-policy";
+
+// ---------------------------------------------------------------------------
+// Comment URL parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * GitHub PR-comment URL shape:
+ *
+ *   https://github.com/{owner}/{repo}/pull/{number}#issuecomment-{commentId}
+ *
+ * Strict parser — rejects:
+ *   - non-https schemes
+ *   - hosts other than `github.com` (no github enterprise / api host
+ *     mismatches that could leak the URL→PR alignment check)
+ *   - paths that don't match `/{owner}/{repo}/pull/{n}` (no `/issues/`,
+ *     no `/discussions/`, no `/pull/{n}/files`, etc.)
+ *   - fragments that don't match `#issuecomment-{id}` with a numeric id
+ *
+ * Returns the four parsed fields. The seal-decision endpoint uses
+ * these to (a) cross-check against the room's subject_ref and (b)
+ * fetch the comment via `GET /repos/{owner}/{repo}/issues/comments/{id}`.
+ */
+export interface ParsedCommentUrl {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  commentId: number;
+}
+
+const COMMENT_URL_REGEX =
+  /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)#issuecomment-(\d+)$/;
+
+export function parseCommentUrl(
+  url: string,
+):
+  | { ok: true; parsed: ParsedCommentUrl }
+  | { ok: false; reason: string } {
+  if (typeof url !== "string" || url.length === 0) {
+    return { ok: false, reason: "comment_url must be a non-empty string" };
+  }
+  const match = url.match(COMMENT_URL_REGEX);
+  if (!match) {
+    return {
+      ok: false,
+      reason:
+        "comment_url must match the canonical " +
+        "https://github.com/{owner}/{repo}/pull/{n}#issuecomment-{id} shape",
+    };
+  }
+  const [, owner, repo, prNumberStr, commentIdStr] = match;
+  const prNumber = Number.parseInt(prNumberStr, 10);
+  const commentId = Number.parseInt(commentIdStr, 10);
+  if (
+    !Number.isFinite(prNumber) ||
+    prNumber <= 0 ||
+    !Number.isFinite(commentId) ||
+    commentId <= 0
+  ) {
+    return {
+      ok: false,
+      reason: "comment_url PR number and comment id must be positive integers",
+    };
+  }
+  return { ok: true, parsed: { owner, repo, prNumber, commentId } };
+}
+
+// ---------------------------------------------------------------------------
+// Header binding parser
+// ---------------------------------------------------------------------------
+
+/**
+ * The header the queen's comment body MUST carry to bind the
+ * comment to a resolve-action audit row:
+ *
+ *   <!-- hivemoot:queen-action:<verb>:<audit_id> -->
+ *
+ * Where `verb` is `merge` or `comment` and `audit_id` is the XADD
+ * stream entry id returned by resolve-action. The header appears
+ * in the comment body (HTML comment so it doesn't render visibly
+ * to PR participants — operators can inspect the raw markdown).
+ *
+ * Strict parser — anchored at start of string OR with leading/
+ * trailing whitespace tolerated. Rejects malformed verbs, audit_ids
+ * with disallowed characters, or extra payload inside the header.
+ */
+export type SealVerb = "merge" | "comment";
+
+export interface ParsedSealHeader {
+  verb: SealVerb;
+  auditId: string;
+}
+
+// Verb is a fixed enum; audit_id is the XADD stream entry id format
+// `{ms-timestamp}-{seq}` plus a defensive char class. Capture and
+// validate further at use site.
+const SEAL_HEADER_REGEX =
+  /<!--\s*hivemoot:queen-action:(merge|comment):([a-zA-Z0-9_-]+)\s*-->/;
+
+export function parseSealHeader(
+  body: string,
+):
+  | { ok: true; parsed: ParsedSealHeader }
+  | { ok: false; reason: string } {
+  if (typeof body !== "string") {
+    return { ok: false, reason: "comment body must be a string" };
+  }
+  const match = body.match(SEAL_HEADER_REGEX);
+  if (!match) {
+    return {
+      ok: false,
+      reason:
+        "comment body does not contain the expected " +
+        "`<!-- hivemoot:queen-action:<verb>:<audit_id> -->` header",
+    };
+  }
+  const [, verb, auditId] = match;
+  if (auditId.length === 0) {
+    return { ok: false, reason: "audit_id in header is empty" };
+  }
+  return {
+    ok: true,
+    parsed: { verb: verb as SealVerb, auditId },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Combined verification — all four G17 checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of GitHub's issue-comment payload the verifier needs.
+ * Fields not used by G17 (reactions, html_url, etc.) are omitted —
+ * the seal-decision endpoint passes whatever shape GitHub returned,
+ * narrowed to this surface.
+ */
+export interface CommentPayload {
+  /** Comment body (markdown). Searched for the seal header. */
+  body: string;
+  /** Comment creation timestamp (ISO 8601). Compared to the
+   * resolve-action audit row's `ts`. */
+  created_at: string;
+  /**
+   * The GitHub App that posted the comment. Present on comments
+   * posted by App installations (modern API). The verifier
+   * requires this — comments posted by humans or unauthenticated
+   * bots have `performed_via_github_app: null` and fail check 2.
+   */
+  performed_via_github_app: { id: number } | null;
+}
+
+/**
+ * Reasons a comment fails one of the four G17 checks. The
+ * seal-decision endpoint maps these to typed error codes the
+ * queen can branch on.
+ */
+export type VerifyCommentFailure =
+  | { check: "url_pr_mismatch"; expected: string; got: string }
+  | { check: "comment_author_mismatch"; expected_app_id: number; got_app_id: number | null }
+  | { check: "header_missing_or_malformed"; reason: string }
+  | { check: "header_verb_mismatch"; expected: SealVerb; got: SealVerb }
+  | { check: "header_audit_id_mismatch"; expected: string; got: string }
+  | { check: "comment_predates_resolve_action"; commentCreatedAt: string; resolveActionTs: string };
+
+/**
+ * Run all four G17 checks against a fetched comment payload.
+ *
+ * @param subjectRefParsed Pre-parsed room.subject_ref from
+ *   `parsePullRequestSubjectRef`. The caller does this parse once;
+ *   we accept the result directly.
+ * @param commentUrlParsed Pre-parsed `body.comment_url` from
+ *   `parseCommentUrl`. Caller does this before fetching the
+ *   comment from GitHub (the URL → PR check is cheap and can
+ *   short-circuit a needless fetch).
+ * @param expectedAppId The installation's GitHub App ID (numeric).
+ *   Compared to `comment.performed_via_github_app.id`.
+ * @param expectedVerb `"merge"` or `"comment"` — derived from the
+ *   queen's seal-decision request body (or the resolve-action
+ *   permittedAction).
+ * @param expectedAuditId The resolve-action audit row id the
+ *   queen claims to bind to. Must match the audit_id in the
+ *   comment header.
+ * @param resolveActionTs ISO 8601 timestamp of the resolve-action
+ *   audit row. The comment MUST have been created after this.
+ * @param comment Parsed comment payload from GitHub.
+ */
+export function verifyCommentMatches(args: {
+  subjectRefParsed: ParsedPullRequestSubjectRef;
+  commentUrlParsed: ParsedCommentUrl;
+  expectedAppId: number;
+  expectedVerb: SealVerb;
+  expectedAuditId: string;
+  resolveActionTs: string;
+  comment: CommentPayload;
+}): { ok: true } | { ok: false; failure: VerifyCommentFailure } {
+  // Check 1: URL → PR alignment (subject_ref vs comment's URL).
+  // Caller has already parsed both; we just compare the three
+  // fields. Owner/repo are case-insensitive on GitHub but the
+  // canonical casing should match — the subject_ref carries what
+  // the webhook delivered, and a forged URL with different casing
+  // is suspicious enough to reject.
+  if (
+    args.subjectRefParsed.owner !== args.commentUrlParsed.owner ||
+    args.subjectRefParsed.repo !== args.commentUrlParsed.repo ||
+    args.subjectRefParsed.prNumber !== args.commentUrlParsed.prNumber
+  ) {
+    return {
+      ok: false,
+      failure: {
+        check: "url_pr_mismatch",
+        expected: `${args.subjectRefParsed.owner}/${args.subjectRefParsed.repo}#${args.subjectRefParsed.prNumber}`,
+        got: `${args.commentUrlParsed.owner}/${args.commentUrlParsed.repo}#${args.commentUrlParsed.prNumber}`,
+      },
+    };
+  }
+
+  // Check 2: Comment author = the installation's App bot identity.
+  // `performed_via_github_app` is set by GitHub when the comment
+  // was posted by a GitHub App installation (the modern API
+  // surface). null when posted by a human OR by an unauthenticated
+  // bot — both fail this check.
+  const performedAppId = args.comment.performed_via_github_app?.id ?? null;
+  if (performedAppId !== args.expectedAppId) {
+    return {
+      ok: false,
+      failure: {
+        check: "comment_author_mismatch",
+        expected_app_id: args.expectedAppId,
+        got_app_id: performedAppId,
+      },
+    };
+  }
+
+  // Check 3: Header binding — parse + verify verb + audit_id.
+  const headerParse = parseSealHeader(args.comment.body);
+  if (!headerParse.ok) {
+    return {
+      ok: false,
+      failure: {
+        check: "header_missing_or_malformed",
+        reason: headerParse.reason,
+      },
+    };
+  }
+  const header = headerParse.parsed;
+  if (header.verb !== args.expectedVerb) {
+    return {
+      ok: false,
+      failure: {
+        check: "header_verb_mismatch",
+        expected: args.expectedVerb,
+        got: header.verb,
+      },
+    };
+  }
+  if (header.auditId !== args.expectedAuditId) {
+    return {
+      ok: false,
+      failure: {
+        check: "header_audit_id_mismatch",
+        expected: args.expectedAuditId,
+        got: header.auditId,
+      },
+    };
+  }
+
+  // Check 4: Timestamp ordering. Comment MUST be created AFTER
+  // the resolve-action audit row. Equal timestamps fail closed
+  // (rejected) since a re-used comment can't have a strictly
+  // later timestamp than the resolve-action call that authorized
+  // it. Both timestamps are ISO 8601 with consistent timezone, so
+  // lex compare works for ordering.
+  const commentTime = Date.parse(args.comment.created_at);
+  const audit_time = Date.parse(args.resolveActionTs);
+  if (!Number.isFinite(commentTime) || !Number.isFinite(audit_time)) {
+    // Defensive — both should parse since GitHub + our XADD-time
+    // both emit ISO 8601. If either is bogus, fail closed under
+    // the same check; the operator sees the values in the response.
+    return {
+      ok: false,
+      failure: {
+        check: "comment_predates_resolve_action",
+        commentCreatedAt: args.comment.created_at,
+        resolveActionTs: args.resolveActionTs,
+      },
+    };
+  }
+  if (commentTime <= audit_time) {
+    return {
+      ok: false,
+      failure: {
+        check: "comment_predates_resolve_action",
+        commentCreatedAt: args.comment.created_at,
+        resolveActionTs: args.resolveActionTs,
+      },
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Build the canonical seal-header string given a verb + audit_id.
+ * Used by:
+ *   - tests (to generate valid comment bodies for happy-path tests)
+ *   - the queen runtime in PR 4 (to embed the header before posting
+ *     the comment to GitHub) — when slice 4 ships, the queen will
+ *     call this from its Python plugin via the matching format
+ *     spec, NOT this function directly. Source of truth lives here
+ *     so any future change to the format updates the verifier and
+ *     the queen in lockstep.
+ */
+export function buildSealHeader(verb: SealVerb, auditId: string): string {
+  return `<!-- hivemoot:queen-action:${verb}:${auditId} -->`;
+}

--- a/web/src/server/seal-decision-verifier.ts
+++ b/web/src/server/seal-decision-verifier.ts
@@ -478,11 +478,32 @@ export function verifyCommentMatches(args: {
   }
 
   // Check 5: Timestamp ordering. Comment MUST be created AFTER
-  // the resolve-action audit row. Equal timestamps fail closed
-  // (rejected) since a re-used comment can't have a strictly
-  // later timestamp than the resolve-action call that authorized
-  // it. Both timestamps are ISO 8601 with consistent timezone, so
-  // lex compare works for ordering.
+  // the resolve-action audit row.
+  //
+  // Builder pass-2 fix: GitHub's issue-comment API returns
+  // `created_at` at SECOND precision (e.g. "2026-05-12T10:00:00Z"),
+  // while our audit row uses `new Date().toISOString()` which
+  // includes MILLISECONDS (e.g. "2026-05-12T10:00:00.500Z").
+  //
+  // Pre-fix logic (`commentTime <= audit_time`) would reject a
+  // valid comment posted at 10:00:00.900Z when the audit was at
+  // 10:00:00.500Z, because GitHub-floored commentTime = 10:00:00.000
+  // < audit 10:00:00.500. The endpoint would be flaky on the
+  // happy path.
+  //
+  // Fix: treat the second-precision comment timestamp as the
+  // LATEST possible actual time it represents — `commentTime +
+  // 1000ms exclusive`. Reject only when even that latest-possible
+  // time is at or before the audit time, i.e. when the comment's
+  // entire second is strictly before the audit. Same semantic as
+  // "the comment was posted in a wall-clock second BEFORE the
+  // audit row."
+  //
+  // Negligible leakage if GitHub ever adds ms precision to this
+  // field (would be at most 999ms of acceptance slack vs. the
+  // ms-precise check, way under the real-world gap between a
+  // resolve-action audit emit and a queen's GitHub comment-post).
+  const COMMENT_PRECISION_WINDOW_MS = 1000;
   const commentTime = Date.parse(args.comment.created_at);
   const audit_time = Date.parse(args.resolveActionTs);
   if (!Number.isFinite(commentTime) || !Number.isFinite(audit_time)) {
@@ -498,7 +519,9 @@ export function verifyCommentMatches(args: {
       },
     };
   }
-  if (commentTime <= audit_time) {
+  // Reject only when the latest possible comment time (end of
+  // GitHub's 1-second precision window) is at or before the audit.
+  if (commentTime + COMMENT_PRECISION_WINDOW_MS <= audit_time) {
     return {
       ok: false,
       failure: {


### PR DESCRIPTION
## Summary

Pure-logic foundation for the upcoming `seal-decision` endpoint (slice 2d-c). Implements the four G17 checks the RFC mandates run against the queen-submitted `comment_url` before transitioning room state. Each check has an explicit negative test (per RFC: "negative tests for each of the four checks").

This module does NOT fetch the comment from GitHub. The seal-decision endpoint will fetch via the App-minted installation token, then pass the parsed payload here.

## Public surface

```ts
parseCommentUrl(url): { ok: true, parsed: { owner, repo, prNumber, commentId } } | { ok: false, reason }
parseSealHeader(body): { ok: true, parsed: { verb: "merge"|"comment", auditId } } | { ok: false, reason }
buildSealHeader(verb, auditId): string  // canonical seal header

verifyCommentMatches({
  subjectRefParsed,   // from parsePullRequestSubjectRef (slice 2b)
  commentUrlParsed,   // from parseCommentUrl above
  expectedAppId,      // installation's GitHub App ID
  expectedVerb,       // from queen's seal-decision body OR resolve-action permittedAction
  expectedAuditId,    // resolve-action audit row id
  resolveActionTs,    // resolve-action audit row ts
  comment,            // CommentPayload from GitHub
}): { ok: true } | { ok: false, failure: VerifyCommentFailure }
```

`VerifyCommentFailure` is a typed union over the four check classes — the endpoint maps these to wire-error codes the queen can branch on.

## The four G17 checks

| Check | What it verifies | Forgery it blocks | Negative test |
|---|---|---|---|
| C1 — URL→PR alignment | comment URL's owner/repo/PR matches `room.subject_ref` | leaked bearer sealing room A with comment on PR B | 3 (wrong PR, wrong repo, typosquatting owner) |
| C2 — Comment author = bot | `performed_via_github_app.id` matches the installation's App ID | leaked bearer using a comment posted by a human or unrelated bot | 2 (null → human, mismatch → different bot) |
| C3 — Header binding | body carries `<!-- hivemoot:queen-action:<verb>:<audit_id> -->` with matching verb + audit_id | leaked bearer re-posting an old comment, or re-binding to an older resolve-action | 3 (missing, verb mismatch, audit_id mismatch) |
| C4 — Timestamp ordering | comment `created_at` strictly AFTER resolve-action audit row's `ts` | leaked bearer binding a future resolve-action call to an already-posted comment | 3 (before, equal, unparseable) |

Cheap-first evaluation: URL → bot-author → header → timestamp. Equal timestamps fail closed (the comment can't have been authorized by an audit in the same millisecond).

## Test plan (32 tests)

- [x] 8 parseCommentUrl (canonical + 7 shape negatives: http, wrong host, /issues/, /files, wrong fragment, zero ids, empty)
- [x] 8 parseSealHeader (canonical merge + comment, whitespace tolerance, missing header, wrong verb, disallowed audit_id chars, wrong namespace, round-trip via buildSealHeader)
- [x] 1 happy path on verifyCommentMatches
- [x] 4 negative tests for C1 — URL alignment (wrong PR, wrong repo, typosquatting)
- [x] 2 negative tests for C2 — author (null, different App ID)
- [x] 3 negative tests for C3 — header (missing, verb mismatch, audit_id mismatch)
- [x] 3 negative tests for C4 — timestamp (predates, equal, unparseable)
- [x] 3 evaluation-order pins

Web suite: 1774 passing.

## What this slice does NOT do

- No GitHub fetching (slice 2d-c will mint a token + fetch the comment via `GET /repos/{owner}/{repo}/issues/comments/{id}`).
- No Lua / no state transition (slice 2d-b ships the `deciding → decided_pending_action` / `deciding → closed` Lua + storage primitive).
- No endpoint surface (slice 2d-c wires everything: verifier + Lua + GitHub fetch + audit emit).

## Stack position

- ✅ slices 2a-2c-b all in main
- 🔄 **This PR (slice 2d-a)** — G17 verifier pure logic
- ⏳ slice 2d-b — Lua atomic transition + sealDecision storage primitive
- ⏳ slice 2d-c — seal-decision endpoint wiring all together
- ⏳ slices 2e (confirm-merge + report-merge-result) + 2f (G32 reconciler)
- ⏳ PR 4 (hive queen agent plugin) + PR 7 (deploy + e2e)