### PR TITLE
Fix local queen maintenance workflow Node mode

### DIFF
--- a/.github/workflows/maintenance-local-queen-merge-token.yml
+++ b/.github/workflows/maintenance-local-queen-merge-token.yml
@@ -47,7 +47,7 @@ jobs:
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
           GITHUB_SHA_VALUE: ${{ github.sha }}
         run: |
-          node <<'NODE'
+          node --input-type=commonjs <<'NODE'
           const fs = require("fs");
           const crypto = require("crypto");
 


### PR DESCRIPTION
Fixes the dispatch-only local queen token maintenance workflow so the inline Node script runs as CommonJS under GitHub Actions.

The previous run failed before touching Redis because stdin was evaluated as ESM and `require` was unavailable.

Validation: YAML parsed locally with PyYAML.