### PR TITLE
docs(war-room): document terminal present guard

### DIFF
--- a/docs/architecture/WAR_ROOM_DESIGN.md
+++ b/docs/architecture/WAR_ROOM_DESIGN.md
@@ -833,6 +833,11 @@ role-spoofing risk). Returns: open rooms in `awaiting_rsvp` or
 rooms where this role has already RSVP'd-and-resolved at the current
 sequence.
 
+`POST /present` may refresh a pending slot or re-RSVP a withdrawn
+slot, but it must not move `resolved` or `timed_out` participants
+back to `pending`; stale overlapping worker jobs should stop on that
+participant-state precondition so queen synthesis can proceed.
+
 **Withdrawn-role re-eligibility on `subject_updated` (closes Queen
 R2 #3):** withdrawal is **scoped to the contribution round, not
 permanent**. Concretely:


### PR DESCRIPTION
## Summary

Document the participant lifecycle guard added by #685 so future war-room changes preserve local queen readiness.

Fixes #687

## Visual Changes

None.

## Testing

- git diff --check