### PR TITLE
Add explicit PR merge capability

### DIFF
--- a/docs/architecture/CAPABILITIES_DESIGN.md
+++ b/docs/architecture/CAPABILITIES_DESIGN.md
@@ -452,6 +452,7 @@ expansion.
 | Capability | Endpoint(s) gated | Notes |
 |---|---|---|
 | `installation_token.mint` | `POST /api/github/installation-tokens` | Apiarist's only required cap |
+| `pull_requests.merge` | `POST /api/github/installation-tokens` | Allows a local_queen bearer to mint merge-capable GitHub tokens when paired with `installation_token.mint` and exact merge policy |
 | `agent_health.report` | `POST /api/agent-health` | Workers, queen, anyone reporting |
 | `agent_health.read` | `GET /api/agent-health/*` | Monitoring tools |
 | `tasks.claim` | `POST /api/tasks/claim` | Worker side |
@@ -463,18 +464,19 @@ expansion.
 | `tasks.verify` | `POST /api/tasks/{id}/verify` (future) | Future task-verifier role |
 | `rooms.watch` | `GET /api/rooms/watching` (Phase D) | Worker side |
 | `rooms.read` | `GET /api/rooms/{id}`, `GET /api/rooms/{id}/events` | Worker (own role's rooms) + queen + monitoring |
+| `rooms.read_all` | room list / monitoring endpoints | Installation-wide room read |
 | `rooms.contribute` | `POST /api/rooms/{id}/{present,withdraw,contribute}` (Phase D) | Worker side |
 | `rooms.create` | `POST /api/rooms` | Bot (queen module) |
 | `rooms.update` | `POST /api/rooms/{id}/event` | Bot (queen module) |
 | `rooms.decide` | `POST /api/rooms/{id}/decide`, `DELETE /api/rooms/{id}/claim` | Bot (queen module) |
 | `rooms.close` | `POST /api/rooms/{id}/close` | Bot (queen module) |
+| `rooms.synthesize` | local queen synthesis/merge endpoints | Local-mode queen synthesis and merge confirmation path |
 | `rooms.force_close` | `POST /api/rooms/{id}/force-close`, `POST /api/rooms/{id}/replay` | Admin |
 | `agent_tokens.manage` | `POST /api/agent-tokens`, `DELETE /api/agent-tokens/{name}`, `POST /api/agent-tokens/{name}/set-capabilities`, etc. | Token-management endpoints — see §Per-installation admin protection |
 | `*` | All capabilities (admin tokens only) | NOT included by `agent_tokens.manage` unless explicit (see §Wildcard) |
 
-**Total: 19 capabilities** + `*` wildcard. (R1 said 17, vocabulary
-table had 18 — recount yields 19 after `agent_tokens.manage` added
-and `rooms.read` carved out from worker preset.)
+**Total: 22 capabilities** + `*` wildcard. Recount includes
+`rooms.read_all`, `rooms.synthesize`, and `pull_requests.merge`.
 
 ### `tasks.create` dual-auth
 
@@ -504,6 +506,7 @@ Wildcards expand at request time against a single TypeScript `const`:
 // web/src/server/agent-token-capabilities.ts
 export const KNOWN_CAPABILITIES = [
   "installation_token.mint",
+  "pull_requests.merge",
   "agent_health.report",
   "agent_health.read",
   "tasks.claim",
@@ -515,19 +518,24 @@ export const KNOWN_CAPABILITIES = [
   "tasks.verify",
   "rooms.watch",
   "rooms.read",
+  "rooms.read_all",
   "rooms.contribute",
   "rooms.create",
   "rooms.update",
   "rooms.decide",
   "rooms.close",
+  "rooms.synthesize",
   "rooms.force_close",
   "agent_tokens.manage",
 ] as const;
 
-// Capabilities that admin classes alone can grant. Even prefix
-// wildcards must explicitly list these — never reachable by an
-// unsuspecting `agent_tokens.*` glob (closes guard R2 N3).
-const ADMIN_CLASS_CAPABILITIES = new Set<string>(["agent_tokens.manage"]);
+// Capabilities that must be listed explicitly. Even prefix wildcards
+// never reach these, so `agent_tokens.*` does not grant token
+// management and `pull_requests.*` does not grant merge execution.
+const ADMIN_CLASS_CAPABILITIES = new Set<string>([
+  "agent_tokens.manage",
+  "pull_requests.merge",
+]);
 
 export function expandWildcards(capabilities: string[]): Set<string> {
   const out = new Set<string>();
@@ -564,8 +572,9 @@ call out wildcard implication ("now grants `X` to existing
 
 **Bare `*`**: must be opted into at issue time via `--allow-wildcards`
 flag on `tokens issue`. CLI default rejects bare `*`. Excludes
-`agent_tokens.manage` unless explicitly added. Closes guard issue
-"`*` includes token management" trap.
+`agent_tokens.manage` or `pull_requests.merge` unless explicitly
+added. Closes guard issue "`*` includes token management" trap and
+keeps merge execution from appearing on old wildcard tokens.
 
 **Capability count surfacing**: the dashboard (Phase I) shows a
 "this token can call:" list expanded against current
@@ -585,6 +594,7 @@ in the issue CLI. Operators always free to bypass with explicit
 | `apiarist` | `installation_token.mint` | Host-side daemon. Single cap. Used by the apiarist UDS path; never put in a container. |
 | `worker` | `agent_health.report`, `tasks.claim`, `tasks.progress`, `tasks.complete`, `rooms.watch`, `rooms.read`, `rooms.contribute` | Containers (drone, builder, guard, etc.). **Does NOT include `installation_token.mint`** — workers always go through apiarist (closes hivemoot reviewer #3 issue 1). |
 | `queen` | worker − `tasks.claim`/`tasks.progress`/`tasks.complete` + `tasks.create`, `tasks.read`, `tasks.cancel`, `rooms.create`, `rooms.read`, `rooms.update`, `rooms.decide`, `rooms.close` | Bot's room-management token (bot-as-queen — see WAR_ROOM_DESIGN.md §V1 architecture decision). |
+| `local_queen` | `queen` + `rooms.synthesize`, `installation_token.mint`, `pull_requests.merge` | Local hive queen; requires explicit repo and merge-permission policy |
 | `dispatcher` | `tasks.create`, `tasks.read` | Dashboard or external task creator |
 | `monitoring` | `agent_health.read`, `tasks.read`, `rooms.read` | Read-only operator |
 | `admin` | `*` + `agent_tokens.manage` (explicit, opted-in) | Admin tokens; see §Per-installation admin protection |

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts
@@ -309,6 +309,19 @@ describe("POST /api/agent-tokens/{name}/set-capabilities", () => {
     expect(mockedSet).not.toHaveBeenCalled();
   });
 
+  it("set explicit pull_requests.merge → 400 (merge-capable transition refused)", async () => {
+    mockedAuth.mockResolvedValue(makeAuthOk());
+    const res = await POST(
+      makeRequest({
+        capabilities: ["pull_requests.merge", "rooms.read"],
+      }),
+      makeContext("worker"),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).message).toMatch(/mint-capable shape/);
+    expect(mockedSet).not.toHaveBeenCalled();
+  });
+
   it("set preset 'apiarist' → falls through to set (legacy carve-out)", async () => {
     mockedAuth.mockResolvedValue(makeAuthOk());
     mockedSet.mockResolvedValue({

--- a/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
+++ b/web/src/app/api/agent-tokens/[name]/set-capabilities/route.ts
@@ -164,7 +164,11 @@ export async function POST(
     capabilities,
     "installation_token.mint",
   );
-  if (transitionsToMint) {
+  const transitionsToMerge = bearerHasCapability(
+    capabilities,
+    "pull_requests.merge",
+  );
+  if (transitionsToMint || transitionsToMerge) {
     const isLegacyPreset =
       body.preset === "apiarist" || body.preset === "admin";
     if (!isLegacyPreset) {
@@ -177,7 +181,7 @@ export async function POST(
           "via POST /api/agent-tokens with policy: { allowedRepos, " +
           "allowedPermissions } and revoke this one instead. (This " +
           "applies to wildcard forms like 'installation_token.*' and " +
-          "'*' too — they expand to 'installation_token.mint' at " +
+          "'*' too — they expand to mint or merge capabilities at " +
           "request time.)",
         400,
       );

--- a/web/src/app/api/agent-tokens/route.test.ts
+++ b/web/src/app/api/agent-tokens/route.test.ts
@@ -292,7 +292,15 @@ describe("POST /api/agent-tokens — body validation", () => {
         name: "queen-hive-1",
         agent_role: "local_queen",
         preset: "local_queen",
-        policy: { allowedRepos: [], allowedPermissions: { contents: "read" } },
+        policy: {
+          allowedRepos: [],
+          allowedPermissions: {
+            contents: "write",
+            pull_requests: "write",
+            issues: "write",
+            metadata: "read",
+          },
+        },
       }),
     );
     expect(res.status).toBe(400);
@@ -335,10 +343,9 @@ describe("POST /api/agent-tokens — body validation", () => {
   });
 
   it("preset 'local_queen' with allowedRepos but NO allowedPermissions → 400 (pass-3 D10 half 2)", async () => {
-    // Pass-2 accepted this shape; pass-3 rejects because the mint
-    // endpoint falls back to V1_PERMISSIONS (which includes
-    // contents:read) when allowedPermissions is omitted, violating
-    // RFC D10's permission-scope half.
+    // Pass-2 accepted this shape; the gate now requires an explicit
+    // permission policy so merge-capable local queen tokens are
+    // issued with the intended scope.
     const res = await POST(
       makeRequest("POST", {
         name: "queen-hive-1",
@@ -354,7 +361,7 @@ describe("POST /api/agent-tokens — body validation", () => {
     expect(body.message).toMatch(/contents/);
   });
 
-  it("preset 'local_queen' with allowedPermissions including contents → 400 (D10 forbids contents)", async () => {
+  it("preset 'local_queen' with contents narrower than merge scope → 400", async () => {
     const res = await POST(
       makeRequest("POST", {
         name: "queen-hive-1",
@@ -395,6 +402,7 @@ describe("POST /api/agent-tokens — body validation", () => {
         policy: {
           allowedRepos: ["hivemoot/colony"],
           allowedPermissions: {
+            contents: "write",
             pull_requests: "write",
             issues: "write",
             metadata: "read",
@@ -439,6 +447,7 @@ describe("POST /api/agent-tokens — body validation", () => {
         policy: {
           allowedRepos: ["hivemoot/colony"],
           allowedPermissions: {
+            contents: "write",
             pull_requests: "write",
             issues: "write",
             metadata: "read",

--- a/web/src/app/api/dashboard/agent-tokens/route.test.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.test.ts
@@ -420,6 +420,21 @@ describe("POST /api/dashboard/agent-tokens — mint-capable preset deny list (PR
     expect(mockedIssue).not.toHaveBeenCalled();
   });
 
+  it("explicit capabilities including pull_requests.merge → 400", async () => {
+    const res = await POST(
+      makeRequest("POST", {
+        name: "merger",
+        agent_role: "merger",
+        capabilities: ["pull_requests.merge", "rooms.read"],
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("agent_tokens_v1_invalid_capabilities");
+    expect(body.message).toMatch(/admin-class/);
+    expect(mockedIssue).not.toHaveBeenCalled();
+  });
+
   it("label-laundering attempt — explicit caps with role=apiarist → 400 (admin-class deny list, no preset escape)", async () => {
     // The pass-1 bypass: caller submits explicit caps with
     // `agent_role: "apiarist"` claiming the legacy-permissive
@@ -481,6 +496,7 @@ describe("GET /api/dashboard/agent-tokens — catalogs (presets + capabilities)"
     // PR 645 builder pass-2 (defense-in-depth on top of the policy
     // gate — the dashboard has no policy input surface).
     expect(body.capabilities).not.toContain("installation_token.mint");
+    expect(body.capabilities).not.toContain("pull_requests.merge");
     // Sanity: non-mint preset capabilities ARE in the catalog so the
     // UI can faithfully render preset → custom transitions.
     expect(body.capabilities).toEqual(

--- a/web/src/app/api/dashboard/agent-tokens/route.ts
+++ b/web/src/app/api/dashboard/agent-tokens/route.ts
@@ -102,6 +102,7 @@ const ADMIN_CLASS_CAPABILITIES: ReadonlySet<string> = new Set([
   "*",
   "agent_tokens.manage",
   "installation_token.mint",
+  "pull_requests.merge",
 ]);
 
 // ---------------------------------------------------------------------------

--- a/web/src/app/api/github/installation-tokens/route.test.ts
+++ b/web/src/app/api/github/installation-tokens/route.test.ts
@@ -65,13 +65,19 @@ function authOk(
         allowed_permissions?: Record<string, "read" | "write" | "admin">;
       }
     | undefined = undefined,
+  roleAndCaps: {
+    agent_role?: string;
+    capabilities?: string[];
+  } = {},
 ) {
+  const agentRole = roleAndCaps.agent_role ?? "worker";
+  const capabilities = roleAndCaps.capabilities ?? ["installation_token.mint"];
   return {
     ok: true as const,
     installationId,
     name: "test-agent",
-    agent_role: "worker",
-    capabilities: ["installation_token.mint"],
+    agent_role: agentRole,
+    capabilities,
     envelope: {
       // Encryption fields required by AgentTokenEnvelopeV1 type even
       // though tests don't decrypt — vitest hoisted-mock would also
@@ -86,13 +92,26 @@ function authOk(
       createdBy: "test",
       expiresAt: null,
       name: "test-agent",
-      agent_role: "worker",
-      capabilities: ["installation_token.mint"],
+      agent_role: agentRole,
+      capabilities,
       ...(policy ? { policy } : {}),
     },
     redis: {} as never,
   };
 }
+
+const LOCAL_QUEEN_MERGE_POLICY = {
+  allowed_repos: ["owner/repo"],
+  allowed_permissions: {
+    contents: "write",
+    pull_requests: "write",
+    issues: "write",
+    metadata: "read",
+  },
+} satisfies {
+  allowed_repos: string[];
+  allowed_permissions: Record<string, "read" | "write" | "admin">;
+};
 
 function authFailure(status = 401, code = "agent_health_not_authenticated") {
   return {
@@ -380,6 +399,57 @@ describe("POST /api/github/installation-tokens — happy path", () => {
       appId: "12345",
       appPrivateKeyPem: "fake-pem",
     });
+  });
+
+  it("uses merge-capable ceiling when bearer has pull_requests.merge", async () => {
+    mockedAuth.mockResolvedValue(
+      authOk("99999", LOCAL_QUEEN_MERGE_POLICY, {
+        agent_role: "local_queen",
+        capabilities: [
+          "installation_token.mint",
+          "pull_requests.merge",
+        ],
+      }),
+    );
+    mockedMint.mockResolvedValue(
+      successMint({
+        permissions: {
+          contents: "write",
+          pull_requests: "write",
+          issues: "write",
+          metadata: "read",
+        },
+      }),
+    );
+
+    await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(mockedMint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "99999",
+        repo: "owner/repo",
+        allowedPermissions: LOCAL_QUEEN_MERGE_POLICY.allowed_permissions,
+        permissionCeiling: LOCAL_QUEEN_MERGE_POLICY.allowed_permissions,
+      }),
+    );
+  });
+
+  it("rejects pull_requests.merge without matching local queen policy", async () => {
+    mockedAuth.mockResolvedValue(
+      authOk("99999", { allowed_repos: ["owner/repo"] }, {
+        agent_role: "local_queen",
+        capabilities: [
+          "installation_token.mint",
+          "pull_requests.merge",
+        ],
+      }),
+    );
+
+    const res = await POST(makeRequest({ repo: "owner/repo" }));
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).message).toMatch(/pull_requests\.merge/);
+    expect(mockedMint).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/app/api/github/installation-tokens/route.ts
+++ b/web/src/app/api/github/installation-tokens/route.ts
@@ -19,6 +19,11 @@ import {
   MintError,
   V1_PERMISSIONS,
 } from "@/server/github-installation-token";
+import {
+  LOCAL_QUEEN_REQUIRED_PERMISSIONS,
+  bearerHasCapability,
+} from "@/server/agent-token-capabilities";
+import type { GitHubPermissionLevel } from "@/server/agent-token-v1";
 
 const BAD_REQUEST_BODY = {
   error: "bad_request",
@@ -35,6 +40,15 @@ const SERVER_MISCONFIG_BODY = {
 const INTERNAL_BODY = {
   error: "internal_error",
   message: "Unexpected error during mint; see backend logs for details.",
+} as const;
+
+const MERGE_POLICY_VIOLATION_BODY = {
+  error: "policy_violation",
+  message:
+    "pull_requests.merge requires a local_queen bearer issued with " +
+    "policy.allowedPermissions exactly matching the local queen " +
+    "merge scope (contents: write, pull_requests: write, issues: write, " +
+    "metadata: read).",
 } as const;
 
 /**
@@ -54,8 +68,8 @@ const INTERNAL_BODY = {
  * = equal regardless of insertion order.
  */
 export function permissionsEqual(
-  a: Record<string, string>,
-  b: Record<string, string>,
+  a: Readonly<Record<string, string>>,
+  b: Readonly<Record<string, string>>,
 ): boolean {
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
@@ -195,16 +209,62 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // wire (apiarist's daemon parses `error` as the discriminator).
   const start = Date.now();
   try {
-    const tokenResponse = await mintInstallationToken({
+    const mintOptions: Parameters<typeof mintInstallationToken>[0] = {
       installationId: auth.installationId,
       repo,
       appId: githubAppId,
       appPrivateKeyPem: githubAppPrivateKey,
+    };
+
+    const mergeMint = bearerHasCapability(
+      auth.envelope.capabilities,
+      "pull_requests.merge",
+    );
+    if (mergeMint) {
+      if (
+        !bearerHasCapability(
+          auth.envelope.capabilities,
+          "installation_token.mint",
+        )
+      ) {
+        console.warn("[installation-tokens] merge bearer missing mint cap", {
+          installationId: auth.installationId,
+          repo,
+          agentId,
+          agentRole: auth.envelope.agent_role,
+        });
+        return NextResponse.json(MERGE_POLICY_VIOLATION_BODY, { status: 403 });
+      }
+      const policyPermissions = auth.envelope.policy?.allowed_permissions;
+      if (
+        auth.envelope.agent_role !== "local_queen" ||
+        !policyPermissions ||
+        !permissionsEqual(policyPermissions, LOCAL_QUEEN_REQUIRED_PERMISSIONS)
+      ) {
+        console.warn("[installation-tokens] merge capability policy violation", {
+          installationId: auth.installationId,
+          repo,
+          agentId,
+          agentRole: auth.envelope.agent_role,
+          hasAllowedPermissions: Boolean(policyPermissions),
+        });
+        return NextResponse.json(MERGE_POLICY_VIOLATION_BODY, { status: 403 });
+      }
+      mintOptions.permissionCeiling =
+        LOCAL_QUEEN_REQUIRED_PERMISSIONS as Readonly<
+          Record<string, GitHubPermissionLevel>
+        >;
+      mintOptions.allowedPermissions = policyPermissions;
+    } else if (auth.envelope.policy?.allowed_permissions !== undefined) {
       // V1.6: pass token's allowed_permissions through. Undefined for
       // legacy / V1.5 tokens (mint asks for V1_PERMISSIONS unchanged);
       // when set, mintInstallationToken intersects it with V1_PERMISSIONS
       // before sending to GitHub. The token can narrow scope, never raise.
-      allowedPermissions: auth.envelope.policy?.allowed_permissions,
+      mintOptions.allowedPermissions = auth.envelope.policy.allowed_permissions;
+    }
+
+    const tokenResponse = await mintInstallationToken({
+      ...mintOptions,
     });
     // Audit log: success. Token VALUE never logged — only metadata.
     // hashed_token is the audit-correlation handle (sha256/base64 of
@@ -229,6 +289,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       // field is set on the envelope, regardless of effect."
       policyHasAllowedPermissions:
         auth.envelope.policy?.allowed_permissions !== undefined,
+      mergeMint,
       // Whether the granted permissions actually differ from V1_PERMISSIONS.
       // True = some narrowing took effect (from token policy OR installation
       // grant); false = mint received the V1 default scope. This is the

--- a/web/src/server/agent-token-capabilities.test.ts
+++ b/web/src/server/agent-token-capabilities.test.ts
@@ -53,6 +53,7 @@ describe("CAPABILITY_REGEX", () => {
       "tasks.*",
       "agent_health.report",
       "installation_token.mint",
+      "pull_requests.merge",
       "rooms.read",
       "single",            // single-segment identifier
     ]) {
@@ -170,6 +171,10 @@ describe("expandCapabilities", () => {
     expect(expandCapabilities(["*"]).has("agent_tokens.manage")).toBe(false);
   });
 
+  it("bare * does NOT include pull_requests.merge", () => {
+    expect(expandCapabilities(["*"]).has("pull_requests.merge")).toBe(false);
+  });
+
   it("tasks.* expands only tasks.* entries (and excludes admin-class even if a task admin existed)", () => {
     const out = expandCapabilities(["tasks.*"]);
     expect(out.has("tasks.claim")).toBe(true);
@@ -196,6 +201,12 @@ describe("expandCapabilities", () => {
     // KNOWN_CAPABILITIES under that prefix, so the expansion is
     // empty. That's correct — the test pins the invariant for when
     // future agent_tokens.* entries arrive.
+    expect(out.size).toBe(0);
+  });
+
+  it("pull_requests.* does NOT expand to pull_requests.merge", () => {
+    const out = expandCapabilities(["pull_requests.*"]);
+    expect(out.has("pull_requests.merge")).toBe(false);
     expect(out.size).toBe(0);
   });
 
@@ -296,6 +307,7 @@ describe("PRESETS", () => {
   it("local_queen preset has rooms.synthesize + installation_token.mint (RFC PR 3 + G16)", () => {
     expect(PRESETS.local_queen.includes("rooms.synthesize")).toBe(true);
     expect(PRESETS.local_queen.includes("installation_token.mint")).toBe(true);
+    expect(PRESETS.local_queen.includes("pull_requests.merge")).toBe(true);
   });
 
   it("local_queen preset does NOT include rooms.watch (RFC builder pass-7 §5: queen polls synthesis-ready, not /watching)", () => {
@@ -339,11 +351,15 @@ describe("PRESETS", () => {
     expect(PRESETS.admin.includes("agent_tokens.manage")).toBe(true);
   });
 
-  it("admin preset's effective capability set covers EVERY KNOWN_CAPABILITIES entry", () => {
+  it("admin preset's effective capability set covers every non-admin-class capability", () => {
     const effective = expandCapabilities(PRESETS.admin);
     for (const k of KNOWN_CAPABILITIES) {
-      expect(effective.has(k), `admin should grant ${k}`).toBe(true);
+      if (!ADMIN_CLASS_CAPABILITIES.has(k)) {
+        expect(effective.has(k), `admin should grant ${k}`).toBe(true);
+      }
     }
+    expect(effective.has("agent_tokens.manage")).toBe(true);
+    expect(effective.has("pull_requests.merge")).toBe(false);
   });
 });
 
@@ -411,16 +427,17 @@ describe("cross-invariants", () => {
     }
   });
 
-  it("KNOWN_CAPABILITIES count matches the design doc claim (21)", () => {
+  it("KNOWN_CAPABILITIES count matches the design doc claim (22)", () => {
     // R2.2 baseline: 19 capabilities.
     // R3 (D.1.b-i): added `rooms.read_all` to differentiate
     // installation-wide listing (queen / monitoring) from worker
     // self-rooms reads (`rooms.read`). +1 → 20.
     // RFC PR 3 (D14): added `rooms.synthesize` for the local-mode
     // queen synthesis-path endpoints. +1 → 21.
+    // Local queen merge execution: added `pull_requests.merge`. +1 → 22.
     // If this fails, the doc section "Total: N capabilities" needs
     // to be updated alongside the addition.
-    expect(KNOWN_CAPABILITIES.length).toBe(21);
+    expect(KNOWN_CAPABILITIES.length).toBe(22);
   });
 });
 
@@ -434,6 +451,7 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   const D10_POLICY = {
     allowed_repos: ["hivemoot/colony"],
     allowed_permissions: {
+      contents: "write",
       pull_requests: "write",
       issues: "write",
       metadata: "read",
@@ -484,10 +502,9 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
   // ----- D10 half 2: allowed_permissions (builder pass-3) -----
 
   it("rejects local_queen with allowedRepos but NO allowedPermissions (pass-3 builder fix)", () => {
-    // Pass-2 accepted this shape; pass-3 closes it because the mint
-    // endpoint falls back to V1_PERMISSIONS (which includes
-    // contents:read) when allowedPermissions is omitted, violating
-    // RFC D10's permission scope half.
+    // Pass-2 accepted this shape; the gate now requires an explicit
+    // permission policy so merge-capable local queen tokens are
+    // issued with the intended scope.
     const result = validateMintPolicyRequirement({
       capabilities: PRESETS.local_queen,
       presetName: "local_queen",
@@ -500,11 +517,8 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     }
   });
 
-  it("rejects local_queen with allowedPermissions including 'contents' (any value)", () => {
-    // RFC D10 explicitly drops `contents` — the local queen
-    // synthesizes verdicts and posts comments; it must not read
-    // repo files.
-    for (const level of ["read", "write", "admin"]) {
+  it("rejects local_queen with contents narrower or broader than the merge scope", () => {
+    for (const level of ["read", "admin"]) {
       const result = validateMintPolicyRequirement({
         capabilities: PRESETS.local_queen,
         presetName: "local_queen",
@@ -534,6 +548,7 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
         allowed_permissions: {
           pull_requests: "read", // should be "write"
           issues: "write",
+          contents: "write",
           metadata: "read",
         },
       },
@@ -550,6 +565,7 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
         allowed_permissions: {
           pull_requests: "write",
           issues: "write",
+          contents: "write",
           metadata: "read",
           actions: "read", // not in D10's set
         },
@@ -617,12 +633,30 @@ describe("validateMintPolicyRequirement — RFC D10 + G16 + PR 645 builder pass-
     expect(result.ok).toBe(true);
   });
 
+  it("explicit pull_requests.merge also requires the full D10 policy", () => {
+    const rejected = validateMintPolicyRequirement({
+      capabilities: ["pull_requests.merge"],
+      presetName: null,
+      policy: { allowed_repos: ["hivemoot/colony"] },
+    });
+    expect(rejected.ok).toBe(false);
+
+    const accepted = validateMintPolicyRequirement({
+      capabilities: ["pull_requests.merge"],
+      presetName: null,
+      policy: D10_POLICY,
+    });
+    expect(accepted.ok).toBe(true);
+  });
+
   // ----- Wildcard-aware capability detection (pass-3 follow-up B1) -----
   // Pass-1 through pass-3 used `capabilities.includes("installation_token.mint")`
   // as a literal string check. The mint endpoint's auth uses
   // bearerHasCapability which expands wildcards. The asymmetry meant
   // `["installation_token.*"]` and `["*"]` slipped past the gate but
-  // satisfied auth. Now both gates use the same expansion semantics.
+  // satisfied auth. `pull_requests.*` has the same issue for
+  // pull_requests.merge. Now both gates use the same expansion
+  // semantics.
 
   it("rejects capabilities ['installation_token.*'] without policy (wildcard expands to mint)", () => {
     // The literal includes() would say false; bearerHasCapability

--- a/web/src/server/agent-token-capabilities.ts
+++ b/web/src/server/agent-token-capabilities.ts
@@ -121,6 +121,9 @@ export function validateCapabilityString(value: string): void {
 export const KNOWN_CAPABILITIES = [
   // Installation-token brokerage (apiarist's only required cap).
   "installation_token.mint",
+  // PR merge execution. Additive to installation_token.mint; the
+  // broker honors it only after the bearer policy is checked.
+  "pull_requests.merge",
   // Agent health observability.
   "agent_health.report",
   "agent_health.read",
@@ -183,11 +186,13 @@ export type KnownCapability = (typeof KNOWN_CAPABILITIES)[number];
  * Without this carve-out, an operator who issued `--capabilities
  * agent_tokens.*` thinking it's "everything in the agent_tokens
  * family except admin" would silently get full token-management
- * capability. Admin-class caps are reachable only via explicit
- * single-string listing.
+ * capability. The same applies to merge execution: pull_requests.*
+ * must not silently grant PR merge rights. Admin-class caps are
+ * reachable only via explicit single-string listing.
  */
 export const ADMIN_CLASS_CAPABILITIES: ReadonlySet<string> = new Set<string>([
   "agent_tokens.manage",
+  "pull_requests.merge",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -313,8 +318,8 @@ export const PRESETS: Readonly<Record<string, readonly string[]>> = {
   // G16 — `installation_token.mint` is normally apiarist-only with
   // a UDS broker pattern. The local queen needs to mint installation
   // tokens directly (it runs in-container, can't go through a host
-  // broker). Blast radius is bounded by D10's token policy —
-  // `policy.allowed_repos = watched_repos` + minimal scopes.
+  // broker). Squash merge execution additionally requires
+  // `pull_requests.merge`; both are bounded by D10's token policy.
   local_queen: [
     "agent_health.report",
     "tasks.create",
@@ -328,6 +333,7 @@ export const PRESETS: Readonly<Record<string, readonly string[]>> = {
     "rooms.close",
     "rooms.synthesize",
     "installation_token.mint",
+    "pull_requests.merge",
   ],
   dispatcher: [
     "tasks.create",
@@ -376,19 +382,18 @@ export function resolvePreset(name: string): readonly string[] {
  * The exact `allowed_permissions` shape RFC D10 specifies for the
  * local_queen mint policy. Mint-capable non-apiarist tokens must be
  * issued with this set verbatim — narrower fails closed (bearer
- * cannot use a permission they didn't request), broader violates
- * D10 by exceeding the queen's needed scope.
+ * cannot use a permission it needs), broader violates D10 by
+ * exceeding the queen's needed scope.
  *
- * Notably **excludes `contents`**: the local queen synthesizes
- * verdicts from war-room contributions and posts comments; it must
- * not read repo files. The default V1_PERMISSIONS shape (used at
- * mint time when `allowed_permissions` is omitted) DOES include
- * `contents: "read"` for legacy apiarist compatibility, which is
- * exactly the gap this gate closes for local_queen.
+ * `contents: "write"` is needed for the approved squash-merge
+ * execution path. The broker's default remains `contents: "read"`;
+ * local queen has to carry `pull_requests.merge` before this scope is
+ * requested.
  */
 export const LOCAL_QUEEN_REQUIRED_PERMISSIONS: Readonly<
   Record<string, "read" | "write" | "admin">
 > = Object.freeze({
+  contents: "write",
   pull_requests: "write",
   issues: "write",
   metadata: "read",
@@ -402,17 +407,14 @@ export const LOCAL_QUEEN_REQUIRED_PERMISSIONS: Readonly<
  * the D10 policy:
  *   - `allowed_repos` — non-empty list (repo fan-out bound)
  *   - `allowed_permissions` — exactly the LOCAL_QUEEN_REQUIRED_PERMISSIONS
- *      set (permission scope bound; see RFC docs/architecture/
- *      QUEEN_EXECUTION_MODE.md:566-567)
+ *      set (permission scope bound, including the contents:write scope
+ *      GitHub requires for squash merge execution)
  *
- * The mint endpoint (web/src/app/api/github/installation-tokens)
- * intersects V1_PERMISSIONS with the bearer's allowed_permissions;
- * if allowed_permissions is omitted, the intersection is the full
- * V1_PERMISSIONS set including `contents: "read"`. Without this
- * gate enforcing both halves, a leaked allowedRepos-only
- * local_queen bearer could mint tokens with `contents: "read"`
- * scope — violating D10's intent that the local queen never reads
- * repo files.
+ * The default mint endpoint intersects V1_PERMISSIONS with the
+ * bearer's allowed_permissions; the merge-capable mint uses this
+ * exact local-queen scope as its ceiling. Without this gate enforcing
+ * both halves, a leaked allowedRepos-only local_queen bearer would
+ * have ambiguous scope at mint time.
  *
  * `apiarist` is exempt from BOTH halves: the existing host-broker
  * preset predates the policy model and tightening it would break
@@ -485,14 +487,16 @@ const MINT_GATE_LEGACY_PRESETS: ReadonlySet<string> = new Set([
  *   - `capabilities: ["installation_token.*"]` does NOT trigger the
  *     gate (no literal match) but DOES satisfy
  *     `requires: "installation_token.mint"` at mint time
+ *   - `capabilities: ["pull_requests.*"]` can satisfy
+ *     `pull_requests.merge` for merge-capable minting
  *   - `capabilities: ["*"]` (with `allowWildcards: true`) has the
  *     same shape
  *
  * Both bypasses are now closed by switching the gate to
- * `bearerHasCapability(capabilities, "installation_token.mint")` —
- * the SAME predicate authorization uses. If the bearer can EVER
- * mint at request time, the gate fires at issue time. Symmetric
- * semantics, no asymmetry to exploit.
+ * `bearerHasCapability` for every mint-capable permission — the SAME
+ * predicate authorization uses. If the bearer can EVER mint at request
+ * time, the gate fires at issue time. Symmetric semantics, no
+ * asymmetry to exploit.
  *
  * `admin` is added to the legacy carve-out alongside `apiarist`.
  * Admin tokens are the chain root and intentionally hold every
@@ -517,10 +521,9 @@ export function validateMintPolicyRequirement(
 ): { ok: true } | { ok: false; message: string } {
   // Wildcard-aware: ["installation_token.*"] and ["*"] both trigger
   // the gate, matching the request-time auth predicate exactly.
-  const grantsMint = bearerHasCapability(
-    args.capabilities,
-    "installation_token.mint",
-  );
+  const grantsMint =
+    bearerHasCapability(args.capabilities, "installation_token.mint") ||
+    bearerHasCapability(args.capabilities, "pull_requests.merge");
   if (!grantsMint) return { ok: true };
 
   // Server-resolved preset-name gate ONLY — agent_role is operator-
@@ -555,7 +558,8 @@ export function validateMintPolicyRequirement(
     return {
       ok: false,
       message:
-        "Tokens granting installation_token.mint must be issued with " +
+        "Tokens granting installation_token.mint or pull_requests.merge " +
+        "must be issued with " +
         "a non-empty policy.allowedRepos list (RFC D10 half 1: bound " +
         "the mint repo fan-out). Pass policy: { allowedRepos: " +
         "['owner/repo', ...] } at issue time. The legacy apiarist " +
@@ -569,13 +573,13 @@ export function validateMintPolicyRequirement(
     return {
       ok: false,
       message:
-        "Tokens granting installation_token.mint must be issued with " +
+        "Tokens granting installation_token.mint or pull_requests.merge " +
+        "must be issued with " +
         "policy.allowedPermissions matching the RFC D10 local-queen " +
-        "permission scope (pull_requests: write, issues: write, " +
-        "metadata: read). Omitting allowedPermissions falls back to " +
-        "V1_PERMISSIONS at mint time, which includes contents:read — " +
-        "violating D10's intent that the local queen never reads " +
-        "repo files.",
+        "permission scope (contents: write, pull_requests: write, " +
+        "issues: write, metadata: read). Omitting allowedPermissions " +
+        "falls back to the broker default at mint time, which is " +
+        "not sufficient for approved squash merge execution.",
     };
   }
 


### PR DESCRIPTION
Adds an explicit `pull_requests.merge` Hivemoot capability so local queen merge authority is visible on the capability bearer instead of hidden in GitHub token scope.

This keeps normal installation-token mints capped at the existing default while allowing a local_queen bearer with the exact merge policy to receive the GitHub `contents:write` scope needed by `gh pr merge`.

Operationally, this unblocks the hive local queen merge path that currently fails with `Resource not accessible by integration (mergePullRequest)`.

Tests:
- `npm test -- src/server/agent-token-capabilities.test.ts src/app/api/github/installation-tokens/route.test.ts src/app/api/agent-tokens/route.test.ts src/app/api/dashboard/agent-tokens/route.test.ts 'src/app/api/agent-tokens/[name]/set-capabilities/route.test.ts'`\n- `npm run typecheck`