### PR TITLE
Add hive local queen runner

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -355,7 +355,7 @@ Write like a teammate, not a report generator. Lead with your point.
 **Hivemoot plugin** (minimal: `AGENT_PLUGINS=hivemoot`; for tasks
 that operate on GitHub repos, add `github`):
 
-The consolidated `hivemoot` plugin bundles three feature-toggled
+The consolidated `hivemoot` plugin bundles feature-toggled
 subsystems (see `plugins.hivemoot` in `hivemoot.yaml`):
 
 - `health` — periodic heartbeats + per-run reports to
@@ -375,6 +375,21 @@ subsystems (see `plugins.hivemoot` in `hivemoot.yaml`):
   operating mode, buzz role loading, skill bundle.  Co-loads with
   the `github` plugin and reads its typed config for `repos[0]` +
   `workspace`.
+- `apiarist` — GitHub installation-token brokering through the host
+  apiarist Unix socket.
+- `war_rooms` — reviewer-side room watching, RSVP/contribution
+  lifecycle, and per-room heartbeat reporting.
+- `queen` — local queen synthesis runner.  When enabled on exactly
+  one hive runner for an installation, it polls
+  `/api/rooms/synthesis-ready`, verifies all participants are
+  non-pending and the room quiet period has elapsed, claims synthesis,
+  captures a fresh PR head SHA with a minted GitHub App token, runs a
+  local synthesis job, posts a verified GitHub App comment, and seals
+  the closed decision through `/api/rooms/:roomId/seal-decision`.
+  It is disabled by default and currently supports the verified
+  comment-close path; keep cloud `queen_mode=cloud` until the runner
+  PR, seal-decision web endpoint, and fleet config are deployed and
+  observed healthy.
 
 Task claim flow: the trigger polls `plugins.hivemoot.tasks.claim_url`
 every `poll_interval_secs` (default 10s).  On a successful claim it
@@ -399,6 +414,18 @@ Backend contract:
   so codex writes its final markdown directly (preferred over NDJSON parsing).
 - Health contract: see
   [`web/AGENT_HEALTH_CONTRACT.md`](../web/AGENT_HEALTH_CONTRACT.md).
+- Local queen rollout: issue local-queen tokens with the
+  `local_queen` preset and a repo-scoped policy, then opt in with:
+
+```yaml
+plugins:
+  hivemoot:
+    token_file: !secret hivemoot_local_queen_token
+    queen:
+      enabled: true
+      base_url: https://www.hivemoot.dev
+      runner_id: hive-queen-1
+```
 
 Both `codex` and `claude` providers support session resume for follow-up work. GitHub mention triggers store one session per notification thread, and delegated task jobs use `task:<task_id>` keys so follow-up work can reuse provider context when `SESSION_RESUME=1`. For Codex the UUID comes from `--json` output (`thread.started.thread_id`) and is resumed via `codex exec resume <SESSION_ID>`. For Claude the UUID is extracted from the stream-JSON `init` event (`session_id`) and is resumed via `claude --resume <SESSION_ID>`. Session maps are persisted under each agent workspace (for example `/workspace/repo/agents/<agent-id>/sessions/<provider>/tool-session-map.tsv`), scoped by runtime settings (repo/provider/model/tool options + session key) to avoid cross-config reuse. Cron ticks (empty session key) always start fresh by design. Resume is strict: sessions reset when idle/age limits are exceeded (`SESSION_RESUME_MAX_IDLE_HOURS` / `SESSION_RESUME_MAX_AGE_HOURS`), and any failed resume is retried once as a fresh session. To disable resume, set `SESSION_RESUME=0`.
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -1,6 +1,6 @@
 """Consolidated Hivemoot ecosystem plugin.
 
-One plugin, five independently-toggleable features:
+One plugin, six independently-toggleable features:
 
   * ``health`` — periodic heartbeats + per-run reports to
     ``POST {base_url}/api/agent-health`` (dashboard Agent Health tab).
@@ -14,6 +14,9 @@ One plugin, five independently-toggleable features:
   * ``war_rooms`` — poll ``/api/rooms/watching``, dispatch a triage
     Job per visible room, parse the agent's structured response,
     and call ``/present + /contribute`` or ``/present + /withdraw``.
+  * ``queen`` — local queen runner: poll synthesis-ready rooms,
+    claim one, run local synthesis, post the verified GitHub comment,
+    and seal the closed decision.
 
 YAML shape (``hivemoot.yaml``):
 
@@ -31,6 +34,8 @@ YAML shape (``hivemoot.yaml``):
           enabled: true
         war_rooms:
           enabled: true
+        queen:
+          enabled: false
 
 Host behaviour is plugin-agnostic per ADR-002; this plugin owns its
 full vertical slice (triggers, lifecycle hooks, system prompts,
@@ -130,6 +135,8 @@ class HivemootPlugin:
         # it (set).  Starts set so the first claim is unblocked.
         self._task_inflight: threading.Event = threading.Event()
         self._task_inflight.set()
+        self._queen_inflight: threading.Event = threading.Event()
+        self._queen_inflight.set()
 
         # ── GitHub-workflows subsystem state ─────────────────────
         self._target_repo: str = ""
@@ -159,6 +166,8 @@ class HivemootPlugin:
         # when the post sequence totally fails. None when war_rooms
         # disabled OR triggers() hasn't been called yet.
         self._war_room_trigger: Any = None
+        # Local queen trigger reference, cached for tests/diagnostics.
+        self._queen_trigger: Any = None
 
         # ── Engine-side lifecycle substrate (PRs C+D of the
         #    JOB_LIFECYCLE_UNIFICATION RFC) ────────────────────────
@@ -194,6 +203,8 @@ class HivemootPlugin:
             errors.extend(self._validate_tasks(cfg))
         if cfg.github_workflows.enabled:
             errors.extend(self._validate_github_workflows(cfg))
+        if cfg.queen.enabled:
+            errors.extend(self._validate_queen(cfg))
 
         return errors
 
@@ -279,6 +290,33 @@ class HivemootPlugin:
                 "PATH (used by the role loader)."
             )
 
+        return errors
+
+    def _validate_queen(self, cfg: "HivemootConfig") -> list[str]:
+        errors: list[str] = []
+        if not cfg.queen.base_url:
+            errors.append(
+                "plugins.hivemoot.queen.base_url is required when "
+                "queen.enabled is true"
+            )
+        if cfg.token_file is None and not (
+            os.environ.get("HIVEMOOT_AGENT_TOKEN_FILE")
+            or os.environ.get("HIVEMOOT_AGENT_TOKEN")
+        ):
+            errors.append(
+                "plugins.hivemoot.token_file (or HIVEMOOT_AGENT_TOKEN"
+                "{,_FILE} env) is required when queen.enabled is true"
+            )
+        if not (cfg.queen.runner_id or self.resolved_agent_id()):
+            errors.append(
+                "AGENT_ID env var or plugins.hivemoot.queen.runner_id "
+                "is required when queen.enabled is true"
+            )
+        if cfg.queen.enable_squash_merge:
+            errors.append(
+                "plugins.hivemoot.queen.enable_squash_merge is reserved "
+                "until confirm-merge/report-merge-result endpoints land"
+            )
         return errors
 
     def setup(self, config: PluginConfig) -> None:
@@ -568,6 +606,32 @@ class HivemootPlugin:
                 ),
             )
 
+        if cfg.queen.enabled:
+            from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+                resolve_agent_token,
+            )
+            from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+                LocalQueenSynthesisTrigger,
+            )
+
+            token_path = str(cfg.token_file) if cfg.token_file else ""
+            runner_id = cfg.queen.runner_id or self.resolved_agent_id()
+            self._queen_trigger = LocalQueenSynthesisTrigger(
+                self,
+                base_url=cfg.queen.base_url,
+                token_resolver=lambda _token=token_path: resolve_agent_token(
+                    _token,
+                ),
+                runner_id=runner_id,
+                agent_id=self.resolved_agent_id(),
+                poll_interval_secs=cfg.queen.poll_interval_secs,
+                ready_limit=cfg.queen.synthesis_ready_limit,
+                claim_ttl_secs=cfg.queen.claim_ttl_secs,
+                fallback_quiet_period_secs=cfg.queen.fallback_quiet_period_secs,
+                gh_timeout_secs=cfg.queen.gh_timeout_secs,
+            )
+            triggers.append(self._queen_trigger)  # type: ignore[arg-type]
+
         return triggers
 
     def system_prompt(self, config: PluginConfig) -> str:
@@ -710,6 +774,23 @@ class HivemootPlugin:
                 # skipped the release.
                 self.release_task_slot()
 
+        if cfg.queen.enabled:
+            from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+                is_queen_job,
+            )
+            if is_queen_job(job):
+                try:
+                    self._queen_on_job_finished(job, result, config)
+                except Exception as exc:
+                    print(
+                        f"[hivemoot-queen] on_job_finished raised "
+                        f"room={job.metadata.get('room_id')}: "
+                        f"{type(exc).__name__}: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
+                finally:
+                    self.release_queen_slot()
+
         if cfg.health.enabled and cfg.health.post_run_reports:
             try:
                 self._health_on_job_finished(job, result)
@@ -820,6 +901,50 @@ class HivemootPlugin:
             on_post_failure=evict,
         )
 
+    def _queen_on_job_finished(
+        self,
+        job: Job,
+        result: AgentResult,
+        config: PluginConfig,
+    ) -> None:
+        from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+            resolve_agent_token,
+        )
+        from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+            handle_queen_job_finished,
+        )
+        from hivemoot_agent.plugins_builtin.hivemoot.tasks import (
+            result_extractor,
+        )
+
+        cfg = self._cfg
+        if cfg is None or not cfg.queen.enabled:
+            return
+
+        bearer = resolve_agent_token(
+            str(cfg.token_file) if cfg.token_file else "",
+        )
+        provider = config.get("AGENT_PROVIDER", "claude")
+        log_path = self._resolve_provider_log_path(config)
+        sidecar = self._codex_sidecar_path
+
+        markdown = result_extractor.extract_result(
+            provider, log_path, sidecar_path=sidecar,
+        )
+        runner_id = cfg.queen.runner_id or self.resolved_agent_id()
+
+        handle_queen_job_finished(
+            job,
+            result,
+            base_url=cfg.queen.base_url,
+            bearer=bearer,
+            extracted_markdown=markdown,
+            queen_runner=runner_id,
+            agent_id=self.resolved_agent_id() or None,
+            gh_timeout_secs=cfg.queen.gh_timeout_secs,
+            enable_squash_merge=cfg.queen.enable_squash_merge,
+        )
+
     # ── Helpers used by triggers ──────────────────────────────────
 
     def resolved_agent_id(self) -> str:
@@ -861,6 +986,24 @@ class HivemootPlugin:
         ``on_job_finished``'s finally block and from the trigger's
         dispatch-failed path."""
         self._task_inflight.set()
