### PR TITLE
Fix fleet rollout blockers

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -2,9 +2,9 @@
 # Must be at global scope (before first FROM) to be usable in FROM directives.
 # Values: all | codex | gemini | kilo | opencode | claude
 ARG PROVIDER=all
-ARG GH_VERSION=2.89.0
+ARG GH_VERSION=2.92.0
 
-FROM golang:1.26.2-bookworm AS gh-builder
+FROM golang:1.26.3-bookworm AS gh-builder
 
 ARG GH_VERSION
 RUN GOBIN=/tmp/gh-bin go install github.com/cli/cli/v2/cmd/gh@v${GH_VERSION}

--- a/bot/api/lib/types.ts
+++ b/bot/api/lib/types.ts
@@ -30,6 +30,7 @@ export interface Repository {
   };
   name: string;
   full_name: string;
+  archived?: boolean;
 }
 
 /**

--- a/bot/scripts/cleanup-stale-prs.test.ts
+++ b/bot/scripts/cleanup-stale-prs.test.ts
@@ -524,4 +524,24 @@ describe("processRepository", () => {
 
     expect(mockPRs.findPRsWithLabel).not.toHaveBeenCalled();
   });
+
+  it("should skip archived repositories before loading config", async () => {
+    const { createPROperations, loadRepositoryConfig, logger } = await import("../api/lib/index.js");
+
+    const mockOctokit = {} as Parameters<typeof processRepository>[0];
+    const repo = {
+      owner: { login: "test-org" },
+      name: "archived-repo",
+      full_name: "test-org/archived-repo",
+      archived: true,
+    };
+
+    await processRepository(mockOctokit, repo, testAppId);
+
+    expect(loadRepositoryConfig).not.toHaveBeenCalled();
+    expect(createPROperations).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      "[test-org/archived-repo] Repository is archived; skipping stale PR cleanup"
+    );
+  });
 });

--- a/bot/scripts/cleanup-stale-prs.ts
+++ b/bot/scripts/cleanup-stale-prs.ts
@@ -106,6 +106,11 @@ export async function processRepository(
   logger.group(`Processing ${repo.full_name}`);
 
   try {
+    if (repo.archived) {
+      logger.info(`[${repo.full_name}] Repository is archived; skipping stale PR cleanup`);
+      return;
+    }
+
     // Load per-repo configuration (returns null when no config file exists)
     const repoConfig = await loadRepositoryConfig(octokit, owner, repoName);
     if (!repoConfig) {


### PR DESCRIPTION
## Description

Fixes the two post-merge rollout blockers that kept the fleet from being clean: the agent image was building `gh` from versions with fixed HIGH vulnerabilities available upstream, and stale PR cleanup was failing on archived legacy repos that GitHub exposes through the App installation but no longer allows mutations against.

Closes #669

## Visual Changes

None.

## Verification

- `npm run test -- scripts/cleanup-stale-prs.test.ts` in `bot/`
- `npm run typecheck` in `bot/`
- `npm run build` in `bot/`
- `bash scripts/test-trivyignore-check.sh` in `agent/`

Docker daemon is not running in this local environment, so the Docker build and Trivy scan need GitHub Actions to verify the image scan.
