### PR TITLE
[codex] Require local queen contributions before synthesis

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -111,6 +111,10 @@ jobs:
         run: python3 cli/tests/test_hivemoot_health_api.py
       - name: Verify hivemoot health heartbeat trigger
         run: python3 cli/tests/test_hivemoot_health_trigger.py
+      - name: Verify hivemoot queen synthesis trigger (eligibility gate + claim race)
+        run: python3 cli/tests/test_hivemoot_queen_trigger.py
+      - name: Verify hivemoot queen trigger wiring (squash-merge flag plumbing)
+        run: python3 cli/tests/test_hivemoot_queen_wiring.py
       - name: Verify dual-source plugin discovery (builtin + external)
         run: python3 cli/tests/test_plugin_discovery.py
       - name: Verify messaging inbound media handling

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc-bin \
   libc6 \
   libcap2 \
+  libgnutls30 \
   libpython3.11-minimal \
   libpython3.11-stdlib \
   libsystemd0 \

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -534,7 +534,17 @@ class LocalQueenSynthesisTrigger:
             )
             return False
 
+        if not participants:
+            print(
+                f"{self._log_prefix} room={room.room_id} not ready: "
+                "no participants",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+
         unresolved = []
+        has_resolved = False
         for role, participant in participants.items():
             status = (
                 str(participant.get("status") or "")
@@ -543,10 +553,20 @@ class LocalQueenSynthesisTrigger:
             )
             if status not in {"resolved", "withdrew", "timed_out"}:
                 unresolved.append(role)
+            if status == "resolved":
+                has_resolved = True
         if unresolved:
             print(
                 f"{self._log_prefix} room={room.room_id} not ready: "
                 f"unresolved participants={','.join(sorted(unresolved))}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+        if not has_resolved:
+            print(
+                f"{self._log_prefix} room={room.room_id} not ready: "
+                "no resolved participants",
                 file=sys.stderr,
                 flush=True,
             )

--- a/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
+++ b/agent/cli/hivemoot_agent/plugins_builtin/hivemoot/queen/trigger.py
@@ -215,6 +215,21 @@ class LocalQueenSynthesisTrigger:
                 )
                 continue
 
+            # Re-gate on the claim's own participant snapshot. The pre-claim
+            # check read participants separately; a participant can change
+            # state in that window, so the claimed snapshot is authoritative.
+            # Bailing here is safe: the claim is a TTL lease that expires and
+            # returns the room to the ready pool, so nothing is stranded.
+            ok, reason = self._participants_eligible(claimed.participants)
+            if not ok:
+                print(
+                    f"{self._log_prefix} room={room.room_id} "
+                    f"not ready after claim: {reason}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+
             try:
                 pr = gh.parse_subject_ref(room.subject_ref)
                 gh_token = self._mint_token(
@@ -521,28 +536,24 @@ class LocalQueenSynthesisTrigger:
                 flush=True,
             )
 
-    def _is_room_ready(self, room: q_api.SynthesisReadyRoom, bearer: str) -> bool:
-        try:
-            participants = self._participants(self._base_url, room.room_id, bearer)
-            events = self._events(self._base_url, room.room_id, bearer, limit=500)
-        except Exception as exc:
-            print(
-                f"{self._log_prefix} eligibility read failed "
-                f"room={room.room_id}: {type(exc).__name__}: {exc}",
-                file=sys.stderr,
-                flush=True,
-            )
-            return False
+    def _participants_eligible(
+        self, participants: dict[str, Any]
+    ) -> tuple[bool, str | None]:
+        """Apply the synthesis participant gate, returning (eligible, reason).
 
+        A room is eligible only when at least one participant exists, none are
+        still unresolved, and at least one has actually resolved. This mirrors
+        the bot-side queen so the local queen never synthesizes an empty or
+        fully-withdrawn room.
+
+        Called both before claiming (against the live participants read) and
+        after claiming (against the claim's own snapshot). The post-claim call
+        closes the read-then-claim race: a participant can change state between
+        the eligibility read and the claim, so the claimed snapshot is the
+        authoritative one to gate on.
+        """
         if not participants:
-            print(
-                f"{self._log_prefix} room={room.room_id} not ready: "
-                "no participants",
-                file=sys.stderr,
-                flush=True,
-            )
-            return False
-
+            return False, "no participants"
         unresolved = []
         has_resolved = False
         for role, participant in participants.items():
@@ -556,17 +567,29 @@ class LocalQueenSynthesisTrigger:
             if status == "resolved":
                 has_resolved = True
         if unresolved:
+            joined = ",".join(sorted(unresolved))
+            return False, f"unresolved participants={joined}"
+        if not has_resolved:
+            return False, "no resolved participants"
+        return True, None
+
+    def _is_room_ready(self, room: q_api.SynthesisReadyRoom, bearer: str) -> bool:
+        try:
+            participants = self._participants(self._base_url, room.room_id, bearer)
+            events = self._events(self._base_url, room.room_id, bearer, limit=500)
+        except Exception as exc:
             print(
-                f"{self._log_prefix} room={room.room_id} not ready: "
-                f"unresolved participants={','.join(sorted(unresolved))}",
+                f"{self._log_prefix} eligibility read failed "
+                f"room={room.room_id}: {type(exc).__name__}: {exc}",
                 file=sys.stderr,
                 flush=True,
             )
             return False
-        if not has_resolved:
+
+        ok, reason = self._participants_eligible(participants)
+        if not ok:
             print(
-                f"{self._log_prefix} room={room.room_id} not ready: "
-                "no resolved participants",
+                f"{self._log_prefix} room={room.room_id} not ready: {reason}",
                 file=sys.stderr,
                 flush=True,
             )

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -75,6 +75,22 @@ def _claimed() -> ClaimedSynthesis:
     )
 
 
+def _claimed_with(participants: dict[str, object]) -> ClaimedSynthesis:
+    """A claimed snapshot with caller-supplied participants.
+
+    Simulates the read-then-claim race: the pre-claim participants read looks
+    eligible, but the claim returns a different (ineligible) snapshot.
+    """
+    return ClaimedSynthesis(
+        room_id="room-1",
+        through_sequence=12,
+        claim_ttl_secs=900,
+        room={"subject_ref": "owner/repo#42"},
+        participants=participants,
+        contributions={},
+    )
+
+
 class LocalQueenTriggerTests(unittest.TestCase):
     def test_dispatches_claimed_ready_room_with_head_sha(self) -> None:
         plugin = SlotPlugin()
@@ -206,6 +222,77 @@ class LocalQueenTriggerTests(unittest.TestCase):
         )
         trigger._tick(dispatcher)
         claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
