### PR TITLE
docs(war-room): describe participant_state_precondition + cover timed_out

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -70,6 +70,11 @@ class RoomStateRaceError(RuntimeError):
 #   * owner_conflict — first-wins gate lost; another runner already
 #     holds this role's slot in subscriber-mode. Surfaced by /present
 #     and /heartbeat.
+#   * participant_state_precondition — same-runner /present on a
+#     terminal slot (``resolved`` or ``timed_out``). Added per #685
+#     so an overlapping worker job cannot regress a synthesized
+#     participant back to ``pending`` and block local queen synthesis.
+#     Surfaced by /present only.
 #
 # 404s (added per guard's PR #615 review feedback so heartbeats stop
 # instead of spinning forever):

--- a/shared/war-room/src/war-room.test.ts
+++ b/shared/war-room/src/war-room.test.ts
@@ -3315,6 +3315,46 @@ describe("D.1.a-ii R2 / B2 — per-(room, role) first-wins gate", () => {
     expect(participants.drone.resolved_at).toBeDefined();
   });
 
+  // Same-agent re-present is rejected identically for both terminal
+  // participant states. The Lua guard checks
+  // `parsed.status == "resolved" or parsed.status == "timed_out"`
+  // as one condition; pin both branches so a future refactor that
+  // splits the condition can't regress `timed_out` silently.
+  it("same agent present cannot regress a timed_out slot back to pending", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await timeoutParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      subjectRole: "drone",
+      watchdogRole: "manager",
+      watchdogAgentId: "bot-queen",
+      sequenceObservedByClient: 2,
+      redis,
+    });
+
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-1",
+        sequenceObservedByClient: 3,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantStatePreconditionError);
+
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("timed_out");
+    expect(participants.drone.resolved_at).toBeDefined();
+  });
+
   it("re-RSVP from withdrew is allowed even with a different agent_id", async () => {
     await presentParticipant({
       installationId: "12345",


### PR DESCRIPTION
## Summary

Two non-blocking cleanups carry-forward from #685's stale-`/present` lifecycle fix, both flagged in the guard re-review and confirmed by Builder as cleanup-grade.

1. **`agent/.../war_rooms/api.py` race-code docstring.** `_RACE_CODES_BY_STATUS[409]` now includes `participant_state_precondition`, but the block comment still only described `status_precondition_failed` and `owner_conflict`. Added a paragraph that names the new code, explains the scenario it covers (same-runner `/present` on a `resolved`/`timed_out` slot), and references #685 so the next reader does not have to reverse-engineer it from the frozenset literal.

2. **`timed_out` regression-test variant.** The Lua guard rejects same-agent re-`/present` on both `resolved` and `timed_out` slots in one condition (`parsed.status == "resolved" or parsed.status == "timed_out"`). The existing regression test only covered `resolved`. Added a companion test that drives the slot to `timed_out` via `timeoutParticipant`, attempts re-`/present`, and asserts it (a) rejects with `RoomParticipantStatePreconditionError` and (b) leaves the slot's `status` + `resolved_at` intact. This pins both terminal branches so a future refactor that splits the condition cannot regress `timed_out` silently.

No production code paths change — both files were already correct; this PR makes them tell the same story to readers and tests.

Fixes #694

## Visual Changes

None.

## Testing

- `git diff --check` — clean
- `python3 -m py_compile agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py` — clean
- `npm test -- ../shared/war-room/src/war-room.test.ts` (from `web/`) — 232 passed (was 231; new test added)
- `npm run build` (from `shared/war-room/`) — clean
- `npm run typecheck` (from `web/`) — clean
