### PR TITLE
Wrap local queen maintenance script

### DIFF
--- a/.github/workflows/maintenance-local-queen-merge-token.yml
+++ b/.github/workflows/maintenance-local-queen-merge-token.yml
@@ -51,6 +51,8 @@ jobs:
           const fs = require("fs");
           const crypto = require("crypto");
 
+          (async () => {
+
           const envPath = ".vercel/.env.production.local";
           const envText = fs.readFileSync(envPath, "utf8");
 
@@ -211,4 +213,8 @@ jobs:
               lockValue,
             ]);
           }
+          })().catch((err) => {
+            console.error(err);
+            process.exit(1);
+          });
           NODE


### PR DESCRIPTION
Fixes the dispatch-only local queen maintenance workflow by wrapping the CommonJS script in an async function.

The previous run failed before touching Redis because top-level await is not available in CommonJS stdin.

Validation:
- YAML parsed locally with PyYAML
- Extracted inline script passed `node --check`