### PR TITLE
fix(agent): cover present guard and subscriber warning

### DIFF
--- a/agent/cli/hivemoot_agent/plugins_builtin/github/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/github/trigger.py
@@ -236,8 +236,8 @@ class _GitHubWatchTrigger:
         # period (subscriber mode, awaiting initial mint) doesn't flood
         # stderr with one warning per poll. One warning per minute
         # covers operator visibility without spam.
-        last_no_token_warn = 0.0
         no_token_warn_interval = 60.0
+        last_no_token_warn = -no_token_warn_interval
 
         while not self._stop_event.is_set():
             # Re-resolve token EACH poll so a rotation in either mode

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py
@@ -70,6 +70,8 @@ class RoomStateRaceError(RuntimeError):
 #   * owner_conflict — first-wins gate lost; another runner already
 #     holds this role's slot in subscriber-mode. Surfaced by /present
 #     and /heartbeat.
+#   * participant_state_precondition — same runner tried to /present a
+#     terminal slot (resolved / timed_out). Treat as stale overlap.
 #
 # 404s (added per guard's PR #615 review feedback so heartbeats stop
 # instead of spinning forever):

--- a/shared/war-room/src/war-room.test.ts
+++ b/shared/war-room/src/war-room.test.ts
@@ -3315,6 +3315,41 @@ describe("D.1.a-ii R2 / B2 — per-(room, role) first-wins gate", () => {
     expect(participants.drone.resolved_at).toBeDefined();
   });
 
+  it("same agent present cannot regress a timed_out slot back to pending", async () => {
+    await presentParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      role: "drone",
+      agentId: "drone-runner-1",
+      sequenceObservedByClient: 1,
+      redis,
+    });
+    await timeoutParticipant({
+      installationId: "12345",
+      roomId: RID_A,
+      subjectRole: "drone",
+      watchdogRole: "manager",
+      watchdogAgentId: "bot-queen",
+      sequenceObservedByClient: 2,
+      redis,
+    });
+
+    await expect(
+      presentParticipant({
+        installationId: "12345",
+        roomId: RID_A,
+        role: "drone",
+        agentId: "drone-runner-1",
+        sequenceObservedByClient: 3,
+        redis,
+      }),
+    ).rejects.toThrow(RoomParticipantStatePreconditionError);
+
+    const participants = await getRoomParticipants({ roomId: RID_A, redis });
+    expect(participants.drone.status).toBe("timed_out");
+    expect(participants.drone.resolved_at).toBeDefined();
+  });
+
   it("re-RSVP from withdrew is allowed even with a different agent_id", async () => {
     await presentParticipant({
       installationId: "12345",


### PR DESCRIPTION
Closes #696.
Closes #698.

This closes the follow-up from the local queen smoke review: the terminal `/present` guard already covered resolved participants, but timed-out participants should have the same explicit regression. The agent client comment now also documents `participant_state_precondition` as a benign stale-overlap race.

Agent CI also exposed a subscriber-mode trigger bug: the first no-token warning could be suppressed on fresh runners whose monotonic clock was still below the rate-limit interval. Initializing the limiter one interval in the past keeps later warnings rate-limited while making the first empty-token poll visible.

Verification:
- `npm test -- ../shared/war-room/src/war-room.test.ts`
- `npm run build` in `shared/war-room`
- `npm run typecheck` in `web`
- `python3 agent/cli/tests/test_github_trigger.py`
- `python3 -m py_compile agent/cli/hivemoot_agent/plugins_builtin/github/trigger.py agent/cli/hivemoot_agent/plugins_builtin/hivemoot/war_rooms/api.py`
- `git diff --check`