+
+    # ── In-flight gate for the local queen trigger ───────────────
+
+    def wait_queen_slot(
+        self, stop_event: threading.Event, timeout: float = 1.0,
+    ) -> bool:
+        """Block until the local queen can claim another room."""
+        if stop_event.is_set():
+            return False
+        return self._queen_inflight.wait(timeout=timeout)
+
+    def reserve_queen_slot(self) -> None:
+        """Mark the local queen as busy with one synthesis job."""
+        self._queen_inflight.clear()
+
+    def release_queen_slot(self) -> None:
+        """Release the local queen synthesis slot."""
+        self._queen_inflight.set()
 
     # ── Private: shared resolvers ─────────────────────────────────
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -1,7 +1,8 @@
 """Pydantic config schema for the consolidated ``hivemoot`` plugin.
 
-One plugin, three features (health / tasks / github_workflows), each
-toggled independently.  The shared inputs (bearer token, base URL)
+One plugin, six features (health / tasks / github_workflows /
+apiarist / war_rooms / queen), each toggled independently.  The
+shared inputs (bearer token, base URL)
 live at the top level so operators don't repeat them under every
 feature block.
 
@@ -22,6 +23,8 @@ YAML shape:
         github_workflows:
           enabled: true
           role_name: builder
+        queen:
+          enabled: false
 """
 
 from __future__ import annotations
@@ -340,6 +343,86 @@ class HivemootWarRoomsConfig(StrictPluginConfig):
     )
 
 
