### PR TITLE
Add hive local queen merge execution

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -385,10 +385,14 @@ subsystems (see `plugins.hivemoot` in `hivemoot.yaml`):
   non-pending and the room quiet period has elapsed, claims synthesis,
   captures a fresh PR head SHA with a minted GitHub App token, runs a
   local synthesis job, posts a verified GitHub App comment, and seals
-  the closed decision through `/api/rooms/:roomId/seal-decision`.
-  It is disabled by default and currently supports the verified
-  comment-close path; keep cloud `queen_mode=cloud` until the runner
-  PR, seal-decision web endpoint, and fleet config are deployed and
+  the decision through `/api/rooms/:roomId/seal-decision`.  When
+  `enable_squash_merge` is true, it also polls
+  `/api/rooms/decided-pending-ready`, calls the server-side
+  `confirm-merge` gate, runs `gh pr merge --squash` only after
+  approval, and reports the GitHub outcome back through
+  `/api/rooms/:roomId/report-merge-result`.  It is disabled by
+  default; keep cloud `queen_mode=cloud` until the web endpoints,
+  runner image, token policy, and fleet config are deployed and
   observed healthy.
 
 Task claim flow: the trigger polls `plugins.hivemoot.tasks.claim_url`
@@ -425,7 +429,14 @@ plugins:
       enabled: true
       base_url: https://www.hivemoot.dev
       runner_id: hive-queen-1
+      enable_squash_merge: false
 ```
+
+Deploy the runner with `enable_squash_merge: false` first to verify
+the comment-close path while the cloud queen is still authoritative.
+After the confirm/report endpoints are live and the runner is healthy,
+set `enable_squash_merge: true`, then flip the installation's
+`queen_mode` from `cloud` to `local`.
 
 Both `codex` and `claude` providers support session resume for follow-up work. GitHub mention triggers store one session per notification thread, and delegated task jobs use `task:<task_id>` keys so follow-up work can reuse provider context when `SESSION_RESUME=1`. For Codex the UUID comes from `--json` output (`thread.started.thread_id`) and is resumed via `codex exec resume <SESSION_ID>`. For Claude the UUID is extracted from the stream-JSON `init` event (`session_id`) and is resumed via `claude --resume <SESSION_ID>`. Session maps are persisted under each agent workspace (for example `/workspace/repo/agents/<agent-id>/sessions/<provider>/tool-session-map.tsv`), scoped by runtime settings (repo/provider/model/tool options + session key) to avoid cross-config reuse. Cron ticks (empty session key) always start fresh by design. Resume is strict: sessions reset when idle/age limits are exceeded (`SESSION_RESUME_MAX_IDLE_HOURS` / `SESSION_RESUME_MAX_AGE_HOURS`), and any failed resume is retried once as a fresh session. To disable resume, set `SESSION_RESUME=0`.
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -355,7 +355,7 @@ Write like a teammate, not a report generator. Lead with your point.
 **Hivemoot plugin** (minimal: `AGENT_PLUGINS=hivemoot`; for tasks
 that operate on GitHub repos, add `github`):
 
-The consolidated `hivemoot` plugin bundles three feature-toggled
+The consolidated `hivemoot` plugin bundles feature-toggled
 subsystems (see `plugins.hivemoot` in `hivemoot.yaml`):
 
 - `health` — periodic heartbeats + per-run reports to
@@ -375,6 +375,21 @@ subsystems (see `plugins.hivemoot` in `hivemoot.yaml`):
   operating mode, buzz role loading, skill bundle.  Co-loads with
   the `github` plugin and reads its typed config for `repos[0]` +
   `workspace`.
+- `apiarist` — GitHub installation-token brokering through the host
+  apiarist Unix socket.
+- `war_rooms` — reviewer-side room watching, RSVP/contribution
+  lifecycle, and per-room heartbeat reporting.
+- `queen` — local queen synthesis runner.  When enabled on exactly
+  one hive runner for an installation, it polls
+  `/api/rooms/synthesis-ready`, verifies all participants are
+  non-pending and the room quiet period has elapsed, claims synthesis,
+  captures a fresh PR head SHA with a minted GitHub App token, runs a
+  local synthesis job, posts a verified GitHub App comment, and seals
+  the closed decision through `/api/rooms/:roomId/seal-decision`.
+  It is disabled by default and currently supports the verified
+  comment-close path; keep cloud `queen_mode=cloud` until the runner
+  PR, seal-decision web endpoint, and fleet config are deployed and
+  observed healthy.
 
 Task claim flow: the trigger polls `plugins.hivemoot.tasks.claim_url`
 every `poll_interval_secs` (default 10s).  On a successful claim it
@@ -399,6 +414,18 @@ Backend contract:
   so codex writes its final markdown directly (preferred over NDJSON parsing).
 - Health contract: see
   [`web/AGENT_HEALTH_CONTRACT.md`](../web/AGENT_HEALTH_CONTRACT.md).
+- Local queen rollout: issue local-queen tokens with the
+  `local_queen` preset and a repo-scoped policy, then opt in with:
+
+```yaml
+plugins:
+  hivemoot:
+    token_file: !secret hivemoot_local_queen_token
+    queen:
+      enabled: true
+      base_url: https://www.hivemoot.dev
+      runner_id: hive-queen-1
+```
 
 Both `codex` and `claude` providers support session resume for follow-up work. GitHub mention triggers store one session per notification thread, and delegated task jobs use `task:<task_id>` keys so follow-up work can reuse provider context when `SESSION_RESUME=1`. For Codex the UUID comes from `--json` output (`thread.started.thread_id`) and is resumed via `codex exec resume <SESSION_ID>`. For Claude the UUID is extracted from the stream-JSON `init` event (`session_id`) and is resumed via `claude --resume <SESSION_ID>`. Session maps are persisted under each agent workspace (for example `/workspace/repo/agents/<agent-id>/sessions/<provider>/tool-session-map.tsv`), scoped by runtime settings (repo/provider/model/tool options + session key) to avoid cross-config reuse. Cron ticks (empty session key) always start fresh by design. Resume is strict: sessions reset when idle/age limits are exceeded (`SESSION_RESUME_MAX_IDLE_HOURS` / `SESSION_RESUME_MAX_AGE_HOURS`), and any failed resume is retried once as a fresh session. To disable resume, set `SESSION_RESUME=0`.
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -388,9 +388,11 @@ subsystems (see `plugins.hivemoot` in `hivemoot.yaml`):
   the decision through `/api/rooms/:roomId/seal-decision`.  When
   `enable_squash_merge` is true, it also polls
   `/api/rooms/decided-pending-ready`, calls the server-side
-  `confirm-merge` gate, runs `gh pr merge --squash` only after
-  approval, and reports the GitHub outcome back through
-  `/api/rooms/:roomId/report-merge-result`.  It is disabled by
+  `confirm-merge` gate, runs `gh pr merge --squash` with
+  `--match-head-commit` only after approval, and reports the GitHub
+  outcome back through `/api/rooms/:roomId/report-merge-result`.
+  Successful merges whose result report fails are retried from the
+  local `merge_report_queue_file`.  It is disabled by
   default; keep cloud `queen_mode=cloud` until the web endpoints,
   runner image, token policy, and fleet config are deployed and
   observed healthy.
@@ -430,6 +432,7 @@ plugins:
       base_url: https://www.hivemoot.dev
       runner_id: hive-queen-1
       enable_squash_merge: false
+      merge_report_queue_file: /workspace/hivemoot-queen-merge-reports.json
 ```
 
 Deploy the runner with `enable_squash_merge: false` first to verify

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -16,7 +16,8 @@ One plugin, six independently-toggleable features:
     and call ``/present + /contribute`` or ``/present + /withdraw``.
   * ``queen`` — local queen runner: poll synthesis-ready rooms,
     claim one, run local synthesis, post the verified GitHub comment,
-    and seal the closed decision.
+    seal the decision, and optionally execute server-confirmed
+    squash merges.
 
 YAML shape (``hivemoot.yaml``):
 
@@ -311,11 +312,6 @@ class HivemootPlugin:
             errors.append(
                 "AGENT_ID env var or plugins.hivemoot.queen.runner_id "
                 "is required when queen.enabled is true"
-            )
-        if cfg.queen.enable_squash_merge:
-            errors.append(
-                "plugins.hivemoot.queen.enable_squash_merge is reserved "
-                "until confirm-merge/report-merge-result endpoints land"
             )
         return errors
 
@@ -629,6 +625,7 @@ class HivemootPlugin:
                 claim_ttl_secs=cfg.queen.claim_ttl_secs,
                 fallback_quiet_period_secs=cfg.queen.fallback_quiet_period_secs,
                 gh_timeout_secs=cfg.queen.gh_timeout_secs,
+                enable_squash_merge=cfg.queen.enable_squash_merge,
             )
             triggers.append(self._queen_trigger)  # type: ignore[arg-type]
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -626,6 +626,7 @@ class HivemootPlugin:
                 fallback_quiet_period_secs=cfg.queen.fallback_quiet_period_secs,
                 gh_timeout_secs=cfg.queen.gh_timeout_secs,
                 enable_squash_merge=cfg.queen.enable_squash_merge,
+                merge_report_queue_file=str(cfg.queen.merge_report_queue_file),
             )
             triggers.append(self._queen_trigger)  # type: ignore[arg-type]
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py
@@ -1,6 +1,6 @@
 """Consolidated Hivemoot ecosystem plugin.
 
-One plugin, five independently-toggleable features:
+One plugin, six independently-toggleable features:
 
   * ``health`` — periodic heartbeats + per-run reports to
     ``POST {base_url}/api/agent-health`` (dashboard Agent Health tab).
@@ -14,6 +14,9 @@ One plugin, five independently-toggleable features:
   * ``war_rooms`` — poll ``/api/rooms/watching``, dispatch a triage
     Job per visible room, parse the agent's structured response,
     and call ``/present + /contribute`` or ``/present + /withdraw``.
+  * ``queen`` — local queen runner: poll synthesis-ready rooms,
+    claim one, run local synthesis, post the verified GitHub comment,
+    and seal the closed decision.
 
 YAML shape (``hivemoot.yaml``):
 
@@ -31,6 +34,8 @@ YAML shape (``hivemoot.yaml``):
           enabled: true
         war_rooms:
           enabled: true
+        queen:
+          enabled: false
 
 Host behaviour is plugin-agnostic per ADR-002; this plugin owns its
 full vertical slice (triggers, lifecycle hooks, system prompts,
@@ -130,6 +135,8 @@ class HivemootPlugin:
         # it (set).  Starts set so the first claim is unblocked.
         self._task_inflight: threading.Event = threading.Event()
         self._task_inflight.set()
+        self._queen_inflight: threading.Event = threading.Event()
+        self._queen_inflight.set()
 
         # ── GitHub-workflows subsystem state ─────────────────────
         self._target_repo: str = ""
@@ -159,6 +166,8 @@ class HivemootPlugin:
         # when the post sequence totally fails. None when war_rooms
         # disabled OR triggers() hasn't been called yet.
         self._war_room_trigger: Any = None
+        # Local queen trigger reference, cached for tests/diagnostics.
+        self._queen_trigger: Any = None
 
         # ── Engine-side lifecycle substrate (PRs C+D of the
         #    JOB_LIFECYCLE_UNIFICATION RFC) ────────────────────────
@@ -194,6 +203,8 @@ class HivemootPlugin:
             errors.extend(self._validate_tasks(cfg))
         if cfg.github_workflows.enabled:
             errors.extend(self._validate_github_workflows(cfg))
+        if cfg.queen.enabled:
+            errors.extend(self._validate_queen(cfg))
 
         return errors
 
@@ -279,6 +290,33 @@ class HivemootPlugin:
                 "PATH (used by the role loader)."
             )
 
+        return errors
+
+    def _validate_queen(self, cfg: "HivemootConfig") -> list[str]:
+        errors: list[str] = []
+        if not cfg.queen.base_url:
+            errors.append(
+                "plugins.hivemoot.queen.base_url is required when "
+                "queen.enabled is true"
+            )
+        if cfg.token_file is None and not (
+            os.environ.get("HIVEMOOT_AGENT_TOKEN_FILE")
+            or os.environ.get("HIVEMOOT_AGENT_TOKEN")
+        ):
+            errors.append(
+                "plugins.hivemoot.token_file (or HIVEMOOT_AGENT_TOKEN"
+                "{,_FILE} env) is required when queen.enabled is true"
+            )
+        if not (cfg.queen.runner_id or self.resolved_agent_id()):
+            errors.append(
+                "AGENT_ID env var or plugins.hivemoot.queen.runner_id "
+                "is required when queen.enabled is true"
+            )
+        if cfg.queen.enable_squash_merge:
+            errors.append(
+                "plugins.hivemoot.queen.enable_squash_merge is reserved "
+                "until confirm-merge/report-merge-result endpoints land"
+            )
         return errors
 
     def setup(self, config: PluginConfig) -> None:
@@ -568,6 +606,32 @@ class HivemootPlugin:
                 ),
             )
 
+        if cfg.queen.enabled:
+            from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+                resolve_agent_token,
+            )
+            from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+                LocalQueenSynthesisTrigger,
+            )
+
+            token_path = str(cfg.token_file) if cfg.token_file else ""
+            runner_id = cfg.queen.runner_id or self.resolved_agent_id()
+            self._queen_trigger = LocalQueenSynthesisTrigger(
+                self,
+                base_url=cfg.queen.base_url,
+                token_resolver=lambda _token=token_path: resolve_agent_token(
+                    _token,
+                ),
+                runner_id=runner_id,
+                agent_id=self.resolved_agent_id(),
+                poll_interval_secs=cfg.queen.poll_interval_secs,
+                ready_limit=cfg.queen.synthesis_ready_limit,
+                claim_ttl_secs=cfg.queen.claim_ttl_secs,
+                fallback_quiet_period_secs=cfg.queen.fallback_quiet_period_secs,
+                gh_timeout_secs=cfg.queen.gh_timeout_secs,
+            )
+            triggers.append(self._queen_trigger)  # type: ignore[arg-type]
+
         return triggers
 
     def system_prompt(self, config: PluginConfig) -> str:
@@ -710,6 +774,23 @@ class HivemootPlugin:
                 # skipped the release.
                 self.release_task_slot()
 
+        if cfg.queen.enabled:
+            from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+                is_queen_job,
+            )
+            if is_queen_job(job):
+                try:
+                    self._queen_on_job_finished(job, result, config)
+                except Exception as exc:
+                    print(
+                        f"[hivemoot-queen] on_job_finished raised "
+                        f"room={job.metadata.get('room_id')}: "
+                        f"{type(exc).__name__}: {exc}",
+                        file=sys.stderr, flush=True,
+                    )
+                finally:
+                    self.release_queen_slot()
+
         if cfg.health.enabled and cfg.health.post_run_reports:
             try:
                 self._health_on_job_finished(job, result)
@@ -820,6 +901,50 @@ class HivemootPlugin:
             on_post_failure=evict,
         )
 
+    def _queen_on_job_finished(
+        self,
+        job: Job,
+        result: AgentResult,
+        config: PluginConfig,
+    ) -> None:
+        from hivemoot_agent.plugins_builtin.hivemoot.auth import (
+            resolve_agent_token,
+        )
+        from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+            handle_queen_job_finished,
+        )
+        from hivemoot_agent.plugins_builtin.hivemoot.tasks import (
+            result_extractor,
+        )
+
+        cfg = self._cfg
+        if cfg is None or not cfg.queen.enabled:
+            return
+
+        bearer = resolve_agent_token(
+            str(cfg.token_file) if cfg.token_file else "",
+        )
+        provider = config.get("AGENT_PROVIDER", "claude")
+        log_path = self._resolve_provider_log_path(config)
+        sidecar = self._codex_sidecar_path
+
+        markdown = result_extractor.extract_result(
+            provider, log_path, sidecar_path=sidecar,
+        )
+        runner_id = cfg.queen.runner_id or self.resolved_agent_id()
+
+        handle_queen_job_finished(
+            job,
+            result,
+            base_url=cfg.queen.base_url,
+            bearer=bearer,
+            extracted_markdown=markdown,
+            queen_runner=runner_id,
+            agent_id=self.resolved_agent_id() or None,
+            gh_timeout_secs=cfg.queen.gh_timeout_secs,
+            enable_squash_merge=cfg.queen.enable_squash_merge,
+        )
+
     # ── Helpers used by triggers ──────────────────────────────────
 
     def resolved_agent_id(self) -> str:
@@ -861,6 +986,24 @@ class HivemootPlugin:
         ``on_job_finished``'s finally block and from the trigger's
         dispatch-failed path."""
         self._task_inflight.set()
