### PR TITLE
feat(web): surface task artifact links in dashboard

### DIFF
--- a/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
+++ b/web/src/app/api/tasks/[taskId]/artifacts/route.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/server/agent-token-v1-auth", () => ({
+  authenticateAgentRequestV1: vi.fn(),
+}));
+
+vi.mock("@/server/task-store", () => ({
+  TASK_ID_PATTERN: /^[a-f0-9]{24}$/,
+  MAX_ARTIFACTS_PER_TASK: 20,
+  getTask: vi.fn(),
+  verifyTaskClaimToken: vi.fn(),
+  validateTaskArtifacts: vi.fn(),
+  addTaskArtifacts: vi.fn(),
+}));
+
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import {
+  getTask,
+  verifyTaskClaimToken,
+  validateTaskArtifacts,
+  addTaskArtifacts,
+} from "@/server/task-store";
+import { POST } from "./route";
+
+const TASK_ID = "abc123abc123abc123abc123";
+const PR_URL = "https://github.com/hivemoot/hivemoot/pull/312";
+
+const BASE_TASK = {
+  task_id: TASK_ID,
+  status: "running" as const,
+  prompt: "Build it",
+  timeout_secs: 300,
+  created_by: "queen",
+  created_at: "2026-03-03T12:00:00.000Z",
+  updated_at: "2026-03-03T12:01:00.000Z",
+};
+
+const NORMALIZED = [{ type: "pull_request" as const, url: PR_URL, number: 312 }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(authenticateAgentRequestV1).mockResolvedValue({
+    ok: true,
+    installationId: "inst-1",
+    name: "test-worker",
+    agent_role: "worker",
+    capabilities: ["tasks.progress"],
+    envelope: {
+      installationId: "inst-1",
+      name: "test-worker",
+      agent_role: "worker",
+      capabilities: ["tasks.progress"],
+      tokenHash: "stub",
+      fingerprint: "stub0001",
+      createdAt: "2026-04-30T00:00:00Z",
+      createdBy: "test",
+      expiresAt: null,
+    } as never,
+    redis: {} as never,
+  } as never);
+
+  vi.mocked(getTask).mockResolvedValue(BASE_TASK);
+  vi.mocked(verifyTaskClaimToken).mockResolvedValue(true);
+  vi.mocked(validateTaskArtifacts).mockReturnValue({ ok: true, artifacts: NORMALIZED });
+  vi.mocked(addTaskArtifacts).mockResolvedValue({
+    ok: true,
+    task: { ...BASE_TASK, artifacts: [{ ...NORMALIZED[0], created_at: BASE_TASK.updated_at }] },
+    added: 1,
+  });
+});
+
+function makeRequest(body: unknown, { claimToken = "claim-token-1", taskId = TASK_ID } = {}) {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (claimToken) headers.set("x-task-claim-token", claimToken);
+
+  return new NextRequest(`https://example.com/api/tasks/${taskId}/artifacts`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/tasks/[taskId]/artifacts", () => {
+  it("records artifacts and returns the updated task", async () => {
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.added).toBe(1);
+    expect(body.task.artifacts).toHaveLength(1);
+    expect(addTaskArtifacts).toHaveBeenCalledWith("inst-1", TASK_ID, NORMALIZED, expect.anything());
+    expect(verifyTaskClaimToken).toHaveBeenCalledWith("inst-1", TASK_ID, "claim-token-1", expect.anything());
+  });
+
+  it("returns 401 when the agent token is invalid", async () => {
+    vi.mocked(authenticateAgentRequestV1).mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "agent_auth_v1_missing_bearer" }, { status: 401 }),
+    });
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an invalid task id", async () => {
+    const res = await POST(makeRequest({ artifacts: [] }, { taskId: "not-a-task" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_invalid_task_id");
+  });
+
+  it("returns 400 when the body is not an object", async () => {
+    const res = await POST(makeRequest([1, 2, 3]));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+  });
+
+  it("returns 400 when artifact validation fails", async () => {
+    vi.mocked(validateTaskArtifacts).mockReturnValue({
+      ok: false,
+      message: "artifacts[0]: url must be on github.com",
+    });
+    const res = await POST(makeRequest({ artifacts: [{ type: "issue", url: "https://evil.test/x" }] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("task_validation_failed");
+    expect(body.message).toContain("github.com");
+    expect(addTaskArtifacts).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the task is missing for the installation", async () => {
+    vi.mocked(getTask).mockResolvedValue(null);
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("task_not_found");
+  });
+
+  it("returns 403 when the claim token is missing", async () => {
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }, { claimToken: "" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+    expect(verifyTaskClaimToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the claim token is invalid", async () => {
+    vi.mocked(verifyTaskClaimToken).mockResolvedValue(false);
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }, { claimToken: "bad" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("task_forbidden");
+    expect(addTaskArtifacts).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the task is not running", async () => {
+    vi.mocked(addTaskArtifacts).mockResolvedValue({ ok: false, reason: "invalid_transition" });
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("task_invalid_transition");
+  });
+
+  it("returns 409 with a distinct code when the artifact cap is hit", async () => {
+    vi.mocked(addTaskArtifacts).mockResolvedValue({ ok: false, reason: "limit_exceeded" });
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("task_artifact_limit_exceeded");
+  });
+
+  it("returns 429 when the lock acquisition times out", async () => {
+    vi.mocked(addTaskArtifacts).mockResolvedValue({ ok: false, reason: "lock_timeout" });
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.code).toBe("task_lock_timeout");
+  });
+
+  it("returns 500 when getTask throws", async () => {
+    vi.mocked(getTask).mockRejectedValue(new Error("redis down"));
+    const res = await POST(makeRequest({ artifacts: [{ type: "pull_request", url: PR_URL }] }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe("task_server_error");
+  });
+});

--- a/web/src/app/api/tasks/[taskId]/artifacts/route.ts
+++ b/web/src/app/api/tasks/[taskId]/artifacts/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseContentLength } from "@/server/request-utils";
+import { extractTaskId } from "@/server/task-route-utils";
+import { authenticateAgentRequestV1 } from "@/server/agent-token-v1-auth";
+import { TASK_ERROR, taskError } from "@/server/task-error";
+import {
+  addTaskArtifacts,
+  getTask,
+  MAX_ARTIFACTS_PER_TASK,
+  TASK_ID_PATTERN,
+  validateTaskArtifacts,
+  verifyTaskClaimToken,
+} from "@/server/task-store";
+
+// Matches the execute route's ceiling — artifact batches are tiny, but the
+// shared limit keeps the agent-facing task API consistent.
+const MAX_PAYLOAD_BYTES = 128 * 1024;
+const textEncoder = new TextEncoder();
+
+/**
+ * POST /api/tasks/{taskId}/artifacts — agents declare structured GitHub
+ * outputs (PRs, issues, comments, commits) they produced while working a task
+ * (#332).
+ *
+ * Auth mirrors the execute route: a `tasks.progress` bearer plus the per-task
+ * `x-task-claim-token` proving the caller is the agent currently working this
+ * task. Append-only and deduped by URL, so mid-task retries are idempotent.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await authenticateAgentRequestV1(request, {
+    requires: "tasks.progress",
+  });
+  if (!auth.ok) return auth.response;
+
+  const { pathname } = new URL(request.url);
+  const taskId = extractTaskId(pathname);
+  if (!taskId || !TASK_ID_PATTERN.test(taskId)) {
+    return taskError(TASK_ERROR.INVALID_TASK_ID, "Invalid task id", 400);
+  }
+
+  const contentLength = parseContentLength(request.headers.get("content-length"));
+  if (contentLength !== null && contentLength > MAX_PAYLOAD_BYTES) {
+    return taskError(TASK_ERROR.PAYLOAD_TOO_LARGE, "Payload too large (max 128KB)", 413);
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await request.text();
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  if (textEncoder.encode(bodyText).length > MAX_PAYLOAD_BYTES) {
+    return taskError(TASK_ERROR.PAYLOAD_TOO_LARGE, "Payload too large (max 128KB)", 413);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return taskError(TASK_ERROR.INVALID_JSON, "Invalid JSON body", 400);
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, "Body must be a JSON object", 400);
+  }
+
+  const obj = body as Record<string, unknown>;
+
+  // Validate URLs/shape before any Redis work. Scope to the bearer's
+  // allowed_repos when its policy declares them (additive to the
+  // installation boundary the lookup already enforces).
+  const validation = validateTaskArtifacts(obj.artifacts, {
+    allowedRepos: auth.envelope.policy?.allowed_repos,
+  });
+  if (!validation.ok) {
+    return taskError(TASK_ERROR.VALIDATION_FAILED, validation.message, 400);
+  }
+
+  try {
+    // Installation scoping from the executor token enforces tenant isolation.
+    const existingTask = await getTask(auth.installationId, taskId, auth.redis);
+    if (!existingTask) {
+      return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+    }
+
+    const claimToken = request.headers.get("x-task-claim-token")?.trim() ?? "";
+    if (!claimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Missing task claim token", 403);
+    }
+
+    const validClaimToken = await verifyTaskClaimToken(
+      auth.installationId,
+      taskId,
+      claimToken,
+      auth.redis,
+    );
+    if (!validClaimToken) {
+      return taskError(TASK_ERROR.FORBIDDEN, "Invalid or expired task claim token", 403);
+    }
+
+    const result = await addTaskArtifacts(
+      auth.installationId,
+      taskId,
+      validation.artifacts,
+      auth.redis,
+    );
+
+    if (result.ok) {
+      return NextResponse.json({ task: result.task, added: result.added });
+    }
+
+    if (result.reason === "not_found") {
+      return taskError(TASK_ERROR.TASK_NOT_FOUND, "Task not found", 404);
+    }
+    if (result.reason === "invalid_transition") {
+      return taskError(
+        TASK_ERROR.INVALID_TRANSITION,
+        "Artifacts can only be reported while the task is running",
+        409,
+      );
+    }
+    if (result.reason === "limit_exceeded") {
+      return taskError(
+        TASK_ERROR.ARTIFACT_LIMIT_EXCEEDED,
+        `Task already has the maximum of ${MAX_ARTIFACTS_PER_TASK} artifacts`,
+        409,
+      );
+    }
+    return taskError(
+      TASK_ERROR.LOCK_TIMEOUT,
+      "Task state is temporarily busy, retry shortly",
+      429,
+    );
+  } catch (error) {
+    console.error("[tasks] Failed to record task artifacts", {
+      installationId: auth.installationId,
+      taskId,
+      error,
+    });
+    return taskError(TASK_ERROR.SERVER_ERROR, "Failed to record task artifacts", 500);
+  }
+}

--- a/web/src/app/dashboard/tasks/TasksDashboard.tsx
+++ b/web/src/app/dashboard/tasks/TasksDashboard.tsx
@@ -75,6 +75,24 @@ function XCircleIcon({ className }: { className?: string }) {
   );
 }
 
+function OutputLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-3 w-3"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6.5 9.5a2.5 2.5 0 0 0 3.5 0l2-2a2.5 2.5 0 0 0-3.5-3.5l-1 1" />
+      <path d="M9.5 6.5a2.5 2.5 0 0 0-3.5 0l-2 2a2.5 2.5 0 0 0 3.5 3.5l1-1" />
+    </svg>
+  );
+}
+
 function SendIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -410,9 +428,20 @@ export default function TasksDashboard() {
                     {statusLabel(task.status)}
                   </span>
                 </div>
-                <span className="mt-1.5 block text-xs text-zinc-600" suppressHydrationWarning>
-                  {relativeTime(task.created_at)}
-                </span>
+                <div className="mt-1.5 flex items-center gap-2.5">
+                  <span className="text-xs text-zinc-600" suppressHydrationWarning>
+                    {relativeTime(task.created_at)}
+                  </span>
+                  {task.artifacts && task.artifacts.length > 0 && (
+                    <span className="inline-flex items-center gap-1 text-xs text-honey-500/70">
+                      <OutputLinkIcon className="h-3 w-3" />
+                      {task.artifacts.length}
+                      <span className="sr-only">
+                        {task.artifacts.length === 1 ? "output" : "outputs"}
+                      </span>
+                    </span>
+                  )}
+                </div>
                 {task.progress && task.status !== "pending" && (
                   <p className="mt-1 truncate text-xs text-zinc-500">{task.progress}</p>
                 )}

--- a/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
+++ b/web/src/app/dashboard/tasks/[taskId]/TaskDetail.tsx
@@ -11,7 +11,7 @@ import {
   taskComposerPlaceholder,
 } from "../task-helpers";
 import { MarkdownContent } from "../../MarkdownContent";
-import { type TaskMessage, type TaskRecord } from "../types";
+import { type TaskArtifact, type TaskMessage, type TaskRecord } from "../types";
 
 // ---------------------------------------------------------------------------
 // Icons
@@ -175,6 +175,84 @@ function ClockIcon({ className }: { className?: string }) {
   );
 }
 
+function GitPullRequestIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-4 w-4"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="4" cy="4" r="2" />
+      <circle cx="4" cy="12" r="2" />
+      <circle cx="12" cy="12" r="2" />
+      <line x1="4" y1="6" x2="4" y2="10" />
+      <path d="M12 10V7a2 2 0 0 0-2-2H7.5" />
+      <polyline points="9 3 7 5 9 7" />
+    </svg>
+  );
+}
+
+function IssueIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-4 w-4"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="6" />
+      <circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function GitCommitIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-4 w-4"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="3" />
+      <line x1="1" y1="8" x2="5" y2="8" />
+      <line x1="11" y1="8" x2="15" y2="8" />
+    </svg>
+  );
+}
+
+function ExternalLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className ?? "h-3.5 w-3.5"}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M9 2h5v5" />
+      <path d="M14 2L7 9" />
+      <path d="M12 9.5V13a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h3.5" />
+    </svg>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -293,6 +371,84 @@ function canSendMessage(status: string): boolean {
 
 function messageEndpoint(status: string): "messages" | "follow-up" {
   return status === "needs_follow_up" ? "follow-up" : "messages";
+}
+
+// ---------------------------------------------------------------------------
+// Artifacts
+// ---------------------------------------------------------------------------
+
+function ArtifactTypeIcon({ type, className }: { type: TaskArtifact["type"]; className?: string }) {
+  switch (type) {
+    case "pull_request":
+      return <GitPullRequestIcon className={className} />;
+    case "issue":
+      return <IssueIcon className={className} />;
+    case "issue_comment":
+      return <MessageSquareIcon className={className} />;
+    case "commit":
+      return <GitCommitIcon className={className} />;
+  }
+}
+
+// Short, human ref for an artifact (e.g. "PR #312", "Commit a1b2c3d"). The
+// number is derived server-side from the URL, so it is safe to trust here.
+function artifactRef(artifact: TaskArtifact): string {
+  switch (artifact.type) {
+    case "pull_request":
+      return artifact.number ? `PR #${artifact.number}` : "Pull request";
+    case "issue":
+      return artifact.number ? `Issue #${artifact.number}` : "Issue";
+    case "issue_comment":
+      return artifact.number ? `Comment on #${artifact.number}` : "Comment";
+    case "commit": {
+      const sha = artifact.url.split("/").pop() ?? "";
+      return sha ? `Commit ${sha.slice(0, 7)}` : "Commit";
+    }
+  }
+}
+
+function ArtifactsPanel({ artifacts }: { artifacts: TaskArtifact[] }) {
+  if (artifacts.length === 0) return null;
+
+  return (
+    <div className="mt-4 border-t border-white/[0.06] pt-4">
+      <div className="mb-2.5 flex items-center gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Outputs
+        </span>
+        <span className="rounded-full bg-white/[0.04] px-1.5 py-0.5 text-[11px] font-medium text-zinc-500">
+          {artifacts.length}
+        </span>
+      </div>
+
+      <ul className="space-y-1.5">
+        {artifacts.map((artifact, i) => (
+          <li key={`${artifact.url}-${i}`}>
+            <a
+              href={artifact.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-center gap-2.5 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 transition-colors hover:border-honey-500/30 hover:bg-white/[0.04]"
+            >
+              <ArtifactTypeIcon
+                type={artifact.type}
+                className="h-4 w-4 shrink-0 text-honey-500/80 transition-colors group-hover:text-honey-500"
+              />
+              <span className="flex min-w-0 flex-1 items-baseline gap-2">
+                <span className="shrink-0 text-sm font-medium text-zinc-200">
+                  {artifactRef(artifact)}
+                </span>
+                {artifact.title && (
+                  <span className="truncate text-xs text-zinc-500">{artifact.title}</span>
+                )}
+              </span>
+              <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0 text-zinc-600 transition-colors group-hover:text-honey-500" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -626,6 +782,11 @@ export default function TaskDetail({ taskId }: { taskId: string }) {
           <div className="mt-4 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2.5">
             <p className="text-sm text-red-400">{task.error}</p>
           </div>
+        )}
+
+        {/* Outputs — structured GitHub artifacts the agent produced (#332) */}
+        {task.artifacts && task.artifacts.length > 0 && (
+          <ArtifactsPanel artifacts={task.artifacts} />
         )}
       </div>
 

--- a/web/src/app/dashboard/tasks/types.ts
+++ b/web/src/app/dashboard/tasks/types.ts
@@ -1,5 +1,19 @@
 // Shared client-side task models used by the dashboard task views.
 // Keep these aligned with the task store payload shape.
+export type TaskArtifactType =
+  | "pull_request"
+  | "issue"
+  | "issue_comment"
+  | "commit";
+
+export interface TaskArtifact {
+  type: TaskArtifactType;
+  url: string;
+  number?: number;
+  title?: string;
+  created_at: string;
+}
+
 export interface TaskRecord {
   task_id: string;
   status: string;
@@ -12,6 +26,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface TaskMessage {

--- a/web/src/server/task-error.ts
+++ b/web/src/server/task-error.ts
@@ -16,6 +16,7 @@ export const TASK_ERROR = {
   CONCURRENCY_LIMITED: "task_concurrency_limited",
   LOCK_TIMEOUT: "task_lock_timeout",
   FOLLOW_UP_NOT_ALLOWED: "task_follow_up_not_allowed",
+  ARTIFACT_LIMIT_EXCEEDED: "task_artifact_limit_exceeded",
   SERVER_ERROR: "task_server_error",
 } as const;
 

--- a/web/src/server/task-store.test.ts
+++ b/web/src/server/task-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type Redis } from "@upstash/redis";
 import {
+  addTaskArtifacts,
   addUserMessage,
   appendTaskMessage,
   checkTaskCreateRateLimit,
@@ -10,6 +11,7 @@ import {
   DEFAULT_TASK_TIMEOUT_SECONDS,
   deleteTask,
   getTaskMessages,
+  MAX_ARTIFACTS_PER_TASK,
   MAX_CONCURRENT_TASKS,
   heartbeatTask,
   markTaskRunning,
@@ -23,6 +25,7 @@ import {
   listRecentTasks,
   TASK_CREATE_RATE_LIMIT_PER_MINUTE,
   validateCreateTaskRequest,
+  validateTaskArtifacts,
   COMPLETED_TASK_TTL_SECONDS,
   FAILED_TASK_TTL_SECONDS,
 } from "./task-store";
@@ -1906,5 +1909,222 @@ describe("addUserMessage", () => {
     const userMsg = messages[messages.length - 2];
     expect(userMsg.role).toBe("user");
     expect(userMsg.content).toBe("Do more");
+  });
+});
+
+describe("validateTaskArtifacts", () => {
+  const PR = "https://github.com/hivemoot/hivemoot/pull/312";
+  const ISSUE = "https://github.com/hivemoot/hivemoot/issues/45";
+  const COMMENT = "https://github.com/hivemoot/hivemoot/issues/45#issuecomment-987";
+  const COMMIT = "https://github.com/hivemoot/hivemoot/commit/a1b2c3d4e5f6a7b8";
+
+  it("accepts each artifact type and derives the number from the url", () => {
+    const result = validateTaskArtifacts([
+      { type: "pull_request", url: PR },
+      { type: "issue", url: ISSUE },
+      { type: "issue_comment", url: COMMENT },
+      { type: "commit", url: COMMIT },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.artifacts[0]).toEqual({ type: "pull_request", url: PR, number: 312 });
+    expect(result.artifacts[1].number).toBe(45);
+    expect(result.artifacts[2].number).toBe(45);
+    expect(result.artifacts[3].number).toBeUndefined();
+  });
+
+  it("rejects a non-array, empty array, and over-limit batch", () => {
+    expect(validateTaskArtifacts({}).ok).toBe(false);
+    expect(validateTaskArtifacts([]).ok).toBe(false);
+    const tooMany = Array.from({ length: MAX_ARTIFACTS_PER_TASK + 1 }, (_, i) => ({
+      type: "issue" as const,
+      url: `https://github.com/hivemoot/hivemoot/issues/${i + 1}`,
+    }));
+    expect(validateTaskArtifacts(tooMany).ok).toBe(false);
+  });
+
+  it("rejects non-github hosts and dangerous schemes", () => {
+    expect(validateTaskArtifacts([{ type: "pull_request", url: "https://evil.example/hivemoot/hivemoot/pull/1" }]).ok).toBe(false);
+    expect(validateTaskArtifacts([{ type: "pull_request", url: "https://github.com.attacker.test/a/b/pull/1" }]).ok).toBe(false);
+    expect(validateTaskArtifacts([{ type: "pull_request", url: "http://github.com/a/b/pull/1" }]).ok).toBe(false);
+    expect(validateTaskArtifacts([{ type: "issue", url: "javascript:alert(1)" }]).ok).toBe(false);
+    expect(validateTaskArtifacts([{ type: "pull_request", url: "https://user:pass@github.com/a/b/pull/1" }]).ok).toBe(false);
+  });
+
+  it("rejects a path shape that does not match the declared type", () => {
+    // issue url declared as a pull_request
+    expect(validateTaskArtifacts([{ type: "pull_request", url: ISSUE }]).ok).toBe(false);
+    // pull url declared as an issue
+    expect(validateTaskArtifacts([{ type: "issue", url: PR }]).ok).toBe(false);
+    // issue_comment without a comment anchor
+    expect(validateTaskArtifacts([{ type: "issue_comment", url: ISSUE }]).ok).toBe(false);
+    // commit with a non-hex sha
+    expect(validateTaskArtifacts([{ type: "commit", url: "https://github.com/a/b/commit/zzzz" }]).ok).toBe(false);
+  });
+
+  it("rejects a supplied number that disagrees with the url", () => {
+    expect(validateTaskArtifacts([{ type: "pull_request", url: PR, number: 999 }]).ok).toBe(false);
+    expect(validateTaskArtifacts([{ type: "pull_request", url: PR, number: 312 }]).ok).toBe(true);
+    // commits carry no number
+    expect(validateTaskArtifacts([{ type: "commit", url: COMMIT, number: 1 }]).ok).toBe(false);
+  });
+
+  it("rejects unknown fields", () => {
+    expect(validateTaskArtifacts([{ type: "issue", url: ISSUE, titel: "typo" }]).ok).toBe(false);
+  });
+
+  it("sanitizes and caps the title, dropping an empty one", () => {
+    const longTitle = "x".repeat(500);
+    const result = validateTaskArtifacts([
+      { type: "issue", url: ISSUE, title: `  Fix the\tbug\n  ${longTitle}` },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.artifacts[0].title!.length).toBeLessThanOrEqual(200);
+    expect(result.artifacts[0].title).not.toContain("\t");
+
+    const empty = validateTaskArtifacts([{ type: "issue", url: ISSUE, title: "   " }]);
+    expect(empty.ok).toBe(true);
+    if (empty.ok) expect(empty.artifacts[0].title).toBeUndefined();
+  });
+
+  it("scopes to allowed_repos when the token declares them", () => {
+    const inScope = validateTaskArtifacts([{ type: "pull_request", url: PR }], {
+      allowedRepos: ["HiveMoot/Hivemoot"], // case-insensitive match
+    });
+    expect(inScope.ok).toBe(true);
+
+    const outOfScope = validateTaskArtifacts([{ type: "pull_request", url: PR }], {
+      allowedRepos: ["someone/else"],
+    });
+    expect(outOfScope.ok).toBe(false);
+
+    // Empty/absent policy → no repo scoping (installation boundary only).
+    expect(validateTaskArtifacts([{ type: "pull_request", url: PR }], { allowedRepos: [] }).ok).toBe(true);
+  });
+});
+
+describe("addTaskArtifacts", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  async function seedRunningTask(): Promise<string> {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Build it", timeout_secs: 300 },
+      redis,
+    );
+    if (!created.ok) throw new Error("seed failed");
+    await markTaskRunning("inst-1", created.task.task_id, redis);
+    return created.task.task_id;
+  }
+
+  const PR = "https://github.com/hivemoot/hivemoot/pull/312";
+  const ISSUE = "https://github.com/hivemoot/hivemoot/issues/45";
+
+  it("appends artifacts to a running task and exposes them via getTask", async () => {
+    const taskId = await seedRunningTask();
+    const result = await addTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "pull_request", url: PR, number: 312 }],
+      redis,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.added).toBe(1);
+    expect(result.task.artifacts).toHaveLength(1);
+    expect(result.task.artifacts![0].url).toBe(PR);
+    expect(result.task.artifacts![0].created_at).toBeTruthy();
+
+    const fetched = await getTask("inst-1", taskId, redis);
+    expect(fetched?.artifacts).toHaveLength(1);
+  });
+
+  it("dedupes repeated URLs across calls (idempotent retries)", async () => {
+    const taskId = await seedRunningTask();
+    await addTaskArtifacts("inst-1", taskId, [{ type: "pull_request", url: PR, number: 312 }], redis);
+    const second = await addTaskArtifacts(
+      "inst-1",
+      taskId,
+      [
+        { type: "pull_request", url: PR, number: 312 }, // duplicate
+        { type: "issue", url: ISSUE, number: 45 },
+      ],
+      redis,
+    );
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.added).toBe(1);
+    expect(second.task.artifacts).toHaveLength(2);
+  });
+
+  it("rejects when the running total would exceed the cap", async () => {
+    const taskId = await seedRunningTask();
+    const batch = Array.from({ length: MAX_ARTIFACTS_PER_TASK }, (_, i) => ({
+      type: "issue" as const,
+      url: `https://github.com/hivemoot/hivemoot/issues/${i + 1}`,
+      number: i + 1,
+    }));
+    const first = await addTaskArtifacts("inst-1", taskId, batch, redis);
+    expect(first.ok).toBe(true);
+
+    const overflow = await addTaskArtifacts(
+      "inst-1",
+      taskId,
+      [{ type: "pull_request", url: PR, number: 312 }],
+      redis,
+    );
+    expect(overflow.ok).toBe(false);
+    if (overflow.ok) return;
+    expect(overflow.reason).toBe("limit_exceeded");
+  });
+
+  it("returns not_found for an unknown task", async () => {
+    const result = await addTaskArtifacts(
+      "inst-1",
+      "ffffffffffffffffffffffff",
+      [{ type: "pull_request", url: PR, number: 312 }],
+      redis,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("not_found");
+  });
+
+  it("rejects artifacts when the task is not running", async () => {
+    const created = await createTask(
+      "inst-1",
+      "queen",
+      { prompt: "Build it", timeout_secs: 300 },
+      redis,
+    );
+    if (!created.ok) throw new Error("seed failed");
+    // Still pending — never marked running.
+    const result = await addTaskArtifacts(
+      "inst-1",
+      created.task.task_id,
+      [{ type: "pull_request", url: PR, number: 312 }],
+      redis,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("invalid_transition");
+  });
+
+  it("preserves artifacts through completion", async () => {
+    const taskId = await seedRunningTask();
+    await addTaskArtifacts("inst-1", taskId, [{ type: "pull_request", url: PR, number: 312 }], redis);
+    const completed = await completeTask("inst-1", taskId, "all done", redis);
+    expect(completed.ok).toBe(true);
+
+    const fetched = await getTask("inst-1", taskId, redis);
+    expect(fetched?.status).toBe("completed");
+    expect(fetched?.artifacts).toHaveLength(1);
+    expect(fetched?.artifacts![0].url).toBe(PR);
   });
 });

--- a/web/src/server/task-store.ts
+++ b/web/src/server/task-store.ts
@@ -31,6 +31,53 @@ export interface TaskMessage {
 const MAX_MESSAGE_CONTENT_CHARS = 128_000;
 const MAX_MESSAGES_PER_TASK = 200;
 
+// ---------------------------------------------------------------------------
+// Task artifacts (#332) — structured GitHub outputs an agent produced while
+// working a task (PRs opened, issues filed, comments posted, commits pushed).
+// Surfaced on the dashboard so a reviewer can jump straight to the result
+// instead of scrubbing the chat log.
+// ---------------------------------------------------------------------------
+
+export type TaskArtifactType =
+  | "pull_request"
+  | "issue"
+  | "issue_comment"
+  | "commit";
+
+const TASK_ARTIFACT_TYPES = new Set<TaskArtifactType>([
+  "pull_request",
+  "issue",
+  "issue_comment",
+  "commit",
+]);
+
+export interface TaskArtifact {
+  type: TaskArtifactType;
+  url: string;
+  /** PR or issue number when the type implies one (absent for commits). */
+  number?: number;
+  /** Display name, sanitized + capped. */
+  title?: string;
+  /** Server-stamped when the artifact was first recorded. */
+  created_at: string;
+}
+
+/** Artifact shape after validation but before the store stamps `created_at`. */
+export type NormalizedTaskArtifact = Omit<TaskArtifact, "created_at">;
+
+// 20 is generous for any real task and bounds both storage growth and the
+// blast radius of a misbehaving agent spamming the append endpoint.
+export const MAX_ARTIFACTS_PER_TASK = 20;
+const MAX_ARTIFACT_TITLE_CHARS = 200;
+
+// GitHub owner logins: alphanumeric + single hyphens, ≤39 chars, no leading
+// hyphen. Repos: alphanumeric plus `.`, `_`, `-`, ≤100 chars. These mirror
+// GitHub's own naming rules closely enough to reject path-traversal and
+// obviously-malformed slugs without a network round-trip.
+const GITHUB_OWNER_REGEX = /^[A-Za-z0-9][A-Za-z0-9-]{0,38}$/;
+const GITHUB_REPO_REGEX = /^[A-Za-z0-9._-]{1,100}$/;
+const GITHUB_COMMIT_SHA_REGEX = /^[0-9a-fA-F]{7,40}$/;
+
 export interface TaskRecord {
   task_id: string;
   status: TaskStatus;
@@ -43,6 +90,7 @@ export interface TaskRecord {
   finished_at?: string;
   error?: string;
   progress?: string;
+  artifacts?: TaskArtifact[];
 }
 
 export interface ClaimedTask {
@@ -61,6 +109,10 @@ interface StoredTaskRecord {
   started_at?: string;
   finished_at?: string;
   error?: string;
+  // Artifacts ride on the stored record so they carry through finalize/retry
+  // (which spread `...stored`) and inherit the record's terminal TTL — no
+  // separate key to TTL-manage. See addTaskArtifacts.
+  artifacts?: TaskArtifact[];
 }
 
 export interface CreateTaskRequest {
@@ -174,6 +226,41 @@ function sanitizeText(input: string, maxLength: number): string {
   return trimmed.slice(0, maxLength);
 }
 
+// Lenient: drop individual malformed artifacts rather than failing the whole
+// task parse (which would trip cleanupMissingTask and delete a live task).
+function parseStoredArtifacts(raw: unknown): TaskArtifact[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+
+  const out: TaskArtifact[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const o = entry as Record<string, unknown>;
+    if (
+      typeof o.type !== "string"
+      || !TASK_ARTIFACT_TYPES.has(o.type as TaskArtifactType)
+      || typeof o.url !== "string"
+      || typeof o.created_at !== "string"
+    ) {
+      continue;
+    }
+
+    const artifact: TaskArtifact = {
+      type: o.type as TaskArtifactType,
+      url: o.url,
+      created_at: o.created_at,
+    };
+    if (typeof o.number === "number" && Number.isInteger(o.number)) {
+      artifact.number = o.number;
+    }
+    if (typeof o.title === "string") {
+      artifact.title = o.title;
+    }
+    out.push(artifact);
+  }
+
+  return out.length > 0 ? out : undefined;
+}
+
 function parseStoredTask(raw: unknown): StoredTaskRecord | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
@@ -206,6 +293,9 @@ function parseStoredTask(raw: unknown): StoredTaskRecord | null {
   if (typeof obj.started_at === "string") parsed.started_at = obj.started_at;
   if (typeof obj.finished_at === "string") parsed.finished_at = obj.finished_at;
   if (typeof obj.error === "string") parsed.error = obj.error;
+
+  const artifacts = parseStoredArtifacts(obj.artifacts);
+  if (artifacts) parsed.artifacts = artifacts;
 
   return parsed;
 }
@@ -1379,6 +1469,334 @@ export async function addUserMessage(
         taskId,
       });
       return { ok: false, reason: "concurrency_limited" };
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task artifacts (#332)
+// ---------------------------------------------------------------------------
+
+const ARTIFACT_ALLOWED_KEYS = new Set(["type", "url", "number", "title"]);
+
+export type ValidateTaskArtifactsResult =
+  | { ok: true; artifacts: NormalizedTaskArtifact[] }
+  | { ok: false; message: string };
+
+function sanitizeArtifactTitle(value: string): string {
+  // Replace control characters (the value is rendered in the dashboard)
+  // with spaces, collapse whitespace runs, then cap length. The \u escapes
+  // keep the source pure-ASCII (no literal control bytes in the regex).
+  const cleaned = value
+    .replace(/[\u0000-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned.slice(0, MAX_ARTIFACT_TITLE_CHARS);
+}
+
+function parsePositiveInt(segment: string): number | null {
+  if (!/^\d{1,9}$/.test(segment)) return null;
+  const n = Number.parseInt(segment, 10);
+  return n > 0 ? n : null;
+}
+
+type ParsedArtifactUrl =
+  | { ok: true; owner: string; repo: string; number?: number }
+  | { ok: false; message: string };
+
+// Strict, network-free validation: the URL must be an https github.com link
+// whose path shape matches the declared artifact type. This is the primary
+// defense against an agent attaching unrelated/external/`javascript:` URLs.
+function parseGitHubArtifactUrl(
+  rawUrl: string,
+  type: TaskArtifactType,
+): ParsedArtifactUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, message: "url must be a valid absolute URL" };
+  }
+
+  if (parsed.protocol !== "https:") {
+    return { ok: false, message: "url must use https" };
+  }
+  // Exact host match — blocks gist.github.com, look-alikes, and
+  // `github.com.attacker.example` style suffixes.
+  if (parsed.hostname.toLowerCase() !== "github.com") {
+    return { ok: false, message: "url must be on github.com" };
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, message: "url must not embed credentials" };
+  }
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length < 4) {
+    return { ok: false, message: "url must point to a specific GitHub resource" };
+  }
+
+  const [owner, repo, kind, id] = segments;
+  if (!GITHUB_OWNER_REGEX.test(owner)) {
+    return { ok: false, message: "url has an invalid repository owner" };
+  }
+  if (!GITHUB_REPO_REGEX.test(repo) || repo === "." || repo === "..") {
+    return { ok: false, message: "url has an invalid repository name" };
+  }
+
+  switch (type) {
+    case "pull_request": {
+      if (kind !== "pull") {
+        return { ok: false, message: "pull_request url must look like /{owner}/{repo}/pull/{number}" };
+      }
+      const number = parsePositiveInt(id);
+      if (number === null) {
+        return { ok: false, message: "pull_request url must end in a positive PR number" };
+      }
+      return { ok: true, owner, repo, number };
+    }
+    case "issue": {
+      if (kind !== "issues") {
+        return { ok: false, message: "issue url must look like /{owner}/{repo}/issues/{number}" };
+      }
+      const number = parsePositiveInt(id);
+      if (number === null) {
+        return { ok: false, message: "issue url must end in a positive issue number" };
+      }
+      return { ok: true, owner, repo, number };
+    }
+    case "issue_comment": {
+      // Comments live under issues/ or pull/; the comment id is in the
+      // fragment (e.g. #issuecomment-123), so require a non-empty hash.
+      if (kind !== "issues" && kind !== "pull") {
+        return { ok: false, message: "issue_comment url must reference an issue or pull request" };
+      }
+      const number = parsePositiveInt(id);
+      if (number === null) {
+        return { ok: false, message: "issue_comment url must include the issue or PR number" };
+      }
+      if (parsed.hash.length <= 1) {
+        return { ok: false, message: "issue_comment url must include a comment anchor (e.g. #issuecomment-123)" };
+      }
+      return { ok: true, owner, repo, number };
+    }
+    case "commit": {
+      if (kind !== "commit") {
+        return { ok: false, message: "commit url must look like /{owner}/{repo}/commit/{sha}" };
+      }
+      if (!GITHUB_COMMIT_SHA_REGEX.test(id)) {
+        return { ok: false, message: "commit url must end in a valid commit sha" };
+      }
+      return { ok: true, owner, repo };
+    }
+  }
+}
+
+function validateSingleArtifact(
+  entry: unknown,
+  allowedRepos: Set<string> | null,
+): { ok: true; artifact: NormalizedTaskArtifact } | { ok: false; message: string } {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return { ok: false, message: "must be an object" };
+  }
+  const o = entry as Record<string, unknown>;
+
+  for (const key of Object.keys(o)) {
+    if (!ARTIFACT_ALLOWED_KEYS.has(key)) {
+      return { ok: false, message: `unknown field: ${key}` };
+    }
+  }
+
+  if (typeof o.type !== "string" || !TASK_ARTIFACT_TYPES.has(o.type as TaskArtifactType)) {
+    return {
+      ok: false,
+      message: "type must be one of: pull_request, issue, issue_comment, commit",
+    };
+  }
+  const type = o.type as TaskArtifactType;
+
+  if (typeof o.url !== "string" || o.url.trim().length === 0) {
+    return { ok: false, message: "url is required" };
+  }
+
+  const parsedUrl = parseGitHubArtifactUrl(o.url.trim(), type);
+  if (!parsedUrl.ok) {
+    return { ok: false, message: parsedUrl.message };
+  }
+
+  // Additive repo scoping: when the agent token declares allowed_repos,
+  // the artifact must point at one of them. Tokens without a repo policy
+  // fall back to the installation boundary already enforced by the caller.
+  if (allowedRepos) {
+    const slug = `${parsedUrl.owner}/${parsedUrl.repo}`.toLowerCase();
+    if (!allowedRepos.has(slug)) {
+      return {
+        ok: false,
+        message: `url repository ${parsedUrl.owner}/${parsedUrl.repo} is outside this token's allowed repositories`,
+      };
+    }
+  }
+
+  const artifact: NormalizedTaskArtifact = {
+    type,
+    url: o.url.trim(),
+  };
+
+  // Number: derive from the URL as the source of truth. If the caller also
+  // supplied one, it must agree (catches copy-paste/format drift); commits
+  // carry no number so any supplied value is rejected.
+  if (parsedUrl.number !== undefined) {
+    if (o.number !== undefined) {
+      if (typeof o.number !== "number" || !Number.isInteger(o.number)) {
+        return { ok: false, message: "number must be an integer" };
+      }
+      if (o.number !== parsedUrl.number) {
+        return {
+          ok: false,
+          message: `number ${o.number} does not match the number in the url (${parsedUrl.number})`,
+        };
+      }
+    }
+    artifact.number = parsedUrl.number;
+  } else if (o.number !== undefined) {
+    return { ok: false, message: "commit artifacts must not include a number" };
+  }
+
+  if (o.title !== undefined) {
+    if (typeof o.title !== "string") {
+      return { ok: false, message: "title must be a string" };
+    }
+    const title = sanitizeArtifactTitle(o.title);
+    if (title.length > 0) artifact.title = title;
+  }
+
+  return { ok: true, artifact };
+}
+
+/**
+ * Validate + normalize a batch of artifact inputs from an agent.
+ *
+ * Pure (no Redis) so it is exhaustively unit-testable. `allowedRepos` is the
+ * agent token's `policy.allowed_repos` (optional); when present and non-empty
+ * it bounds artifacts to those repositories.
+ */
+export function validateTaskArtifacts(
+  input: unknown,
+  options: { allowedRepos?: readonly string[] } = {},
+): ValidateTaskArtifactsResult {
+  if (!Array.isArray(input)) {
+    return { ok: false, message: "artifacts must be an array" };
+  }
+  if (input.length === 0) {
+    return { ok: false, message: "artifacts must contain at least one entry" };
+  }
+  if (input.length > MAX_ARTIFACTS_PER_TASK) {
+    return {
+      ok: false,
+      message: `artifacts must not exceed ${MAX_ARTIFACTS_PER_TASK} entries per request`,
+    };
+  }
+
+  const allowedRepos = normalizeAllowedRepos(options.allowedRepos);
+  const artifacts: NormalizedTaskArtifact[] = [];
+  for (let i = 0; i < input.length; i += 1) {
+    const result = validateSingleArtifact(input[i], allowedRepos);
+    if (!result.ok) {
+      return { ok: false, message: `artifacts[${i}]: ${result.message}` };
+    }
+    artifacts.push(result.artifact);
+  }
+
+  return { ok: true, artifacts };
+}
+
+function normalizeAllowedRepos(
+  allowedRepos: readonly string[] | undefined,
+): Set<string> | null {
+  if (!allowedRepos || allowedRepos.length === 0) return null;
+  const set = new Set<string>();
+  for (const repo of allowedRepos) {
+    if (typeof repo === "string" && repo.includes("/")) {
+      set.add(repo.toLowerCase());
+    }
+  }
+  return set.size > 0 ? set : null;
+}
+
+export type AddTaskArtifactsResult =
+  | { ok: true; task: TaskRecord; added: number }
+  | {
+      ok: false;
+      reason: "not_found" | "invalid_transition" | "limit_exceeded" | "lock_timeout";
+    };
+
+/**
+ * Append artifacts to a running task (append-only, deduped by URL).
+ *
+ * Only valid while the task is `running` — that is the exact window the
+ * per-task claim token is live (it is deleted on finalize/follow-up), so the
+ * caller's claim-token check already gates this to the agent currently
+ * working the task. Re-reporting the same URL is a no-op (idempotent retries),
+ * and the write doubles as a liveness signal like a heartbeat.
+ */
+export async function addTaskArtifacts(
+  installationId: string,
+  taskId: string,
+  artifacts: NormalizedTaskArtifact[],
+  redis: Redis,
+): Promise<AddTaskArtifactsResult> {
+  try {
+    return await withTaskInstallationLock(installationId, redis, async () => {
+      const stored = await loadStoredTask(installationId, taskId, redis);
+      if (!stored) return { ok: false, reason: "not_found" };
+
+      if (stored.status !== "running") {
+        return { ok: false, reason: "invalid_transition" };
+      }
+
+      const existing = stored.artifacts ?? [];
+      const seen = new Set(existing.map((a) => a.url.toLowerCase()));
+      const timestamp = nowIso();
+
+      const additions: TaskArtifact[] = [];
+      for (const candidate of artifacts) {
+        const key = candidate.url.toLowerCase();
+        if (seen.has(key)) continue; // dedup vs existing + within-batch
+        seen.add(key);
+        additions.push({ ...candidate, created_at: timestamp });
+      }
+
+      const merged = [...existing, ...additions];
+      if (merged.length > MAX_ARTIFACTS_PER_TASK) {
+        return { ok: false, reason: "limit_exceeded" };
+      }
+
+      const nextStored: StoredTaskRecord = {
+        ...stored,
+        artifacts: merged,
+        updated_at: timestamp,
+      };
+
+      await redis
+        .multi()
+        .set(taskKey(installationId, taskId), nextStored)
+        .zadd(runningKey(installationId), { score: Date.now(), member: taskId })
+        .zadd(recentKey(installationId), { score: Date.now(), member: taskId })
+        .exec();
+
+      return {
+        ok: true,
+        task: await buildTaskRecord(installationId, nextStored, redis),
+        added: additions.length,
+      };
+    });
+  } catch (error) {
+    if (error instanceof LockTimeoutError) {
+      console.warn("[tasks] Task artifacts lock timeout", {
+        installationId,
+        taskId,
+      });
+      return { ok: false, reason: "lock_timeout" };
     }
     throw error;
   }


### PR DESCRIPTION
## What

Adds **structured task artifacts** — the GitHub outputs an agent produced while working a task (PRs, issues, comments, commits) — and surfaces them as clickable links in the dashboard.

Fixes #332

## Why

When an agent runs a task, the dashboard showed the transcript and status but not *what the agent actually produced on GitHub*. Finding "this task opened PR #312" meant scrubbing the chat log or searching GitHub by hand. Artifacts make the result of a task one click away.

## How it works

- **New endpoint** `POST /api/tasks/{taskId}/artifacts` — append-only, the working agent reports artifacts incrementally *while the task runs* (so a PR opened on hour 2 of a 6-hour task shows up immediately, not only at completion).
- **Auth** reuses the existing surface (Approach B from the issue, "no new auth surface"): a `tasks.progress` bearer + the per-task `x-task-claim-token`. That token is only live while the task is `running`, so the endpoint is naturally gated to the agent currently working the task. Re-reporting a URL is idempotent (deduped), so retries are safe and the write doubles as a heartbeat.
- **Storage**: artifacts ride on the task record, so they carry through completion/retry and inherit the record's TTL — no separate key to expire.
- **Validation** is strict and network-free: URL must be `https://github.com/{owner}/{repo}/…` whose path shape matches the declared type; the PR/issue number is derived from the URL (a mismatched supplied number is rejected); titles are sanitized + capped at 200 chars; the batch is capped at 20 per task. When the agent token declares `policy.allowed_repos`, artifacts are additionally scoped to those repos.

## What it looks like

**Before** — task detail page ends at the transcript; the PR the agent opened is only findable in the chat log:

```text
● Completed · 2h ago
Build the artifact-links feature
Timeout 10m
─────────────────────────────────────
(conversation transcript…)
```

**After** — an "Outputs" panel lists the agent's GitHub results as links; the task list shows a count:

```text
● Completed · 2h ago
Build the artifact-links feature
Timeout 10m

OUTPUTS  2
┌──────────────────────────────────────────────┐
│ [PR]  PR #312    Add structured task artifacts  ↗ │
│ [IS]  Issue #45  Surface agent outputs          ↗ │
└──────────────────────────────────────────────┘
```

Task list row:

```text
●  Build the artifact-links feature              Completed
   2h ago   🔗 2
```

**API — before/after request/response:**

```jsonc
// NEW: POST /api/tasks/{taskId}/artifacts
// headers: Authorization: Bearer <agent-token>, x-task-claim-token: <token>
// request:
{ "artifacts": [ { "type": "pull_request", "url": "https://github.com/hivemoot/hivemoot/pull/312", "title": "Add structured task artifacts" } ] }
// response 200:
{ "task": { "...": "...", "artifacts": [ { "type": "pull_request", "url": "…/pull/312", "number": 312, "title": "Add structured task artifacts", "created_at": "2026-05-29T…Z" } ] }, "added": 1 }
```

| Scenario | Response |
|---|---|
| Valid artifacts on a running task | `200` + updated task |
| URL not on `github.com` / wrong scheme / shape mismatch | `400 task_validation_failed` |
| Task not running (claim token already cleared) | `409 task_invalid_transition` |
| Would exceed 20 artifacts | `409 task_artifact_limit_exceeded` |
| Missing/invalid claim token | `403 task_forbidden` |

## Notes

- **Scope:** web only (endpoint + store + dashboard + tests). The issue specifies scoping artifacts to "the repos the task ran against," but tasks carry no per-task repo list — the real boundary is the installation (already enforced by installation-scoped lookups) plus the additive `allowed_repos` token-policy check. The strict `github.com` validator blocks the primary abuse vector (arbitrary external/`javascript:` URLs).
- **Agent adoption is a follow-up** (separate PR in `agent/`) — this PR lands the contract + UI. Until an agent calls the endpoint, the Outputs panel simply doesn't render (fully backward compatible; absent field).
- Tests: `validateTaskArtifacts` (types, host/scheme/shape, number cross-check, title sanitize, repo scoping, caps) + `addTaskArtifacts` (append, dedup, cap, state, carry-through completion) + full route coverage. `npm test` 1871 passing, typecheck/lint/build clean.
