### PR TITLE
fix(local-queen): recover PR review flow

### DIFF
--- a/bot/api/github/webhooks/index.test.ts
+++ b/bot/api/github/webhooks/index.test.ts
@@ -9,6 +9,10 @@ import { LABELS, MESSAGES, REQUIRED_REPOSITORY_LABELS } from "../../config.js";
 import type { IssueRef } from "../../lib/types.js";
 import type { IncomingMessage, ServerResponse } from "http";
 import { app as registerWebhookApp } from "./index.js";
+import {
+  maybeCreatePrReviewRoom,
+  maybeEmitSubjectUpdated,
+} from "../../lib/war-room-routing.js";
 
 // Mock probot to prevent actual initialization
 vi.mock("../../lib/war-room-routing.js", () => ({
@@ -2191,6 +2195,8 @@ describe("Queen Bot", () => {
       vi.mocked(getLinkedIssues).mockReset();
       vi.mocked(loadRepositoryConfig).mockReset();
       vi.mocked(disablePullRequestAutoMerge).mockReset().mockResolvedValue(undefined);
+      vi.mocked(maybeCreatePrReviewRoom).mockReset().mockResolvedValue({ roomId: null });
+      vi.mocked(maybeEmitSubjectUpdated).mockReset().mockResolvedValue({ sequence: null });
     });
 
     it("should call processImplementationIntake on pull_request.opened", async () => {
@@ -2214,6 +2220,36 @@ describe("Queen Bot", () => {
       );
     });
 
+    it("creates the PR review room on opened before intake can fail", async () => {
+      const { handlers } = createWebhookHarness();
+      vi.mocked(getLinkedIssues).mockResolvedValue([
+        { number: 689, title: "issue", state: "OPEN", labels: { nodes: [] } },
+      ] as any);
+      vi.mocked(loadRepositoryConfig).mockResolvedValue(prConfig as any);
+      vi.mocked(processImplementationIntake).mockRejectedValueOnce(new Error("intake failed"));
+
+      await expect(
+        handlers.get("pull_request.opened")!({
+          octokit: mkOctokit(),
+          log: mkLog(),
+          payload: {
+            installation: { id: 12345 },
+            pull_request: { number: 690, body: "Fixes #689", base: { ref: "main" } },
+            repository: testRepo,
+          },
+        }),
+      ).rejects.toThrow("intake failed");
+
+      expect(maybeCreatePrReviewRoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "hivemoot",
+          repo: "test-repo",
+          installationId: 12345,
+          prNumber: 690,
+        }),
+      );
+    });
+
     it("should call processImplementationIntake on pull_request.synchronize", async () => {
       const { handlers } = createWebhookHarness();
       vi.mocked(getLinkedIssues).mockResolvedValue([]);
@@ -2230,6 +2266,52 @@ describe("Queen Bot", () => {
 
       expect(processImplementationIntake).toHaveBeenCalledWith(
         expect.objectContaining({ trigger: "updated" })
+      );
+    });
+
+    it("creates the PR review room on synchronize when subject_updated finds no room", async () => {
+      const { handlers } = createWebhookHarness();
+      vi.mocked(getLinkedIssues).mockResolvedValue([]);
+      vi.mocked(loadRepositoryConfig).mockResolvedValue(prConfig as any);
+      vi.mocked(maybeEmitSubjectUpdated)
+        .mockResolvedValueOnce({ sequence: null, skipped: "no_room" })
+        .mockResolvedValueOnce({ sequence: 7 });
+      vi.mocked(maybeCreatePrReviewRoom).mockResolvedValue({
+        roomId: "875e5bb0-27a2-4e6c-bb13-08904919f194",
+      });
+
+      await handlers.get("pull_request.synchronize")!({
+        octokit: mkOctokit(),
+        log: mkLog(),
+        payload: {
+          installation: { id: 12345 },
+          pull_request: {
+            number: 688,
+            base: { ref: "main" },
+            head: { sha: "new-head-sha" },
+          },
+          repository: testRepo,
+        },
+      });
+
+      expect(maybeCreatePrReviewRoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "hivemoot",
+          repo: "test-repo",
+          installationId: 12345,
+          prNumber: 688,
+        }),
+      );
+      expect(maybeEmitSubjectUpdated).toHaveBeenCalledTimes(2);
+      expect(maybeEmitSubjectUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          owner: "hivemoot",
+          repo: "test-repo",
+          installationId: 12345,
+          prNumber: 688,
+          changeKind: "synchronize",
+          headSha: "new-head-sha",
+        }),
       );
     });
 

