### PR TITLE
fix(local-queen): accept parsed audit rows

### DIFF
--- a/web/src/server/queen-audit.test.ts
+++ b/web/src/server/queen-audit.test.ts
@@ -439,6 +439,19 @@ describe("readQueenResolveActionAuditRow — seal-decision lookup", () => {
     expect(row.detail.permitted_action).toBe("comment");
   });
 
+  it("accepts parsed JSON audit entries returned by Redis clients", async () => {
+    const fakeRedis = {
+      eval: vi.fn(async () => makeEntry()),
+    } as never;
+    const row = await readQueenResolveActionAuditRow({
+      redis: fakeRedis,
+      installationId: "12345",
+      auditId: "1715000000000-0",
+    });
+    expect(row.id).toBe("1715000000000-0");
+    expect(row.detail.room_id).toBe("rm-1");
+  });
+
   it("throws typed not-found when the stream row is missing", async () => {
     const fakeRedis = {
       eval: vi.fn(async () => null),

--- a/web/src/server/queen-audit.ts
+++ b/web/src/server/queen-audit.ts
@@ -446,16 +446,9 @@ export async function readQueenResolveActionAuditRow(args: {
   if (raw === null || raw === undefined) {
     throw new QueenResolveActionAuditNotFoundError(args.auditId);
   }
-  if (typeof raw !== "string") {
-    throw new QueenResolveActionAuditMalformedError(
-      args.auditId,
-      "entry payload is not a string",
-    );
-  }
-
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
   } catch {
     throw new QueenResolveActionAuditMalformedError(
       args.auditId,


### PR DESCRIPTION
## Summary

Let seal-decision verify resolve-action audit rows when Redis returns the stream entry payload as an already-parsed JSON object. This keeps the already-posted local queen aggregate comment from leaving the room stuck in deciding.

Fixes #692

## Visual Changes

None.

## Testing

- git diff --check
- npm test -- src/server/queen-audit.test.ts src/app/api/rooms/[roomId]/seal-decision/route.test.ts
- npm run typecheck
- npm run lint -- src/server/queen-audit.ts src/server/queen-audit.test.ts src/app/api/rooms/[roomId]/seal-decision/route.test.ts (existing unrelated warnings only)