+
+    # ── In-flight gate for the local queen trigger ───────────────
+
+    def wait_queen_slot(
+        self, stop_event: threading.Event, timeout: float = 1.0,
+    ) -> bool:
+        """Block until the local queen can claim another room."""
+        if stop_event.is_set():
+            return False
+        return self._queen_inflight.wait(timeout=timeout)
+
+    def reserve_queen_slot(self) -> None:
+        """Mark the local queen as busy with one synthesis job."""
+        self._queen_inflight.clear()
+
+    def release_queen_slot(self) -> None:
+        """Release the local queen synthesis slot."""
+        self._queen_inflight.set()
 
     # ── Private: shared resolvers ─────────────────────────────────
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -423,6 +423,14 @@ class HivemootQueenConfig(StrictPluginConfig):
             "Keep false until the web confirm/report endpoints are deployed."
         ),
     )
+    merge_report_queue_file: Path = Field(
+        default=Path("/tmp/hivemoot-queen-merge-reports.json"),
+        description=(
+            "Local retry queue for successful GitHub merges whose "
+            "report-merge-result call failed. Keep this on writable "
+            "persistent storage when enable_squash_merge is true."
+        ),
+    )
 
 
 class HivemootConfig(StrictPluginConfig):

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -1,7 +1,8 @@
 """Pydantic config schema for the consolidated ``hivemoot`` plugin.
 
-One plugin, three features (health / tasks / github_workflows), each
-toggled independently.  The shared inputs (bearer token, base URL)
+One plugin, six features (health / tasks / github_workflows /
+apiarist / war_rooms / queen), each toggled independently.  The
+shared inputs (bearer token, base URL)
 live at the top level so operators don't repeat them under every
 feature block.
 
@@ -22,6 +23,8 @@ YAML shape:
         github_workflows:
           enabled: true
           role_name: builder
+        queen:
+          enabled: false
 """
 
 from __future__ import annotations
@@ -340,6 +343,86 @@ class HivemootWarRoomsConfig(StrictPluginConfig):
     )
 
 
