### PR TITLE
refactor(web): unify dashboard UI with a shared component kit

### DIFF
--- a/web/src/app/dashboard/AgentHealthDashboard.tsx
+++ b/web/src/app/dashboard/AgentHealthDashboard.tsx
@@ -10,6 +10,13 @@ import {
   type GroupStatus,
 } from "./agent-health-grouping";
 import { MarkdownContent } from "./MarkdownContent";
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  StatusBadge,
+  type StatusTone,
+} from "@/app/dashboard/ui";
 
 // ---------------------------------------------------------------------------
 // Types (matches server-side HealthOverviewEntry and HealthReport)
@@ -132,6 +139,19 @@ function statusLabel(status: GroupStatus): string {
       return "Late";
     case "unknown":
       return "Unknown";
+  }
+}
+
+function statusTone(status: GroupStatus): StatusTone {
+  switch (status) {
+    case "ok":
+      return "green";
+    case "failed":
+      return "red";
+    case "late":
+      return "amber";
+    case "unknown":
+      return "zinc";
   }
 }
 
@@ -468,9 +488,7 @@ export default function AgentHealthDashboard() {
         {historyLoading ? (
           <p className="text-sm text-zinc-500">Loading history…</p>
         ) : historyError ? (
-          <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-4">
-            <p className="text-sm text-red-400">{historyError}</p>
-          </div>
+          <ErrorBanner tone="red">{historyError}</ErrorBanner>
         ) : history.length === 0 ? (
           <p className="text-sm text-zinc-500">No run history available.</p>
         ) : (
@@ -562,36 +580,20 @@ export default function AgentHealthDashboard() {
   // -------------------------------------------------------------------------
 
   if (loading) {
-    return (
-      <div className="flex items-center gap-3 text-sm text-zinc-500">
-        <PulseIcon className="h-4 w-4 animate-pulse" />
-        Loading agent status…
-      </div>
-    );
+    return <LoadingState label="Loading agent status…" />;
   }
 
   if (error) {
-    return (
-      <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-6">
-        <p className="text-sm text-red-400">{error}</p>
-      </div>
-    );
+    return <ErrorBanner tone="red">{error}</ErrorBanner>;
   }
 
   if (agents.length === 0) {
     return (
-      <div className="rounded-xl border border-white/[0.06] bg-[#141414] p-8 text-center">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-honey-500/10">
-          <PulseIcon className="h-5 w-5 text-honey-500" />
-        </div>
-        <h3 className="mt-4 text-sm font-semibold text-[#fafafa]">
-          No agents reporting
-        </h3>
-        <p className="mt-2 text-sm text-zinc-400">
-          Once your agents start sending health reports, they&apos;ll appear
-          here.
-        </p>
-      </div>
+      <EmptyState
+        icon={<PulseIcon className="h-5 w-5" />}
+        title="No agents reporting"
+        description="Once your agents start sending health reports, they'll appear here."
+      />
     );
   }
 
@@ -639,17 +641,11 @@ export default function AgentHealthDashboard() {
                   if (count === 0) return null;
 
                   return (
-                    <span
+                    <StatusBadge
                       key={status}
-                      className="inline-flex items-center gap-1.5 text-xs text-zinc-300"
-                    >
-                      <span
-                        className={`inline-block h-2 w-2 rounded-full ${
-                          GROUP_STATUS_META[status].colorClass
-                        }`}
-                      />
-                      {count} {GROUP_STATUS_META[status].label}
-                    </span>
+                      tone={statusTone(status)}
+                      label={`${count} ${GROUP_STATUS_META[status].label}`}
+                    />
                   );
                 })}
               </div>
@@ -663,7 +659,7 @@ export default function AgentHealthDashboard() {
                   <button
                     key={`${group.name}:${agent.agent_id}:${agent.repo}`}
                     onClick={() => viewHistory(agent.agent_id, agent.repo)}
-                    className="group rounded-xl border border-white/[0.06] bg-[#141414] p-5 text-left transition-colors hover:border-white/10"
+                    className="group rounded-2xl border border-white/[0.06] bg-[#141414] p-5 text-left transition-colors hover:border-white/10"
                   >
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2.5">

--- a/web/src/app/dashboard/fleet/[owner]/[repo]/roles/RolesPanel.tsx
+++ b/web/src/app/dashboard/fleet/[owner]/[repo]/roles/RolesPanel.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { Card, EmptyState, LoadingState, ErrorBanner } from "@/app/dashboard/ui";
+
 interface RoleEntry {
   name: string;
   description: string;
@@ -14,11 +16,21 @@ type RolesState =
   | { kind: "data"; roles: RoleEntry[]; source: string }
   | { kind: "error"; message: string };
 
-function SpinnerIcon() {
+function DocumentIcon({ className }: { className?: string }) {
   return (
-    <svg className="h-4 w-4 animate-spin" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.25" />
-      <path d="M8 2a6 6 0 0 1 6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    <svg
+      className={className ?? "h-6 w-6"}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8l-5-5z" />
+      <path d="M14 3v5h5" />
+      <path d="M9 13h6M9 17h6" />
     </svg>
   );
 }
@@ -54,18 +66,11 @@ export function RolesPanel({ owner, repo }: { owner: string; repo: string }) {
   }, [owner, repo]);
 
   if (state.kind === "loading") {
-    return (
-      <div className="flex items-center gap-2 text-sm text-zinc-400">
-        <SpinnerIcon />
-        <span>Loading roles…</span>
-      </div>
-    );
+    return <LoadingState label="Loading roles…" />;
   }
 
   if (state.kind === "error") {
-    return (
-      <p className="text-sm text-red-400">Failed to load roles: {state.message}</p>
-    );
+    return <ErrorBanner tone="red">Failed to load roles: {state.message}</ErrorBanner>;
   }
 
   const { roles, source } = state;
@@ -77,32 +82,34 @@ export function RolesPanel({ owner, repo }: { owner: string; repo: string }) {
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <span className="inline-flex items-center rounded-full border border-white/10 bg-zinc-900 px-2.5 py-0.5 text-xs text-zinc-400">
+        <span className="inline-flex items-center rounded-full border border-white/[0.08] bg-white/[0.04] px-2.5 py-0.5 text-xs text-zinc-400">
           {sourceBadge}
         </span>
       </div>
 
       {roles.length === 0 ? (
-        <p className="text-sm text-zinc-500">No roles found in .github/hivemoot.yml.</p>
+        <EmptyState
+          icon={<DocumentIcon />}
+          title="No roles found in .github/hivemoot.yml."
+        />
       ) : (
-        <ul className="divide-y divide-white/5 rounded-lg border border-white/5">
+        <Card padding="none" className="overflow-hidden divide-y divide-white/[0.06]">
           {roles.map((role) => (
-            <li key={role.name}>
-              <Link
-                href={`/dashboard/fleet/${owner}/${repo}/roles/${role.name}`}
-                className="group flex items-center justify-between px-4 py-4 hover:bg-white/[0.02] transition-colors"
-              >
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-[#fafafa]">{role.name}</p>
-                  {role.description && (
-                    <p className="mt-0.5 truncate text-xs text-zinc-400">{role.description}</p>
-                  )}
-                </div>
-                <PencilIcon className="ml-4 h-3.5 w-3.5 flex-shrink-0 text-zinc-600 group-hover:text-honey-500 transition-colors" />
-              </Link>
-            </li>
+            <Link
+              key={role.name}
+              href={`/dashboard/fleet/${owner}/${repo}/roles/${role.name}`}
+              className="group flex items-center justify-between px-4 py-4 hover:bg-white/[0.02] transition-colors"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-[#fafafa]">{role.name}</p>
+                {role.description && (
+                  <p className="mt-0.5 truncate text-xs text-zinc-400">{role.description}</p>
+                )}
+              </div>
+              <PencilIcon className="ml-4 h-3.5 w-3.5 flex-shrink-0 text-zinc-600 group-hover:text-honey-500 transition-colors" />
+            </Link>
           ))}
-        </ul>
+        </Card>
       )}
     </div>
   );

--- a/web/src/app/dashboard/fleet/[owner]/[repo]/roles/[role]/RoleEditor.tsx
+++ b/web/src/app/dashboard/fleet/[owner]/[repo]/roles/[role]/RoleEditor.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { Button, ErrorBanner, LoadingState, Spinner } from "@/app/dashboard/ui";
+
 interface RoleEntry {
   name: string;
   description: string;
@@ -16,14 +18,8 @@ type LoadState =
 
 type SaveState = "idle" | "saving" | "saved" | "conflict" | "error";
 
-function SpinnerIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className ?? "h-4 w-4 animate-spin"} viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.25" />
-      <path d="M8 2a6 6 0 0 1 6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-    </svg>
-  );
-}
+const INPUT_CLASS =
+  "w-full rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-sm text-[#fafafa] placeholder-zinc-600 focus:border-honey-500/30 focus:outline-none focus:ring-2 focus:ring-honey-500/10";
 
 export function RoleEditor({
   owner,
@@ -128,16 +124,11 @@ export function RoleEditor({
   }
 
   if (load.kind === "loading") {
-    return (
-      <div className="flex items-center gap-2 text-sm text-zinc-400">
-        <SpinnerIcon />
-        <span>Loading…</span>
-      </div>
-    );
+    return <LoadingState label="Loading…" />;
   }
 
   if (load.kind === "error") {
-    return <p className="text-sm text-red-400">{load.message}</p>;
+    return <ErrorBanner tone="red">{load.message}</ErrorBanner>;
   }
 
   const { source } = load;
@@ -151,11 +142,11 @@ export function RoleEditor({
       <div className="flex items-center justify-between">
         <Link
           href={`/dashboard/fleet/${owner}/${repo}/roles`}
-          className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+          className="text-xs text-zinc-500 transition-colors hover:text-zinc-300"
         >
           ← Roles
         </Link>
-        <span className="inline-flex items-center rounded-full border border-white/10 bg-zinc-900 px-2.5 py-0.5 text-xs text-zinc-400">
+        <span className="inline-flex items-center rounded-full border border-white/[0.08] bg-white/[0.04] px-2.5 py-0.5 text-xs text-zinc-400">
           {sourceBadge}
         </span>
       </div>
@@ -177,7 +168,7 @@ export function RoleEditor({
               if (saveState === "saved") setSaveState("idle");
             }}
             placeholder="Short description of this role"
-            className="w-full rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm text-[#fafafa] placeholder:text-zinc-600 focus:border-honey-500 focus:outline-none"
+            className={INPUT_CLASS}
           />
         </div>
 
@@ -197,42 +188,44 @@ export function RoleEditor({
             }}
             rows={14}
             placeholder="Role instructions passed to the agent at runtime"
-            className="w-full rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm font-mono text-[#fafafa] placeholder:text-zinc-600 focus:border-honey-500 focus:outline-none resize-y"
+            className={`${INPUT_CLASS} resize-y font-mono`}
           />
         </div>
       </div>
 
       {saveState === "conflict" && (
-        <div className="rounded-md border border-amber-500/30 bg-amber-900/20 px-4 py-3 space-y-2">
-          <p className="text-xs text-amber-300">{conflictMessage}</p>
-          <p className="text-xs text-zinc-400">
-            Your edits are still in the fields above. After reloading the latest config, review
-            any differences and save again.
-          </p>
-          <button
-            onClick={handleConflictReload}
-            className="text-xs text-amber-400 underline hover:text-amber-300 transition-colors"
-          >
-            Reload latest config
-          </button>
-        </div>
+        <ErrorBanner tone="amber">
+          <div className="space-y-2">
+            <p className="text-xs text-amber-300">{conflictMessage}</p>
+            <p className="text-xs text-zinc-400">
+              Your edits are still in the fields above. After reloading the latest config, review
+              any differences and save again.
+            </p>
+            <button
+              onClick={handleConflictReload}
+              className="text-xs text-amber-400 underline transition-colors hover:text-amber-300"
+            >
+              Reload latest config
+            </button>
+          </div>
+        </ErrorBanner>
       )}
 
       <div className="flex items-center gap-4">
-        <button
+        <Button
+          variant="primary"
           onClick={handleSave}
           disabled={saveState === "saving"}
-          className="rounded-md bg-honey-500 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-honey-400 disabled:opacity-50 transition-colors"
         >
           {saveState === "saving" ? (
             <span className="flex items-center gap-2">
-              <SpinnerIcon className="h-3.5 w-3.5 animate-spin" />
+              <Spinner className="h-3.5 w-3.5 animate-spin" />
               Saving…
             </span>
           ) : (
             "Save via PR"
           )}
-        </button>
+        </Button>
 
         {saveState === "saved" && prUrl && (
           <p className="text-xs text-emerald-400">

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
 import AgentHealthDashboard from "./AgentHealthDashboard";
+import { PageHeader } from "@/app/dashboard/ui";
 import { SETUP_SESSION_COOKIE, getSetupSession } from "@/server/setup-session";
 import { getRedisClient } from "@/server/redis";
 import { validateEnv } from "@/server/env";
@@ -104,14 +105,10 @@ export default async function DashboardPage() {
   if (!hasInstallation) {
     return (
       <>
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
-            Welcome to Hivemoot
-          </h1>
-          <p className="mt-2 text-sm text-zinc-400">
-            One step to unlock the dashboard.
-          </p>
-        </div>
+        <PageHeader
+          title="Welcome to Hivemoot"
+          description="One step to unlock the dashboard."
+        />
 
         <ConnectRepoCta />
       </>
@@ -120,14 +117,10 @@ export default async function DashboardPage() {
 
   return (
     <>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
-          Agent Health
-        </h1>
-        <p className="mt-2 text-sm text-zinc-400">
-          Live status of your autonomous agents. Updates every 30 seconds.
-        </p>
-      </div>
+      <PageHeader
+        title="Agent Health"
+        description="Live status of your autonomous agents. Updates every 30 seconds."
+      />
 
       <AgentHealthDashboard />
     </>

--- a/web/src/app/dashboard/rooms/RoomsList.tsx
+++ b/web/src/app/dashboard/rooms/RoomsList.tsx
@@ -4,6 +4,16 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  Button,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  StatusBadge,
+  type StatusTone,
+} from "@/app/dashboard/ui";
+import {
   countRoomsByFilter,
   extractDecisionVerdict,
   hasDiffDriftedPostVerdict,
@@ -13,15 +23,56 @@ import {
   roomMatchesSubjectQuery,
   sortRoomsByStuckness,
   statusLabel,
-  statusPillClass,
   subjectLabel,
   timeUntilDeadline,
   verdictPillClass,
   type RoomStatusFilter,
 } from "./room-helpers";
-import type { RoomCoreWithId } from "./types";
+import type { RoomCoreWithId, RoomStatus } from "./types";
+
+// Map a room's lifecycle status onto the shared UI kit's semantic
+// tones so room pills read with the same dot+label vocabulary as the
+// Tasks screens. The label text itself still comes from
+// `statusLabel()` so the wording stays unchanged:
+//   awaiting_contributions → amber (waiting on contributions)
+//   deciding               → blue  (active synthesis in progress)
+//   closed                 → green (decided / terminal-clean)
+//   expired                → red   (timed out / terminal-error)
+function statusTone(status: RoomStatus): StatusTone {
+  switch (status) {
+    case "awaiting_contributions":
+      return "amber";
+    case "deciding":
+      return "blue";
+    case "closed":
+      return "green";
+    case "expired":
+      return "red";
+    default:
+      return "zinc";
+  }
+}
 
 const REFRESH_INTERVAL_MS = 30_000;
+
+// Inline chat-bubble glyph for the empty-state icon slot. Kept local
+// (the shared kit only ships a Spinner) and sized via `className`.
+function RoomIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.8-.9L3 21l1.9-5.7a8.5 8.5 0 0 1-.9-3.8A8.38 8.38 0 0 1 12.5 3a8.38 8.38 0 0 1 8.5 8.5z" />
+    </svg>
+  );
+}
 
 type FetchState =
   | { status: "loading" }
@@ -113,25 +164,21 @@ export default function RoomsList() {
 
   return (
     <div className="space-y-6">
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-zinc-100">
-            War Rooms
-          </h1>
-          <p className="mt-1 text-sm text-zinc-500">
-            Active and past governance synthesis rooms for this installation.
-            Refreshes every 30 seconds.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => setCreatorOpen(true)}
-          className="inline-flex items-center gap-1.5 rounded-md bg-honey-500/15 px-3 py-1.5 text-sm font-medium text-honey-300 ring-1 ring-honey-500/40 transition-colors hover:bg-honey-500/25"
-        >
-          <span aria-hidden="true">+</span>
-          <span>New war-room</span>
-        </button>
-      </header>
+      <PageHeader
+        title="War Rooms"
+        description="Active and past governance synthesis rooms for this installation. Refreshes every 30 seconds."
+        actions={
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={() => setCreatorOpen(true)}
+          >
+            <span aria-hidden="true">+</span>
+            <span>New war-room</span>
+          </Button>
+        }
+      />
 
       {creatorOpen && (
         <CreateRoomModal
@@ -158,41 +205,52 @@ export default function RoomsList() {
         </div>
       )}
 
-      {state.status === "loading" && (
-        <p className="text-sm text-zinc-500">Loading rooms…</p>
-      )}
+      {state.status === "loading" && <LoadingState label="Loading rooms…" />}
 
       {state.status === "error" && (
-        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
-          <p className="text-sm text-red-300">{state.message}</p>
-          <button
+        <ErrorBanner tone="red">
+          <p>{state.message}</p>
+          <Button
             type="button"
+            variant="secondary"
+            size="sm"
             onClick={fetchRooms}
-            className="mt-2 text-xs text-red-300 underline hover:text-red-200"
+            className="mt-2"
           >
             Retry
-          </button>
-        </div>
+          </Button>
+        </ErrorBanner>
       )}
 
       {state.status === "ready" && state.rooms.length === 0 && (
-        <div className="rounded-lg border border-white/5 bg-zinc-900/50 p-6 text-center">
-          <p className="text-sm text-zinc-400">
-            No war rooms yet. Rooms appear when the bot creates one for a
-            PR review or @hivemoot mention.
-          </p>
-        </div>
+        <EmptyState
+          icon={<RoomIcon className="h-6 w-6" />}
+          title="No war rooms yet"
+          description="Rooms appear when the bot creates one for a PR review or @hivemoot mention."
+          action={
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={() => setCreatorOpen(true)}
+            >
+              <span aria-hidden="true">+</span>
+              <span>New war-room</span>
+            </Button>
+          }
+        />
       )}
 
       {state.status === "ready" &&
         state.rooms.length > 0 &&
         visibleRooms.length === 0 && (
-          <div className="rounded-lg border border-white/5 bg-zinc-900/50 p-6 text-center">
-            <p className="text-sm text-zinc-400">
-              No rooms match the current filter
-              {search.trim() !== "" && ` and search "${search.trim()}"`}.
-            </p>
-          </div>
+          <EmptyState
+            icon={<RoomIcon className="h-6 w-6" />}
+            title="No matching rooms"
+            description={`No rooms match the current filter${
+              search.trim() !== "" ? ` and search "${search.trim()}"` : ""
+            }.`}
+          />
         )}
 
       {state.status === "ready" && visibleRooms.length > 0 && (
@@ -200,11 +258,14 @@ export default function RoomsList() {
         // then terminal rooms by opened_at DESC. Per
         // WAR_ROOM_DESIGN.md L1247 — operators see rooms that
         // need attention without filtering. Closes #553 builder R1.
-        <ul className="divide-y divide-white/5 overflow-hidden rounded-lg border border-white/5 bg-zinc-900/50">
+        <Card
+          padding="none"
+          className="overflow-hidden divide-y divide-white/[0.06]"
+        >
           {visibleRooms.map((room) => (
             <RoomRow key={room.roomId} room={room} />
           ))}
-        </ul>
+        </Card>
       )}
     </div>
   );
@@ -339,18 +400,17 @@ function RoomRow({ room }: { room: RoomCoreWithId }) {
     room.timing_config,
   );
   return (
-    <li className={stuckHighlight}>
+    <div className={stuckHighlight}>
       <Link
         href={`/dashboard/rooms/${room.roomId}`}
         className="block px-4 py-3 transition-colors hover:bg-white/5"
       >
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
-            <span
-              className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusPillClass(room.status)}`}
-            >
-              {statusLabel(room.status)}
-            </span>
+            <StatusBadge
+              tone={statusTone(room.status)}
+              label={statusLabel(room.status)}
+            />
             {verdict && (
               <span
                 className={`rounded-full px-2 py-0.5 text-xs font-medium ${verdictPillClass(verdict)}`}
@@ -395,7 +455,7 @@ function RoomRow({ room }: { room: RoomCoreWithId }) {
           </span>
         </div>
       </Link>
-    </li>
+    </div>
   );
 }
 

--- a/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
+++ b/web/src/app/dashboard/rooms/[roomId]/RoomDetail.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  Card,
+  ErrorBanner,
+  LoadingState,
+  SectionHeader,
+  StatusBadge,
+  type StatusTone,
+} from "@/app/dashboard/ui";
 import { MarkdownContent } from "../../MarkdownContent";
 import {
   heartbeatFreshnessDotClass,
@@ -10,7 +18,6 @@ import {
   participantStatusCounts,
   relativeTime,
   statusLabel,
-  statusPillClass,
   subjectGithubUrl,
   subjectLabel,
 } from "../room-helpers";
@@ -19,7 +26,29 @@ import type {
   RoomDetailResponse,
   RoomEvent,
   RoomParticipant,
+  RoomStatus,
 } from "../types";
+
+/**
+ * Map a room status to a shared-kit StatusBadge tone. Mirrors the
+ * dashboard's color vocabulary (was `statusPillClass`): honey while
+ * awaiting contributions, blue while synthesizing, green when closed,
+ * red when expired. Unknown statuses fall back to a neutral zinc.
+ */
+function statusTone(status: RoomStatus): StatusTone {
+  switch (status) {
+    case "awaiting_contributions":
+      return "honey";
+    case "deciding":
+      return "blue";
+    case "closed":
+      return "green";
+    case "expired":
+      return "red";
+    default:
+      return "zinc";
+  }
+}
 
 const REFRESH_INTERVAL_MS = 30_000;
 
@@ -79,12 +108,10 @@ export default function RoomDetail({ roomId }: { roomId: string }) {
         </Link>
       </nav>
 
-      {state.status === "loading" && (
-        <p className="text-sm text-zinc-500">Loading room…</p>
-      )}
+      {state.status === "loading" && <LoadingState label="Loading room…" />}
 
       {state.status === "not_found" && (
-        <div className="rounded-lg border border-white/5 bg-zinc-900/50 p-6">
+        <Card padding="md">
           <p className="text-sm text-zinc-300">
             Room <span className="font-mono">{roomId}</span> not found.
           </p>
@@ -92,20 +119,20 @@ export default function RoomDetail({ roomId }: { roomId: string }) {
             It may have expired (30-day retention after close), or it
             belongs to a different installation.
           </p>
-        </div>
+        </Card>
       )}
 
       {state.status === "error" && (
-        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
-          <p className="text-sm text-red-300">{state.message}</p>
+        <ErrorBanner tone="red">
+          <p>{state.message}</p>
           <button
             type="button"
             onClick={fetchDetail}
-            className="mt-2 text-xs text-red-300 underline hover:text-red-200"
+            className="mt-2 text-xs underline hover:text-red-300"
           >
             Retry
           </button>
-        </div>
+        </ErrorBanner>
       )}
 
       {state.status === "ready" && (
@@ -130,16 +157,15 @@ function RoomDetailContent({
     <>
       <header className="space-y-2">
         <div className="flex flex-wrap items-center gap-3">
-          <span
-            className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusPillClass(core.status)}`}
-          >
-            {statusLabel(core.status)}
-          </span>
+          <StatusBadge
+            tone={statusTone(core.status)}
+            label={statusLabel(core.status)}
+          />
           <span className="text-xs uppercase tracking-wide text-zinc-500">
             {subjectLabel(core.subject_type)}
           </span>
         </div>
-        <h1 className="text-xl font-semibold text-zinc-100">
+        <h1 className="text-xl font-semibold text-[#fafafa]">
           {githubUrl ? (
             <a
               href={githubUrl}
@@ -178,13 +204,15 @@ function RoomDetailContent({
       </header>
 
       <section>
-        <h2 className="mb-2 text-sm font-semibold text-zinc-300">
-          Participants ({partCounts.total})
-        </h2>
+        <SectionHeader
+          title={`Participants (${partCounts.total})`}
+          className="mb-2"
+        />
         {partCounts.total === 0 ? (
-          <p className="text-sm text-zinc-500">
-            No participants have RSVP&apos;d yet.
-          </p>
+          <SubsectionEmpty
+            icon={<ParticipantsIcon />}
+            label="No participants have RSVP'd yet."
+          />
         ) : (
           <p className="mb-3 text-xs text-zinc-500">
             {partCounts.resolved} resolved · {partCounts.pending} pending ·{" "}
@@ -195,11 +223,15 @@ function RoomDetailContent({
       </section>
 
       <section>
-        <h2 className="mb-2 text-sm font-semibold text-zinc-300">
-          Contributions ({Object.keys(contributions).length})
-        </h2>
+        <SectionHeader
+          title={`Contributions (${Object.keys(contributions).length})`}
+          className="mb-2"
+        />
         {Object.keys(contributions).length === 0 ? (
-          <p className="text-sm text-zinc-500">No contributions submitted.</p>
+          <SubsectionEmpty
+            icon={<ContributionsIcon />}
+            label="No contributions submitted."
+          />
         ) : (
           <ContributionsList contributions={contributions} />
         )}
@@ -207,17 +239,18 @@ function RoomDetailContent({
 
       {core.decision && (
         <section>
-          <h2 className="mb-2 text-sm font-semibold text-zinc-300">Decision</h2>
+          <SectionHeader title="Decision" className="mb-2" />
           <DecisionBlock decision={core.decision} />
         </section>
       )}
 
       <section>
-        <h2 className="mb-2 text-sm font-semibold text-zinc-300">
-          Recent events ({events.length})
-        </h2>
+        <SectionHeader
+          title={`Recent events (${events.length})`}
+          className="mb-2"
+        />
         {events.length === 0 ? (
-          <p className="text-sm text-zinc-500">No events yet.</p>
+          <SubsectionEmpty icon={<EventsIcon />} label="No events yet." />
         ) : (
           <EventsList events={events} />
         )}
@@ -325,7 +358,7 @@ function ContributionsList({
               >
                 {initial}
               </div>
-              <div className="min-w-0 flex-1 rounded-2xl border border-white/5 bg-zinc-900/60 px-4 py-3">
+              <Card padding="none" className="min-w-0 flex-1 px-4 py-3">
                 {/* Header: role · verdict · timestamp. Time pushed
                     to the right via ml-auto so the visual rhythm
                     is consistent with chat clients (sender top-left,
@@ -368,7 +401,7 @@ function ContributionsList({
                     )}
                   </>
                 )}
-              </div>
+              </Card>
             </li>
           );
         })}
@@ -382,10 +415,13 @@ function DecisionBlock({
   decision: NonNullable<RoomDetailResponse["core"]["decision"]>;
 }) {
   return (
-    <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.04] px-4 py-3">
+    // Card with a green accent override — the decision block is
+    // semantically "decided", so it keeps a green-tinted border/bg
+    // (kit's green tone) instead of the neutral panel surface.
+    <Card padding="none" className="border-green-500/20 bg-green-500/[0.04] px-4 py-3">
       <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
         <span>
-          <span className="text-emerald-400">●</span> synthesized{" "}
+          <span className="text-green-400">●</span> synthesized{" "}
           {relativeTime(decision.synthesized_at)}
         </span>
         <span>·</span>
@@ -394,7 +430,7 @@ function DecisionBlock({
         <span>through seq {decision.sequence_closed}</span>
       </div>
       <MarkdownContent>{decision.content}</MarkdownContent>
-    </div>
+    </Card>
   );
 }
 
@@ -402,23 +438,104 @@ function EventsList({ events }: { events: RoomEvent[] }) {
   return (
     <ol className="space-y-1 text-xs">
       {events.map((e) => (
-        <li
-          key={e.seq}
-          className="flex items-baseline gap-3 rounded border border-white/5 bg-zinc-900/30 px-2 py-1"
-        >
-          <span className="font-mono text-zinc-600">#{e.seq}</span>
-          <span className="font-medium text-zinc-300">{e.event_type}</span>
-          <span className="text-zinc-500">
-            by{" "}
-            <span className="font-mono">
-              {e.actor_role}/{e.actor_id}
+        <li key={e.seq}>
+          <Card
+            padding="none"
+            className="flex items-baseline gap-3 px-2 py-1"
+          >
+            <span className="font-mono text-zinc-600">#{e.seq}</span>
+            <span className="font-medium text-zinc-300">{e.event_type}</span>
+            <span className="text-zinc-500">
+              by{" "}
+              <span className="font-mono">
+                {e.actor_role}/{e.actor_id}
+              </span>
             </span>
-          </span>
-          <span className="ml-auto text-zinc-600">
-            {relativeTime(e.timestamp)}
-          </span>
+            <span className="ml-auto text-zinc-600">
+              {relativeTime(e.timestamp)}
+            </span>
+          </Card>
         </li>
       ))}
     </ol>
+  );
+}
+
+/**
+ * Lighter inline empty-state for the room's subsections. A full
+ * EmptyState Card (centered, py-14) is too heavy stacked three times
+ * inside this single page, so each subsection gets a compact muted
+ * icon + label instead. Kept consistent across Participants /
+ * Contributions / Events.
+ */
+function SubsectionEmpty({
+  icon,
+  label,
+}: {
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <p className="flex items-center gap-2 text-sm text-zinc-500">
+      <span className="text-zinc-600">{icon}</span>
+      {label}
+    </p>
+  );
+}
+
+function ParticipantsIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="6" cy="5" r="2.5" />
+      <path d="M1.5 13.5a4.5 4.5 0 0 1 9 0" />
+      <path d="M11 3.2a2.5 2.5 0 0 1 0 4.6" />
+      <path d="M12.5 13.5a4.5 4.5 0 0 0-2.2-3.8" />
+    </svg>
+  );
+}
+
+function ContributionsIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2.5 3.5h11v8h-7l-3 2.5z" />
+      <path d="M5 6.5h6" />
+      <path d="M5 8.8h4" />
+    </svg>
+  );
+}
+
+function EventsIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="6" />
+      <path d="M8 4.5V8l2.2 2.2" />
+    </svg>
   );
 }

--- a/web/src/app/dashboard/settings/SettingsDashboard.tsx
+++ b/web/src/app/dashboard/settings/SettingsDashboard.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
+import { Button, Card, ErrorBanner, LoadingState, PageHeader } from "@/app/dashboard/ui";
+
 type QueenMode = "cloud" | "local";
 
 interface QueenSettings {
@@ -141,28 +143,26 @@ export default function SettingsDashboard() {
   );
 
   if (load.kind === "loading") {
-    return (
-      <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center">
-        <p className="text-sm text-zinc-400">Loading settings…</p>
-      </div>
-    );
+    return <LoadingState label="Loading settings…" />;
   }
 
   if (load.kind === "error") {
     return (
-      <div className="rounded-lg border border-rose-500/30 bg-rose-500/5 p-8">
-        <h2 className="mb-2 text-lg font-semibold text-rose-300">
+      <Card padding="lg">
+        <h2 className="mb-2 text-lg font-semibold text-red-400">
           Couldn&apos;t load settings
         </h2>
-        <p className="text-sm text-zinc-400">{load.message}</p>
-        <button
+        <ErrorBanner tone="red">{load.message}</ErrorBanner>
+        <Button
+          variant="secondary"
+          size="sm"
           type="button"
           onClick={() => void fetchSettings()}
-          className="mt-4 inline-flex items-center gap-2 rounded-md bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-200 hover:bg-zinc-700"
+          className="mt-4"
         >
           Retry
-        </button>
-      </div>
+        </Button>
+      </Card>
     );
   }
 
@@ -175,20 +175,20 @@ export default function SettingsDashboard() {
 
   return (
     <>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
-          Settings
-        </h1>
-        <p className="mt-2 text-sm text-zinc-400">
-          Per-installation configuration. See also{" "}
-          <Link href="/dashboard/settings/byok" className="text-honey-400 hover:underline">
-            BYOK credentials
-          </Link>
-          .
-        </p>
-      </div>
+      <PageHeader
+        title="Settings"
+        description={
+          <>
+            Per-installation configuration. See also{" "}
+            <Link href="/dashboard/settings/byok" className="text-honey-400 hover:underline">
+              BYOK credentials
+            </Link>
+            .
+          </>
+        }
+      />
 
-      <section className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900 p-6">
+      <Card padding="lg" className="mb-8">
         <h2 className="text-lg font-semibold text-[#fafafa]">Queen execution mode</h2>
         <p className="mt-1 text-sm text-zinc-400">
           Where war-room synthesis runs for installation{" "}
@@ -238,39 +238,39 @@ export default function SettingsDashboard() {
         </details>
 
         <div className="mt-6 flex items-center gap-3">
-          <button
+          <Button
+            variant="primary"
             type="button"
             disabled={!dirty || save.kind === "saving"}
             onClick={() => {
               if (modeChanged) setConfirmFlip(draftMode);
               else void handleSave();
             }}
-            className="inline-flex items-center gap-2 rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] transition-colors hover:bg-honey-400 disabled:cursor-not-allowed disabled:bg-zinc-700 disabled:text-zinc-500"
           >
             {save.kind === "saving" ? "Saving…" : "Save"}
-          </button>
+          </Button>
           {dirty && save.kind !== "saving" && (
-            <button
+            <Button
+              variant="secondary"
               type="button"
               onClick={() => {
                 setDraftMode(settings.queen_mode);
                 setDraftOverride(settings.queen_prompt_override ?? "");
                 setSave({ kind: "idle" });
               }}
-              className="text-sm text-zinc-400 hover:text-zinc-200"
             >
               Cancel
-            </button>
+            </Button>
           )}
           {save.kind === "error" && (
-            <p className="text-sm text-rose-300">{save.message}</p>
+            <p className="text-sm text-red-400">{save.message}</p>
           )}
         </div>
 
         {save.kind === "blocked" && (
           <BlockedRoomsBanner blocked={save.blocked} />
         )}
-      </section>
+      </Card>
 
       {confirmFlip !== null && (
         <FlipConfirmModal
@@ -417,30 +417,30 @@ function FlipConfirmModal({
       aria-modal="true"
       aria-labelledby="flip-modal-title"
     >
-      <div className="w-full max-w-lg rounded-lg border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
+      <Card padding="lg" className="w-full max-w-lg shadow-2xl">
         <h3 id="flip-modal-title" className="text-lg font-semibold text-[#fafafa]">
           Confirm mode flip: {currentMode} → {targetMode}
         </h3>
         <p className="mt-3 text-sm text-zinc-300">{message}</p>
         <div className="mt-6 flex justify-end gap-3">
-          <button
+          <Button
+            variant="secondary"
             type="button"
             onClick={onCancel}
-            className="rounded-md px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
             disabled={saving}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
             type="button"
             onClick={onConfirm}
             disabled={saving}
-            className="rounded-md bg-honey-500 px-4 py-2 text-sm font-semibold text-[#111114] hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? "Flipping…" : "Confirm flip"}
-          </button>
+          </Button>
         </div>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/web/src/app/dashboard/settings/byok/page.tsx
+++ b/web/src/app/dashboard/settings/byok/page.tsx
@@ -10,11 +10,15 @@ import {
   SETUP_SESSION_COOKIE,
 } from "@/server/setup-session";
 import ByokPanel from "./ByokPanel";
+import { PageHeader } from "@/app/dashboard/ui";
 
 export const metadata: Metadata = {
   title: "BYOK Credentials — Hivemoot Dashboard",
   description: "Manage LLM API keys and agent tokens.",
 };
+
+const CREDENTIALS_DESCRIPTION =
+  "Manage your LLM API key and agent authentication token.";
 
 export default async function ByokSettingsPage() {
   const cookieStore = await cookies();
@@ -49,14 +53,7 @@ export default async function ByokSettingsPage() {
   if (!hasInstallation) {
     return (
       <>
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
-            Credentials
-          </h1>
-          <p className="mt-2 text-sm text-zinc-400">
-            Manage your LLM API key and agent authentication token.
-          </p>
-        </div>
+        <PageHeader title="Credentials" description={CREDENTIALS_DESCRIPTION} />
 
         <div className="rounded-lg border border-honey-500/20 bg-honey-500/5 p-8 text-center">
           <p className="mb-4 text-sm text-zinc-300">
@@ -78,16 +75,9 @@ export default async function ByokSettingsPage() {
   if (!fresh) {
     return (
       <>
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">
-            Credentials
-          </h1>
-          <p className="mt-2 text-sm text-zinc-400">
-            Manage your LLM API key and agent authentication token.
-          </p>
-        </div>
+        <PageHeader title="Credentials" description={CREDENTIALS_DESCRIPTION} />
 
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center">
+        <div className="rounded-2xl border border-white/[0.06] bg-[#141414] p-8 text-center">
           <p className="text-sm text-zinc-300 mb-4">
             Re-authenticate to access your credentials. This page requires a fresh login
             (within the last 15 minutes) for security.

--- a/web/src/app/dashboard/ui.tsx
+++ b/web/src/app/dashboard/ui.tsx
@@ -1,0 +1,270 @@
+/**
+ * Shared dashboard UI kit — the single source of truth for the dashboard's
+ * visual language. Derived from the Tasks screens (the reference design).
+ *
+ * These are presentational components with no hooks, so they're usable from
+ * both server and client components. Screens should render their chrome
+ * (cards, headers, status, empty/loading/error states, buttons) from here
+ * instead of hand-rolling class strings, so the whole dashboard stays
+ * consistent.
+ */
+
+import Link from "next/link";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+// ---------------------------------------------------------------------------
+// Status palette — one place that maps a semantic tone to Tailwind classes.
+// ---------------------------------------------------------------------------
+
+export type StatusTone = "green" | "blue" | "zinc" | "amber" | "red" | "honey";
+
+interface ToneClasses {
+  text: string;
+  dot: string;
+  bg: string;
+}
+
+const TONE: Record<StatusTone, ToneClasses> = {
+  green: { text: "text-green-400", dot: "bg-green-400", bg: "bg-green-500/10" },
+  blue: { text: "text-blue-400", dot: "bg-blue-400", bg: "bg-blue-500/10" },
+  zinc: { text: "text-zinc-400", dot: "bg-zinc-400", bg: "bg-zinc-500/10" },
+  amber: { text: "text-amber-400", dot: "bg-amber-400", bg: "bg-amber-500/10" },
+  red: { text: "text-red-400", dot: "bg-red-400", bg: "bg-red-500/10" },
+  honey: { text: "text-honey-400", dot: "bg-honey-400", bg: "bg-honey-500/10" },
+};
+
+export function toneClasses(tone: StatusTone): ToneClasses {
+  return TONE[tone];
+}
+
+// ---------------------------------------------------------------------------
+// Icons (kept here so the kit is self-contained)
+// ---------------------------------------------------------------------------
+
+export function Spinner({ className }: { className?: string }) {
+  return (
+    <svg className={className ?? "h-4 w-4 animate-spin"} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.25" />
+      <path d="M8 2a6 6 0 0 1 6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card — the canonical panel container.
+// ---------------------------------------------------------------------------
+
+export function Card({
+  children,
+  className = "",
+  padding = "md",
+}: {
+  children: ReactNode;
+  className?: string;
+  /** md = p-4 sm:p-6 (default), lg = p-6 sm:p-8, none = no padding (e.g. lists). */
+  padding?: "none" | "md" | "lg";
+}) {
+  const pad = padding === "lg" ? "p-6 sm:p-8" : padding === "md" ? "p-4 sm:p-6" : "";
+  return (
+    <div className={`rounded-2xl border border-white/[0.06] bg-[#141414] ${pad} ${className}`.trim()}>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page + section headers
+// ---------------------------------------------------------------------------
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  /** Right-aligned actions (buttons, links). */
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+      <div className="min-w-0">
+        <h1 className="text-2xl font-bold tracking-tight text-[#fafafa]">{title}</h1>
+        {description && (
+          <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-zinc-400">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+export function SectionHeader({
+  title,
+  description,
+  className = "",
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <h2 className="text-sm font-semibold text-[#fafafa]">{title}</h2>
+      {description && <p className="mt-1 text-sm text-zinc-400">{description}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// State components: loading / empty / error
+// ---------------------------------------------------------------------------
+
+export function LoadingState({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div className="flex items-center gap-3 py-12 text-sm text-zinc-500">
+      <Spinner />
+      {label}
+    </div>
+  );
+}
+
+export function ErrorBanner({
+  children,
+  tone = "red",
+  className = "",
+}: {
+  children: ReactNode;
+  tone?: "red" | "amber";
+  className?: string;
+}) {
+  const styles =
+    tone === "amber"
+      ? "border-amber-500/20 bg-amber-500/5 text-amber-400"
+      : "border-red-500/20 bg-red-500/5 text-red-400";
+  return (
+    <div className={`rounded-lg border px-4 py-3 ${styles} ${className}`.trim()}>
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <Card className="flex flex-col items-center justify-center py-14 text-center">
+      {icon && (
+        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-honey-500/10 text-honey-500">
+          {icon}
+        </div>
+      )}
+      <p className="text-sm font-semibold text-[#fafafa]">{title}</p>
+      {description && <p className="mt-1.5 max-w-sm text-sm text-zinc-500">{description}</p>}
+      {action && <div className="mt-5">{action}</div>}
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StatusBadge — pill with a colored dot + label.
+// ---------------------------------------------------------------------------
+
+export function StatusBadge({
+  tone,
+  label,
+  pulse = false,
+}: {
+  tone: StatusTone;
+  label: ReactNode;
+  /** Animate the dot (e.g. for "running"). */
+  pulse?: boolean;
+}) {
+  const t = TONE[tone];
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 ${t.bg}`}>
+      <span className={`h-1.5 w-1.5 rounded-full ${t.dot} ${pulse ? "animate-pulse" : ""}`} />
+      <span className={`text-xs font-medium ${t.text}`}>{label}</span>
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Button — primary / secondary / danger, optionally rendered as a Link.
+// ---------------------------------------------------------------------------
+
+type ButtonVariant = "primary" | "secondary" | "danger";
+type ButtonSize = "sm" | "md";
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary:
+    "bg-honey-500 font-semibold text-[#0a0a0a] hover:bg-honey-400 disabled:cursor-not-allowed disabled:opacity-50",
+  secondary:
+    "border border-white/[0.08] text-zinc-300 hover:border-white/20 hover:text-[#fafafa] disabled:cursor-not-allowed disabled:opacity-50",
+  danger:
+    "border border-white/[0.08] text-zinc-400 hover:border-red-500/30 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50",
+};
+
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: "gap-1.5 rounded-lg px-3 py-1.5 text-xs",
+  md: "gap-2 rounded-lg px-4 py-2 text-sm",
+};
+
+function buttonClassName(variant: ButtonVariant, size: ButtonSize, extra = ""): string {
+  return `inline-flex items-center justify-center font-medium transition-colors ${VARIANT_CLASSES[variant]} ${SIZE_CLASSES[size]} ${extra}`.trim();
+}
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  className = "",
+  children,
+  ...props
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+} & ComponentPropsWithoutRef<"button">) {
+  return (
+    <button className={buttonClassName(variant, size, className)} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export function ButtonLink({
+  variant = "primary",
+  size = "md",
+  className = "",
+  href,
+  children,
+  external = false,
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+  href: string;
+  children: ReactNode;
+  external?: boolean;
+}) {
+  const cls = buttonClassName(variant, size, className);
+  if (external) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={cls}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className={cls}>
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## What

Introduce a shared dashboard UI kit (`web/src/app/dashboard/ui.tsx`) and migrate the dashboard screens to render their chrome from it, so the whole dashboard shares one visual language.

## Why

The dashboard had drifted into an inconsistent patchwork: three competing card recipes (`bg-[#141414]` vs `bg-zinc-900/50` vs `border-zinc-800 bg-zinc-900`), mixed corner radii (`rounded-md`/`xl`/`2xl`), two different status-badge styles (dot+text vs `bg/15 + ring`), `rose` vs `red` errors, and several text-only empty states. The Tasks screens already looked polished; everything else felt unfinished next to them. This makes the dashboard feel cohesive and "usable + clean" without changing any behavior.

## What's in the kit

`Card`, `PageHeader`, `SectionHeader`, `StatusBadge`, `EmptyState`, `LoadingState`, `ErrorBanner`, `Button`/`ButtonLink`, plus a single `toneClasses()` status palette — all derived from the Tasks reference (`rounded-2xl border-white/[0.06] bg-[#141414]`, honey accents, the green/blue/zinc/amber/red status colors).

## What it looks like

Every screen now shares the same page header, card, status badge, and empty/loading/error chrome. Concretely:

| Screen | Before | After |
|---|---|---|
| Settings | `border-zinc-800 bg-zinc-900` cards, `rose-500` errors | `Card` + red `ErrorBanner` (matches Tasks) |
| War Rooms | `bg-zinc-900/50` list, `bg/15 + ring` status pills, text-only empty | `Card` list, `StatusBadge` (dot+label), icon `EmptyState` |
| Room detail | `bg-zinc-900/60` + `bg-zinc-900/30` mixed panels, text-only empties | unified `Card` panels, `StatusBadge`, consistent empties |
| Agent Health | `rounded-xl` cards | `rounded-2xl` `Card`, `StatusBadge`, `LoadingState`/`ErrorBanner` |
| Roles list / editor | bare list, `rounded-md bg-zinc-900` inputs | `Card` list + icon `EmptyState`; canonical input style; amber `ErrorBanner` for conflicts |
| Page headers | duplicated h1 markup across 4 files | one `PageHeader` |

Error/empty/loading states (the parts visible without live data) now render identically across screens — e.g. the load-error on War Rooms, Settings, and Agent Health is the same `Card` + red `ErrorBanner` + secondary Retry, where before each used a different palette.

## Notes

- **Visual-only**: no logic, data fetching, polling, handlers, props, routing, `data-testid`/`aria`, or grouping/counts were changed. The Tasks screens (the reference) and ByokPanel (already consistent) keep their existing inline markup; the kit is the canonical implementation new/fixed screens render from.
- Conservative where it mattered: Agent Health's interactive per-agent cards stay `<button>`s (only the radius was normalized); Room detail uses a lighter inline empty treatment for its three stacked subsections rather than three full empty-state cards.
- Verified: `npm test` 1897 passing, typecheck/lint (0 errors)/build all clean; landing + dashboard render confirmed in a local browser (headers + error/empty chrome consistent across screens).
- Owner-directed dashboard consistency pass; not tied to a `ready-to-implement` issue.