+class HivemootQueenConfig(StrictPluginConfig):
+    """Local queen runner — claims synthesis-ready rooms and posts
+    verified GitHub comments through the local hive container.
+
+    Disabled by default. Operators should enable this only after the
+    web-side local-queen endpoints are deployed and the installation is
+    still in cloud mode; the final ``queen_mode=local`` flip is a
+    separate rollout step.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable the local queen synthesis trigger + on_job_finished "
+            "handler. Off by default; fleet YAML opts one runner in."
+        ),
+    )
+    base_url: str = Field(
+        default="https://www.hivemoot.dev",
+        description=(
+            "Base URL for the local-queen API endpoints. The runner "
+            "polls /api/rooms/synthesis-ready and posts resolve/seal "
+            "requests under this base."
+        ),
+    )
+    poll_interval_secs: int = Field(
+        default=60,
+        ge=5,
+        description=(
+            "Seconds between local queen synthesis polls. Default 60s "
+            "matches the cloud queen tick cadence; floor prevents "
+            "tight-looping during backend failures."
+        ),
+    )
+    synthesis_ready_limit: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description=(
+            "Max rooms fetched from /synthesis-ready per poll. The "
+            "trigger claims at most one room per tick/run."
+        ),
+    )
+    claim_ttl_secs: int = Field(
+        default=900,
+        ge=60,
+        le=900,
+        description=(
+            "TTL requested for /claim-synthesis. Must stay within the "
+            "server's 15 minute seal-decision audit window."
+        ),
+    )
+    fallback_quiet_period_secs: int = Field(
+        default=60,
+        ge=0,
+        description=(
+            "Quiet period used when a room core lacks timing_config."
+        ),
+    )
+    runner_id: str = Field(
+        default="",
+        description=(
+            "Stable local queen runner id. Empty = AGENT_ID. This value "
+            "must match the claim and seal-decision queenRunner field."
+        ),
+    )
+    gh_timeout_secs: int = Field(
+        default=30,
+        ge=1,
+        description="Timeout for individual gh CLI calls.",
+    )
+    enable_squash_merge: bool = Field(
+        default=False,
+        description=(
+            "Reserved for the future confirm-merge/report-merge-result "
+            "slice. This PR supports only the verified comment-close path."
+        ),
+    )
+
+
 class HivemootConfig(StrictPluginConfig):
     """Top-level typed config for the consolidated hivemoot plugin."""
 
@@ -372,4 +455,8 @@ class HivemootConfig(StrictPluginConfig):
     war_rooms: HivemootWarRoomsConfig = Field(
         default_factory=HivemootWarRoomsConfig,
         description="War-room watcher + per-room triage/contribution handler.",
+    )
+    queen: HivemootQueenConfig = Field(
+        default_factory=HivemootQueenConfig,
+        description="Local queen synthesis runner.",
     )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/__init__.py
@@ -1,0 +1,36 @@
+"""Local queen feature block for the consolidated hivemoot plugin."""
+
+from __future__ import annotations
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
+    ClaimedSynthesis,
+    QueenAPIConflictError,
+    ResolveActionResult,
+    SealDecisionResult,
+    SynthesisReadyRoom,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.handler import (
+    JOB_KIND_SYNTHESIS,
+    build_seal_header,
+    handle_queen_job_finished,
+    is_queen_job,
+    parse_decision_output,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.trigger import (
+    LocalQueenSynthesisTrigger,
+)
+
+
+__all__ = (
+    "ClaimedSynthesis",
+    "JOB_KIND_SYNTHESIS",
+    "LocalQueenSynthesisTrigger",
+    "QueenAPIConflictError",
+    "ResolveActionResult",
+    "SealDecisionResult",
+    "SynthesisReadyRoom",
+    "build_seal_header",
+    "handle_queen_job_finished",
+    "is_queen_job",
+    "parse_decision_output",
+)

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/api.py
@@ -1,0 +1,396 @@
+"""Local queen API client.
+
+Worker-side wrappers for the web endpoints used by the hive-hosted
+queen runner. The transport stays on the shared hivemoot HTTP client
+so bearer handling, redirect refusal, and timeout behavior match the
+existing tasks and war-room clients.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+from hivemoot_agent.plugins_builtin.hivemoot.http import (
+    DEFAULT_TIMEOUT_SECS,
+    get_json,
+    post_json,
+)
+
+
+__all__ = (
+    "ClaimedSynthesis",
+    "QueenAPIConflictError",
+    "ResolveActionResult",
+    "SealDecisionResult",
+    "SynthesisReadyRoom",
+    "claim_synthesis",
+    "get_room_participants",
+    "list_room_events",
+    "list_synthesis_ready_rooms",
+    "mint_installation_token",
+    "resolve_action",
+    "seal_decision",
+)
+
+
+class QueenAPIConflictError(RuntimeError):
+    """A benign 409 from a local-queen endpoint.
+
+    The room moved, the claim is already held, or the caller's claim
+    view is stale. Trigger/handler code should log and wait for the
+    next poll rather than crashing the agent process.
+    """
+
+    def __init__(self, op: str, code: str, body_excerpt: str) -> None:
+        super().__init__(f"{op} returned conflict code={code}: {body_excerpt}")
+        self.op = op
+        self.code = code
+        self.body_excerpt = body_excerpt
+
+
+@dataclass
+class SynthesisReadyRoom:
+    room_id: str
+    status: str
+    subject_type: str
+    subject_ref: str
+    manager: str
+    opened_at: str
+    timing_config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ClaimedSynthesis:
+    room_id: str
+    through_sequence: int
+    claim_ttl_secs: int
+    room: dict[str, Any]
+    participants: dict[str, Any]
+    contributions: dict[str, Any]
+
+
+@dataclass
+class ResolveActionResult:
+    permitted_action: str
+    clamped_verdict: str
+    downgrade_reason: str | None
+    reviewed_head_sha: str
+    current_head_sha: str
+    floor_overridden: bool
+    audit_id: str
+
+
+@dataclass
+class SealDecisionResult:
+    final_state: str
+    closed_sequence: int
+    audit_id: str
+    idempotent: bool = False
+
+
+def _room_path(room_id: str) -> str:
+    return quote(room_id, safe="")
+
+
+def _body_excerpt(raw: bytes) -> str:
+    return raw.decode(errors="replace")[:200]
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _parse_ready_room(entry: dict[str, Any]) -> SynthesisReadyRoom:
+    room_id = str(entry.get("roomId") or entry.get("room_id") or "").strip()
+    if not room_id:
+        raise RuntimeError(f"synthesis-ready room missing roomId: {str(entry)[:200]}")
+    return SynthesisReadyRoom(
+        room_id=room_id,
+        status=str(entry.get("status") or ""),
+        subject_type=str(entry.get("subject_type") or entry.get("subjectType") or ""),
+        subject_ref=str(entry.get("subject_ref") or entry.get("subjectRef") or ""),
+        manager=str(entry.get("manager") or ""),
+        opened_at=str(entry.get("opened_at") or entry.get("openedAt") or ""),
+        timing_config=_as_dict(
+            entry.get("timing_config") or entry.get("timingConfig"),
+        ),
+    )
+
+
+def list_synthesis_ready_rooms(
+    base_url: str,
+    bearer: str,
+    *,
+    limit: int = 10,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> list[SynthesisReadyRoom]:
+    url = (
+        f"{base_url.rstrip('/')}/api/rooms/synthesis-ready?"
+        f"limit={max(1, int(limit))}"
+    )
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"synthesis-ready returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("synthesis-ready response was not a JSON object")
+    rooms_raw = parsed.get("rooms")
+    if rooms_raw is None:
+        return []
+    if not isinstance(rooms_raw, list):
+        raise RuntimeError("synthesis-ready response `rooms` must be a list")
+    rooms: list[SynthesisReadyRoom] = []
+    for entry in rooms_raw:
+        if isinstance(entry, dict):
+            rooms.append(_parse_ready_room(entry))
+    return rooms
+
+
+def get_room_participants(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/participants"
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"participants returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("participants response was not a JSON object")
+    return _as_dict(parsed.get("participants"))
+
+
+def list_room_events(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    limit: int = 500,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> list[dict[str, Any]]:
+    url = (
+        f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/events?"
+        f"limit={max(1, int(limit))}"
+    )
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(f"events returned status {status}: {_body_excerpt(raw)}")
+    if not isinstance(parsed, dict):
+        raise RuntimeError("events response was not a JSON object")
+    events = parsed.get("events")
+    if events is None:
+        return []
+    if not isinstance(events, list):
+        raise RuntimeError("events response `events` must be a list")
+    return [e for e in events if isinstance(e, dict)]
+
+
+def claim_synthesis(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    claim_ttl_secs: int,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> ClaimedSynthesis:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/claim-synthesis"
+    status, parsed, raw = post_json(
+        url,
+        {"queenRunner": queen_runner, "claimTtlSecs": claim_ttl_secs},
+        bearer,
+        timeout=timeout,
+    )
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "claim-synthesis",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"claim-synthesis returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("claim-synthesis response was not a JSON object")
+
+    claim = _as_dict(parsed.get("claim"))
+    through = _as_int(
+        claim.get("throughSequence") or claim.get("through_sequence"),
+    )
+    if through < 0:
+        raise RuntimeError("claim-synthesis returned invalid throughSequence")
+    return ClaimedSynthesis(
+        room_id=room_id,
+        through_sequence=through,
+        claim_ttl_secs=_as_int(
+            claim.get("claimTtlSecs") or claim.get("claim_ttl_secs"),
+            default=claim_ttl_secs,
+        ),
+        room=_as_dict(parsed.get("room")),
+        participants=_as_dict(parsed.get("participants")),
+        contributions=_as_dict(parsed.get("contributions")),
+    )
+
+
+def mint_installation_token(
+    base_url: str,
+    bearer: str,
+    *,
+    repo: str,
+    agent_id: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> str:
+    url = f"{base_url.rstrip('/')}/api/github/installation-tokens"
+    body: dict[str, Any] = {"repo": repo}
+    if agent_id:
+        body["agent_id"] = agent_id
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"installation-token mint returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("token"), str):
+        raise RuntimeError("installation-token response missing token")
+    return parsed["token"]
+
+
+def resolve_action(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    verdict: str,
+    reasoning: str,
+    recommended_action: str,
+    reviewed_head_sha: str,
+    sealed_through_sequence: int,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> ResolveActionResult:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/resolve-action"
+    status, parsed, raw = post_json(
+        url,
+        {
+            "queenRunner": queen_runner,
+            "derivedVerdict": {"verdict": verdict, "reasoning": reasoning},
+            "recommendedAction": recommended_action,
+            "reviewedHeadSha": reviewed_head_sha,
+            "sealedThroughSequence": sealed_through_sequence,
+        },
+        bearer,
+        timeout=timeout,
+    )
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "resolve-action",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"resolve-action returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("resolve-action response was not a JSON object")
+    audit_id = parsed.get("auditId") or parsed.get("audit_id")
+    if not isinstance(audit_id, str) or not audit_id:
+        raise RuntimeError("resolve-action response missing auditId")
+    return ResolveActionResult(
+        permitted_action=str(
+            parsed.get("permittedAction") or parsed.get("permitted_action") or "",
+        ),
+        clamped_verdict=str(
+            parsed.get("clampedVerdict") or parsed.get("clamped_verdict") or "",
+        ),
+        downgrade_reason=(
+            str(parsed.get("downgradeReason") or parsed.get("downgrade_reason"))
+            if parsed.get("downgradeReason") or parsed.get("downgrade_reason")
+            else None
+        ),
+        reviewed_head_sha=str(
+            parsed.get("reviewedHeadSha") or parsed.get("reviewed_head_sha") or "",
+        ),
+        current_head_sha=str(
+            parsed.get("currentHeadSha") or parsed.get("current_head_sha") or "",
+        ),
+        floor_overridden=bool(
+            parsed.get("floorOverridden") or parsed.get("floor_overridden") or False,
+        ),
+        audit_id=audit_id,
+    )
+
+
+def seal_decision(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    audit_id: str,
+    sealed_through_sequence: int,
+    decision: dict[str, Any],
+    comment_url: str | None = None,
+    downgrade_reason: str | None = None,
+    error_class: str | None = None,
+    retry_count: int | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> SealDecisionResult:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/seal-decision"
+    body: dict[str, Any] = {
+        "queenRunner": queen_runner,
+        "auditId": audit_id,
+        "finalState": "closed",
+        "sealedThroughSequence": sealed_through_sequence,
+        "decision": decision,
+    }
+    if comment_url:
+        body["commentUrl"] = comment_url
+    if downgrade_reason:
+        body["downgradeReason"] = downgrade_reason
+    if error_class:
+        body["errorClass"] = error_class
+    if retry_count is not None:
+        body["retryCount"] = retry_count
+
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "seal-decision",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"seal-decision returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("seal-decision response was not a JSON object")
+    return SealDecisionResult(
+        final_state=str(parsed.get("finalState") or parsed.get("final_state") or ""),
+        closed_sequence=_as_int(
+            parsed.get("closedSequence") or parsed.get("closed_sequence"),
+        ),
+        audit_id=str(parsed.get("auditId") or parsed.get("audit_id") or ""),
+        idempotent=bool(parsed.get("idempotent") or False),
+    )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
@@ -1,0 +1,176 @@
+"""GitHub CLI helpers for the local queen.
+
+The local queen uses short-lived GitHub App installation tokens minted
+by the web API. Tokens are passed only through the subprocess
+environment, never argv, so process listings and command logs do not
+expose them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import Sequence
+
+
+__all__ = (
+    "GHCommandError",
+    "PullRequestRef",
+    "get_pr_head_sha",
+    "parse_subject_ref",
+    "post_pr_comment",
+)
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def full_repo(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+
+class GHCommandError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        returncode: int | None = None,
+        stderr: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+_SUBJECT_RE = re.compile(r"^([^/\s]+)/([^#\s]+)#([1-9][0-9]*)$")
+
+
+def parse_subject_ref(subject_ref: str) -> PullRequestRef:
+    match = _SUBJECT_RE.match(subject_ref.strip())
+    if not match:
+        raise ValueError(
+            "subject_ref must have owner/repo#number shape; "
+            f"got {subject_ref!r}"
+        )
+    owner, repo, number = match.groups()
+    return PullRequestRef(owner=owner, repo=repo, number=int(number))
+
+
+def _run_gh(
+    args: Sequence[str],
+    *,
+    token: str,
+    timeout_secs: int,
+) -> str:
+    if not token:
+        raise GHCommandError("missing GitHub token")
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout_secs,
+        )
+    except FileNotFoundError as exc:
+        raise GHCommandError("gh CLI is not installed or not in PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GHCommandError(
+            f"gh command timed out after {timeout_secs}s",
+            stderr=(exc.stderr or "") if isinstance(exc.stderr, str) else "",
+        ) from exc
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        raise GHCommandError(
+            f"gh command failed with exit {proc.returncode}: {stderr[:300]}",
+            returncode=proc.returncode,
+            stderr=stderr,
+        )
+    return (proc.stdout or "").strip()
+
+
+def get_pr_head_sha(
+    pr: PullRequestRef,
+    *,
+    token: str,
+    timeout_secs: int = 30,
+) -> str:
+    out = _run_gh(
+        [
+            "pr",
+            "view",
+            str(pr.number),
+            "--repo",
+            pr.full_repo,
+            "--json",
+            "headRefOid",
+            "--jq",
+            ".headRefOid",
+        ],
+        token=token,
+        timeout_secs=timeout_secs,
+    )
+    if not out:
+        raise GHCommandError(f"gh pr view returned empty head SHA for {pr.full_repo}#{pr.number}")
+    return out
+
+
+def post_pr_comment(
+    pr: PullRequestRef,
+    body: str,
+    *,
+    token: str,
+    timeout_secs: int = 30,
+) -> str:
+    if not body.strip():
+        raise ValueError("comment body must be non-empty")
+
+    path = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            suffix=".json",
+            delete=False,
+        ) as f:
+            path = f.name
+            json.dump({"body": body}, f, ensure_ascii=False)
+
+        out = _run_gh(
+            [
+                "api",
+                "--method",
+                "POST",
+                f"repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments",
+                "--input",
+                path,
+                "--jq",
+                ".html_url",
+            ],
+            token=token,
+            timeout_secs=timeout_secs,
+        )
+        if not out:
+            raise GHCommandError(
+                f"gh api returned empty comment URL for {pr.full_repo}#{pr.number}"
+            )
+        return out
+    finally:
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
@@ -1,0 +1,275 @@
+"""Local queen job completion handler."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.queen import api as q_api
+from hivemoot_agent.plugins_builtin.hivemoot.queen import gh
+
+
+JOB_KIND_SYNTHESIS = "queen_synthesis"
+
+_VALID_VERDICTS = {"APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"}
+_VALID_ACTIONS = {"comment", "squash-merge"}
+_SEAL_HEADER_RE = re.compile(
+    r"<!--\s*hivemoot:queen-action:(?:merge|comment):[a-zA-Z0-9_-]+\s*-->"
+)
+
+
+@dataclass
+class QueenDecisionOutput:
+    verdict: str
+    reasoning: str
+    recommended_action: str
+    comment_body: str
+
+
+def is_queen_job(job: Job) -> bool:
+    return bool(
+        job.metadata.get("job_kind") == JOB_KIND_SYNTHESIS
+        and job.metadata.get("room_id")
+    )
+
+
+def build_seal_header(verb: str, audit_id: str) -> str:
+    if verb not in {"merge", "comment"}:
+        raise ValueError("seal verb must be merge or comment")
+    if not audit_id:
+        raise ValueError("audit_id must be non-empty")
+    return f"<!-- hivemoot:queen-action:{verb}:{audit_id} -->"
+
+
+def parse_decision_output(markdown: str) -> QueenDecisionOutput:
+    data = _extract_json_object(markdown)
+    verdict = str(data.get("verdict") or "").strip().upper()
+    if verdict not in _VALID_VERDICTS:
+        raise ValueError(
+            f"verdict must be one of {', '.join(sorted(_VALID_VERDICTS))}"
+        )
+
+    reasoning = str(data.get("reasoning") or "").strip()
+    if len(reasoning) > 500:
+        reasoning = reasoning[:500]
+
+    action = str(
+        data.get("recommended_action")
+        or data.get("recommendedAction")
+        or "",
+    ).strip().lower()
+    if action not in _VALID_ACTIONS:
+        raise ValueError("recommended_action must be comment or squash-merge")
+
+    body = str(
+        data.get("comment_body")
+        or data.get("commentBody")
+        or data.get("body")
+        or "",
+    ).strip()
+    if not body:
+        body = reasoning or f"Queen synthesized verdict: {verdict}."
+
+    return QueenDecisionOutput(
+        verdict=verdict,
+        reasoning=reasoning,
+        recommended_action=action,
+        comment_body=_sanitize_comment_body(body),
+    )
+
+
+def handle_queen_job_finished(
+    job: Job,
+    result: AgentResult,
+    *,
+    base_url: str,
+    bearer: str,
+    extracted_markdown: str,
+    queen_runner: str,
+    agent_id: str | None = None,
+    gh_timeout_secs: int = 30,
+    enable_squash_merge: bool = False,
+) -> None:
+    if not is_queen_job(job):
+        return
+
+    room_id = str(job.metadata.get("room_id") or "")
+    subject_ref = str(job.metadata.get("subject_ref") or "")
+    sealed_through_sequence = _metadata_int(job, "sealed_through_sequence")
+    reviewed_head_sha = str(job.metadata.get("reviewed_head_sha") or "").strip()
+
+    if result.exit_code != 0:
+        print(
+            f"[hivemoot-queen] synthesis job failed room={room_id} "
+            f"exit={result.exit_code}; claim TTL will release",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if not bearer:
+        raise RuntimeError("missing local queen bearer")
+    if not queen_runner:
+        raise RuntimeError("missing queen runner id")
+    if not room_id or not subject_ref:
+        raise RuntimeError("queen job metadata missing room_id/subject_ref")
+    if sealed_through_sequence < 0:
+        raise RuntimeError("queen job metadata missing sealed_through_sequence")
+    if not reviewed_head_sha:
+        raise RuntimeError("queen job metadata missing reviewed_head_sha")
+
+    decision = parse_decision_output(extracted_markdown)
+    recommended_action = (
+        decision.recommended_action if enable_squash_merge else "comment"
+    )
+
+    resolved = q_api.resolve_action(
+        base_url,
+        room_id,
+        bearer,
+        queen_runner=queen_runner,
+        verdict=decision.verdict,
+        reasoning=decision.reasoning,
+        recommended_action=recommended_action,
+        reviewed_head_sha=reviewed_head_sha,
+        sealed_through_sequence=sealed_through_sequence,
+    )
+
+    if resolved.permitted_action != "comment":
+        raise RuntimeError(
+            "local queen squash-merge path is not implemented in this "
+            f"runner slice (permittedAction={resolved.permitted_action})"
+        )
+
+    pr = gh.parse_subject_ref(subject_ref)
+    token = q_api.mint_installation_token(
+        base_url,
+        bearer,
+        repo=pr.full_repo,
+        agent_id=agent_id,
+    )
+
+    public_comment = _build_public_comment(
+        decision=decision,
+        audit_id=resolved.audit_id,
+        permitted_action=resolved.permitted_action,
+    )
+
+    try:
+        comment_url = gh.post_pr_comment(
+            pr,
+            public_comment,
+            token=token,
+            timeout_secs=gh_timeout_secs,
+        )
+    except Exception as exc:
+        if resolved.permitted_action == "squash-merge":
+            q_api.seal_decision(
+                base_url,
+                room_id,
+                bearer,
+                queen_runner=queen_runner,
+                audit_id=resolved.audit_id,
+                sealed_through_sequence=sealed_through_sequence,
+                decision=_room_decision(
+                    queen_runner=queen_runner,
+                    sealed_through_sequence=sealed_through_sequence,
+                    content=decision.comment_body,
+                ),
+                downgrade_reason="intended_action_post_failed",
+                error_class=type(exc).__name__,
+                retry_count=1,
+            )
+        raise
+
+    sealed = q_api.seal_decision(
+        base_url,
+        room_id,
+        bearer,
+        queen_runner=queen_runner,
+        audit_id=resolved.audit_id,
+        sealed_through_sequence=sealed_through_sequence,
+        decision=_room_decision(
+            queen_runner=queen_runner,
+            sealed_through_sequence=sealed_through_sequence,
+            content=decision.comment_body,
+        ),
+        comment_url=comment_url,
+    )
+
+    print(
+        f"[hivemoot-queen] sealed room={room_id} "
+        f"finalState={sealed.final_state} auditId={sealed.audit_id}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _extract_json_object(markdown: str) -> dict[str, Any]:
+    text = markdown.strip()
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        first = text.find("{")
+        if first >= 0:
+            text = text[first:]
+
+    decoder = json.JSONDecoder()
+    try:
+        parsed, _ = decoder.raw_decode(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("queen output did not contain a JSON object") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("queen output JSON must be an object")
+    return parsed
+
+
+def _sanitize_comment_body(body: str) -> str:
+    cleaned = _SEAL_HEADER_RE.sub("", body).strip()
+    return cleaned or "Queen synthesized a decision for this PR."
+
+
+def _build_public_comment(
+    *,
+    decision: QueenDecisionOutput,
+    audit_id: str,
+    permitted_action: str,
+) -> str:
+    verb = "merge" if permitted_action == "squash-merge" else "comment"
+    header = build_seal_header(verb, audit_id)
+    return f"{header}\n\n{decision.comment_body.strip()}\n"
+
+
+def _room_decision(
+    *,
+    queen_runner: str,
+    sealed_through_sequence: int,
+    content: str,
+) -> dict[str, Any]:
+    return {
+        "synthesized_at": datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "synthesis_runner": queen_runner,
+        "content": content,
+        "sequence_closed": sealed_through_sequence,
+    }
+
+
+def _metadata_int(job: Job, key: str) -> int:
+    value = job.metadata.get(key)
+    if isinstance(value, bool):
+        return -1
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return -1
+    return -1

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/prompts.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/prompts.py
@@ -1,0 +1,61 @@
+"""Prompt builder for the local queen synthesis job."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
+    ClaimedSynthesis,
+)
+
+
+__all__ = ("build_synthesis_prompt",)
+
+
+def build_synthesis_prompt(
+    *,
+    claimed: ClaimedSynthesis,
+    reviewed_head_sha: str,
+) -> str:
+    payload: dict[str, Any] = {
+        "room_id": claimed.room_id,
+        "sealed_through_sequence": claimed.through_sequence,
+        "reviewed_head_sha": reviewed_head_sha,
+        "room": claimed.room,
+        "participants": claimed.participants,
+        "contributions": claimed.contributions,
+    }
+    room_json = json.dumps(payload, indent=2, sort_keys=True, default=str)
+
+    return f"""# Local Queen Synthesis
+
+You are the Hivemoot local queen for a PR review war room. Synthesize the
+participants' contributions into one public PR comment.
+
+Important constraints:
+- Use only the room payload below as evidence.
+- The reviewed PR head SHA is `{reviewed_head_sha}`.
+- This runner slice is comment-close only. Set `recommended_action` to `comment`.
+- Do not include any `hivemoot:queen-action` seal header; the runner adds it.
+- Keep the public comment concise, specific, and actionable.
+
+Return exactly one fenced JSON block and no other prose:
+
+```json
+{{
+  "verdict": "APPROVE",
+  "reasoning": "Short explanation, 500 chars max.",
+  "recommended_action": "comment",
+  "comment_body": "Markdown body to post publicly on the PR."
+}}
+```
+
+Valid verdicts: APPROVE, COMMENT, CONCERNS, REQUEST_CHANGES.
+
+Room payload:
+
+```json
+{room_json}
+```
+"""

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -1,0 +1,329 @@
+"""Local queen synthesis trigger.
+
+Polls rooms that are candidates for synthesis, applies the local
+eligibility gates that the status-only endpoint intentionally omits,
+claims one room, captures a fresh PR head SHA, and dispatches a single
+agent job.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from hivemoot_agent.plugins.interfaces import Job, JobDispatcher, PluginConfig
+from hivemoot_agent.plugins_builtin.hivemoot.queen import api as q_api
+from hivemoot_agent.plugins_builtin.hivemoot.queen import gh
+from hivemoot_agent.plugins_builtin.hivemoot.queen.handler import (
+    JOB_KIND_SYNTHESIS,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.prompts import (
+    build_synthesis_prompt,
+)
+
+
+DEFAULT_POLL_INTERVAL_SECS = 60
+
+
+class LocalQueenSynthesisTrigger:
+    """Poll and dispatch one local queen synthesis job at a time."""
+
+    name = "hivemoot-queen"
+
+    def __init__(
+        self,
+        plugin: Any,
+        *,
+        base_url: str,
+        token_resolver: Callable[[], str],
+        runner_id: str,
+        agent_id: str,
+        poll_interval_secs: int = DEFAULT_POLL_INTERVAL_SECS,
+        ready_limit: int = 10,
+        claim_ttl_secs: int = 900,
+        fallback_quiet_period_secs: int = 60,
+        gh_timeout_secs: int = 30,
+        log_prefix: str = "[hivemoot-queen]",
+        list_ready_fn: Callable[
+            ..., list[q_api.SynthesisReadyRoom]
+        ] = q_api.list_synthesis_ready_rooms,
+        participants_fn: Callable[..., dict[str, Any]] = q_api.get_room_participants,
+        events_fn: Callable[..., list[dict[str, Any]]] = q_api.list_room_events,
+        claim_fn: Callable[..., q_api.ClaimedSynthesis] = q_api.claim_synthesis,
+        mint_token_fn: Callable[..., str] = q_api.mint_installation_token,
+        get_head_sha_fn: Callable[..., str] = gh.get_pr_head_sha,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._plugin = plugin
+        self._base_url = base_url
+        self._token_resolver = token_resolver
+        self._runner_id = runner_id
+        self._agent_id = agent_id
+        self._poll_interval_secs = max(1, poll_interval_secs)
+        self._ready_limit = max(1, ready_limit)
+        self._claim_ttl_secs = max(1, claim_ttl_secs)
+        self._fallback_quiet_period_secs = max(0, fallback_quiet_period_secs)
+        self._gh_timeout_secs = max(1, gh_timeout_secs)
+        self._log_prefix = log_prefix
+        self._list_ready = list_ready_fn
+        self._participants = participants_fn
+        self._events = events_fn
+        self._claim = claim_fn
+        self._mint_token = mint_token_fn
+        self._get_head_sha = get_head_sha_fn
+        self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))
+        self._stop_event = threading.Event()
+
+    def validate(self, config: PluginConfig) -> list[str]:
+        del config
+        return []
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def start(self, config: PluginConfig, dispatcher: JobDispatcher) -> None:
+        del config
+        self._stop_event.clear()
+        print(
+            f"{self._log_prefix} polling "
+            f"{self._base_url}/api/rooms/synthesis-ready every "
+            f"{self._poll_interval_secs}s",
+            file=sys.stderr,
+            flush=True,
+        )
+
+        while not self._stop_event.is_set():
+            try:
+                self._tick(dispatcher)
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} tick error: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            self._stop_event.wait(self._poll_interval_secs)
+
+    def _tick(self, dispatcher: JobDispatcher) -> None:
+        if not self._plugin.wait_queen_slot(self._stop_event, timeout=0):
+            return
+
+        bearer = self._token_resolver()
+        if not bearer:
+            return
+
+        try:
+            rooms = self._list_ready(
+                self._base_url,
+                bearer,
+                limit=self._ready_limit,
+            )
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} synthesis-ready failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+
+        for room in rooms:
+            if not self._is_room_ready(room, bearer):
+                continue
+
+            try:
+                claimed = self._claim(
+                    self._base_url,
+                    room.room_id,
+                    bearer,
+                    queen_runner=self._runner_id,
+                    claim_ttl_secs=self._claim_ttl_secs,
+                )
+            except q_api.QueenAPIConflictError as exc:
+                print(
+                    f"{self._log_prefix} claim skipped room={room.room_id}: "
+                    f"{exc.code}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} claim failed room={room.room_id}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+
+            try:
+                pr = gh.parse_subject_ref(room.subject_ref)
+                gh_token = self._mint_token(
+                    self._base_url,
+                    bearer,
+                    repo=pr.full_repo,
+                    agent_id=self._agent_id or None,
+                )
+                reviewed_head_sha = self._get_head_sha(
+                    pr,
+                    token=gh_token,
+                    timeout_secs=self._gh_timeout_secs,
+                )
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} head-sha capture failed "
+                    f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return
+
+            job = self._build_job(
+                room=room,
+                claimed=claimed,
+                reviewed_head_sha=reviewed_head_sha,
+            )
+
+            self._plugin.reserve_queen_slot()
+            try:
+                ok = dispatcher.dispatch(job)
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} dispatch raised room={room.room_id}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                self._plugin.release_queen_slot()
+                return
+            if not ok:
+                print(
+                    f"{self._log_prefix} dispatch refused room={room.room_id}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                self._plugin.release_queen_slot()
+                return
+
+            print(
+                f"{self._log_prefix} dispatched room={room.room_id} "
+                f"subject={room.subject_ref} seq={claimed.through_sequence}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+
+    def _is_room_ready(self, room: q_api.SynthesisReadyRoom, bearer: str) -> bool:
+        try:
+            participants = self._participants(self._base_url, room.room_id, bearer)
+            events = self._events(self._base_url, room.room_id, bearer, limit=500)
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} eligibility read failed "
+                f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
+        unresolved = []
+        for role, participant in participants.items():
+            status = (
+                str(participant.get("status") or "")
+                if isinstance(participant, dict)
+                else ""
+            )
+            if status not in {"resolved", "withdrew", "timed_out"}:
+                unresolved.append(role)
+        if unresolved:
+            print(
+                f"{self._log_prefix} room={room.room_id} not ready: "
+                f"unresolved participants={','.join(sorted(unresolved))}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
+        quiet_period = self._quiet_period_for(room)
+        if quiet_period <= 0:
+            return True
+
+        last_ts = self._last_event_timestamp(room, events)
+        if last_ts is None:
+            return False
+        age = (self._now_fn() - last_ts).total_seconds()
+        if age < quiet_period:
+            print(
+                f"{self._log_prefix} room={room.room_id} not ready: "
+                f"quiet age={int(age)}s required={quiet_period}s",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+        return True
+
+    def _quiet_period_for(self, room: q_api.SynthesisReadyRoom) -> int:
+        value = room.timing_config.get("quiet_period_secs")
+        if isinstance(value, bool):
+            return self._fallback_quiet_period_secs
+        if isinstance(value, int):
+            return max(0, value)
+        if isinstance(value, str):
+            try:
+                return max(0, int(value))
+            except ValueError:
+                pass
+        return self._fallback_quiet_period_secs
+
+    def _last_event_timestamp(
+        self,
+        room: q_api.SynthesisReadyRoom,
+        events: list[dict[str, Any]],
+    ) -> datetime | None:
+        for event in reversed(events):
+            parsed = _parse_iso(str(event.get("timestamp") or ""))
+            if parsed is not None:
+                return parsed
+        return _parse_iso(room.opened_at)
+
+    def _build_job(
+        self,
+        *,
+        room: q_api.SynthesisReadyRoom,
+        claimed: q_api.ClaimedSynthesis,
+        reviewed_head_sha: str,
+    ) -> Job:
+        metadata = {
+            "job_kind": JOB_KIND_SYNTHESIS,
+            "room_id": room.room_id,
+            "subject_type": room.subject_type,
+            "subject_ref": room.subject_ref,
+            "manager": room.manager,
+            "sealed_through_sequence": claimed.through_sequence,
+            "queen_runner": self._runner_id,
+            "reviewed_head_sha": reviewed_head_sha,
+            "coalesce_key": f"queen:{room.room_id}",
+        }
+        return Job(
+            session_key=f"queen:{room.room_id}@{claimed.through_sequence}",
+            prompt=build_synthesis_prompt(
+                claimed=claimed,
+                reviewed_head_sha=reviewed_head_sha,
+            ),
+            metadata=metadata,
+        )
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except ValueError:
+        return None

--- a/agent/cli/tests/test_hivemoot_config.py
+++ b/agent/cli/tests/test_hivemoot_config.py
@@ -15,6 +15,7 @@ from hivemoot_agent.plugins_builtin.hivemoot.config import (
     HivemootConfig,
     HivemootGithubWorkflowsConfig,
     HivemootHealthConfig,
+    HivemootQueenConfig,
     HivemootTasksConfig,
     HivemootWarRoomsConfig,
 )
@@ -28,6 +29,7 @@ class DefaultsTests(unittest.TestCase):
         self.assertFalse(cfg.github_workflows.enabled)
         self.assertFalse(cfg.apiarist.enabled)
         self.assertFalse(cfg.war_rooms.enabled)
+        self.assertFalse(cfg.queen.enabled)
 
     def test_war_rooms_defaults(self) -> None:
         cfg = HivemootWarRoomsConfig()
@@ -77,6 +79,16 @@ class DefaultsTests(unittest.TestCase):
         self.assertEqual(cfg.service, "")
         self.assertEqual(cfg.repo, "")
 
+    def test_queen_defaults(self) -> None:
+        cfg = HivemootQueenConfig()
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.base_url, "https://www.hivemoot.dev")
+        self.assertEqual(cfg.poll_interval_secs, 60)
+        self.assertEqual(cfg.synthesis_ready_limit, 10)
+        self.assertEqual(cfg.claim_ttl_secs, 900)
+        self.assertEqual(cfg.runner_id, "")
+        self.assertFalse(cfg.enable_squash_merge)
+
 
 class StrictnessTests(unittest.TestCase):
     """StrictPluginConfig forbids unknown fields — catches operator
@@ -110,6 +122,25 @@ class RangeTests(unittest.TestCase):
             HivemootApiaristConfig(timeout_seconds=0)
         with self.assertRaises(ValidationError):
             HivemootApiaristConfig(timeout_seconds=-1)
+
+    def test_queen_poll_interval_min_5s(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(poll_interval_secs=4)
+        HivemootQueenConfig(poll_interval_secs=5)
+
+    def test_queen_ready_limit_range(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(synthesis_ready_limit=0)
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(synthesis_ready_limit=51)
+        HivemootQueenConfig(synthesis_ready_limit=50)
+
+    def test_queen_claim_ttl_range(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(claim_ttl_secs=59)
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(claim_ttl_secs=901)
+        HivemootQueenConfig(claim_ttl_secs=900)
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_queen_api.py
+++ b/agent/cli/tests/test_hivemoot_queen_api.py
@@ -1,0 +1,149 @@
+"""Tests for the local queen API client."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen import api as q_api
+
+
+class QueenApiTests(unittest.TestCase):
+    def test_list_synthesis_ready_rooms_parses_room_core(self) -> None:
+        with patch.object(
+            q_api,
+            "get_json",
+            return_value=(
+                200,
+                {
+                    "rooms": [
+                        {
+                            "roomId": "room-1",
+                            "status": "awaiting_contributions",
+                            "subject_type": "pr_review",
+                            "subject_ref": "owner/repo#42",
+                            "manager": "bot-queen",
+                            "opened_at": "2026-05-15T00:00:00Z",
+                            "timing_config": {"quiet_period_secs": 60},
+                        },
+                    ],
+                    "count": 1,
+                },
+                b"",
+            ),
+        ) as get_mock:
+            rooms = q_api.list_synthesis_ready_rooms(
+                "https://api.example", "bearer", limit=7,
+            )
+        get_mock.assert_called_once_with(
+            "https://api.example/api/rooms/synthesis-ready?limit=7",
+            "bearer",
+            timeout=10,
+        )
+        self.assertEqual(len(rooms), 1)
+        self.assertEqual(rooms[0].room_id, "room-1")
+        self.assertEqual(rooms[0].subject_ref, "owner/repo#42")
+        self.assertEqual(rooms[0].timing_config["quiet_period_secs"], 60)
+
+    def test_claim_synthesis_maps_conflict(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                409,
+                {"code": "claim_already_held"},
+                b'{"code":"claim_already_held"}',
+            ),
+        ):
+            with self.assertRaises(q_api.QueenAPIConflictError) as ctx:
+                q_api.claim_synthesis(
+                    "https://api.example",
+                    "room-1",
+                    "bearer",
+                    queen_runner="runner",
+                    claim_ttl_secs=900,
+                )
+        self.assertEqual(ctx.exception.code, "claim_already_held")
+
+    def test_resolve_action_payload_and_result(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "permittedAction": "comment",
+                    "clampedVerdict": "APPROVE",
+                    "downgradeReason": None,
+                    "reviewedHeadSha": "abc",
+                    "currentHeadSha": "abc",
+                    "floorOverridden": False,
+                    "auditId": "123-0",
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.resolve_action(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                verdict="APPROVE",
+                reasoning="ok",
+                recommended_action="comment",
+                reviewed_head_sha="abc",
+                sealed_through_sequence=12,
+            )
+
+        args = post_mock.call_args[0]
+        self.assertEqual(
+            args[0],
+            "https://api.example/api/rooms/room-1/resolve-action",
+        )
+        self.assertEqual(args[1]["queenRunner"], "runner")
+        self.assertEqual(args[1]["derivedVerdict"]["verdict"], "APPROVE")
+        self.assertEqual(args[1]["sealedThroughSequence"], 12)
+        self.assertEqual(result.audit_id, "123-0")
+        self.assertEqual(result.permitted_action, "comment")
+
+    def test_seal_decision_sends_comment_url(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "finalState": "closed",
+                    "closedSequence": 13,
+                    "auditId": "123-0",
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.seal_decision(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                audit_id="123-0",
+                sealed_through_sequence=12,
+                decision={
+                    "synthesized_at": "2026-05-15T00:00:00Z",
+                    "synthesis_runner": "runner",
+                    "content": "ok",
+                    "sequence_closed": 12,
+                },
+                comment_url="https://github.com/o/r/pull/1#issuecomment-2",
+            )
+        body = post_mock.call_args[0][1]
+        self.assertEqual(body["finalState"], "closed")
+        self.assertEqual(body["commentUrl"], "https://github.com/o/r/pull/1#issuecomment-2")
+        self.assertEqual(result.closed_sequence, 13)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_handler.py
+++ b/agent/cli/tests/test_hivemoot_queen_handler.py
@@ -1,0 +1,156 @@
+"""Tests for the local queen completion handler."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
+    ResolveActionResult,
+    SealDecisionResult,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.handler import (
+    build_seal_header,
+    handle_queen_job_finished,
+    is_queen_job,
+    parse_decision_output,
+)
+
+
+def _job() -> Job:
+    return Job(
+        session_key="queen:room-1@12",
+        prompt="ignored",
+        metadata={
+            "job_kind": "queen_synthesis",
+            "room_id": "room-1",
+            "subject_ref": "owner/repo#42",
+            "sealed_through_sequence": 12,
+            "queen_runner": "queen-a",
+            "reviewed_head_sha": "abc123",
+        },
+    )
+
+
+def _markdown() -> str:
+    return """```json
+{
+  "verdict": "APPROVE",
+  "reasoning": "All checks pass.",
+  "recommended_action": "comment",
+  "comment_body": "Approved after reviewing the worker feedback."
+}
+```"""
+
+
+class QueenHandlerParserTests(unittest.TestCase):
+    def test_is_queen_job_requires_discriminator(self) -> None:
+        self.assertTrue(is_queen_job(_job()))
+        self.assertFalse(is_queen_job(Job("task:1", "x", {"task_id": "1"})))
+
+    def test_parse_decision_output_accepts_fenced_json(self) -> None:
+        parsed = parse_decision_output(_markdown())
+        self.assertEqual(parsed.verdict, "APPROVE")
+        self.assertEqual(parsed.recommended_action, "comment")
+        self.assertIn("Approved", parsed.comment_body)
+
+    def test_parse_decision_output_strips_model_supplied_seal_header(self) -> None:
+        parsed = parse_decision_output(
+            """{"verdict":"COMMENT","reasoning":"ok","recommended_action":"comment",
+            "comment_body":"<!-- hivemoot:queen-action:comment:bad -->\\nBody"}"""
+        )
+        self.assertEqual(parsed.comment_body, "Body")
+
+    def test_build_seal_header_matches_web_verifier_contract(self) -> None:
+        self.assertEqual(
+            build_seal_header("comment", "123-0"),
+            "<!-- hivemoot:queen-action:comment:123-0 -->",
+        )
+
+
+class QueenHandlerFlowTests(unittest.TestCase):
+    def test_comment_path_resolves_posts_comment_and_seals(self) -> None:
+        resolved = ResolveActionResult(
+            permitted_action="comment",
+            clamped_verdict="APPROVE",
+            downgrade_reason=None,
+            reviewed_head_sha="abc123",
+            current_head_sha="abc123",
+            floor_overridden=False,
+            audit_id="123-0",
+        )
+        sealed = SealDecisionResult(
+            final_state="closed",
+            closed_sequence=13,
+            audit_id="123-0",
+        )
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",
+            return_value=resolved,
+        ) as resolve_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.mint_installation_token",
+            return_value="ghs_x",
+        ) as mint_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.gh.post_pr_comment",
+            return_value="https://github.com/owner/repo/pull/42#issuecomment-7",
+        ) as comment_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.seal_decision",
+            return_value=sealed,
+        ) as seal_mock:
+            handle_queen_job_finished(
+                _job(),
+                AgentResult(0, ""),
+                base_url="https://api.example",
+                bearer="bearer",
+                extracted_markdown=_markdown(),
+                queen_runner="queen-a",
+                agent_id="queen-a",
+            )
+
+        resolve_mock.assert_called_once()
+        resolve_kwargs = resolve_mock.call_args.kwargs
+        self.assertEqual(resolve_kwargs["recommended_action"], "comment")
+        self.assertEqual(resolve_kwargs["reviewed_head_sha"], "abc123")
+        mint_mock.assert_called_once_with(
+            "https://api.example",
+            "bearer",
+            repo="owner/repo",
+            agent_id="queen-a",
+        )
+        public_comment = comment_mock.call_args[0][1]
+        self.assertIn(
+            "<!-- hivemoot:queen-action:comment:123-0 -->",
+            public_comment,
+        )
+        seal_kwargs = seal_mock.call_args.kwargs
+        self.assertEqual(
+            seal_kwargs["comment_url"],
+            "https://github.com/owner/repo/pull/42#issuecomment-7",
+        )
+        self.assertEqual(seal_kwargs["decision"]["sequence_closed"], 12)
+        self.assertNotIn("hivemoot:queen-action", seal_kwargs["decision"]["content"])
+
+    def test_nonzero_exit_does_not_mutate(self) -> None:
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",
+            MagicMock(),
+        ) as resolve_mock:
+            handle_queen_job_finished(
+                _job(),
+                AgentResult(1, "failed"),
+                base_url="https://api.example",
+                bearer="bearer",
+                extracted_markdown="",
+                queen_runner="queen-a",
+            )
+        resolve_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -1,0 +1,171 @@
+"""Tests for the local queen synthesis trigger."""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+    ClaimedSynthesis,
+    LocalQueenSynthesisTrigger,
+    SynthesisReadyRoom,
+)
+
+
+class SlotPlugin:
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.event.set()
+        self.reserved = 0
+        self.released = 0
+
+    def wait_queen_slot(self, stop_event, timeout=1.0):
+        del stop_event, timeout
+        return self.event.is_set()
+
+    def reserve_queen_slot(self):
+        self.reserved += 1
+        self.event.clear()
+
+    def release_queen_slot(self):
+        self.released += 1
+        self.event.set()
+
+
+def _room() -> SynthesisReadyRoom:
+    return SynthesisReadyRoom(
+        room_id="room-1",
+        status="awaiting_contributions",
+        subject_type="pr_review",
+        subject_ref="owner/repo#42",
+        manager="bot-queen",
+        opened_at="2026-05-15T00:00:00Z",
+        timing_config={"quiet_period_secs": 60},
+    )
+
+
+def _claimed() -> ClaimedSynthesis:
+    return ClaimedSynthesis(
+        room_id="room-1",
+        through_sequence=12,
+        claim_ttl_secs=900,
+        room={"subject_ref": "owner/repo#42"},
+        participants={"guard": {"status": "resolved"}},
+        contributions={"guard": {"raw_md": "lgtm"}},
+    )
+
+
+class LocalQueenTriggerTests(unittest.TestCase):
+    def test_dispatches_claimed_ready_room_with_head_sha(self) -> None:
+        plugin = SlotPlugin()
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = True
+
+        trigger = LocalQueenSynthesisTrigger(
+            plugin,
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=MagicMock(return_value=_claimed()),
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+
+        trigger._tick(dispatcher)
+
+        dispatcher.dispatch.assert_called_once()
+        job = dispatcher.dispatch.call_args[0][0]
+        self.assertEqual(job.session_key, "queen:room-1@12")
+        self.assertEqual(job.metadata["job_kind"], "queen_synthesis")
+        self.assertEqual(job.metadata["reviewed_head_sha"], "abc123")
+        self.assertEqual(job.metadata["coalesce_key"], "queen:room-1")
+        self.assertIn("comment-close only", job.prompt)
+        self.assertEqual(plugin.reserved, 1)
+        self.assertEqual(plugin.released, 0)
+
+    def test_skips_pending_participant_before_claim(self) -> None:
+        claim_fn = MagicMock(return_value=_claimed())
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "pending"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
+    def test_skips_room_until_quiet_period_elapsed(self) -> None:
+        claim_fn = MagicMock(return_value=_claimed())
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:01:30Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
+    def test_dispatch_refusal_releases_slot(self) -> None:
+        plugin = SlotPlugin()
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = False
+        trigger = LocalQueenSynthesisTrigger(
+            plugin,
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=MagicMock(return_value=_claimed()),
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        self.assertEqual(plugin.reserved, 1)
+        self.assertEqual(plugin.released, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_wiring.py
+++ b/agent/cli/tests/test_hivemoot_queen_wiring.py
@@ -1,0 +1,147 @@
+"""Tests for local queen wiring in the consolidated hivemoot plugin."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job, PluginConfig
+from hivemoot_agent.plugins_builtin.hivemoot import HivemootPlugin
+from hivemoot_agent.plugins_builtin.hivemoot.config import (
+    HivemootConfig,
+    HivemootQueenConfig,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+    JOB_KIND_SYNTHESIS,
+    LocalQueenSynthesisTrigger,
+)
+
+
+_TOKEN_FILE = Path("/tmp/.hivemoot-queen-test-token")
+
+
+def _ensure_token_file() -> Path:
+    if not _TOKEN_FILE.exists():
+        _TOKEN_FILE.write_text("test-token")
+    return _TOKEN_FILE
+
+
+def _mk_config(*, queen: HivemootQueenConfig | None = None) -> PluginConfig:
+    typed = HivemootConfig(
+        token_file=_ensure_token_file(),
+        queen=queen or HivemootQueenConfig(),
+    )
+    return PluginConfig(name="hivemoot", settings={}, typed=typed)
+
+
+def _queen_job() -> Job:
+    return Job(
+        session_key="queen:room-1@12",
+        prompt="ignored",
+        metadata={
+            "job_kind": JOB_KIND_SYNTHESIS,
+            "room_id": "room-1",
+            "subject_ref": "owner/repo#42",
+            "sealed_through_sequence": 12,
+            "queen_runner": "queen-a",
+            "reviewed_head_sha": "abc123",
+        },
+    )
+
+
+class QueenTriggerWiringTests(unittest.TestCase):
+    def test_disabled_by_default_no_trigger(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config().typed
+        self.assertEqual(plugin.triggers(), [])
+        self.assertIsNone(plugin._queen_trigger)
+
+    def test_enabled_instantiates_queen_trigger(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        ).typed
+        triggers = plugin.triggers()
+        self.assertEqual(len(triggers), 1)
+        self.assertIsInstance(triggers[0], LocalQueenSynthesisTrigger)
+        self.assertIs(plugin._queen_trigger, triggers[0])
+
+    def test_trigger_constructed_with_config_values(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(
+                enabled=True,
+                base_url="https://staging.example",
+                poll_interval_secs=30,
+                synthesis_ready_limit=5,
+                runner_id="queen-a",
+            ),
+        ).typed
+        trigger = plugin.triggers()[0]
+        self.assertEqual(trigger._base_url, "https://staging.example")
+        self.assertEqual(trigger._poll_interval_secs, 30)
+        self.assertEqual(trigger._ready_limit, 5)
+
+    def test_validate_rejects_reserved_squash_merge_flag(self) -> None:
+        plugin = HivemootPlugin()
+        config = _mk_config(
+            queen=HivemootQueenConfig(
+                enabled=True,
+                runner_id="queen-a",
+                enable_squash_merge=True,
+            ),
+        )
+        errors = plugin.validate(config)
+        self.assertTrue(
+            any("enable_squash_merge is reserved" in e for e in errors),
+            errors,
+        )
+
+
+class QueenOnFinishedWiringTests(unittest.TestCase):
+    def test_queen_job_dispatched_when_enabled(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        ).typed
+        config = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        )
+
+        with patch.object(plugin, "_queen_on_job_finished") as bridge_mock:
+            plugin.on_job_finished(_queen_job(), AgentResult(0, ""), config)
+        bridge_mock.assert_called_once()
+
+    def test_queen_job_not_dispatched_when_disabled(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config().typed
+        with patch.object(plugin, "_queen_on_job_finished") as bridge_mock:
+            plugin.on_job_finished(_queen_job(), AgentResult(0, ""), _mk_config())
+        bridge_mock.assert_not_called()
+
+    def test_queen_slot_released_when_bridge_raises(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        ).typed
+        plugin.reserve_queen_slot()
+        self.assertFalse(plugin._queen_inflight.is_set())
+        config = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        )
+        with patch.object(
+            plugin,
+            "_queen_on_job_finished",
+            side_effect=RuntimeError("boom"),
+        ):
+            plugin.on_job_finished(_queen_job(), AgentResult(0, ""), config)
+        self.assertTrue(plugin._queen_inflight.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #675.

Part of #672. This adds the disabled-by-default hive-side local queen runner for the verified comment-close path now that #674 has landed. It does not flip `queen_mode=local` and intentionally rejects the reserved squash-merge flag until confirm/report merge endpoints exist.

What changed:
- Adds `plugins.hivemoot.queen` config with conservative defaults.
- Polls `synthesis-ready`, pre-checks participants plus quiet period, claims one room at a time, captures fresh PR head SHA via a minted App token, and dispatches a coalesced queen synthesis job.
- Parses structured queen JSON, calls `resolve-action`, posts the App-authored PR comment with the seal header, and calls `seal-decision` for the closed/comment path.
- Keeps GitHub tokens out of argv/logs by passing them only through `GH_TOKEN`/`GITHUB_TOKEN`.
- Documents the hive rollout shape in `agent/README.md`.

Validation:
- `python3 -m compileall agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py`
- `python3 -m unittest discover -s agent/cli/tests -p 'test_hivemoot*.py'` (330 tests)\n- `git diff --check origin/main..HEAD`