--- a/bot/api/github/webhooks/index.ts
+++ b/bot/api/github/webhooks/index.ts
@@ -164,6 +164,17 @@ export function app(probotApp: Probot): void {
         context.log.debug(`No config in ${fullName}; skipping PR automation`);
         return;
       }
+      // War-room routing is intentionally early: intake/automerge may
+      // post comments or mutate labels before throwing, and the review
+      // room must still exist for the fleet to inspect the PR.
+      await maybeCreatePrReviewRoom({
+        owner,
+        repo,
+        installationId: context.payload.installation?.id,
+        prNumber: number,
+        log: context.log,
+      });
+
       let linkedIssues = initialLinkedIssues;
       const hasBodyClosingKeyword = linkedIssues.length === 0
         ? hasSameRepoClosingKeywordRef(context.payload.pull_request.body, { owner, repo })
@@ -236,21 +247,6 @@ export function app(probotApp: Probot): void {
         });
       }
 
-      // War-room routing. Non-fatal: a failure here never breaks
-      // the existing intake / governance flow; the routing helper
-      // logs + returns gracefully on errors. Gated on
-      // `HIVEMOOT_REDIS_REST_URL/TOKEN` env vars (same vars BYOK
-      // already uses) so the integration is opt-in via the Redis
-      // env config. Idempotent on webhook re-delivery (server
-      // returns 409 subject_already_open → routing helper reuses
-      // existingRoomId).
-      await maybeCreatePrReviewRoom({
-        owner,
-        repo,
-        installationId: context.payload.installation?.id,
-        prNumber: number,
-        log: context.log,
-      });
     } catch (error) {
       context.log.error({ err: error, pr: number, repo: fullName }, "Failed to process PR");
       throw error;
@@ -355,7 +351,7 @@ export function app(probotApp: Probot): void {
       // break the existing intake flow. The deterministic roomId
       // derivation (derivePrRoomId) means we hit the same room as
       // the E.1 create call without any lookup.
-      await maybeEmitSubjectUpdated({
+      const subjectUpdated = await maybeEmitSubjectUpdated({
         owner,
         repo,
         installationId: context.payload.installation?.id,
@@ -364,6 +360,26 @@ export function app(probotApp: Probot): void {
         headSha: context.payload.pull_request.head?.sha,
         log: context.log,
       });
+      if (subjectUpdated.skipped === "no_room") {
+        const created = await maybeCreatePrReviewRoom({
+          owner,
+          repo,
+          installationId: context.payload.installation?.id,
+          prNumber: number,
+          log: context.log,
+        });
+        if (created.roomId) {
+          await maybeEmitSubjectUpdated({
+            owner,
+            repo,
+            installationId: context.payload.installation?.id,
+            prNumber: number,
+            changeKind: "synchronize",
+            headSha: context.payload.pull_request.head?.sha,
+            log: context.log,
+          });
+        }
+      }
     } catch (error) {
       context.log.error({ err: error, pr: number, repo: fullName }, "Failed to process PR update");
       throw error;

--- a/web/src/app/api/rooms/[roomId]/resolve-action/route.test.ts
+++ b/web/src/app/api/rooms/[roomId]/resolve-action/route.test.ts
@@ -93,7 +93,7 @@ const mockedRateLimit = vi.mocked(checkResolveActionRateLimit);
 const HEAD_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
 function makeRedis(
-  claimRaw: string | null = JSON.stringify({
+  claimRaw: unknown = JSON.stringify({
     runner: "queen-hive-1",
     throughSequence: 42,
   }),
@@ -393,6 +393,27 @@ describe("POST /api/rooms/:roomId/resolve-action — claim verification", () => 
 
   it("returns 409 claim_payload_corrupt when the claim JSON is unparseable", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk(makeRedis("not-json-at-all")));
+    mockedGetRoomCore.mockResolvedValue(makeRoom());
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(makeRequest(makeBody()), makeContext());
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("claim_payload_corrupt");
+    errSpy.mockRestore();
+  });
+
+  it("accepts claims returned as parsed JSON objects by Redis clients", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk(makeRedis({ runner: "queen-hive-1", throughSequence: 42 })),
+    );
+    mockedGetRoomCore.mockResolvedValue(makeRoom());
+    const res = await POST(makeRequest(makeBody()), makeContext());
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 409 claim_payload_corrupt for malformed object claims", async () => {
+    mockedAuth.mockResolvedValue(
+      makeAuthOk(makeRedis({ runner: "queen-hive-1", throughSequence: "42" })),
+    );
     mockedGetRoomCore.mockResolvedValue(makeRoom());
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const res = await POST(makeRequest(makeBody()), makeContext());

--- a/web/src/app/api/rooms/[roomId]/resolve-action/route.ts
+++ b/web/src/app/api/rooms/[roomId]/resolve-action/route.ts
@@ -213,9 +213,9 @@ interface ClaimPayload {
   throughSequence: number;
 }
 
-function parseClaim(raw: string): ClaimPayload | null {
+function parseClaim(raw: unknown): ClaimPayload | null {
   try {
-    const parsed: unknown = JSON.parse(raw);
+    const parsed: unknown = typeof raw === "string" ? JSON.parse(raw) : raw;
     if (parsed === null || typeof parsed !== "object") return null;
     const p = parsed as Record<string, unknown>;
     if (typeof p.runner !== "string") return null;
@@ -223,6 +223,15 @@ function parseClaim(raw: string): ClaimPayload | null {
     return { runner: p.runner, throughSequence: p.throughSequence };
   } catch {
     return null;
+  }
+}
+
+function claimLogExcerpt(raw: unknown): string {
+  if (typeof raw === "string") return raw.slice(0, 200);
+  try {
+    return JSON.stringify(raw).slice(0, 200);
+  } catch {
+    return String(raw).slice(0, 200);
   }
 }
 
@@ -379,7 +388,7 @@ export async function POST(
   // ----- verify claim (held by this runner, expected throughSequence) -----
   let rawClaim;
   try {
-    rawClaim = await auth.redis.get<string>(claimKey(roomId));
+    rawClaim = await auth.redis.get(claimKey(roomId));
   } catch (err) {
     console.error("[rooms.resolve-action] claim fetch failed", {
       installationId: auth.installationId,
@@ -407,7 +416,7 @@ export async function POST(
     console.error("[rooms.resolve-action] claim payload corrupt", {
       installationId: auth.installationId,
       roomId,
-      rawClaim: rawClaim.slice(0, 200),
+      rawClaim: claimLogExcerpt(rawClaim),
     });
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary

Recover the local queen PR review path end to end. The opened webhook now creates the review room as soon as repository config is known, synchronize recreates the deterministic room when subject_updated finds it missing, and resolve-action accepts parsed Redis claim payloads instead of crashing before claim validation.

Fixes #689
Fixes #691

## Visual Changes

None.

## Testing

- git diff --check
- npm test -- api/github/webhooks/index.test.ts api/lib/war-room-routing.test.ts
- npm run typecheck (bot)
- npm run lint -- api/github/webhooks/index.ts api/github/webhooks/index.test.ts (bot)
- npm test -- src/app/api/rooms/[roomId]/resolve-action/route.test.ts
- npm run typecheck (web)
- npm run lint -- src/app/api/rooms/[roomId]/resolve-action/route.ts src/app/api/rooms/[roomId]/resolve-action/route.test.ts (web; existing unrelated warnings only)