+    def test_skips_when_claim_snapshot_loses_resolved_participant(self) -> None:
+        # Read-then-claim race: the pre-claim read is eligible, but by the time
+        # the claim lands every participant has withdrawn or timed out, so the
+        # claimed snapshot has no resolved participant. Synthesis must not fire.
+        claim_fn = MagicMock(
+            return_value=_claimed_with(
+                {
+                    "guard": {"status": "withdrew"},
+                    "drone": {"status": "timed_out"},
+                }
+            )
+        )
+        get_head_sha = MagicMock(return_value="abc123")
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(
+                return_value={"guard": {"status": "resolved"}}
+            ),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=get_head_sha,
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_called_once()
+        dispatcher.dispatch.assert_not_called()
+        # Fail-fast: bail before the head-SHA capture network call.
+        get_head_sha.assert_not_called()
+
+    def test_skips_when_claim_snapshot_has_pending_participant(self) -> None:
+        # Read-then-claim race: a participant re-RSVPs to pending between the
+        # eligibility read and the claim, so the claimed snapshot is no longer
+        # fully resolved. Synthesis must not fire.
+        claim_fn = MagicMock(
+            return_value=_claimed_with(
+                {
+                    "guard": {"status": "resolved"},
+                    "drone": {"status": "pending"},
+                }
+            )
+        )
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(
+                return_value={"guard": {"status": "resolved"}}
+            ),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_called_once()
         dispatcher.dispatch.assert_not_called()
 
     def test_skips_room_until_quiet_period_elapsed(self) -> None:

--- a/agent/cli/tests/test_hivemoot_queen_trigger.py
+++ b/agent/cli/tests/test_hivemoot_queen_trigger.py
@@ -159,6 +159,55 @@ class LocalQueenTriggerTests(unittest.TestCase):
         claim_fn.assert_not_called()
         dispatcher.dispatch.assert_not_called()
 
+    def test_skips_room_with_no_participants_before_claim(self) -> None:
+        claim_fn = MagicMock(return_value=_claimed())
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(return_value={}),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
+    def test_skips_room_without_resolved_participant_before_claim(self) -> None:
+        claim_fn = MagicMock(return_value=_claimed())
+        dispatcher = MagicMock()
+        trigger = LocalQueenSynthesisTrigger(
+            SlotPlugin(),
+            base_url="https://api.example",
+            token_resolver=lambda: "bearer",
+            agent_id="queen-a",
+            list_ready_fn=MagicMock(return_value=[_room()]),
+            participants_fn=MagicMock(
+                return_value={
+                    "guard": {"status": "withdrew"},
+                    "drone": {"status": "timed_out"},
+                }
+            ),
+            events_fn=MagicMock(
+                return_value=[{"timestamp": "2026-05-15T00:00:00Z"}],
+            ),
+            claim_fn=claim_fn,
+            mint_token_fn=MagicMock(return_value="ghs_x"),
+            get_head_sha_fn=MagicMock(return_value="abc123"),
+            now_fn=lambda: datetime(2026, 5, 15, 0, 2, tzinfo=timezone.utc),
+        )
+        trigger._tick(dispatcher)
+        claim_fn.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+
     def test_skips_room_until_quiet_period_elapsed(self) -> None:
         claim_fn = MagicMock(return_value=_claimed())
         dispatcher = MagicMock()


### PR DESCRIPTION
## Summary

This aligns the local queen readiness gate with the bot-side queen loop. The local queen now refuses to synthesize rooms with no participants and rooms where every participant withdrew or timed out.

Fixes https://github.com/hivemoot/hivemoot/issues/713

## Root Cause

The local queen treated an empty participant map as having no unresolved participants. After the quiet period elapsed, sweep-created rooms could be claimed and closed before workers successfully joined. This produced neutral no-contribution comments even though hive workers saw the room and later hit status_precondition_failed on /present.

## CI Fix

The agent image security scan also started failing on fixed Debian libgnutls30 CVEs from the base image. The Dockerfile now includes libgnutls30 in the existing apt --only-upgrade pass so cached base layers pick up Debian security updates before Trivy scans the final image.

## Validation

- python3 -m unittest tests.test_hivemoot_queen_trigger
- git diff --check