+class HivemootQueenConfig(StrictPluginConfig):
+    """Local queen runner — claims synthesis-ready rooms and posts
+    verified GitHub comments through the local hive container.
+
+    Disabled by default. Operators should enable this only after the
+    web-side local-queen endpoints are deployed and the installation is
+    still in cloud mode; the final ``queen_mode=local`` flip is a
+    separate rollout step.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable the local queen synthesis trigger + on_job_finished "
+            "handler. Off by default; fleet YAML opts one runner in."
+        ),
+    )
+    base_url: str = Field(
+        default="https://www.hivemoot.dev",
+        description=(
+            "Base URL for the local-queen API endpoints. The runner "
+            "polls /api/rooms/synthesis-ready and posts resolve/seal "
+            "requests under this base."
+        ),
+    )
+    poll_interval_secs: int = Field(
+        default=60,
+        ge=5,
+        description=(
+            "Seconds between local queen synthesis polls. Default 60s "
+            "matches the cloud queen tick cadence; floor prevents "
+            "tight-looping during backend failures."
+        ),
+    )
+    synthesis_ready_limit: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description=(
+            "Max rooms fetched from /synthesis-ready per poll. The "
+            "trigger claims at most one room per tick/run."
+        ),
+    )
+    claim_ttl_secs: int = Field(
+        default=900,
+        ge=60,
+        le=900,
+        description=(
+            "TTL requested for /claim-synthesis. Must stay within the "
+            "server's 15 minute seal-decision audit window."
+        ),
+    )
+    fallback_quiet_period_secs: int = Field(
+        default=60,
+        ge=0,
+        description=(
+            "Quiet period used when a room core lacks timing_config."
+        ),
+    )
+    runner_id: str = Field(
+        default="",
+        description=(
+            "Stable local queen runner id. Empty = AGENT_ID. This value "
+            "must match the claim and seal-decision queenRunner field."
+        ),
+    )
+    gh_timeout_secs: int = Field(
+        default=30,
+        ge=1,
+        description="Timeout for individual gh CLI calls.",
+    )
+    enable_squash_merge: bool = Field(
+        default=False,
+        description=(
+            "Reserved for the future confirm-merge/report-merge-result "
+            "slice. This PR supports only the verified comment-close path."
+        ),
+    )
+
+
 class HivemootConfig(StrictPluginConfig):
     """Top-level typed config for the consolidated hivemoot plugin."""
 
@@ -372,4 +455,8 @@ class HivemootConfig(StrictPluginConfig):
     war_rooms: HivemootWarRoomsConfig = Field(
         default_factory=HivemootWarRoomsConfig,
         description="War-room watcher + per-room triage/contribution handler.",
+    )
+    queen: HivemootQueenConfig = Field(
+        default_factory=HivemootQueenConfig,
+        description="Local queen synthesis runner.",
     )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py
@@ -417,8 +417,10 @@ class HivemootQueenConfig(StrictPluginConfig):
     enable_squash_merge: bool = Field(
         default=False,
         description=(
-            "Reserved for the future confirm-merge/report-merge-result "
-            "slice. This PR supports only the verified comment-close path."
+            "When true, the local queen may seal squash-merge intents, "
+            "poll decided-pending rooms, call confirm-merge, run "
+            "``gh pr merge --squash``, and report the GitHub outcome. "
+            "Keep false until the web confirm/report endpoints are deployed."
         ),
     )
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/__init__.py
@@ -1,0 +1,36 @@
+"""Local queen feature block for the consolidated hivemoot plugin."""
+
+from __future__ import annotations
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
+    ClaimedSynthesis,
+    QueenAPIConflictError,
+    ResolveActionResult,
+    SealDecisionResult,
+    SynthesisReadyRoom,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.handler import (
+    JOB_KIND_SYNTHESIS,
+    build_seal_header,
+    handle_queen_job_finished,
+    is_queen_job,
+    parse_decision_output,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.trigger import (
+    LocalQueenSynthesisTrigger,
+)
+
+
+__all__ = (
+    "ClaimedSynthesis",
+    "JOB_KIND_SYNTHESIS",
+    "LocalQueenSynthesisTrigger",
+    "QueenAPIConflictError",
+    "ResolveActionResult",
+    "SealDecisionResult",
+    "SynthesisReadyRoom",
+    "build_seal_header",
+    "handle_queen_job_finished",
+    "is_queen_job",
+    "parse_decision_output",
+)

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/__init__.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
     ClaimedSynthesis,
+    ConfirmMergeResult,
+    MergeReportResult,
     QueenAPIConflictError,
     ResolveActionResult,
     SealDecisionResult,
@@ -23,8 +25,10 @@ from hivemoot_agent.plugins_builtin.hivemoot.queen.trigger import (
 
 __all__ = (
     "ClaimedSynthesis",
+    "ConfirmMergeResult",
     "JOB_KIND_SYNTHESIS",
     "LocalQueenSynthesisTrigger",
+    "MergeReportResult",
     "QueenAPIConflictError",
     "ResolveActionResult",
     "SealDecisionResult",

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/api.py
@@ -1,0 +1,396 @@
+"""Local queen API client.
+
+Worker-side wrappers for the web endpoints used by the hive-hosted
+queen runner. The transport stays on the shared hivemoot HTTP client
+so bearer handling, redirect refusal, and timeout behavior match the
+existing tasks and war-room clients.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+from hivemoot_agent.plugins_builtin.hivemoot.http import (
+    DEFAULT_TIMEOUT_SECS,
+    get_json,
+    post_json,
+)
+
+
+__all__ = (
+    "ClaimedSynthesis",
+    "QueenAPIConflictError",
+    "ResolveActionResult",
+    "SealDecisionResult",
+    "SynthesisReadyRoom",
+    "claim_synthesis",
+    "get_room_participants",
+    "list_room_events",
+    "list_synthesis_ready_rooms",
+    "mint_installation_token",
+    "resolve_action",
+    "seal_decision",
+)
+
+
+class QueenAPIConflictError(RuntimeError):
+    """A benign 409 from a local-queen endpoint.
+
+    The room moved, the claim is already held, or the caller's claim
+    view is stale. Trigger/handler code should log and wait for the
+    next poll rather than crashing the agent process.
+    """
+
+    def __init__(self, op: str, code: str, body_excerpt: str) -> None:
+        super().__init__(f"{op} returned conflict code={code}: {body_excerpt}")
+        self.op = op
+        self.code = code
+        self.body_excerpt = body_excerpt
+
+
+@dataclass
+class SynthesisReadyRoom:
+    room_id: str
+    status: str
+    subject_type: str
+    subject_ref: str
+    manager: str
+    opened_at: str
+    timing_config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ClaimedSynthesis:
+    room_id: str
+    through_sequence: int
+    claim_ttl_secs: int
+    room: dict[str, Any]
+    participants: dict[str, Any]
+    contributions: dict[str, Any]
+
+
+@dataclass
+class ResolveActionResult:
+    permitted_action: str
+    clamped_verdict: str
+    downgrade_reason: str | None
+    reviewed_head_sha: str
+    current_head_sha: str
+    floor_overridden: bool
+    audit_id: str
+
+
+@dataclass
+class SealDecisionResult:
+    final_state: str
+    closed_sequence: int
+    audit_id: str
+    idempotent: bool = False
+
+
+def _room_path(room_id: str) -> str:
+    return quote(room_id, safe="")
+
+
+def _body_excerpt(raw: bytes) -> str:
+    return raw.decode(errors="replace")[:200]
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _parse_ready_room(entry: dict[str, Any]) -> SynthesisReadyRoom:
+    room_id = str(entry.get("roomId") or entry.get("room_id") or "").strip()
+    if not room_id:
+        raise RuntimeError(f"synthesis-ready room missing roomId: {str(entry)[:200]}")
+    return SynthesisReadyRoom(
+        room_id=room_id,
+        status=str(entry.get("status") or ""),
+        subject_type=str(entry.get("subject_type") or entry.get("subjectType") or ""),
+        subject_ref=str(entry.get("subject_ref") or entry.get("subjectRef") or ""),
+        manager=str(entry.get("manager") or ""),
+        opened_at=str(entry.get("opened_at") or entry.get("openedAt") or ""),
+        timing_config=_as_dict(
+            entry.get("timing_config") or entry.get("timingConfig"),
+        ),
+    )
+
+
+def list_synthesis_ready_rooms(
+    base_url: str,
+    bearer: str,
+    *,
+    limit: int = 10,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> list[SynthesisReadyRoom]:
+    url = (
+        f"{base_url.rstrip('/')}/api/rooms/synthesis-ready?"
+        f"limit={max(1, int(limit))}"
+    )
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"synthesis-ready returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("synthesis-ready response was not a JSON object")
+    rooms_raw = parsed.get("rooms")
+    if rooms_raw is None:
+        return []
+    if not isinstance(rooms_raw, list):
+        raise RuntimeError("synthesis-ready response `rooms` must be a list")
+    rooms: list[SynthesisReadyRoom] = []
+    for entry in rooms_raw:
+        if isinstance(entry, dict):
+            rooms.append(_parse_ready_room(entry))
+    return rooms
+
+
+def get_room_participants(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/participants"
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"participants returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("participants response was not a JSON object")
+    return _as_dict(parsed.get("participants"))
+
+
+def list_room_events(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    limit: int = 500,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> list[dict[str, Any]]:
+    url = (
+        f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/events?"
+        f"limit={max(1, int(limit))}"
+    )
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(f"events returned status {status}: {_body_excerpt(raw)}")
+    if not isinstance(parsed, dict):
+        raise RuntimeError("events response was not a JSON object")
+    events = parsed.get("events")
+    if events is None:
+        return []
+    if not isinstance(events, list):
+        raise RuntimeError("events response `events` must be a list")
+    return [e for e in events if isinstance(e, dict)]
+
+
+def claim_synthesis(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    claim_ttl_secs: int,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> ClaimedSynthesis:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/claim-synthesis"
+    status, parsed, raw = post_json(
+        url,
+        {"queenRunner": queen_runner, "claimTtlSecs": claim_ttl_secs},
+        bearer,
+        timeout=timeout,
+    )
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "claim-synthesis",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"claim-synthesis returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("claim-synthesis response was not a JSON object")
+
+    claim = _as_dict(parsed.get("claim"))
+    through = _as_int(
+        claim.get("throughSequence") or claim.get("through_sequence"),
+    )
+    if through < 0:
+        raise RuntimeError("claim-synthesis returned invalid throughSequence")
+    return ClaimedSynthesis(
+        room_id=room_id,
+        through_sequence=through,
+        claim_ttl_secs=_as_int(
+            claim.get("claimTtlSecs") or claim.get("claim_ttl_secs"),
+            default=claim_ttl_secs,
+        ),
+        room=_as_dict(parsed.get("room")),
+        participants=_as_dict(parsed.get("participants")),
+        contributions=_as_dict(parsed.get("contributions")),
+    )
+
+
+def mint_installation_token(
+    base_url: str,
+    bearer: str,
+    *,
+    repo: str,
+    agent_id: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> str:
+    url = f"{base_url.rstrip('/')}/api/github/installation-tokens"
+    body: dict[str, Any] = {"repo": repo}
+    if agent_id:
+        body["agent_id"] = agent_id
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"installation-token mint returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("token"), str):
+        raise RuntimeError("installation-token response missing token")
+    return parsed["token"]
+
+
+def resolve_action(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    verdict: str,
+    reasoning: str,
+    recommended_action: str,
+    reviewed_head_sha: str,
+    sealed_through_sequence: int,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> ResolveActionResult:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/resolve-action"
+    status, parsed, raw = post_json(
+        url,
+        {
+            "queenRunner": queen_runner,
+            "derivedVerdict": {"verdict": verdict, "reasoning": reasoning},
+            "recommendedAction": recommended_action,
+            "reviewedHeadSha": reviewed_head_sha,
+            "sealedThroughSequence": sealed_through_sequence,
+        },
+        bearer,
+        timeout=timeout,
+    )
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "resolve-action",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"resolve-action returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("resolve-action response was not a JSON object")
+    audit_id = parsed.get("auditId") or parsed.get("audit_id")
+    if not isinstance(audit_id, str) or not audit_id:
+        raise RuntimeError("resolve-action response missing auditId")
+    return ResolveActionResult(
+        permitted_action=str(
+            parsed.get("permittedAction") or parsed.get("permitted_action") or "",
+        ),
+        clamped_verdict=str(
+            parsed.get("clampedVerdict") or parsed.get("clamped_verdict") or "",
+        ),
+        downgrade_reason=(
+            str(parsed.get("downgradeReason") or parsed.get("downgrade_reason"))
+            if parsed.get("downgradeReason") or parsed.get("downgrade_reason")
+            else None
+        ),
+        reviewed_head_sha=str(
+            parsed.get("reviewedHeadSha") or parsed.get("reviewed_head_sha") or "",
+        ),
+        current_head_sha=str(
+            parsed.get("currentHeadSha") or parsed.get("current_head_sha") or "",
+        ),
+        floor_overridden=bool(
+            parsed.get("floorOverridden") or parsed.get("floor_overridden") or False,
+        ),
+        audit_id=audit_id,
+    )
+
+
+def seal_decision(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    audit_id: str,
+    sealed_through_sequence: int,
+    decision: dict[str, Any],
+    comment_url: str | None = None,
+    downgrade_reason: str | None = None,
+    error_class: str | None = None,
+    retry_count: int | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> SealDecisionResult:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/seal-decision"
+    body: dict[str, Any] = {
+        "queenRunner": queen_runner,
+        "auditId": audit_id,
+        "finalState": "closed",
+        "sealedThroughSequence": sealed_through_sequence,
+        "decision": decision,
+    }
+    if comment_url:
+        body["commentUrl"] = comment_url
+    if downgrade_reason:
+        body["downgradeReason"] = downgrade_reason
+    if error_class:
+        body["errorClass"] = error_class
+    if retry_count is not None:
+        body["retryCount"] = retry_count
+
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "seal-decision",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"seal-decision returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("seal-decision response was not a JSON object")
+    return SealDecisionResult(
+        final_state=str(parsed.get("finalState") or parsed.get("final_state") or ""),
+        closed_sequence=_as_int(
+            parsed.get("closedSequence") or parsed.get("closed_sequence"),
+        ),
+        audit_id=str(parsed.get("auditId") or parsed.get("audit_id") or ""),
+        idempotent=bool(parsed.get("idempotent") or False),
+    )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/api.py
@@ -21,15 +21,20 @@ from hivemoot_agent.plugins_builtin.hivemoot.http import (
 
 __all__ = (
     "ClaimedSynthesis",
+    "ConfirmMergeResult",
+    "MergeReportResult",
     "QueenAPIConflictError",
     "ResolveActionResult",
     "SealDecisionResult",
     "SynthesisReadyRoom",
     "claim_synthesis",
+    "confirm_merge",
     "get_room_participants",
     "list_room_events",
+    "list_decided_pending_ready_rooms",
     "list_synthesis_ready_rooms",
     "mint_installation_token",
+    "report_merge_result",
     "resolve_action",
     "seal_decision",
 )
@@ -87,6 +92,26 @@ class SealDecisionResult:
     final_state: str
     closed_sequence: int
     audit_id: str
+    pending_sequence: int = 0
+    idempotent: bool = False
+
+
+@dataclass
+class ConfirmMergeResult:
+    decision_outcome: str
+    decision_outcome_reason: str | None
+    github_merge_status: str | None
+    merge_attempt_id: str
+    closed_sequence: int
+    idempotent: bool = False
+
+
+@dataclass
+class MergeReportResult:
+    github_merge_status: str
+    merge_attempt_id: str
+    merge_commit_oid: str | None
+    error_class: str | None
     idempotent: bool = False
 
 
@@ -155,6 +180,36 @@ def list_synthesis_ready_rooms(
         return []
     if not isinstance(rooms_raw, list):
         raise RuntimeError("synthesis-ready response `rooms` must be a list")
+    rooms: list[SynthesisReadyRoom] = []
+    for entry in rooms_raw:
+        if isinstance(entry, dict):
+            rooms.append(_parse_ready_room(entry))
+    return rooms
+
+
+def list_decided_pending_ready_rooms(
+    base_url: str,
+    bearer: str,
+    *,
+    limit: int = 10,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> list[SynthesisReadyRoom]:
+    url = (
+        f"{base_url.rstrip('/')}/api/rooms/decided-pending-ready?"
+        f"limit={max(1, int(limit))}"
+    )
+    status, parsed, raw = get_json(url, bearer, timeout=timeout)
+    if status != 200:
+        raise RuntimeError(
+            f"decided-pending-ready returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("decided-pending-ready response was not a JSON object")
+    rooms_raw = parsed.get("rooms")
+    if rooms_raw is None:
+        return []
+    if not isinstance(rooms_raw, list):
+        raise RuntimeError("decided-pending-ready response `rooms` must be a list")
     rooms: list[SynthesisReadyRoom] = []
     for entry in rooms_raw:
         if isinstance(entry, dict):
@@ -350,6 +405,7 @@ def seal_decision(
     audit_id: str,
     sealed_through_sequence: int,
     decision: dict[str, Any],
+    final_state: str = "closed",
     comment_url: str | None = None,
     downgrade_reason: str | None = None,
     error_class: str | None = None,
@@ -360,7 +416,7 @@ def seal_decision(
     body: dict[str, Any] = {
         "queenRunner": queen_runner,
         "auditId": audit_id,
-        "finalState": "closed",
+        "finalState": final_state,
         "sealedThroughSequence": sealed_through_sequence,
         "decision": decision,
     }
@@ -391,6 +447,131 @@ def seal_decision(
         closed_sequence=_as_int(
             parsed.get("closedSequence") or parsed.get("closed_sequence"),
         ),
+        pending_sequence=_as_int(
+            parsed.get("pendingSequence") or parsed.get("pending_sequence"),
+        ),
         audit_id=str(parsed.get("auditId") or parsed.get("audit_id") or ""),
+        idempotent=bool(parsed.get("idempotent") or False),
+    )
+
+
+def confirm_merge(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    merge_attempt_id: str,
+    current_head_sha: str,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> ConfirmMergeResult:
+    url = f"{base_url.rstrip('/')}/api/rooms/{_room_path(room_id)}/confirm-merge"
+    status, parsed, raw = post_json(
+        url,
+        {
+            "queenRunner": queen_runner,
+            "mergeAttemptId": merge_attempt_id,
+            "currentHeadSha": current_head_sha,
+        },
+        bearer,
+        timeout=timeout,
+    )
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "confirm-merge",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"confirm-merge returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("confirm-merge response was not a JSON object")
+    return ConfirmMergeResult(
+        decision_outcome=str(
+            parsed.get("decisionOutcome") or parsed.get("decision_outcome") or "",
+        ),
+        decision_outcome_reason=(
+            str(
+                parsed.get("decisionOutcomeReason")
+                or parsed.get("decision_outcome_reason")
+            )
+            if (
+                parsed.get("decisionOutcomeReason")
+                or parsed.get("decision_outcome_reason")
+            )
+            else None
+        ),
+        github_merge_status=(
+            str(parsed.get("githubMergeStatus") or parsed.get("github_merge_status"))
+            if parsed.get("githubMergeStatus") or parsed.get("github_merge_status")
+            else None
+        ),
+        merge_attempt_id=str(
+            parsed.get("mergeAttemptId") or parsed.get("merge_attempt_id") or "",
+        ),
+        closed_sequence=_as_int(
+            parsed.get("closedSequence") or parsed.get("closed_sequence"),
+        ),
+        idempotent=bool(parsed.get("idempotent") or False),
+    )
+
+
+def report_merge_result(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    merge_attempt_id: str,
+    github_merge_status: str,
+    merge_commit_oid: str | None = None,
+    error_class: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECS,
+) -> MergeReportResult:
+    url = (
+        f"{base_url.rstrip('/')}/api/rooms/"
+        f"{_room_path(room_id)}/report-merge-result"
+    )
+    body: dict[str, Any] = {
+        "queenRunner": queen_runner,
+        "mergeAttemptId": merge_attempt_id,
+        "githubMergeStatus": github_merge_status,
+    }
+    if merge_commit_oid:
+        body["mergeCommitOid"] = merge_commit_oid
+    if error_class:
+        body["errorClass"] = error_class
+    status, parsed, raw = post_json(url, body, bearer, timeout=timeout)
+    if status == 409 and isinstance(parsed, dict):
+        raise QueenAPIConflictError(
+            "report-merge-result",
+            str(parsed.get("code") or "conflict"),
+            _body_excerpt(raw),
+        )
+    if status != 200:
+        raise RuntimeError(
+            f"report-merge-result returned status {status}: {_body_excerpt(raw)}"
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("report-merge-result response was not a JSON object")
+    return MergeReportResult(
+        github_merge_status=str(
+            parsed.get("githubMergeStatus") or parsed.get("github_merge_status") or "",
+        ),
+        merge_attempt_id=str(
+            parsed.get("mergeAttemptId") or parsed.get("merge_attempt_id") or "",
+        ),
+        merge_commit_oid=(
+            str(parsed.get("mergeCommitOid") or parsed.get("merge_commit_oid"))
+            if parsed.get("mergeCommitOid") or parsed.get("merge_commit_oid")
+            else None
+        ),
+        error_class=(
+            str(parsed.get("errorClass") or parsed.get("error_class"))
+            if parsed.get("errorClass") or parsed.get("error_class")
+            else None
+        ),
         idempotent=bool(parsed.get("idempotent") or False),
     )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
@@ -1,0 +1,176 @@
+"""GitHub CLI helpers for the local queen.
+
+The local queen uses short-lived GitHub App installation tokens minted
+by the web API. Tokens are passed only through the subprocess
+environment, never argv, so process listings and command logs do not
+expose them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import Sequence
+
+
+__all__ = (
+    "GHCommandError",
+    "PullRequestRef",
+    "get_pr_head_sha",
+    "parse_subject_ref",
+    "post_pr_comment",
+)
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def full_repo(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+
+class GHCommandError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        returncode: int | None = None,
+        stderr: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+_SUBJECT_RE = re.compile(r"^([^/\s]+)/([^#\s]+)#([1-9][0-9]*)$")
+
+
+def parse_subject_ref(subject_ref: str) -> PullRequestRef:
+    match = _SUBJECT_RE.match(subject_ref.strip())
+    if not match:
+        raise ValueError(
+            "subject_ref must have owner/repo#number shape; "
+            f"got {subject_ref!r}"
+        )
+    owner, repo, number = match.groups()
+    return PullRequestRef(owner=owner, repo=repo, number=int(number))
+
+
+def _run_gh(
+    args: Sequence[str],
+    *,
+    token: str,
+    timeout_secs: int,
+) -> str:
+    if not token:
+        raise GHCommandError("missing GitHub token")
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout_secs,
+        )
+    except FileNotFoundError as exc:
+        raise GHCommandError("gh CLI is not installed or not in PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GHCommandError(
+            f"gh command timed out after {timeout_secs}s",
+            stderr=(exc.stderr or "") if isinstance(exc.stderr, str) else "",
+        ) from exc
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        raise GHCommandError(
+            f"gh command failed with exit {proc.returncode}: {stderr[:300]}",
+            returncode=proc.returncode,
+            stderr=stderr,
+        )
+    return (proc.stdout or "").strip()
+
+
+def get_pr_head_sha(
+    pr: PullRequestRef,
+    *,
+    token: str,
+    timeout_secs: int = 30,
+) -> str:
+    out = _run_gh(
+        [
+            "pr",
+            "view",
+            str(pr.number),
+            "--repo",
+            pr.full_repo,
+            "--json",
+            "headRefOid",
+            "--jq",
+            ".headRefOid",
+        ],
+        token=token,
+        timeout_secs=timeout_secs,
+    )
+    if not out:
+        raise GHCommandError(f"gh pr view returned empty head SHA for {pr.full_repo}#{pr.number}")
+    return out
+
+
+def post_pr_comment(
+    pr: PullRequestRef,
+    body: str,
+    *,
+    token: str,
+    timeout_secs: int = 30,
+) -> str:
+    if not body.strip():
+        raise ValueError("comment body must be non-empty")
+
+    path = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            suffix=".json",
+            delete=False,
+        ) as f:
+            path = f.name
+            json.dump({"body": body}, f, ensure_ascii=False)
+
+        out = _run_gh(
+            [
+                "api",
+                "--method",
+                "POST",
+                f"repos/{pr.owner}/{pr.repo}/issues/{pr.number}/comments",
+                "--input",
+                path,
+                "--jq",
+                ".html_url",
+            ],
+            token=token,
+            timeout_secs=timeout_secs,
+        )
+        if not out:
+            raise GHCommandError(
+                f"gh api returned empty comment URL for {pr.full_repo}#{pr.number}"
+            )
+        return out
+    finally:
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
@@ -21,8 +21,10 @@ __all__ = (
     "GHCommandError",
     "PullRequestRef",
     "get_pr_head_sha",
+    "get_pr_merge_commit_sha",
     "parse_subject_ref",
     "post_pr_comment",
+    "squash_merge_pr",
 )
 
 
@@ -126,6 +128,59 @@ def get_pr_head_sha(
     if not out:
         raise GHCommandError(f"gh pr view returned empty head SHA for {pr.full_repo}#{pr.number}")
     return out
+
+
+def get_pr_merge_commit_sha(
+    pr: PullRequestRef,
+    *,
+    token: str,
+    timeout_secs: int = 30,
+) -> str:
+    out = _run_gh(
+        [
+            "pr",
+            "view",
+            str(pr.number),
+            "--repo",
+            pr.full_repo,
+            "--json",
+            "mergeCommit",
+            "--jq",
+            ".mergeCommit.oid // \"\"",
+        ],
+        token=token,
+        timeout_secs=timeout_secs,
+    )
+    if not out:
+        raise GHCommandError(
+            f"gh pr view returned empty merge commit for {pr.full_repo}#{pr.number}"
+        )
+    return out
+
+
+def squash_merge_pr(
+    pr: PullRequestRef,
+    *,
+    token: str,
+    timeout_secs: int = 30,
+) -> str:
+    _run_gh(
+        [
+            "pr",
+            "merge",
+            str(pr.number),
+            "--repo",
+            pr.full_repo,
+            "--squash",
+        ],
+        token=token,
+        timeout_secs=timeout_secs,
+    )
+    return get_pr_merge_commit_sha(
+        pr,
+        token=token,
+        timeout_secs=timeout_secs,
+    )
 
 
 def post_pr_comment(

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/gh.py
@@ -74,7 +74,22 @@ def _run_gh(
 ) -> str:
     if not token:
         raise GHCommandError("missing GitHub token")
-    env = os.environ.copy()
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key
+        in {
+            "PATH",
+            "HOME",
+            "LANG",
+            "LC_ALL",
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "NO_PROXY",
+        }
+    }
     env["GH_TOKEN"] = token
     env["GITHUB_TOKEN"] = token
     try:
@@ -161,9 +176,13 @@ def get_pr_merge_commit_sha(
 def squash_merge_pr(
     pr: PullRequestRef,
     *,
+    expected_head_sha: str,
     token: str,
     timeout_secs: int = 30,
 ) -> str:
+    expected = expected_head_sha.strip()
+    if not expected:
+        raise ValueError("expected_head_sha must be non-empty")
     _run_gh(
         [
             "pr",
@@ -172,6 +191,8 @@ def squash_merge_pr(
             "--repo",
             pr.full_repo,
             "--squash",
+            "--match-head-commit",
+            expected,
         ],
         token=token,
         timeout_secs=timeout_secs,

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
@@ -1,0 +1,275 @@
+"""Local queen job completion handler."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.queen import api as q_api
+from hivemoot_agent.plugins_builtin.hivemoot.queen import gh
+
+
+JOB_KIND_SYNTHESIS = "queen_synthesis"
+
+_VALID_VERDICTS = {"APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"}
+_VALID_ACTIONS = {"comment", "squash-merge"}
+_SEAL_HEADER_RE = re.compile(
+    r"<!--\s*hivemoot:queen-action:(?:merge|comment):[a-zA-Z0-9_-]+\s*-->"
+)
+
+
+@dataclass
+class QueenDecisionOutput:
+    verdict: str
+    reasoning: str
+    recommended_action: str
+    comment_body: str
+
+
+def is_queen_job(job: Job) -> bool:
+    return bool(
+        job.metadata.get("job_kind") == JOB_KIND_SYNTHESIS
+        and job.metadata.get("room_id")
+    )
+
+
+def build_seal_header(verb: str, audit_id: str) -> str:
+    if verb not in {"merge", "comment"}:
+        raise ValueError("seal verb must be merge or comment")
+    if not audit_id:
+        raise ValueError("audit_id must be non-empty")
+    return f"<!-- hivemoot:queen-action:{verb}:{audit_id} -->"
+
+
+def parse_decision_output(markdown: str) -> QueenDecisionOutput:
+    data = _extract_json_object(markdown)
+    verdict = str(data.get("verdict") or "").strip().upper()
+    if verdict not in _VALID_VERDICTS:
+        raise ValueError(
+            f"verdict must be one of {', '.join(sorted(_VALID_VERDICTS))}"
+        )
+
+    reasoning = str(data.get("reasoning") or "").strip()
+    if len(reasoning) > 500:
+        reasoning = reasoning[:500]
+
+    action = str(
+        data.get("recommended_action")
+        or data.get("recommendedAction")
+        or "",
+    ).strip().lower()
+    if action not in _VALID_ACTIONS:
+        raise ValueError("recommended_action must be comment or squash-merge")
+
+    body = str(
+        data.get("comment_body")
+        or data.get("commentBody")
+        or data.get("body")
+        or "",
+    ).strip()
+    if not body:
+        body = reasoning or f"Queen synthesized verdict: {verdict}."
+
+    return QueenDecisionOutput(
+        verdict=verdict,
+        reasoning=reasoning,
+        recommended_action=action,
+        comment_body=_sanitize_comment_body(body),
+    )
+
+
+def handle_queen_job_finished(
+    job: Job,
+    result: AgentResult,
+    *,
+    base_url: str,
+    bearer: str,
+    extracted_markdown: str,
+    queen_runner: str,
+    agent_id: str | None = None,
+    gh_timeout_secs: int = 30,
+    enable_squash_merge: bool = False,
+) -> None:
+    if not is_queen_job(job):
+        return
+
+    room_id = str(job.metadata.get("room_id") or "")
+    subject_ref = str(job.metadata.get("subject_ref") or "")
+    sealed_through_sequence = _metadata_int(job, "sealed_through_sequence")
+    reviewed_head_sha = str(job.metadata.get("reviewed_head_sha") or "").strip()
+
+    if result.exit_code != 0:
+        print(
+            f"[hivemoot-queen] synthesis job failed room={room_id} "
+            f"exit={result.exit_code}; claim TTL will release",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if not bearer:
+        raise RuntimeError("missing local queen bearer")
+    if not queen_runner:
+        raise RuntimeError("missing queen runner id")
+    if not room_id or not subject_ref:
+        raise RuntimeError("queen job metadata missing room_id/subject_ref")
+    if sealed_through_sequence < 0:
+        raise RuntimeError("queen job metadata missing sealed_through_sequence")
+    if not reviewed_head_sha:
+        raise RuntimeError("queen job metadata missing reviewed_head_sha")
+
+    decision = parse_decision_output(extracted_markdown)
+    recommended_action = (
+        decision.recommended_action if enable_squash_merge else "comment"
+    )
+
+    resolved = q_api.resolve_action(
+        base_url,
+        room_id,
+        bearer,
+        queen_runner=queen_runner,
+        verdict=decision.verdict,
+        reasoning=decision.reasoning,
+        recommended_action=recommended_action,
+        reviewed_head_sha=reviewed_head_sha,
+        sealed_through_sequence=sealed_through_sequence,
+    )
+
+    if resolved.permitted_action != "comment":
+        raise RuntimeError(
+            "local queen squash-merge path is not implemented in this "
+            f"runner slice (permittedAction={resolved.permitted_action})"
+        )
+
+    pr = gh.parse_subject_ref(subject_ref)
+    token = q_api.mint_installation_token(
+        base_url,
+        bearer,
+        repo=pr.full_repo,
+        agent_id=agent_id,
+    )
+
+    public_comment = _build_public_comment(
+        decision=decision,
+        audit_id=resolved.audit_id,
+        permitted_action=resolved.permitted_action,
+    )
+
+    try:
+        comment_url = gh.post_pr_comment(
+            pr,
+            public_comment,
+            token=token,
+            timeout_secs=gh_timeout_secs,
+        )
+    except Exception as exc:
+        if resolved.permitted_action == "squash-merge":
+            q_api.seal_decision(
+                base_url,
+                room_id,
+                bearer,
+                queen_runner=queen_runner,
+                audit_id=resolved.audit_id,
+                sealed_through_sequence=sealed_through_sequence,
+                decision=_room_decision(
+                    queen_runner=queen_runner,
+                    sealed_through_sequence=sealed_through_sequence,
+                    content=decision.comment_body,
+                ),
+                downgrade_reason="intended_action_post_failed",
+                error_class=type(exc).__name__,
+                retry_count=1,
+            )
+        raise
+
+    sealed = q_api.seal_decision(
+        base_url,
+        room_id,
+        bearer,
+        queen_runner=queen_runner,
+        audit_id=resolved.audit_id,
+        sealed_through_sequence=sealed_through_sequence,
+        decision=_room_decision(
+            queen_runner=queen_runner,
+            sealed_through_sequence=sealed_through_sequence,
+            content=decision.comment_body,
+        ),
+        comment_url=comment_url,
+    )
+
+    print(
+        f"[hivemoot-queen] sealed room={room_id} "
+        f"finalState={sealed.final_state} auditId={sealed.audit_id}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _extract_json_object(markdown: str) -> dict[str, Any]:
+    text = markdown.strip()
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        first = text.find("{")
+        if first >= 0:
+            text = text[first:]
+
+    decoder = json.JSONDecoder()
+    try:
+        parsed, _ = decoder.raw_decode(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("queen output did not contain a JSON object") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("queen output JSON must be an object")
+    return parsed
+
+
+def _sanitize_comment_body(body: str) -> str:
+    cleaned = _SEAL_HEADER_RE.sub("", body).strip()
+    return cleaned or "Queen synthesized a decision for this PR."
+
+
+def _build_public_comment(
+    *,
+    decision: QueenDecisionOutput,
+    audit_id: str,
+    permitted_action: str,
+) -> str:
+    verb = "merge" if permitted_action == "squash-merge" else "comment"
+    header = build_seal_header(verb, audit_id)
+    return f"{header}\n\n{decision.comment_body.strip()}\n"
+
+
+def _room_decision(
+    *,
+    queen_runner: str,
+    sealed_through_sequence: int,
+    content: str,
+) -> dict[str, Any]:
+    return {
+        "synthesized_at": datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "synthesis_runner": queen_runner,
+        "content": content,
+        "sequence_closed": sealed_through_sequence,
+    }
+
+
+def _metadata_int(job: Job, key: str) -> int:
+    value = job.metadata.get(key)
+    if isinstance(value, bool):
+        return -1
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return -1
+    return -1

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
@@ -18,8 +18,9 @@ JOB_KIND_SYNTHESIS = "queen_synthesis"
 
 _VALID_VERDICTS = {"APPROVE", "COMMENT", "CONCERNS", "REQUEST_CHANGES"}
 _VALID_ACTIONS = {"comment", "squash-merge"}
-_SEAL_HEADER_RE = re.compile(
-    r"<!--\s*hivemoot:queen-action:(?:merge|comment):[a-zA-Z0-9_-]+\s*-->"
+_HIVEMOOT_HTML_COMMENT_RE = re.compile(
+    r"<!--\s*hivemoot(?:[-:][\s\S]*?)?-->",
+    re.IGNORECASE,
 )
 
 
@@ -195,7 +196,7 @@ def handle_queen_job_finished(
         if resolved.permitted_action == "squash-merge"
         else "closed"
     )
-    sealed = q_api.seal_decision(
+    sealed = _seal_decision_with_retry(
         base_url,
         room_id,
         bearer,
@@ -240,8 +241,41 @@ def _extract_json_object(markdown: str) -> dict[str, Any]:
 
 
 def _sanitize_comment_body(body: str) -> str:
-    cleaned = _SEAL_HEADER_RE.sub("", body).strip()
+    cleaned = _HIVEMOOT_HTML_COMMENT_RE.sub("", body).strip()
     return cleaned or "Queen synthesized a decision for this PR."
+
+
+def _seal_decision_with_retry(
+    base_url: str,
+    room_id: str,
+    bearer: str,
+    *,
+    queen_runner: str,
+    audit_id: str,
+    sealed_through_sequence: int,
+    decision: dict[str, Any],
+    final_state: str,
+    comment_url: str,
+) -> q_api.SealDecisionResult:
+    kwargs: dict[str, Any] = {
+        "queen_runner": queen_runner,
+        "audit_id": audit_id,
+        "sealed_through_sequence": sealed_through_sequence,
+        "decision": decision,
+        "final_state": final_state,
+        "comment_url": comment_url,
+    }
+    try:
+        return q_api.seal_decision(base_url, room_id, bearer, **kwargs)
+    except Exception as exc:
+        print(
+            f"[hivemoot-queen] seal-decision retry room={room_id}: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
+        kwargs["retry_count"] = 1
+        return q_api.seal_decision(base_url, room_id, bearer, **kwargs)
 
 
 def _build_public_comment(

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/handler.py
@@ -139,10 +139,14 @@ def handle_queen_job_finished(
         sealed_through_sequence=sealed_through_sequence,
     )
 
-    if resolved.permitted_action != "comment":
+    if resolved.permitted_action == "squash-merge" and not enable_squash_merge:
         raise RuntimeError(
-            "local queen squash-merge path is not implemented in this "
-            f"runner slice (permittedAction={resolved.permitted_action})"
+            "local queen squash-merge path was permitted while "
+            "enable_squash_merge=false"
+        )
+    if resolved.permitted_action not in {"comment", "squash-merge"}:
+        raise RuntimeError(
+            f"resolve-action returned unknown permittedAction={resolved.permitted_action}"
         )
 
     pr = gh.parse_subject_ref(subject_ref)
@@ -186,6 +190,11 @@ def handle_queen_job_finished(
             )
         raise
 
+    final_state = (
+        "decided_pending_action"
+        if resolved.permitted_action == "squash-merge"
+        else "closed"
+    )
     sealed = q_api.seal_decision(
         base_url,
         room_id,
@@ -198,6 +207,7 @@ def handle_queen_job_finished(
             sealed_through_sequence=sealed_through_sequence,
             content=decision.comment_body,
         ),
+        final_state=final_state,
         comment_url=comment_url,
     )
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/prompts.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/prompts.py
@@ -17,6 +17,7 @@ def build_synthesis_prompt(
     *,
     claimed: ClaimedSynthesis,
     reviewed_head_sha: str,
+    enable_squash_merge: bool = False,
 ) -> str:
     payload: dict[str, Any] = {
         "room_id": claimed.room_id,
@@ -27,6 +28,13 @@ def build_synthesis_prompt(
         "contributions": claimed.contributions,
     }
     room_json = json.dumps(payload, indent=2, sort_keys=True, default=str)
+    action_constraint = (
+        "If the final verdict is APPROVE and the PR should be merged, set "
+        "`recommended_action` to `squash-merge`; otherwise set it to `comment`."
+        if enable_squash_merge
+        else "This runner slice is comment-close only. Set `recommended_action` to `comment`."
+    )
+    example_action = "squash-merge" if enable_squash_merge else "comment"
 
     return f"""# Local Queen Synthesis
 
@@ -36,7 +44,7 @@ participants' contributions into one public PR comment.
 Important constraints:
 - Use only the room payload below as evidence.
 - The reviewed PR head SHA is `{reviewed_head_sha}`.
-- This runner slice is comment-close only. Set `recommended_action` to `comment`.
+- {action_constraint}
 - Do not include any `hivemoot:queen-action` seal header; the runner adds it.
 - Keep the public comment concise, specific, and actionable.
 
@@ -46,12 +54,13 @@ Return exactly one fenced JSON block and no other prose:
 {{
   "verdict": "APPROVE",
   "reasoning": "Short explanation, 500 chars max.",
-  "recommended_action": "comment",
+  "recommended_action": "{example_action}",
   "comment_body": "Markdown body to post publicly on the PR."
 }}
 ```
 
 Valid verdicts: APPROVE, COMMENT, CONCERNS, REQUEST_CHANGES.
+Valid recommended_action values: comment, squash-merge.
 
 Room payload:
 

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/prompts.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/prompts.py
@@ -1,0 +1,61 @@
+"""Prompt builder for the local queen synthesis job."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
+    ClaimedSynthesis,
+)
+
+
+__all__ = ("build_synthesis_prompt",)
+
+
+def build_synthesis_prompt(
+    *,
+    claimed: ClaimedSynthesis,
+    reviewed_head_sha: str,
+) -> str:
+    payload: dict[str, Any] = {
+        "room_id": claimed.room_id,
+        "sealed_through_sequence": claimed.through_sequence,
+        "reviewed_head_sha": reviewed_head_sha,
+        "room": claimed.room,
+        "participants": claimed.participants,
+        "contributions": claimed.contributions,
+    }
+    room_json = json.dumps(payload, indent=2, sort_keys=True, default=str)
+
+    return f"""# Local Queen Synthesis
+
+You are the Hivemoot local queen for a PR review war room. Synthesize the
+participants' contributions into one public PR comment.
+
+Important constraints:
+- Use only the room payload below as evidence.
+- The reviewed PR head SHA is `{reviewed_head_sha}`.
+- This runner slice is comment-close only. Set `recommended_action` to `comment`.
+- Do not include any `hivemoot:queen-action` seal header; the runner adds it.
+- Keep the public comment concise, specific, and actionable.
+
+Return exactly one fenced JSON block and no other prose:
+
+```json
+{{
+  "verdict": "APPROVE",
+  "reasoning": "Short explanation, 500 chars max.",
+  "recommended_action": "comment",
+  "comment_body": "Markdown body to post publicly on the PR."
+}}
+```
+
+Valid verdicts: APPROVE, COMMENT, CONCERNS, REQUEST_CHANGES.
+
+Room payload:
+
+```json
+{room_json}
+```
+"""

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -168,7 +168,8 @@ class LocalQueenSynthesisTrigger:
             return
 
         if self._enable_squash_merge:
-            self._flush_pending_merge_reports(bearer)
+            if self._flush_pending_merge_reports(bearer):
+                return
             if self._confirm_pending_merge(bearer):
                 return
 
@@ -399,9 +400,9 @@ class LocalQueenSynthesisTrigger:
 
         return False
 
-    def _flush_pending_merge_reports(self, bearer: str) -> None:
+    def _flush_pending_merge_reports(self, bearer: str) -> bool:
         if not self._pending_merge_reports:
-            return
+            return False
         remaining: list[PendingMergeReport] = []
         for report in self._pending_merge_reports:
             try:
@@ -432,6 +433,7 @@ class LocalQueenSynthesisTrigger:
         if len(remaining) != len(self._pending_merge_reports):
             self._pending_merge_reports = remaining
             self._save_pending_merge_reports()
+        return bool(self._pending_merge_reports)
 
     def _enqueue_pending_merge_report(self, report: PendingMergeReport) -> None:
         self._pending_merge_reports = [

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -1,0 +1,329 @@
+"""Local queen synthesis trigger.
+
+Polls rooms that are candidates for synthesis, applies the local
+eligibility gates that the status-only endpoint intentionally omits,
+claims one room, captures a fresh PR head SHA, and dispatches a single
+agent job.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from hivemoot_agent.plugins.interfaces import Job, JobDispatcher, PluginConfig
+from hivemoot_agent.plugins_builtin.hivemoot.queen import api as q_api
+from hivemoot_agent.plugins_builtin.hivemoot.queen import gh
+from hivemoot_agent.plugins_builtin.hivemoot.queen.handler import (
+    JOB_KIND_SYNTHESIS,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.prompts import (
+    build_synthesis_prompt,
+)
+
+
+DEFAULT_POLL_INTERVAL_SECS = 60
+
+
+class LocalQueenSynthesisTrigger:
+    """Poll and dispatch one local queen synthesis job at a time."""
+
+    name = "hivemoot-queen"
+
+    def __init__(
+        self,
+        plugin: Any,
+        *,
+        base_url: str,
+        token_resolver: Callable[[], str],
+        runner_id: str,
+        agent_id: str,
+        poll_interval_secs: int = DEFAULT_POLL_INTERVAL_SECS,
+        ready_limit: int = 10,
+        claim_ttl_secs: int = 900,
+        fallback_quiet_period_secs: int = 60,
+        gh_timeout_secs: int = 30,
+        log_prefix: str = "[hivemoot-queen]",
+        list_ready_fn: Callable[
+            ..., list[q_api.SynthesisReadyRoom]
+        ] = q_api.list_synthesis_ready_rooms,
+        participants_fn: Callable[..., dict[str, Any]] = q_api.get_room_participants,
+        events_fn: Callable[..., list[dict[str, Any]]] = q_api.list_room_events,
+        claim_fn: Callable[..., q_api.ClaimedSynthesis] = q_api.claim_synthesis,
+        mint_token_fn: Callable[..., str] = q_api.mint_installation_token,
+        get_head_sha_fn: Callable[..., str] = gh.get_pr_head_sha,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._plugin = plugin
+        self._base_url = base_url
+        self._token_resolver = token_resolver
+        self._runner_id = runner_id
+        self._agent_id = agent_id
+        self._poll_interval_secs = max(1, poll_interval_secs)
+        self._ready_limit = max(1, ready_limit)
+        self._claim_ttl_secs = max(1, claim_ttl_secs)
+        self._fallback_quiet_period_secs = max(0, fallback_quiet_period_secs)
+        self._gh_timeout_secs = max(1, gh_timeout_secs)
+        self._log_prefix = log_prefix
+        self._list_ready = list_ready_fn
+        self._participants = participants_fn
+        self._events = events_fn
+        self._claim = claim_fn
+        self._mint_token = mint_token_fn
+        self._get_head_sha = get_head_sha_fn
+        self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))
+        self._stop_event = threading.Event()
+
+    def validate(self, config: PluginConfig) -> list[str]:
+        del config
+        return []
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def start(self, config: PluginConfig, dispatcher: JobDispatcher) -> None:
+        del config
+        self._stop_event.clear()
+        print(
+            f"{self._log_prefix} polling "
+            f"{self._base_url}/api/rooms/synthesis-ready every "
+            f"{self._poll_interval_secs}s",
+            file=sys.stderr,
+            flush=True,
+        )
+
+        while not self._stop_event.is_set():
+            try:
+                self._tick(dispatcher)
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} tick error: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            self._stop_event.wait(self._poll_interval_secs)
+
+    def _tick(self, dispatcher: JobDispatcher) -> None:
+        if not self._plugin.wait_queen_slot(self._stop_event, timeout=0):
+            return
+
+        bearer = self._token_resolver()
+        if not bearer:
+            return
+
+        try:
+            rooms = self._list_ready(
+                self._base_url,
+                bearer,
+                limit=self._ready_limit,
+            )
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} synthesis-ready failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+
+        for room in rooms:
+            if not self._is_room_ready(room, bearer):
+                continue
+
+            try:
+                claimed = self._claim(
+                    self._base_url,
+                    room.room_id,
+                    bearer,
+                    queen_runner=self._runner_id,
+                    claim_ttl_secs=self._claim_ttl_secs,
+                )
+            except q_api.QueenAPIConflictError as exc:
+                print(
+                    f"{self._log_prefix} claim skipped room={room.room_id}: "
+                    f"{exc.code}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} claim failed room={room.room_id}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+
+            try:
+                pr = gh.parse_subject_ref(room.subject_ref)
+                gh_token = self._mint_token(
+                    self._base_url,
+                    bearer,
+                    repo=pr.full_repo,
+                    agent_id=self._agent_id or None,
+                )
+                reviewed_head_sha = self._get_head_sha(
+                    pr,
+                    token=gh_token,
+                    timeout_secs=self._gh_timeout_secs,
+                )
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} head-sha capture failed "
+                    f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return
+
+            job = self._build_job(
+                room=room,
+                claimed=claimed,
+                reviewed_head_sha=reviewed_head_sha,
+            )
+
+            self._plugin.reserve_queen_slot()
+            try:
+                ok = dispatcher.dispatch(job)
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} dispatch raised room={room.room_id}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                self._plugin.release_queen_slot()
+                return
+            if not ok:
+                print(
+                    f"{self._log_prefix} dispatch refused room={room.room_id}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                self._plugin.release_queen_slot()
+                return
+
+            print(
+                f"{self._log_prefix} dispatched room={room.room_id} "
+                f"subject={room.subject_ref} seq={claimed.through_sequence}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+
+    def _is_room_ready(self, room: q_api.SynthesisReadyRoom, bearer: str) -> bool:
+        try:
+            participants = self._participants(self._base_url, room.room_id, bearer)
+            events = self._events(self._base_url, room.room_id, bearer, limit=500)
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} eligibility read failed "
+                f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
+        unresolved = []
+        for role, participant in participants.items():
+            status = (
+                str(participant.get("status") or "")
+                if isinstance(participant, dict)
+                else ""
+            )
+            if status not in {"resolved", "withdrew", "timed_out"}:
+                unresolved.append(role)
+        if unresolved:
+            print(
+                f"{self._log_prefix} room={room.room_id} not ready: "
+                f"unresolved participants={','.join(sorted(unresolved))}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
+        quiet_period = self._quiet_period_for(room)
+        if quiet_period <= 0:
+            return True
+
+        last_ts = self._last_event_timestamp(room, events)
+        if last_ts is None:
+            return False
+        age = (self._now_fn() - last_ts).total_seconds()
+        if age < quiet_period:
+            print(
+                f"{self._log_prefix} room={room.room_id} not ready: "
+                f"quiet age={int(age)}s required={quiet_period}s",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+        return True
+
+    def _quiet_period_for(self, room: q_api.SynthesisReadyRoom) -> int:
+        value = room.timing_config.get("quiet_period_secs")
+        if isinstance(value, bool):
+            return self._fallback_quiet_period_secs
+        if isinstance(value, int):
+            return max(0, value)
+        if isinstance(value, str):
+            try:
+                return max(0, int(value))
+            except ValueError:
+                pass
+        return self._fallback_quiet_period_secs
+
+    def _last_event_timestamp(
+        self,
+        room: q_api.SynthesisReadyRoom,
+        events: list[dict[str, Any]],
+    ) -> datetime | None:
+        for event in reversed(events):
+            parsed = _parse_iso(str(event.get("timestamp") or ""))
+            if parsed is not None:
+                return parsed
+        return _parse_iso(room.opened_at)
+
+    def _build_job(
+        self,
+        *,
+        room: q_api.SynthesisReadyRoom,
+        claimed: q_api.ClaimedSynthesis,
+        reviewed_head_sha: str,
+    ) -> Job:
+        metadata = {
+            "job_kind": JOB_KIND_SYNTHESIS,
+            "room_id": room.room_id,
+            "subject_type": room.subject_type,
+            "subject_ref": room.subject_ref,
+            "manager": room.manager,
+            "sealed_through_sequence": claimed.through_sequence,
+            "queen_runner": self._runner_id,
+            "reviewed_head_sha": reviewed_head_sha,
+            "coalesce_key": f"queen:{room.room_id}",
+        }
+        return Job(
+            session_key=f"queen:{room.room_id}@{claimed.through_sequence}",
+            prompt=build_synthesis_prompt(
+                claimed=claimed,
+                reviewed_head_sha=reviewed_head_sha,
+            ),
+            metadata=metadata,
+        )
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except ValueError:
+        return None

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -8,8 +8,11 @@ agent job.
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable
 
@@ -25,6 +28,37 @@ from hivemoot_agent.plugins_builtin.hivemoot.queen.prompts import (
 
 
 DEFAULT_POLL_INTERVAL_SECS = 60
+
+
+@dataclass(frozen=True)
+class PendingMergeReport:
+    room_id: str
+    subject_ref: str
+    merge_attempt_id: str
+    merge_commit_oid: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PendingMergeReport | None":
+        room_id = str(data.get("room_id") or "").strip()
+        subject_ref = str(data.get("subject_ref") or "").strip()
+        merge_attempt_id = str(data.get("merge_attempt_id") or "").strip()
+        merge_commit_oid = str(data.get("merge_commit_oid") or "").strip()
+        if not room_id or not merge_attempt_id or not merge_commit_oid:
+            return None
+        return cls(
+            room_id=room_id,
+            subject_ref=subject_ref,
+            merge_attempt_id=merge_attempt_id,
+            merge_commit_oid=merge_commit_oid,
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "room_id": self.room_id,
+            "subject_ref": self.subject_ref,
+            "merge_attempt_id": self.merge_attempt_id,
+            "merge_commit_oid": self.merge_commit_oid,
+        }
 
 
 class LocalQueenSynthesisTrigger:
@@ -46,6 +80,7 @@ class LocalQueenSynthesisTrigger:
         fallback_quiet_period_secs: int = 60,
         gh_timeout_secs: int = 30,
         enable_squash_merge: bool = False,
+        merge_report_queue_file: str = "",
         log_prefix: str = "[hivemoot-queen]",
         list_ready_fn: Callable[
             ..., list[q_api.SynthesisReadyRoom]
@@ -79,6 +114,8 @@ class LocalQueenSynthesisTrigger:
         self._gh_timeout_secs = max(1, gh_timeout_secs)
         self._enable_squash_merge = enable_squash_merge
         self._log_prefix = log_prefix
+        self._merge_report_queue_file = merge_report_queue_file
+        self._pending_merge_reports = self._load_pending_merge_reports()
         self._list_ready = list_ready_fn
         self._list_pending = list_pending_fn
         self._participants = participants_fn
@@ -130,8 +167,10 @@ class LocalQueenSynthesisTrigger:
         if not bearer:
             return
 
-        if self._enable_squash_merge and self._confirm_pending_merge(bearer):
-            return
+        if self._enable_squash_merge:
+            self._flush_pending_merge_reports(bearer)
+            if self._confirm_pending_merge(bearer):
+                return
 
         try:
             rooms = self._list_ready(
@@ -304,6 +343,7 @@ class LocalQueenSynthesisTrigger:
             try:
                 merge_commit_oid = self._squash_merge(
                     pr,
+                    expected_head_sha=current_head_sha,
                     token=gh_token,
                     timeout_secs=self._gh_timeout_secs,
                 )
@@ -333,6 +373,14 @@ class LocalQueenSynthesisTrigger:
                     merge_commit_oid=merge_commit_oid,
                 )
             except Exception as exc:
+                self._enqueue_pending_merge_report(
+                    PendingMergeReport(
+                        room_id=room.room_id,
+                        subject_ref=room.subject_ref,
+                        merge_attempt_id=confirmed.merge_attempt_id,
+                        merge_commit_oid=merge_commit_oid,
+                    ),
+                )
                 print(
                     f"{self._log_prefix} merge result report failed "
                     f"room={room.room_id}: {type(exc).__name__}: {exc}",
@@ -350,6 +398,102 @@ class LocalQueenSynthesisTrigger:
             return True
 
         return False
+
+    def _flush_pending_merge_reports(self, bearer: str) -> None:
+        if not self._pending_merge_reports:
+            return
+        remaining: list[PendingMergeReport] = []
+        for report in self._pending_merge_reports:
+            try:
+                self._report_merge_result(
+                    self._base_url,
+                    report.room_id,
+                    bearer,
+                    queen_runner=self._runner_id,
+                    merge_attempt_id=report.merge_attempt_id,
+                    github_merge_status="succeeded",
+                    merge_commit_oid=report.merge_commit_oid,
+                )
+            except Exception as exc:
+                remaining.append(report)
+                print(
+                    f"{self._log_prefix} queued merge-result report failed "
+                    f"room={report.room_id}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+            print(
+                f"{self._log_prefix} reported queued squash merge "
+                f"room={report.room_id} commit={report.merge_commit_oid}",
+                file=sys.stderr,
+                flush=True,
+            )
+        if len(remaining) != len(self._pending_merge_reports):
+            self._pending_merge_reports = remaining
+            self._save_pending_merge_reports()
+
+    def _enqueue_pending_merge_report(self, report: PendingMergeReport) -> None:
+        self._pending_merge_reports = [
+            existing
+            for existing in self._pending_merge_reports
+            if existing.merge_attempt_id != report.merge_attempt_id
+        ]
+        self._pending_merge_reports.append(report)
+        self._save_pending_merge_reports()
+
+    def _load_pending_merge_reports(self) -> list[PendingMergeReport]:
+        path = self._merge_report_queue_file
+        if not path:
+            return []
+        try:
+            with open(path, encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except FileNotFoundError:
+            return []
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} merge report queue load failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return []
+        if not isinstance(raw, list):
+            return []
+        reports: list[PendingMergeReport] = []
+        for entry in raw:
+            if isinstance(entry, dict):
+                parsed = PendingMergeReport.from_dict(entry)
+                if parsed is not None:
+                    reports.append(parsed)
+        return reports
+
+    def _save_pending_merge_reports(self) -> None:
+        path = self._merge_report_queue_file
+        if not path:
+            return
+        try:
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            tmp_path = f"{path}.tmp"
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                json.dump(
+                    [report.to_dict() for report in self._pending_merge_reports],
+                    fh,
+                    indent=2,
+                    sort_keys=True,
+                )
+                fh.write("\n")
+            os.replace(tmp_path, path)
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} merge report queue save failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
 
     def _report_merge_failure(
         self,
@@ -473,6 +617,7 @@ class LocalQueenSynthesisTrigger:
             prompt=build_synthesis_prompt(
                 claimed=claimed,
                 reviewed_head_sha=reviewed_head_sha,
+                enable_squash_merge=self._enable_squash_merge,
             ),
             metadata=metadata,
         )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -45,15 +45,26 @@ class LocalQueenSynthesisTrigger:
         claim_ttl_secs: int = 900,
         fallback_quiet_period_secs: int = 60,
         gh_timeout_secs: int = 30,
+        enable_squash_merge: bool = False,
         log_prefix: str = "[hivemoot-queen]",
         list_ready_fn: Callable[
             ..., list[q_api.SynthesisReadyRoom]
         ] = q_api.list_synthesis_ready_rooms,
+        list_pending_fn: Callable[
+            ..., list[q_api.SynthesisReadyRoom]
+        ] = q_api.list_decided_pending_ready_rooms,
         participants_fn: Callable[..., dict[str, Any]] = q_api.get_room_participants,
         events_fn: Callable[..., list[dict[str, Any]]] = q_api.list_room_events,
         claim_fn: Callable[..., q_api.ClaimedSynthesis] = q_api.claim_synthesis,
+        confirm_merge_fn: Callable[
+            ..., q_api.ConfirmMergeResult
+        ] = q_api.confirm_merge,
+        report_merge_result_fn: Callable[
+            ..., q_api.MergeReportResult
+        ] = q_api.report_merge_result,
         mint_token_fn: Callable[..., str] = q_api.mint_installation_token,
         get_head_sha_fn: Callable[..., str] = gh.get_pr_head_sha,
+        squash_merge_fn: Callable[..., str] = gh.squash_merge_pr,
         now_fn: Callable[[], datetime] | None = None,
     ) -> None:
         self._plugin = plugin
@@ -66,13 +77,18 @@ class LocalQueenSynthesisTrigger:
         self._claim_ttl_secs = max(1, claim_ttl_secs)
         self._fallback_quiet_period_secs = max(0, fallback_quiet_period_secs)
         self._gh_timeout_secs = max(1, gh_timeout_secs)
+        self._enable_squash_merge = enable_squash_merge
         self._log_prefix = log_prefix
         self._list_ready = list_ready_fn
+        self._list_pending = list_pending_fn
         self._participants = participants_fn
         self._events = events_fn
         self._claim = claim_fn
+        self._confirm_merge = confirm_merge_fn
+        self._report_merge_result = report_merge_result_fn
         self._mint_token = mint_token_fn
         self._get_head_sha = get_head_sha_fn
+        self._squash_merge = squash_merge_fn
         self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))
         self._stop_event = threading.Event()
 
@@ -112,6 +128,9 @@ class LocalQueenSynthesisTrigger:
 
         bearer = self._token_resolver()
         if not bearer:
+            return
+
+        if self._enable_squash_merge and self._confirm_pending_merge(bearer):
             return
 
         try:
@@ -214,6 +233,149 @@ class LocalQueenSynthesisTrigger:
                 flush=True,
             )
             return
+
+    def _confirm_pending_merge(self, bearer: str) -> bool:
+        try:
+            rooms = self._list_pending(
+                self._base_url,
+                bearer,
+                limit=self._ready_limit,
+            )
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} decided-pending-ready failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
+        for room in rooms:
+            try:
+                pr = gh.parse_subject_ref(room.subject_ref)
+                gh_token = self._mint_token(
+                    self._base_url,
+                    bearer,
+                    repo=pr.full_repo,
+                    agent_id=self._agent_id or None,
+                )
+                current_head_sha = self._get_head_sha(
+                    pr,
+                    token=gh_token,
+                    timeout_secs=self._gh_timeout_secs,
+                )
+                merge_attempt_id = (
+                    f"{self._runner_id}:{room.room_id}:{current_head_sha[:12]}"
+                )
+                confirmed = self._confirm_merge(
+                    self._base_url,
+                    room.room_id,
+                    bearer,
+                    queen_runner=self._runner_id,
+                    merge_attempt_id=merge_attempt_id,
+                    current_head_sha=current_head_sha,
+                )
+            except q_api.QueenAPIConflictError as exc:
+                print(
+                    f"{self._log_prefix} confirm skipped room={room.room_id}: "
+                    f"{exc.code}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} confirm failed room={room.room_id}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+
+            if confirmed.decision_outcome != "merge_approved":
+                print(
+                    f"{self._log_prefix} merge downgraded room={room.room_id} "
+                    f"reason={confirmed.decision_outcome_reason}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return True
+
+            try:
+                merge_commit_oid = self._squash_merge(
+                    pr,
+                    token=gh_token,
+                    timeout_secs=self._gh_timeout_secs,
+                )
+            except Exception as exc:
+                self._report_merge_failure(
+                    bearer=bearer,
+                    room=room,
+                    merge_attempt_id=confirmed.merge_attempt_id,
+                    error_class=type(exc).__name__,
+                )
+                print(
+                    f"{self._log_prefix} squash merge failed "
+                    f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return True
+
+            try:
+                self._report_merge_result(
+                    self._base_url,
+                    room.room_id,
+                    bearer,
+                    queen_runner=self._runner_id,
+                    merge_attempt_id=confirmed.merge_attempt_id,
+                    github_merge_status="succeeded",
+                    merge_commit_oid=merge_commit_oid,
+                )
+            except Exception as exc:
+                print(
+                    f"{self._log_prefix} merge result report failed "
+                    f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return True
+
+            print(
+                f"{self._log_prefix} squash merged room={room.room_id} "
+                f"commit={merge_commit_oid}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return True
+
+        return False
+
+    def _report_merge_failure(
+        self,
+        *,
+        bearer: str,
+        room: q_api.SynthesisReadyRoom,
+        merge_attempt_id: str,
+        error_class: str,
+    ) -> None:
+        try:
+            self._report_merge_result(
+                self._base_url,
+                room.room_id,
+                bearer,
+                queen_runner=self._runner_id,
+                merge_attempt_id=merge_attempt_id,
+                github_merge_status="failed",
+                error_class=error_class,
+            )
+        except Exception as exc:
+            print(
+                f"{self._log_prefix} failed merge-result report failed "
+                f"room={room.room_id}: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
 
     def _is_room_ready(self, room: q_api.SynthesisReadyRoom, bearer: str) -> bool:
         try:

--- a/agent/cli/tests/test_hivemoot_config.py
+++ b/agent/cli/tests/test_hivemoot_config.py
@@ -15,6 +15,7 @@ from hivemoot_agent.plugins_builtin.hivemoot.config import (
     HivemootConfig,
     HivemootGithubWorkflowsConfig,
     HivemootHealthConfig,
+    HivemootQueenConfig,
     HivemootTasksConfig,
     HivemootWarRoomsConfig,
 )
@@ -28,6 +29,7 @@ class DefaultsTests(unittest.TestCase):
         self.assertFalse(cfg.github_workflows.enabled)
         self.assertFalse(cfg.apiarist.enabled)
         self.assertFalse(cfg.war_rooms.enabled)
+        self.assertFalse(cfg.queen.enabled)
 
     def test_war_rooms_defaults(self) -> None:
         cfg = HivemootWarRoomsConfig()
@@ -77,6 +79,16 @@ class DefaultsTests(unittest.TestCase):
         self.assertEqual(cfg.service, "")
         self.assertEqual(cfg.repo, "")
 
+    def test_queen_defaults(self) -> None:
+        cfg = HivemootQueenConfig()
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.base_url, "https://www.hivemoot.dev")
+        self.assertEqual(cfg.poll_interval_secs, 60)
+        self.assertEqual(cfg.synthesis_ready_limit, 10)
+        self.assertEqual(cfg.claim_ttl_secs, 900)
+        self.assertEqual(cfg.runner_id, "")
+        self.assertFalse(cfg.enable_squash_merge)
+
 
 class StrictnessTests(unittest.TestCase):
     """StrictPluginConfig forbids unknown fields — catches operator
@@ -110,6 +122,25 @@ class RangeTests(unittest.TestCase):
             HivemootApiaristConfig(timeout_seconds=0)
         with self.assertRaises(ValidationError):
             HivemootApiaristConfig(timeout_seconds=-1)
+
+    def test_queen_poll_interval_min_5s(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(poll_interval_secs=4)
+        HivemootQueenConfig(poll_interval_secs=5)
+
+    def test_queen_ready_limit_range(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(synthesis_ready_limit=0)
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(synthesis_ready_limit=51)
+        HivemootQueenConfig(synthesis_ready_limit=50)
+
+    def test_queen_claim_ttl_range(self) -> None:
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(claim_ttl_secs=59)
+        with self.assertRaises(ValidationError):
+            HivemootQueenConfig(claim_ttl_secs=901)
+        HivemootQueenConfig(claim_ttl_secs=900)
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_queen_api.py
+++ b/agent/cli/tests/test_hivemoot_queen_api.py
@@ -1,0 +1,149 @@
+"""Tests for the local queen API client."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen import api as q_api
+
+
+class QueenApiTests(unittest.TestCase):
+    def test_list_synthesis_ready_rooms_parses_room_core(self) -> None:
+        with patch.object(
+            q_api,
+            "get_json",
+            return_value=(
+                200,
+                {
+                    "rooms": [
+                        {
+                            "roomId": "room-1",
+                            "status": "awaiting_contributions",
+                            "subject_type": "pr_review",
+                            "subject_ref": "owner/repo#42",
+                            "manager": "bot-queen",
+                            "opened_at": "2026-05-15T00:00:00Z",
+                            "timing_config": {"quiet_period_secs": 60},
+                        },
+                    ],
+                    "count": 1,
+                },
+                b"",
+            ),
+        ) as get_mock:
+            rooms = q_api.list_synthesis_ready_rooms(
+                "https://api.example", "bearer", limit=7,
+            )
+        get_mock.assert_called_once_with(
+            "https://api.example/api/rooms/synthesis-ready?limit=7",
+            "bearer",
+            timeout=10,
+        )
+        self.assertEqual(len(rooms), 1)
+        self.assertEqual(rooms[0].room_id, "room-1")
+        self.assertEqual(rooms[0].subject_ref, "owner/repo#42")
+        self.assertEqual(rooms[0].timing_config["quiet_period_secs"], 60)
+
+    def test_claim_synthesis_maps_conflict(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                409,
+                {"code": "claim_already_held"},
+                b'{"code":"claim_already_held"}',
+            ),
+        ):
+            with self.assertRaises(q_api.QueenAPIConflictError) as ctx:
+                q_api.claim_synthesis(
+                    "https://api.example",
+                    "room-1",
+                    "bearer",
+                    queen_runner="runner",
+                    claim_ttl_secs=900,
+                )
+        self.assertEqual(ctx.exception.code, "claim_already_held")
+
+    def test_resolve_action_payload_and_result(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "permittedAction": "comment",
+                    "clampedVerdict": "APPROVE",
+                    "downgradeReason": None,
+                    "reviewedHeadSha": "abc",
+                    "currentHeadSha": "abc",
+                    "floorOverridden": False,
+                    "auditId": "123-0",
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.resolve_action(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                verdict="APPROVE",
+                reasoning="ok",
+                recommended_action="comment",
+                reviewed_head_sha="abc",
+                sealed_through_sequence=12,
+            )
+
+        args = post_mock.call_args[0]
+        self.assertEqual(
+            args[0],
+            "https://api.example/api/rooms/room-1/resolve-action",
+        )
+        self.assertEqual(args[1]["queenRunner"], "runner")
+        self.assertEqual(args[1]["derivedVerdict"]["verdict"], "APPROVE")
+        self.assertEqual(args[1]["sealedThroughSequence"], 12)
+        self.assertEqual(result.audit_id, "123-0")
+        self.assertEqual(result.permitted_action, "comment")
+
+    def test_seal_decision_sends_comment_url(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "finalState": "closed",
+                    "closedSequence": 13,
+                    "auditId": "123-0",
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.seal_decision(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                audit_id="123-0",
+                sealed_through_sequence=12,
+                decision={
+                    "synthesized_at": "2026-05-15T00:00:00Z",
+                    "synthesis_runner": "runner",
+                    "content": "ok",
+                    "sequence_closed": 12,
+                },
+                comment_url="https://github.com/o/r/pull/1#issuecomment-2",
+            )
+        body = post_mock.call_args[0][1]
+        self.assertEqual(body["finalState"], "closed")
+        self.assertEqual(body["commentUrl"], "https://github.com/o/r/pull/1#issuecomment-2")
+        self.assertEqual(result.closed_sequence, 13)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_api.py
+++ b/agent/cli/tests/test_hivemoot_queen_api.py
@@ -49,6 +49,37 @@ class QueenApiTests(unittest.TestCase):
         self.assertEqual(rooms[0].subject_ref, "owner/repo#42")
         self.assertEqual(rooms[0].timing_config["quiet_period_secs"], 60)
 
+    def test_list_decided_pending_ready_rooms_uses_pending_endpoint(self) -> None:
+        with patch.object(
+            q_api,
+            "get_json",
+            return_value=(
+                200,
+                {
+                    "rooms": [
+                        {
+                            "roomId": "room-1",
+                            "status": "decided_pending_action",
+                            "subject_type": "pr_review",
+                            "subject_ref": "owner/repo#42",
+                            "manager": "bot-queen",
+                            "opened_at": "2026-05-15T00:00:00Z",
+                        },
+                    ],
+                },
+                b"",
+            ),
+        ) as get_mock:
+            rooms = q_api.list_decided_pending_ready_rooms(
+                "https://api.example", "bearer", limit=3,
+            )
+        get_mock.assert_called_once_with(
+            "https://api.example/api/rooms/decided-pending-ready?limit=3",
+            "bearer",
+            timeout=10,
+        )
+        self.assertEqual(rooms[0].status, "decided_pending_action")
+
     def test_claim_synthesis_maps_conflict(self) -> None:
         with patch.object(
             q_api,
@@ -143,6 +174,98 @@ class QueenApiTests(unittest.TestCase):
         self.assertEqual(body["finalState"], "closed")
         self.assertEqual(body["commentUrl"], "https://github.com/o/r/pull/1#issuecomment-2")
         self.assertEqual(result.closed_sequence, 13)
+
+    def test_seal_decision_can_request_pending_merge_state(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "finalState": "decided_pending_action",
+                    "pendingSequence": 13,
+                    "auditId": "123-0",
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.seal_decision(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                audit_id="123-0",
+                sealed_through_sequence=12,
+                decision={
+                    "synthesized_at": "2026-05-15T00:00:00Z",
+                    "synthesis_runner": "runner",
+                    "content": "ok",
+                    "sequence_closed": 12,
+                },
+                final_state="decided_pending_action",
+                comment_url="https://github.com/o/r/pull/1#issuecomment-2",
+            )
+        self.assertEqual(post_mock.call_args[0][1]["finalState"], "decided_pending_action")
+        self.assertEqual(result.pending_sequence, 13)
+
+    def test_confirm_merge_payload_and_result(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "decisionOutcome": "merge_approved",
+                    "decisionOutcomeReason": None,
+                    "githubMergeStatus": "pending",
+                    "mergeAttemptId": "attempt-1",
+                    "closedSequence": 9,
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.confirm_merge(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                merge_attempt_id="attempt-1",
+                current_head_sha="abc",
+            )
+        body = post_mock.call_args[0][1]
+        self.assertEqual(body["mergeAttemptId"], "attempt-1")
+        self.assertEqual(body["currentHeadSha"], "abc")
+        self.assertEqual(result.decision_outcome, "merge_approved")
+        self.assertEqual(result.github_merge_status, "pending")
+
+    def test_report_merge_result_payload_and_result(self) -> None:
+        with patch.object(
+            q_api,
+            "post_json",
+            return_value=(
+                200,
+                {
+                    "githubMergeStatus": "succeeded",
+                    "mergeAttemptId": "attempt-1",
+                    "mergeCommitOid": "feedface",
+                    "errorClass": None,
+                },
+                b"",
+            ),
+        ) as post_mock:
+            result = q_api.report_merge_result(
+                "https://api.example",
+                "room-1",
+                "bearer",
+                queen_runner="runner",
+                merge_attempt_id="attempt-1",
+                github_merge_status="succeeded",
+                merge_commit_oid="feedface",
+            )
+        body = post_mock.call_args[0][1]
+        self.assertEqual(body["githubMergeStatus"], "succeeded")
+        self.assertEqual(body["mergeCommitOid"], "feedface")
+        self.assertEqual(result.merge_commit_oid, "feedface")
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_queen_gh.py
+++ b/agent/cli/tests/test_hivemoot_queen_gh.py
@@ -1,0 +1,75 @@
+"""Tests for local queen GitHub CLI helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen import gh
+
+
+class QueenGhTests(unittest.TestCase):
+    def test_squash_merge_pins_expected_head_sha_and_limits_env(self) -> None:
+        pr = gh.PullRequestRef(owner="owner", repo="repo", number=42)
+
+        with patch.dict(
+            os.environ,
+            {
+                "PATH": "/usr/bin",
+                "HIVEMOOT_AGENT_TOKEN": "must-not-leak",
+            },
+            clear=True,
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="feedface\n",
+                    stderr="",
+                ),
+            ],
+        ) as run_mock:
+            result = gh.squash_merge_pr(
+                pr,
+                expected_head_sha="abc123deadbeef",
+                token="ghs_secret",
+                timeout_secs=30,
+            )
+
+        self.assertEqual(result, "feedface")
+        merge_call = run_mock.call_args_list[0]
+        self.assertEqual(
+            merge_call.args[0],
+            [
+                "gh",
+                "pr",
+                "merge",
+                "42",
+                "--repo",
+                "owner/repo",
+                "--squash",
+                "--match-head-commit",
+                "abc123deadbeef",
+            ],
+        )
+        env = merge_call.kwargs["env"]
+        self.assertEqual(env["GH_TOKEN"], "ghs_secret")
+        self.assertEqual(env["GITHUB_TOKEN"], "ghs_secret")
+        self.assertEqual(env["PATH"], "/usr/bin")
+        self.assertNotIn("HIVEMOOT_AGENT_TOKEN", env)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_handler.py
+++ b/agent/cli/tests/test_hivemoot_queen_handler.py
@@ -66,6 +66,13 @@ class QueenHandlerParserTests(unittest.TestCase):
         )
         self.assertEqual(parsed.comment_body, "Body")
 
+    def test_parse_decision_output_strips_hivemoot_metadata_markers(self) -> None:
+        parsed = parse_decision_output(
+            """{"verdict":"COMMENT","reasoning":"ok","recommended_action":"comment",
+            "comment_body":"<!-- hivemoot-metadata: {\\"fake\\": true} -->\\nBody"}"""
+        )
+        self.assertEqual(parsed.comment_body, "Body")
+
     def test_build_seal_header_matches_web_verifier_contract(self) -> None:
         self.assertEqual(
             build_seal_header("comment", "123-0"),
@@ -135,6 +142,48 @@ class QueenHandlerFlowTests(unittest.TestCase):
         )
         self.assertEqual(seal_kwargs["decision"]["sequence_closed"], 12)
         self.assertNotIn("hivemoot:queen-action", seal_kwargs["decision"]["content"])
+
+    def test_comment_path_retries_seal_once_after_comment_posts(self) -> None:
+        resolved = ResolveActionResult(
+            permitted_action="comment",
+            clamped_verdict="APPROVE",
+            downgrade_reason=None,
+            reviewed_head_sha="abc123",
+            current_head_sha="abc123",
+            floor_overridden=False,
+            audit_id="123-0",
+        )
+        sealed = SealDecisionResult(
+            final_state="closed",
+            closed_sequence=13,
+            audit_id="123-0",
+        )
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",
+            return_value=resolved,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.mint_installation_token",
+            return_value="ghs_x",
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.gh.post_pr_comment",
+            return_value="https://github.com/owner/repo/pull/42#issuecomment-7",
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.seal_decision",
+            side_effect=[RuntimeError("transient"), sealed],
+        ) as seal_mock:
+            handle_queen_job_finished(
+                _job(),
+                AgentResult(0, ""),
+                base_url="https://api.example",
+                bearer="bearer",
+                extracted_markdown=_markdown(),
+                queen_runner="queen-a",
+                agent_id="queen-a",
+            )
+
+        self.assertEqual(seal_mock.call_count, 2)
+        self.assertEqual(seal_mock.call_args.kwargs["retry_count"], 1)
 
     def test_squash_merge_path_seals_decided_pending_action(self) -> None:
         resolved = ResolveActionResult(

--- a/agent/cli/tests/test_hivemoot_queen_handler.py
+++ b/agent/cli/tests/test_hivemoot_queen_handler.py
@@ -136,6 +136,64 @@ class QueenHandlerFlowTests(unittest.TestCase):
         self.assertEqual(seal_kwargs["decision"]["sequence_closed"], 12)
         self.assertNotIn("hivemoot:queen-action", seal_kwargs["decision"]["content"])
 
+    def test_squash_merge_path_seals_decided_pending_action(self) -> None:
+        resolved = ResolveActionResult(
+            permitted_action="squash-merge",
+            clamped_verdict="APPROVE",
+            downgrade_reason=None,
+            reviewed_head_sha="abc123",
+            current_head_sha="abc123",
+            floor_overridden=False,
+            audit_id="123-0",
+        )
+        sealed = SealDecisionResult(
+            final_state="decided_pending_action",
+            closed_sequence=0,
+            audit_id="123-0",
+            pending_sequence=13,
+        )
+        markdown = """```json
+{
+  "verdict": "APPROVE",
+  "reasoning": "All checks pass.",
+  "recommended_action": "squash-merge",
+  "comment_body": "Intent to squash merge after override window."
+}
+```"""
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",
+            return_value=resolved,
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.mint_installation_token",
+            return_value="ghs_x",
+        ), patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.gh.post_pr_comment",
+            return_value="https://github.com/owner/repo/pull/42#issuecomment-7",
+        ) as comment_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.seal_decision",
+            return_value=sealed,
+        ) as seal_mock:
+            handle_queen_job_finished(
+                _job(),
+                AgentResult(0, ""),
+                base_url="https://api.example",
+                bearer="bearer",
+                extracted_markdown=markdown,
+                queen_runner="queen-a",
+                agent_id="queen-a",
+                enable_squash_merge=True,
+            )
+
+        self.assertIn(
+            "<!-- hivemoot:queen-action:merge:123-0 -->",
+            comment_mock.call_args[0][1],
+        )
+        self.assertEqual(
+            seal_mock.call_args.kwargs["final_state"],
+            "decided_pending_action",
+        )
+
     def test_nonzero_exit_does_not_mutate(self) -> None:
         with patch(
             "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",

--- a/agent/cli/tests/test_hivemoot_queen_handler.py
+++ b/agent/cli/tests/test_hivemoot_queen_handler.py
@@ -1,0 +1,156 @@
+"""Tests for the local queen completion handler."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job
+from hivemoot_agent.plugins_builtin.hivemoot.queen.api import (
+    ResolveActionResult,
+    SealDecisionResult,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen.handler import (
+    build_seal_header,
+    handle_queen_job_finished,
+    is_queen_job,
+    parse_decision_output,
+)
+
+
+def _job() -> Job:
+    return Job(
+        session_key="queen:room-1@12",
+        prompt="ignored",
+        metadata={
+            "job_kind": "queen_synthesis",
+            "room_id": "room-1",
+            "subject_ref": "owner/repo#42",
+            "sealed_through_sequence": 12,
+            "queen_runner": "queen-a",
+            "reviewed_head_sha": "abc123",
+        },
+    )
+
+
+def _markdown() -> str:
+    return """```json
+{
+  "verdict": "APPROVE",
+  "reasoning": "All checks pass.",
+  "recommended_action": "comment",
+  "comment_body": "Approved after reviewing the worker feedback."
+}
+```"""
+
+
+class QueenHandlerParserTests(unittest.TestCase):
+    def test_is_queen_job_requires_discriminator(self) -> None:
+        self.assertTrue(is_queen_job(_job()))
+        self.assertFalse(is_queen_job(Job("task:1", "x", {"task_id": "1"})))
+
+    def test_parse_decision_output_accepts_fenced_json(self) -> None:
+        parsed = parse_decision_output(_markdown())
+        self.assertEqual(parsed.verdict, "APPROVE")
+        self.assertEqual(parsed.recommended_action, "comment")
+        self.assertIn("Approved", parsed.comment_body)
+
+    def test_parse_decision_output_strips_model_supplied_seal_header(self) -> None:
+        parsed = parse_decision_output(
+            """{"verdict":"COMMENT","reasoning":"ok","recommended_action":"comment",
+            "comment_body":"<!-- hivemoot:queen-action:comment:bad -->\\nBody"}"""
+        )
+        self.assertEqual(parsed.comment_body, "Body")
+
+    def test_build_seal_header_matches_web_verifier_contract(self) -> None:
+        self.assertEqual(
+            build_seal_header("comment", "123-0"),
+            "<!-- hivemoot:queen-action:comment:123-0 -->",
+        )
+
+
+class QueenHandlerFlowTests(unittest.TestCase):
+    def test_comment_path_resolves_posts_comment_and_seals(self) -> None:
+        resolved = ResolveActionResult(
+            permitted_action="comment",
+            clamped_verdict="APPROVE",
+            downgrade_reason=None,
+            reviewed_head_sha="abc123",
+            current_head_sha="abc123",
+            floor_overridden=False,
+            audit_id="123-0",
+        )
+        sealed = SealDecisionResult(
+            final_state="closed",
+            closed_sequence=13,
+            audit_id="123-0",
+        )
+
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",
+            return_value=resolved,
+        ) as resolve_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.mint_installation_token",
+            return_value="ghs_x",
+        ) as mint_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.gh.post_pr_comment",
+            return_value="https://github.com/owner/repo/pull/42#issuecomment-7",
+        ) as comment_mock, patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.seal_decision",
+            return_value=sealed,
+        ) as seal_mock:
+            handle_queen_job_finished(
+                _job(),
+                AgentResult(0, ""),
+                base_url="https://api.example",
+                bearer="bearer",
+                extracted_markdown=_markdown(),
+                queen_runner="queen-a",
+                agent_id="queen-a",
+            )
+
+        resolve_mock.assert_called_once()
+        resolve_kwargs = resolve_mock.call_args.kwargs
+        self.assertEqual(resolve_kwargs["recommended_action"], "comment")
+        self.assertEqual(resolve_kwargs["reviewed_head_sha"], "abc123")
+        mint_mock.assert_called_once_with(
+            "https://api.example",
+            "bearer",
+            repo="owner/repo",
+            agent_id="queen-a",
+        )
+        public_comment = comment_mock.call_args[0][1]
+        self.assertIn(
+            "<!-- hivemoot:queen-action:comment:123-0 -->",
+            public_comment,
+        )
+        seal_kwargs = seal_mock.call_args.kwargs
+        self.assertEqual(
+            seal_kwargs["comment_url"],
+            "https://github.com/owner/repo/pull/42#issuecomment-7",
+        )
+        self.assertEqual(seal_kwargs["decision"]["sequence_closed"], 12)
+        self.assertNotIn("hivemoot:queen-action", seal_kwargs["decision"]["content"])
+
+    def test_nonzero_exit_does_not_mutate(self) -> None:
+        with patch(
+            "hivemoot_agent.plugins_builtin.hivemoot.queen.handler.q_api.resolve_action",
+            MagicMock(),
+        ) as resolve_mock:
+            handle_queen_job_finished(
+                _job(),
+                AgentResult(1, "failed"),
+                base_url="https://api.example",
+                bearer="bearer",
+                extracted_markdown="",
+                queen_runner="queen-a",
+            )
+        resolve_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from hivemoot_agent.plugins_builtin.hivemoot.queen import (
     ClaimedSynthesis,
+    ConfirmMergeResult,
     LocalQueenSynthesisTrigger,
     SynthesisReadyRoom,
 )
@@ -47,6 +48,18 @@ def _room() -> SynthesisReadyRoom:
         manager="bot-queen",
         opened_at="2026-05-15T00:00:00Z",
         timing_config={"quiet_period_secs": 60},
+    )
+
+
+def _pending_room() -> SynthesisReadyRoom:
+    return SynthesisReadyRoom(
+        room_id="room-2",
+        status="decided_pending_action",
+        subject_type="pr_review",
+        subject_ref="owner/repo#43",
+        manager="bot-queen",
+        opened_at="2026-05-15T00:00:00Z",
+        timing_config={},
     )
 
 
@@ -165,6 +178,77 @@ class LocalQueenTriggerTests(unittest.TestCase):
         trigger._tick(dispatcher)
         self.assertEqual(plugin.reserved, 1)
         self.assertEqual(plugin.released, 1)
+
+    def test_confirmed_pending_merge_runs_squash_and_reports_success(self) -> None:
+        dispatcher = MagicMock()
+        list_ready = MagicMock(return_value=[_room()])
+        report = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            enable_squash_merge=True,
+            list_ready_fn=list_ready,
+            list_pending_fn=MagicMock(return_value=[_pending_room()]),
+            confirm_merge_fn=MagicMock(
+                return_value=ConfirmMergeResult(
+                    decision_outcome="merge_approved",
+                    decision_outcome_reason=None,
+                    github_merge_status="pending",
+                    merge_attempt_id="queen-a:room-2:abc123",
+                    closed_sequence=9,
+                ),
+            ),
+            report_merge_result_fn=report,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123deadbeef"),
+            squash_merge_fn=MagicMock(return_value="feedface"),
+        )
+
+        trigger._tick(dispatcher)
+
+        dispatcher.dispatch.assert_not_called()
+        list_ready.assert_not_called()
+        report.assert_called_once_with(
+            "https://api.example",
+            "room-2",
+            "bearer",
+            queen_runner="queen-a",
+            merge_attempt_id="queen-a:room-2:abc123",
+            github_merge_status="succeeded",
+            merge_commit_oid="feedface",
+        )
+
+    def test_pending_merge_downgrade_does_not_run_gh_merge(self) -> None:
+        squash_merge = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            enable_squash_merge=True,
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            list_pending_fn=MagicMock(return_value=[_pending_room()]),
+            confirm_merge_fn=MagicMock(
+                return_value=ConfirmMergeResult(
+                    decision_outcome="merge_downgraded",
+                    decision_outcome_reason="head_sha_drift",
+                    github_merge_status=None,
+                    merge_attempt_id="queen-a:room-2:abc123",
+                    closed_sequence=9,
+                ),
+            ),
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123deadbeef"),
+            squash_merge_fn=squash_merge,
+        )
+
+        trigger._tick(MagicMock())
+
+        squash_merge.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+import tempfile
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -109,6 +110,35 @@ class LocalQueenTriggerTests(unittest.TestCase):
         self.assertEqual(plugin.reserved, 1)
         self.assertEqual(plugin.released, 0)
 
+    def test_dispatch_prompt_allows_squash_merge_when_enabled(self) -> None:
+        plugin = SlotPlugin()
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = True
+
+        trigger = LocalQueenSynthesisTrigger(
+            plugin,
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            enable_squash_merge=True,
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=MagicMock(return_value=_claimed()),
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+
+        trigger._tick(dispatcher)
+
+        job = dispatcher.dispatch.call_args[0][0]
+        self.assertIn('"recommended_action": "squash-merge"', job.prompt)
+        self.assertNotIn("comment-close only", job.prompt)
+
     def test_skips_pending_participant_before_claim(self) -> None:
         claim_fn = MagicMock(return_value=_claimed())
         dispatcher = MagicMock()
@@ -183,6 +213,16 @@ class LocalQueenTriggerTests(unittest.TestCase):
         dispatcher = MagicMock()
         list_ready = MagicMock(return_value=[_room()])
         report = MagicMock()
+        confirm = MagicMock(
+            return_value=ConfirmMergeResult(
+                decision_outcome="merge_approved",
+                decision_outcome_reason=None,
+                github_merge_status="pending",
+                merge_attempt_id="queen-a:room-2:abc123deadbe",
+                closed_sequence=9,
+            ),
+        )
+        squash_merge = MagicMock(return_value="feedface")
         trigger = LocalQueenSynthesisTrigger(
             SlotPlugin(),
             base_url="https://api.example",
@@ -192,34 +232,100 @@ class LocalQueenTriggerTests(unittest.TestCase):
             enable_squash_merge=True,
             list_ready_fn=list_ready,
             list_pending_fn=MagicMock(return_value=[_pending_room()]),
-            confirm_merge_fn=MagicMock(
-                return_value=ConfirmMergeResult(
-                    decision_outcome="merge_approved",
-                    decision_outcome_reason=None,
-                    github_merge_status="pending",
-                    merge_attempt_id="queen-a:room-2:abc123",
-                    closed_sequence=9,
-                ),
-            ),
+            confirm_merge_fn=confirm,
             report_merge_result_fn=report,
             mint_token_fn=MagicMock(return_value="ghs_x"),
             get_head_sha_fn=MagicMock(return_value="abc123deadbeef"),
-            squash_merge_fn=MagicMock(return_value="feedface"),
+            squash_merge_fn=squash_merge,
         )
 
         trigger._tick(dispatcher)
 
         dispatcher.dispatch.assert_not_called()
         list_ready.assert_not_called()
+        confirm.assert_called_once_with(
+            "https://api.example",
+            "room-2",
+            "bearer",
+            queen_runner="queen-a",
+            merge_attempt_id="queen-a:room-2:abc123deadbe",
+            current_head_sha="abc123deadbeef",
+        )
+        squash_merge.assert_called_once()
+        squash_pr = squash_merge.call_args.args[0]
+        self.assertEqual(squash_pr.full_repo, "owner/repo")
+        self.assertEqual(squash_pr.number, 43)
+        self.assertEqual(
+            squash_merge.call_args.kwargs["expected_head_sha"],
+            "abc123deadbeef",
+        )
+        self.assertEqual(squash_merge.call_args.kwargs["token"], "ghs_x")
+        self.assertEqual(squash_merge.call_args.kwargs["timeout_secs"], 30)
         report.assert_called_once_with(
             "https://api.example",
             "room-2",
             "bearer",
             queen_runner="queen-a",
-            merge_attempt_id="queen-a:room-2:abc123",
+            merge_attempt_id="queen-a:room-2:abc123deadbe",
             github_merge_status="succeeded",
             merge_commit_oid="feedface",
         )
+
+    def test_successful_merge_report_failure_is_persisted_and_retried(self) -> None:
+        dispatcher = MagicMock()
+        report = MagicMock(side_effect=[RuntimeError("api down"), None])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            queue_file = os.path.join(tmpdir, "merge-reports.json")
+            trigger = LocalQueenSynthesisTrigger(
+                SlotPlugin(),
+                base_url="https://api.example",
+                token_resolver=lambda: "bearer",
+                runner_id="queen-a",
+                agent_id="queen-a",
+                enable_squash_merge=True,
+                merge_report_queue_file=queue_file,
+                list_ready_fn=MagicMock(return_value=[_room()]),
+                list_pending_fn=MagicMock(return_value=[_pending_room()]),
+                confirm_merge_fn=MagicMock(
+                    return_value=ConfirmMergeResult(
+                        decision_outcome="merge_approved",
+                        decision_outcome_reason=None,
+                        github_merge_status="pending",
+                        merge_attempt_id="queen-a:room-2:abc123deadbe",
+                        closed_sequence=9,
+                    ),
+                ),
+                report_merge_result_fn=report,
+                mint_token_fn=MagicMock(return_value="ghs_x"),
+                get_head_sha_fn=MagicMock(return_value="abc123deadbeef"),
+                squash_merge_fn=MagicMock(return_value="feedface"),
+            )
+
+            trigger._tick(dispatcher)
+            self.assertTrue(os.path.exists(queue_file))
+
+            retry_trigger = LocalQueenSynthesisTrigger(
+                SlotPlugin(),
+                base_url="https://api.example",
+                token_resolver=lambda: "bearer",
+                runner_id="queen-a",
+                agent_id="queen-a",
+                enable_squash_merge=True,
+                merge_report_queue_file=queue_file,
+                list_ready_fn=MagicMock(return_value=[]),
+                list_pending_fn=MagicMock(return_value=[]),
+                report_merge_result_fn=report,
+            )
+
+            retry_trigger._tick(dispatcher)
+
+        self.assertEqual(report.call_count, 2)
+        self.assertEqual(
+            report.call_args.kwargs["merge_attempt_id"],
+            "queen-a:room-2:abc123deadbe",
+        )
+        self.assertEqual(report.call_args.kwargs["merge_commit_oid"], "feedface")
 
     def test_pending_merge_downgrade_does_not_run_gh_merge(self) -> None:
         squash_merge = MagicMock()

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -327,6 +327,68 @@ class LocalQueenTriggerTests(unittest.TestCase):
         )
         self.assertEqual(report.call_args.kwargs["merge_commit_oid"], "feedface")
 
+    def test_dirty_success_report_queue_blocks_second_merge_attempt(self) -> None:
+        dispatcher = MagicMock()
+        report = MagicMock(
+            side_effect=[RuntimeError("api down"), RuntimeError("still down")]
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            queue_file = os.path.join(tmpdir, "merge-reports.json")
+            first_squash = MagicMock(return_value="feedface")
+            trigger = LocalQueenSynthesisTrigger(
+                SlotPlugin(),
+                base_url="https://api.example",
+                token_resolver=lambda: "bearer",
+                runner_id="queen-a",
+                agent_id="queen-a",
+                enable_squash_merge=True,
+                merge_report_queue_file=queue_file,
+                list_ready_fn=MagicMock(return_value=[_room()]),
+                list_pending_fn=MagicMock(return_value=[_pending_room()]),
+                confirm_merge_fn=MagicMock(
+                    return_value=ConfirmMergeResult(
+                        decision_outcome="merge_approved",
+                        decision_outcome_reason=None,
+                        github_merge_status="pending",
+                        merge_attempt_id="queen-a:room-2:abc123deadbe",
+                        closed_sequence=9,
+                    ),
+                ),
+                report_merge_result_fn=report,
+                mint_token_fn=MagicMock(return_value="ghs_x"),
+                get_head_sha_fn=MagicMock(return_value="abc123deadbeef"),
+                squash_merge_fn=first_squash,
+            )
+
+            trigger._tick(dispatcher)
+            first_squash.assert_called_once()
+
+            list_pending = MagicMock(return_value=[_pending_room()])
+            confirm = MagicMock()
+            second_squash = MagicMock()
+            retry_trigger = LocalQueenSynthesisTrigger(
+                SlotPlugin(),
+                base_url="https://api.example",
+                token_resolver=lambda: "bearer",
+                runner_id="queen-a",
+                agent_id="queen-a",
+                enable_squash_merge=True,
+                merge_report_queue_file=queue_file,
+                list_ready_fn=MagicMock(return_value=[_room()]),
+                list_pending_fn=list_pending,
+                confirm_merge_fn=confirm,
+                report_merge_result_fn=report,
+                squash_merge_fn=second_squash,
+            )
+
+            retry_trigger._tick(dispatcher)
+
+        self.assertEqual(report.call_count, 2)
+        list_pending.assert_not_called()
+        confirm.assert_not_called()
+        second_squash.assert_not_called()
+
     def test_pending_merge_downgrade_does_not_run_gh_merge(self) -> None:
         squash_merge = MagicMock()
         trigger = LocalQueenSynthesisTrigger(

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -1,0 +1,171 @@
+"""Tests for the local queen synthesis trigger."""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+    ClaimedSynthesis,
+    LocalQueenSynthesisTrigger,
+    SynthesisReadyRoom,
+)
+
+
+class SlotPlugin:
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.event.set()
+        self.reserved = 0
+        self.released = 0
+
+    def wait_queen_slot(self, stop_event, timeout=1.0):
+        del stop_event, timeout
+        return self.event.is_set()
+
+    def reserve_queen_slot(self):
+        self.reserved += 1
+        self.event.clear()
+
+    def release_queen_slot(self):
+        self.released += 1
+        self.event.set()
+
+
+def _room() -> SynthesisReadyRoom:
+    return SynthesisReadyRoom(
+        room_id="room-1",
+        status="awaiting_contributions",
+        subject_type="pr_review",
+        subject_ref="owner/repo#42",
+        manager="bot-queen",
+        opened_at="2026-05-15T00:00:00Z",
+        timing_config={"quiet_period_secs": 60},
+    )
+
+
+def _claimed() -> ClaimedSynthesis:
+    return ClaimedSynthesis(
+        room_id="room-1",
+        through_sequence=12,
+        claim_ttl_secs=900,
+        room={"subject_ref": "owner/repo#42"},
+        participants={"guard": {"status": "resolved"}},
+        contributions={"guard": {"raw_md": "lgtm"}},
+    )
+
+
+class LocalQueenTriggerTests(unittest.TestCase):
+    def test_dispatches_claimed_ready_room_with_head_sha(self) -> None:
+        plugin = SlotPlugin()
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = True
+
+        trigger = LocalQueenSynthesisTrigger(
+            plugin,
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=MagicMock(return_value=_claimed()),
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+
+        trigger._tick(dispatcher)
+
+        dispatcher.dispatch.assert_called_once()
+        job = dispatcher.dispatch.call_args[0][0]
+        self.assertEqual(job.session_key, "queen:room-1@12")
+        self.assertEqual(job.metadata["job_kind"], "queen_synthesis")
+        self.assertEqual(job.metadata["reviewed_head_sha"], "abc123")
+        self.assertEqual(job.metadata["coalesce_key"], "queen:room-1")
+        self.assertIn("comment-close only", job.prompt)
+        self.assertEqual(plugin.reserved, 1)
+        self.assertEqual(plugin.released, 0)
+
+    def test_skips_pending_participant_before_claim(self) -> None:
+        claim_fn = MagicMock(return_value=_claimed())
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "pending"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
+    def test_skips_room_until_quiet_period_elapsed(self) -> None:
+        claim_fn = MagicMock(return_value=_claimed())
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:01:30Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
+    def test_dispatch_refusal_releases_slot(self) -> None:
+        plugin = SlotPlugin()
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = False
+        trigger = LocalQueenSynthesisTrigger(
+            plugin,
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            runner_id="queen-a",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={"guard": {"status": "resolved"}}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=MagicMock(return_value=_claimed()),
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        self.assertEqual(plugin.reserved, 1)
+        self.assertEqual(plugin.released, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_wiring.py
+++ b/agent/cli/tests/test_hivemoot_queen_wiring.py
@@ -1,0 +1,147 @@
+"""Tests for local queen wiring in the consolidated hivemoot plugin."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hivemoot_agent.plugins.interfaces import AgentResult, Job, PluginConfig
+from hivemoot_agent.plugins_builtin.hivemoot import HivemootPlugin
+from hivemoot_agent.plugins_builtin.hivemoot.config import (
+    HivemootConfig,
+    HivemootQueenConfig,
+)
+from hivemoot_agent.plugins_builtin.hivemoot.queen import (
+    JOB_KIND_SYNTHESIS,
+    LocalQueenSynthesisTrigger,
+)
+
+
+_TOKEN_FILE = Path("/tmp/.hivemoot-queen-test-token")
+
+
+def _ensure_token_file() -> Path:
+    if not _TOKEN_FILE.exists():
+        _TOKEN_FILE.write_text("test-token")
+    return _TOKEN_FILE
+
+
+def _mk_config(*, queen: HivemootQueenConfig | None = None) -> PluginConfig:
+    typed = HivemootConfig(
+        token_file=_ensure_token_file(),
+        queen=queen or HivemootQueenConfig(),
+    )
+    return PluginConfig(name="hivemoot", settings={}, typed=typed)
+
+
+def _queen_job() -> Job:
+    return Job(
+        session_key="queen:room-1@12",
+        prompt="ignored",
+        metadata={
+            "job_kind": JOB_KIND_SYNTHESIS,
+            "room_id": "room-1",
+            "subject_ref": "owner/repo#42",
+            "sealed_through_sequence": 12,
+            "queen_runner": "queen-a",
+            "reviewed_head_sha": "abc123",
+        },
+    )
+
+
+class QueenTriggerWiringTests(unittest.TestCase):
+    def test_disabled_by_default_no_trigger(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config().typed
+        self.assertEqual(plugin.triggers(), [])
+        self.assertIsNone(plugin._queen_trigger)
+
+    def test_enabled_instantiates_queen_trigger(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        ).typed
+        triggers = plugin.triggers()
+        self.assertEqual(len(triggers), 1)
+        self.assertIsInstance(triggers[0], LocalQueenSynthesisTrigger)
+        self.assertIs(plugin._queen_trigger, triggers[0])
+
+    def test_trigger_constructed_with_config_values(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(
+                enabled=True,
+                base_url="https://staging.example",
+                poll_interval_secs=30,
+                synthesis_ready_limit=5,
+                runner_id="queen-a",
+            ),
+        ).typed
+        trigger = plugin.triggers()[0]
+        self.assertEqual(trigger._base_url, "https://staging.example")
+        self.assertEqual(trigger._poll_interval_secs, 30)
+        self.assertEqual(trigger._ready_limit, 5)
+
+    def test_validate_rejects_reserved_squash_merge_flag(self) -> None:
+        plugin = HivemootPlugin()
+        config = _mk_config(
+            queen=HivemootQueenConfig(
+                enabled=True,
+                runner_id="queen-a",
+                enable_squash_merge=True,
+            ),
+        )
+        errors = plugin.validate(config)
+        self.assertTrue(
+            any("enable_squash_merge is reserved" in e for e in errors),
+            errors,
+        )
+
+
+class QueenOnFinishedWiringTests(unittest.TestCase):
+    def test_queen_job_dispatched_when_enabled(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        ).typed
+        config = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        )
+
+        with patch.object(plugin, "_queen_on_job_finished") as bridge_mock:
+            plugin.on_job_finished(_queen_job(), AgentResult(0, ""), config)
+        bridge_mock.assert_called_once()
+
+    def test_queen_job_not_dispatched_when_disabled(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config().typed
+        with patch.object(plugin, "_queen_on_job_finished") as bridge_mock:
+            plugin.on_job_finished(_queen_job(), AgentResult(0, ""), _mk_config())
+        bridge_mock.assert_not_called()
+
+    def test_queen_slot_released_when_bridge_raises(self) -> None:
+        plugin = HivemootPlugin()
+        plugin._cfg = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        ).typed
+        plugin.reserve_queen_slot()
+        self.assertFalse(plugin._queen_inflight.is_set())
+        config = _mk_config(
+            queen=HivemootQueenConfig(enabled=True, runner_id="queen-a"),
+        )
+        with patch.object(
+            plugin,
+            "_queen_on_job_finished",
+            side_effect=RuntimeError("boom"),
+        ):
+            plugin.on_job_finished(_queen_job(), AgentResult(0, ""), config)
+        self.assertTrue(plugin._queen_inflight.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/agent/cli/tests/test_hivemoot_queen_wiring.py
+++ b/agent/cli/tests/test_hivemoot_queen_wiring.py
@@ -81,6 +81,7 @@ class QueenTriggerWiringTests(unittest.TestCase):
                 synthesis_ready_limit=5,
                 runner_id="queen-a",
                 enable_squash_merge=True,
+                merge_report_queue_file="/tmp/queen-reports.json",
             ),
         ).typed
         trigger = plugin.triggers()[0]
@@ -88,6 +89,10 @@ class QueenTriggerWiringTests(unittest.TestCase):
         self.assertEqual(trigger._poll_interval_secs, 30)
         self.assertEqual(trigger._ready_limit, 5)
         self.assertTrue(trigger._enable_squash_merge)
+        self.assertEqual(
+            trigger._merge_report_queue_file,
+            "/tmp/queen-reports.json",
+        )
 
     def test_validate_accepts_squash_merge_flag(self) -> None:
         plugin = HivemootPlugin()

--- a/agent/cli/tests/test_hivemoot_queen_wiring.py
+++ b/agent/cli/tests/test_hivemoot_queen_wiring.py
@@ -80,14 +80,16 @@ class QueenTriggerWiringTests(unittest.TestCase):
                 poll_interval_secs=30,
                 synthesis_ready_limit=5,
                 runner_id="queen-a",
+                enable_squash_merge=True,
             ),
         ).typed
         trigger = plugin.triggers()[0]
         self.assertEqual(trigger._base_url, "https://staging.example")
         self.assertEqual(trigger._poll_interval_secs, 30)
         self.assertEqual(trigger._ready_limit, 5)
+        self.assertTrue(trigger._enable_squash_merge)
 
-    def test_validate_rejects_reserved_squash_merge_flag(self) -> None:
+    def test_validate_accepts_squash_merge_flag(self) -> None:
         plugin = HivemootPlugin()
         config = _mk_config(
             queen=HivemootQueenConfig(
@@ -97,10 +99,7 @@ class QueenTriggerWiringTests(unittest.TestCase):
             ),
         )
         errors = plugin.validate(config)
-        self.assertTrue(
-            any("enable_squash_merge is reserved" in e for e in errors),
-            errors,
-        )
+        self.assertEqual(errors, [])
 
 
 class QueenOnFinishedWiringTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds the hive-side local queen runner and merge execution loop so hive can finish server-confirmed squash merges after #679 lands.

Fixes #675.
Fixes #680.
Part of #672.
Supersedes #676 once this receives review, because this PR includes the runner from #676 plus the merge execution slice.

## Details

- Adds the disabled-by-default `plugins.hivemoot.queen` runner that polls synthesis-ready rooms, claims one, captures the reviewed head SHA, runs local synthesis, posts a verified App comment, and seals the decision.
- Adds API client calls for `/api/rooms/decided-pending-ready`, `/confirm-merge`, and `/report-merge-result`.
- Extends the handler so squash-merge intents seal as `decided_pending_action` when `enable_squash_merge=true`.
- Adds a pending-merge trigger pass that captures the fresh head SHA, calls confirm-merge with a stable `merge_attempt_id`, runs `gh pr merge --squash` only on `merge_approved`, and reports succeeded/failed GitHub outcomes.
- Keeps `enable_squash_merge` disabled by default; it is a real explicit rollout flag after the web confirm/report endpoints are deployed.

## Stack Notes

This PR depends on #679 for the web confirm/report endpoints. Merge order should be #679 first, then this PR, then fleet redeploy, then the `queen_mode=local` flip.

## Tests

- `python3 -m compileall agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen agent/cli/hivemoot_agent/plugins_builtin/hivemoot/__init__.py agent/cli/hivemoot_agent/plugins_builtin/hivemoot/config.py`
- `python3 -m unittest discover -s agent/cli/tests -p 'test_hivemoot*.py'` (337 tests)
