### PR TITLE
feat(model-cred): per-installation encrypted model-credential store (stage 1)

### DIFF
--- a/web/src/app/api/model-credentials/[name]/re-encrypt/route.ts
+++ b/web/src/app/api/model-credentials/[name]/re-encrypt/route.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /api/model-credentials/[name]/re-encrypt  (MODEL_AUTH_DESIGN.md §5.3)
+ *
+ * Master-key rebind: decrypt with the old key version, re-encrypt with the
+ * current active version, preserve everything else (mirrors byok/re-encrypt).
+ * Skips revoked / already-current envelopes. requireFresh:true (mutation).
+ * Never returns the secret.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { reEncryptModelCredential } from "@/server/model-credential-store";
+import { mapModelCredentialError } from "@/server/model-credential-routes";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const { name } = await params;
+
+  try {
+    const result = await reEncryptModelCredential({
+      installationId,
+      name,
+      activeKeyVersion: auth.activeKeyVersion,
+      keyring: auth.keyring,
+      redis: auth.redis,
+      auditContext: { operator: auth.session.userLogin },
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    return mapModelCredentialError(err, {
+      route: "POST /api/model-credentials/[name]/re-encrypt",
+      installationId,
+      name,
+    });
+  }
+}

--- a/web/src/app/api/model-credentials/[name]/revoke/route.ts
+++ b/web/src/app/api/model-credentials/[name]/revoke/route.ts
@@ -1,0 +1,43 @@
+/**
+ * POST /api/model-credentials/[name]/revoke  (MODEL_AUTH_DESIGN.md §5.3)
+ *
+ * status → revoked + blank ciphertext, keep metadata for audit (mirrors
+ * byok/revoke). requireFresh:true (mutation). Never returns the secret.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { revokeModelCredential } from "@/server/model-credential-store";
+import { mapModelCredentialError } from "@/server/model-credential-routes";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const { name } = await params;
+
+  try {
+    const summary = await revokeModelCredential({
+      installationId,
+      name,
+      revokedBy: auth.session.userLogin,
+      redis: auth.redis,
+      auditContext: { operator: auth.session.userLogin },
+    });
+    return NextResponse.json(summary);
+  } catch (err) {
+    return mapModelCredentialError(err, {
+      route: "POST /api/model-credentials/[name]/revoke",
+      installationId,
+      name,
+    });
+  }
+}

--- a/web/src/app/api/model-credentials/[name]/rotate/route.ts
+++ b/web/src/app/api/model-credentials/[name]/rotate/route.ts
@@ -1,0 +1,121 @@
+/**
+ * POST /api/model-credentials/[name]/rotate  (MODEL_AUTH_DESIGN.md §5.3)
+ *
+ * Swap a credential's secret VALUE: re-validate (live probe for api_key),
+ * re-encrypt, update fingerprint + rotatedAt, preserve provider/kind.
+ * requireFresh:true (mutation). Never returns/logs the secret value.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { validateProviderKey } from "@/server/provider-validation";
+import {
+  getModelCredential,
+  rotateModelCredential,
+} from "@/server/model-credential-store";
+import {
+  MODEL_CREDENTIAL_ERROR,
+  mcError,
+  readJsonObject,
+  mapModelCredentialError,
+} from "@/server/model-credential-routes";
+
+const LIVE_VALIDATABLE_PROVIDERS = new Set([
+  "anthropic",
+  "openai",
+  "google",
+  "openrouter",
+]);
+
+interface RotateBody {
+  value?: unknown;
+  expiresAt?: unknown;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const { name } = await params;
+
+  const parsed = await readJsonObject(request);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body as RotateBody;
+
+  if (typeof body.value !== "string" || body.value.length === 0) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.VALIDATION,
+      "Missing or invalid 'value'.",
+      400,
+    );
+  }
+  let expiresAt: string | null | undefined;
+  if (body.expiresAt !== undefined) {
+    if (body.expiresAt === null) {
+      expiresAt = null;
+    } else if (
+      typeof body.expiresAt !== "string" ||
+      Number.isNaN(new Date(body.expiresAt).getTime())
+    ) {
+      return mcError(
+        MODEL_CREDENTIAL_ERROR.VALIDATION,
+        "'expiresAt' must be an ISO 8601 timestamp or null.",
+        400,
+      );
+    } else {
+      expiresAt = body.expiresAt;
+    }
+  }
+  const value: string = body.value;
+
+  try {
+    // Read the existing envelope (404 if absent / not yours) to learn the
+    // provider+kind, which are fixed at create and govern re-validation.
+    const existing = await getModelCredential({
+      installationId,
+      name,
+      redis: auth.redis,
+    });
+
+    if (
+      existing.kind === "api_key" &&
+      LIVE_VALIDATABLE_PROVIDERS.has(existing.provider)
+    ) {
+      const validation = await validateProviderKey(existing.provider, value);
+      if (!validation.valid) {
+        return mcError(
+          MODEL_CREDENTIAL_ERROR.VALIDATION,
+          validation.reason ?? "Provider rejected the API key.",
+          400,
+        );
+      }
+    }
+
+    const summary = await rotateModelCredential({
+      installationId,
+      name,
+      value,
+      rotatedBy: auth.session.userLogin,
+      expiresAt,
+      keyring: auth.keyring,
+      keyVersion: auth.activeKeyVersion,
+      redis: auth.redis,
+      auditContext: { operator: auth.session.userLogin },
+    });
+    return NextResponse.json(summary);
+  } catch (err) {
+    return mapModelCredentialError(err, {
+      route: "POST /api/model-credentials/[name]/rotate",
+      installationId,
+      name,
+    });
+  }
+}

--- a/web/src/app/api/model-credentials/[name]/route.test.ts
+++ b/web/src/app/api/model-credentials/[name]/route.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Route tests for /api/model-credentials/[name] and its lifecycle verbs
+ * (GET summary, rotate, revoke, re-encrypt).
+ *
+ * Asserts the route contract:
+ *   - GET passes requireFresh:false; rotate/revoke/re-encrypt pass true
+ *   - GET / rotate / revoke never return ciphertext
+ *   - IDOR: a foreign name → 404 scoped to the caller (store throws NotFound)
+ *   - rotate live-validates an api_key before re-encrypting
+ *   - installationId comes from the session, never the path/body
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+vi.mock("@/server/require-installation", () => ({
+  requireInstallation: vi.fn(),
+}));
+vi.mock("@/server/provider-validation", () => ({
+  validateProviderKey: vi.fn(),
+}));
+vi.mock("@/server/model-credential-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/server/model-credential-store")
+  >("@/server/model-credential-store");
+  return {
+    ...actual,
+    getModelCredentialSummary: vi.fn(),
+    getModelCredential: vi.fn(),
+    rotateModelCredential: vi.fn(),
+    revokeModelCredential: vi.fn(),
+    reEncryptModelCredential: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { validateProviderKey } from "@/server/provider-validation";
+import {
+  getModelCredentialSummary,
+  getModelCredential,
+  rotateModelCredential,
+  revokeModelCredential,
+  reEncryptModelCredential,
+  ModelCredentialNotFoundError,
+} from "@/server/model-credential-store";
+
+import { GET } from "./route";
+import { POST as ROTATE } from "./rotate/route";
+import { POST as REVOKE } from "./revoke/route";
+import { POST as REENCRYPT } from "./re-encrypt/route";
+
+const mockAuth = vi.mocked(authenticateByokRequest);
+const mockRequireInstallation = vi.mocked(requireInstallation);
+const mockValidate = vi.mocked(validateProviderKey);
+const mockGetSummary = vi.mocked(getModelCredentialSummary);
+const mockGet = vi.mocked(getModelCredential);
+const mockRotate = vi.mocked(rotateModelCredential);
+const mockRevoke = vi.mocked(revokeModelCredential);
+const mockReEncrypt = vi.mocked(reEncryptModelCredential);
+
+function authedSession() {
+  mockAuth.mockResolvedValue({
+    ok: true,
+    session: { userLogin: "operator", installationId: "12345" },
+    keyring: new Map([["v1", Buffer.alloc(32)]]),
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  } as never);
+  mockRequireInstallation.mockReturnValue({
+    ok: true,
+    installationId: "12345",
+  } as never);
+}
+
+function makeRequest(body?: unknown) {
+  return {
+    body: body === undefined ? null : {},
+    json: async () => body,
+    cookies: { get: () => undefined },
+  } as never;
+}
+
+function params(name: string) {
+  return { params: Promise.resolve({ name }) };
+}
+
+const SUMMARY = {
+  name: "team-claude",
+  kind: "api_key" as const,
+  provider: "anthropic" as const,
+  status: "active" as const,
+  fingerprint: "deadbeef",
+  createdAt: "2026-05-30T00:00:00.000Z",
+  createdBy: "operator",
+  rotatedAt: null,
+  expiresAt: null,
+  deliverable: true,
+};
+
+const FULL_ENVELOPE = {
+  ...SUMMARY,
+  ciphertext: "AAAA",
+  iv: "BBBB",
+  tag: "CCCC",
+  keyVersion: "v1",
+};
+
+// ---------------------------------------------------------------------------
+// GET [name]
+// ---------------------------------------------------------------------------
+
+describe("GET /api/model-credentials/[name]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+    mockGetSummary.mockResolvedValue(SUMMARY);
+  });
+
+  it("does NOT require a fresh session (read)", async () => {
+    await GET(makeRequest(), params("team-claude"));
+    expect(mockAuth).toHaveBeenCalledWith(expect.anything());
+    expect(mockAuth.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("returns the summary, never ciphertext", async () => {
+    const res = await GET(makeRequest(), params("team-claude"));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect("ciphertext" in json).toBe(false);
+    expect(json.name).toBe("team-claude");
+  });
+
+  it("uses the SESSION installationId, not anything from the path", async () => {
+    await GET(makeRequest(), params("team-claude"));
+    expect(mockGetSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345", name: "team-claude" }),
+    );
+  });
+
+  it("IDOR: a foreign name → 404 (store throws NotFound)", async () => {
+    mockGetSummary.mockRejectedValue(
+      new ModelCredentialNotFoundError("12345", "someone-elses"),
+    );
+    const res = await GET(makeRequest(), params("someone-elses"));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotate
+// ---------------------------------------------------------------------------
+
+describe("POST /api/model-credentials/[name]/rotate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+    mockGet.mockResolvedValue(FULL_ENVELOPE);
+    mockValidate.mockResolvedValue({ valid: true });
+    mockRotate.mockResolvedValue({ ...SUMMARY, rotatedAt: "2026-05-30T01:00:00.000Z" });
+  });
+
+  it("requires a FRESH session (requireFresh:true)", async () => {
+    await ROTATE(makeRequest({ value: "sk-ant-new" }), params("team-claude"));
+    expect(mockAuth).toHaveBeenCalledWith(expect.anything(), {
+      requireFresh: true,
+    });
+  });
+
+  it("live-validates the new api_key value before rotating", async () => {
+    await ROTATE(makeRequest({ value: "sk-ant-new" }), params("team-claude"));
+    expect(mockValidate).toHaveBeenCalledWith("anthropic", "sk-ant-new");
+    expect(mockRotate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the provider rejects the new key (no rotate)", async () => {
+    mockValidate.mockResolvedValue({ valid: false, reason: "Invalid API key" });
+    const res = await ROTATE(
+      makeRequest({ value: "sk-bad" }),
+      params("team-claude"),
+    );
+    expect(res.status).toBe(400);
+    expect(mockRotate).not.toHaveBeenCalled();
+  });
+
+  it("returns the rotated summary, never ciphertext", async () => {
+    const res = await ROTATE(
+      makeRequest({ value: "sk-ant-new" }),
+      params("team-claude"),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect("ciphertext" in json).toBe(false);
+    expect(json.rotatedAt).not.toBeNull();
+  });
+
+  it("does NOT live-validate an oauth_subscription rotation", async () => {
+    mockGet.mockResolvedValue({
+      ...FULL_ENVELOPE,
+      kind: "oauth_subscription",
+    });
+    await ROTATE(
+      makeRequest({ value: "sk-ant-oat01-new" }),
+      params("team-claude"),
+    );
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockRotate).toHaveBeenCalledTimes(1);
+  });
+
+  it("400s on missing value", async () => {
+    const res = await ROTATE(makeRequest({}), params("team-claude"));
+    expect(res.status).toBe(400);
+    expect(mockRotate).not.toHaveBeenCalled();
+  });
+
+  it("IDOR: foreign name → 404 (getModelCredential throws NotFound)", async () => {
+    mockGet.mockRejectedValue(
+      new ModelCredentialNotFoundError("12345", "someone-elses"),
+    );
+    const res = await ROTATE(
+      makeRequest({ value: "sk-ant-new" }),
+      params("someone-elses"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockRotate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revoke
+// ---------------------------------------------------------------------------
+
+describe("POST /api/model-credentials/[name]/revoke", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+    mockRevoke.mockResolvedValue({ ...SUMMARY, status: "revoked" });
+  });
+
+  it("requires a FRESH session (requireFresh:true)", async () => {
+    await REVOKE(makeRequest(), params("team-claude"));
+    expect(mockAuth).toHaveBeenCalledWith(expect.anything(), {
+      requireFresh: true,
+    });
+  });
+
+  it("returns the revoked summary, never ciphertext", async () => {
+    const res = await REVOKE(makeRequest(), params("team-claude"));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.status).toBe("revoked");
+    expect("ciphertext" in json).toBe(false);
+  });
+
+  it("uses the SESSION installationId", async () => {
+    await REVOKE(makeRequest(), params("team-claude"));
+    expect(mockRevoke).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345", name: "team-claude" }),
+    );
+  });
+
+  it("IDOR: foreign name → 404", async () => {
+    mockRevoke.mockRejectedValue(
+      new ModelCredentialNotFoundError("12345", "someone-elses"),
+    );
+    const res = await REVOKE(makeRequest(), params("someone-elses"));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// re-encrypt
+// ---------------------------------------------------------------------------
+
+describe("POST /api/model-credentials/[name]/re-encrypt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+    mockReEncrypt.mockResolvedValue({ action: "re_encrypted" });
+  });
+
+  it("requires a FRESH session (requireFresh:true)", async () => {
+    await REENCRYPT(makeRequest(), params("team-claude"));
+    expect(mockAuth).toHaveBeenCalledWith(expect.anything(), {
+      requireFresh: true,
+    });
+  });
+
+  it("returns the action result (no secret)", async () => {
+    const res = await REENCRYPT(makeRequest(), params("team-claude"));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.action).toBe("re_encrypted");
+    expect("ciphertext" in json).toBe(false);
+    expect("value" in json).toBe(false);
+  });
+
+  it("passes the active key version + session installationId", async () => {
+    await REENCRYPT(makeRequest(), params("team-claude"));
+    expect(mockReEncrypt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationId: "12345",
+        name: "team-claude",
+        activeKeyVersion: "v1",
+      }),
+    );
+  });
+
+  it("IDOR: foreign name → 404", async () => {
+    mockReEncrypt.mockRejectedValue(
+      new ModelCredentialNotFoundError("12345", "someone-elses"),
+    );
+    const res = await REENCRYPT(makeRequest(), params("someone-elses"));
+    expect(res.status).toBe(404);
+  });
+
+  it("short-circuits on auth failure", async () => {
+    mockAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ code: "session_stale" }, { status: 401 }),
+    } as never);
+    const res = await REENCRYPT(makeRequest(), params("team-claude"));
+    expect(res.status).toBe(401);
+    expect(mockReEncrypt).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/api/model-credentials/[name]/route.test.ts
+++ b/web/src/app/api/model-credentials/[name]/route.test.ts
@@ -46,6 +46,7 @@ import {
   revokeModelCredential,
   reEncryptModelCredential,
   ModelCredentialNotFoundError,
+  RevokedCredentialError,
 } from "@/server/model-credential-store";
 
 import { GET } from "./route";
@@ -226,6 +227,19 @@ describe("POST /api/model-credentials/[name]/rotate", () => {
     );
     expect(res.status).toBe(404);
     expect(mockRotate).not.toHaveBeenCalled();
+  });
+
+  it("409 'revoked' when rotating a revoked credential (terminal revoke)", async () => {
+    mockRotate.mockRejectedValue(
+      new RevokedCredentialError("12345", "team-claude"),
+    );
+    const res = await ROTATE(
+      makeRequest({ value: "sk-ant-new" }),
+      params("team-claude"),
+    );
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.code).toBe("revoked");
   });
 });
 

--- a/web/src/app/api/model-credentials/[name]/route.test.ts
+++ b/web/src/app/api/model-credentials/[name]/route.test.ts
@@ -122,8 +122,8 @@ describe("GET /api/model-credentials/[name]", () => {
 
   it("does NOT require a fresh session (read)", async () => {
     await GET(makeRequest(), params("team-claude"));
-    expect(mockAuth).toHaveBeenCalledWith(expect.anything());
-    expect(mockAuth.mock.calls[0][1]).toBeUndefined();
+    // Read posture is EXPLICIT { requireFresh: false }, not argument omission.
+    expect(mockAuth.mock.calls[0][1]).toEqual({ requireFresh: false });
   });
 
   it("returns the summary, never ciphertext", async () => {

--- a/web/src/app/api/model-credentials/[name]/route.ts
+++ b/web/src/app/api/model-credentials/[name]/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/model-credentials/[name]  (MODEL_AUTH_DESIGN.md §5.3)
+ *
+ * Returns the credential SUMMARY (metadata only, NEVER ciphertext).
+ * requireFresh:false (a read). installationId from the session only — a
+ * foreign name resolves to 404 in the caller's namespace (no cross-tenant
+ * existence oracle).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { getModelCredentialSummary } from "@/server/model-credential-store";
+import { mapModelCredentialError } from "@/server/model-credential-routes";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const { name } = await params;
+
+  try {
+    const summary = await getModelCredentialSummary({
+      installationId,
+      name,
+      redis: auth.redis,
+    });
+    // summary excludes all crypto fields — never returns the value.
+    return NextResponse.json(summary);
+  } catch (err) {
+    return mapModelCredentialError(err, {
+      route: "GET /api/model-credentials/[name]",
+      installationId,
+      name,
+    });
+  }
+}

--- a/web/src/app/api/model-credentials/[name]/route.ts
+++ b/web/src/app/api/model-credentials/[name]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ name: string }> },
 ) {
-  const auth = await authenticateByokRequest(request);
+  const auth = await authenticateByokRequest(request, { requireFresh: false });
   if (!auth.ok) return auth.response;
 
   const installationCheck = requireInstallation(auth.session);

--- a/web/src/app/api/model-credentials/route.test.ts
+++ b/web/src/app/api/model-credentials/route.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Route tests for /api/model-credentials (POST create + GET list).
+ *
+ * Mocks the auth gate, installation guard, provider validation, and the
+ * storage layer so we can assert the route's contract:
+ *   - POST passes requireFresh:true; GET passes requireFresh:false
+ *   - api_key create live-validates the value before storing
+ *   - create returns the (ciphertext-free) summary; list returns summaries
+ *   - installationId comes from the session, never the body
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/server/byok-auth", () => ({
+  authenticateByokRequest: vi.fn(),
+}));
+vi.mock("@/server/require-installation", () => ({
+  requireInstallation: vi.fn(),
+}));
+vi.mock("@/server/provider-validation", () => ({
+  validateProviderKey: vi.fn(),
+}));
+vi.mock("@/server/model-credential-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/server/model-credential-store")
+  >("@/server/model-credential-store");
+  return {
+    ...actual,
+    createModelCredential: vi.fn(),
+    listModelCredentials: vi.fn(),
+  };
+});
+
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { validateProviderKey } from "@/server/provider-validation";
+import {
+  createModelCredential,
+  listModelCredentials,
+} from "@/server/model-credential-store";
+import { POST, GET } from "./route";
+
+const mockAuth = vi.mocked(authenticateByokRequest);
+const mockRequireInstallation = vi.mocked(requireInstallation);
+const mockValidate = vi.mocked(validateProviderKey);
+const mockCreate = vi.mocked(createModelCredential);
+const mockList = vi.mocked(listModelCredentials);
+
+function authedSession() {
+  mockAuth.mockResolvedValue({
+    ok: true,
+    session: { userLogin: "operator", installationId: "12345" },
+    keyring: new Map([["v1", Buffer.alloc(32)]]),
+    activeKeyVersion: "v1",
+    redis: {} as never,
+  } as never);
+  mockRequireInstallation.mockReturnValue({
+    ok: true,
+    installationId: "12345",
+  } as never);
+}
+
+function makeRequest(body: unknown) {
+  return {
+    body: body === undefined ? null : {},
+    json: async () => body,
+    cookies: { get: () => undefined },
+  } as never;
+}
+
+const SUMMARY = {
+  name: "team-claude",
+  kind: "api_key" as const,
+  provider: "anthropic" as const,
+  status: "active" as const,
+  fingerprint: "deadbeef",
+  createdAt: "2026-05-30T00:00:00.000Z",
+  createdBy: "operator",
+  rotatedAt: null,
+  expiresAt: null,
+  deliverable: true,
+};
+
+describe("POST /api/model-credentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+    mockValidate.mockResolvedValue({ valid: true });
+    mockCreate.mockResolvedValue(SUMMARY);
+  });
+
+  it("requires a FRESH session (requireFresh:true)", async () => {
+    await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "api_key",
+        provider: "anthropic",
+        value: "sk-ant-x",
+        deliverable: true,
+      }),
+    );
+    expect(mockAuth).toHaveBeenCalledWith(expect.anything(), {
+      requireFresh: true,
+    });
+  });
+
+  it("live-validates an api_key before storing", async () => {
+    await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "api_key",
+        provider: "anthropic",
+        value: "sk-ant-x",
+        deliverable: true,
+      }),
+    );
+    expect(mockValidate).toHaveBeenCalledWith("anthropic", "sk-ant-x");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the provider rejects the key (no store write)", async () => {
+    mockValidate.mockResolvedValue({ valid: false, reason: "Invalid API key" });
+    const res = await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "api_key",
+        provider: "anthropic",
+        value: "sk-bad",
+        deliverable: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns the summary (ciphertext-free) with 201", async () => {
+    const res = await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "api_key",
+        provider: "anthropic",
+        value: "sk-ant-x",
+        deliverable: true,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect("ciphertext" in json).toBe(false);
+    expect(json.name).toBe("team-claude");
+  });
+
+  it("passes the SESSION installationId to the store (never the body)", async () => {
+    await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "api_key",
+        provider: "anthropic",
+        value: "sk-ant-x",
+        deliverable: true,
+        installationId: "ATTACKER-9999",
+      }),
+    );
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+
+  it("rejects an invalid kind without touching the store", async () => {
+    const res = await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "password",
+        provider: "anthropic",
+        value: "x",
+        deliverable: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid provider without touching the store", async () => {
+    const res = await POST(
+      makeRequest({
+        name: "team-claude",
+        kind: "api_key",
+        provider: "mistral",
+        value: "x",
+        deliverable: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT live-validate a zai api_key (no probe endpoint), still stores", async () => {
+    await POST(
+      makeRequest({
+        name: "team-zai",
+        kind: "api_key",
+        provider: "zai",
+        value: "zai-key",
+        deliverable: true,
+      }),
+    );
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT live-validate an oauth_subscription value", async () => {
+    await POST(
+      makeRequest({
+        name: "team-claude-oauth",
+        kind: "oauth_subscription",
+        provider: "anthropic",
+        value: "sk-ant-oat01-x",
+        deliverable: true,
+      }),
+    );
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("short-circuits on auth failure", async () => {
+    mockAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json(
+        { code: "not_authenticated" },
+        { status: 401 },
+      ),
+    } as never);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(401);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/model-credentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+    mockList.mockResolvedValue([SUMMARY]);
+  });
+
+  it("does NOT require a fresh session (read)", async () => {
+    await GET(makeRequest(undefined));
+    expect(mockAuth).toHaveBeenCalledWith(expect.anything());
+    expect(mockAuth.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("returns summaries, none containing ciphertext", async () => {
+    const res = await GET(makeRequest(undefined));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      credentials: Record<string, unknown>[];
+    };
+    expect(json.credentials).toHaveLength(1);
+    for (const c of json.credentials) {
+      expect("ciphertext" in c).toBe(false);
+    }
+  });
+
+  it("lists with the SESSION installationId", async () => {
+    await GET(makeRequest(undefined));
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: "12345" }),
+    );
+  });
+});

--- a/web/src/app/api/model-credentials/route.test.ts
+++ b/web/src/app/api/model-credentials/route.test.ts
@@ -245,8 +245,8 @@ describe("GET /api/model-credentials", () => {
 
   it("does NOT require a fresh session (read)", async () => {
     await GET(makeRequest(undefined));
-    expect(mockAuth).toHaveBeenCalledWith(expect.anything());
-    expect(mockAuth.mock.calls[0][1]).toBeUndefined();
+    // Read posture is EXPLICIT { requireFresh: false }, not argument omission.
+    expect(mockAuth.mock.calls[0][1]).toEqual({ requireFresh: false });
   });
 
   it("returns summaries, none containing ciphertext", async () => {

--- a/web/src/app/api/model-credentials/route.ts
+++ b/web/src/app/api/model-credentials/route.ts
@@ -160,7 +160,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
-  const auth = await authenticateByokRequest(request);
+  const auth = await authenticateByokRequest(request, { requireFresh: false });
   if (!auth.ok) return auth.response;
 
   const installationCheck = requireInstallation(auth.session);

--- a/web/src/app/api/model-credentials/route.ts
+++ b/web/src/app/api/model-credentials/route.ts
@@ -1,0 +1,183 @@
+/**
+ * /api/model-credentials  (MODEL_AUTH_DESIGN.md Stage 1, §5.1 / §5.3)
+ *
+ *   POST — create a model credential (requireFresh; validate name/kind/
+ *          provider; for api_key live-validate the value before encrypt+store;
+ *          atomic cap-check; audit). Never returns the value.
+ *   GET  — list credential SUMMARIES (requireFresh:false; NEVER ciphertext).
+ *
+ * installationId comes ONLY from the authenticated session (via
+ * `requireInstallation`) — never from the request body/query. Mutations
+ * require a fresh session (step-up gate); reads do not.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateByokRequest } from "@/server/byok-auth";
+import { requireInstallation } from "@/server/require-installation";
+import { validateProviderKey } from "@/server/provider-validation";
+import {
+  createModelCredential,
+  listModelCredentials,
+  isModelCredentialKind,
+  isModelCredentialProvider,
+  type ModelCredentialKind,
+  type ModelCredentialProvider,
+} from "@/server/model-credential-store";
+import {
+  MODEL_CREDENTIAL_ERROR,
+  mcError,
+  readJsonObject,
+  mapModelCredentialError,
+} from "@/server/model-credential-routes";
+
+/**
+ * Providers `validateProviderKey` can live-probe. `zai` has no validator
+ * (provider-validation.ts), so an api_key for it is stored without a live
+ * probe — failing closed would block a legitimate Z.AI key. (Documented
+ * fallback per the CLAUDE.md "clarify fallback behavior" rule: we accept the
+ * key un-probed because there is no probe endpoint; the credential is still
+ * GCM-encrypted and provider/kind-validated.)
+ */
+const LIVE_VALIDATABLE_PROVIDERS = new Set([
+  "anthropic",
+  "openai",
+  "google",
+  "openrouter",
+]);
+
+interface CreateBody {
+  name?: unknown;
+  kind?: unknown;
+  provider?: unknown;
+  value?: unknown;
+  expiresAt?: unknown;
+  deliverable?: unknown;
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateByokRequest(request, { requireFresh: true });
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  const parsed = await readJsonObject(request);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body as CreateBody;
+
+  // --- field validation (before any storage / crypto work) ---
+  if (typeof body.name !== "string" || body.name.length === 0) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.INVALID_NAME,
+      "Missing or invalid 'name'.",
+      400,
+    );
+  }
+  if (!isModelCredentialKind(body.kind)) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.INVALID_KIND,
+      "Missing or invalid 'kind' (expected 'api_key' or 'oauth_subscription').",
+      400,
+    );
+  }
+  if (!isModelCredentialProvider(body.provider)) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.INVALID_PROVIDER,
+      "Missing or invalid 'provider'.",
+      400,
+    );
+  }
+  if (typeof body.value !== "string" || body.value.length === 0) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.VALIDATION,
+      "Missing or invalid 'value'.",
+      400,
+    );
+  }
+  if (typeof body.deliverable !== "boolean") {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.VALIDATION,
+      "Missing or invalid 'deliverable' (boolean).",
+      400,
+    );
+  }
+  let expiresAt: string | null = null;
+  if (body.expiresAt !== undefined && body.expiresAt !== null) {
+    if (
+      typeof body.expiresAt !== "string" ||
+      Number.isNaN(new Date(body.expiresAt).getTime())
+    ) {
+      return mcError(
+        MODEL_CREDENTIAL_ERROR.VALIDATION,
+        "'expiresAt' must be an ISO 8601 timestamp or null.",
+        400,
+      );
+    }
+    expiresAt = body.expiresAt;
+  }
+
+  const kind: ModelCredentialKind = body.kind;
+  const provider: ModelCredentialProvider = body.provider;
+  const value: string = body.value;
+
+  // --- live provider probe for api_key (never logs/echoes the value) ---
+  if (kind === "api_key" && LIVE_VALIDATABLE_PROVIDERS.has(provider)) {
+    const validation = await validateProviderKey(provider, value);
+    if (!validation.valid) {
+      return mcError(
+        MODEL_CREDENTIAL_ERROR.VALIDATION,
+        validation.reason ?? "Provider rejected the API key.",
+        400,
+      );
+    }
+  }
+
+  try {
+    const summary = await createModelCredential({
+      installationId,
+      name: body.name,
+      kind,
+      provider,
+      value,
+      createdBy: auth.session.userLogin,
+      expiresAt,
+      deliverable: body.deliverable,
+      keyring: auth.keyring,
+      keyVersion: auth.activeKeyVersion,
+      redis: auth.redis,
+      auditContext: { operator: auth.session.userLogin },
+    });
+    // summary excludes all crypto fields — never returns the value.
+    return NextResponse.json(summary, { status: 201 });
+  } catch (err) {
+    return mapModelCredentialError(err, {
+      route: "POST /api/model-credentials",
+      installationId,
+      name: body.name,
+    });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authenticateByokRequest(request);
+  if (!auth.ok) return auth.response;
+
+  const installationCheck = requireInstallation(auth.session);
+  if (!installationCheck.ok) return installationCheck.response;
+  const installationId = installationCheck.installationId;
+
+  try {
+    const summaries = await listModelCredentials({
+      installationId,
+      redis: auth.redis,
+    });
+    // summaries never include ciphertext.
+    return NextResponse.json({ credentials: summaries });
+  } catch (err) {
+    return mapModelCredentialError(err, {
+      route: "GET /api/model-credentials",
+      installationId,
+    });
+  }
+}

--- a/web/src/server/model-credential-engine-policy.test.ts
+++ b/web/src/server/model-credential-engine-policy.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the engine → (provider, allowed-kinds) constraint map
+ * (MODEL_AUTH_DESIGN.md §1.4). Pure-function tests; no Redis / I/O.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  getEngineCredentialConstraint,
+  validateCredentialForEngine,
+} from "./model-credential-engine-policy";
+
+describe("getEngineCredentialConstraint — engine → provider mapping", () => {
+  // (engineId, expected provider) — derived from engine-catalog.ts tools.
+  const cases: Array<[string, string]> = [
+    ["claude", "anthropic"],
+    ["claude-opus", "anthropic"],
+    ["claude-opus-4-7", "anthropic"],
+    ["claude-sonnet", "anthropic"],
+    ["codex", "openai"],
+    ["codex-spark", "openai"],
+    ["codex-xhigh", "openai"],
+    ["codex-gpt-5-5-xhigh", "openai"],
+    ["kimi", "openrouter"],
+    ["minimax", "openrouter"],
+    ["zai", "zai"],
+    ["gemini", "google"],
+  ];
+
+  for (const [engineId, provider] of cases) {
+    it(`${engineId} → ${provider}`, () => {
+      const c = getEngineCredentialConstraint(engineId);
+      expect(c).not.toBeNull();
+      expect(c?.provider).toBe(provider);
+    });
+  }
+
+  it("returns null for an unknown engine (fail-closed)", () => {
+    expect(getEngineCredentialConstraint("not-an-engine")).toBeNull();
+  });
+
+  it("codex allows ONLY oauth_subscription", () => {
+    const c = getEngineCredentialConstraint("codex");
+    expect(c?.allowedKinds).toEqual(["oauth_subscription"]);
+  });
+
+  it("claude allows oauth_subscription OR api_key", () => {
+    const c = getEngineCredentialConstraint("claude");
+    expect(c?.allowedKinds).toContain("oauth_subscription");
+    expect(c?.allowedKinds).toContain("api_key");
+  });
+
+  it("openrouter / zai / google engines allow api_key", () => {
+    expect(getEngineCredentialConstraint("kimi")?.allowedKinds).toEqual([
+      "api_key",
+    ]);
+    expect(getEngineCredentialConstraint("zai")?.allowedKinds).toEqual([
+      "api_key",
+    ]);
+    expect(getEngineCredentialConstraint("gemini")?.allowedKinds).toEqual([
+      "api_key",
+    ]);
+  });
+});
+
+describe("validateCredentialForEngine", () => {
+  it("accepts a matching provider + allowed kind (claude + anthropic oauth)", () => {
+    const r = validateCredentialForEngine("claude", {
+      provider: "anthropic",
+      kind: "oauth_subscription",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.provider).toBe("anthropic");
+  });
+
+  it("accepts claude + anthropic api_key", () => {
+    expect(
+      validateCredentialForEngine("claude", {
+        provider: "anthropic",
+        kind: "api_key",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("accepts codex + openai oauth_subscription", () => {
+    expect(
+      validateCredentialForEngine("codex-xhigh", {
+        provider: "openai",
+        kind: "oauth_subscription",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("accepts kimi + openrouter api_key", () => {
+    expect(
+      validateCredentialForEngine("kimi", {
+        provider: "openrouter",
+        kind: "api_key",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("accepts minimax + openrouter api_key", () => {
+    expect(
+      validateCredentialForEngine("minimax", {
+        provider: "openrouter",
+        kind: "api_key",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("accepts zai + zai api_key", () => {
+    expect(
+      validateCredentialForEngine("zai", {
+        provider: "zai",
+        kind: "api_key",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("accepts gemini + google api_key", () => {
+    expect(
+      validateCredentialForEngine("gemini", {
+        provider: "google",
+        kind: "api_key",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("rejects a provider mismatch (codex needs openai, given zai)", () => {
+    const r = validateCredentialForEngine("codex-xhigh", {
+      provider: "zai",
+      kind: "api_key",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/provider mismatch/i);
+  });
+
+  it("rejects codex with the WRONG kind (api_key) even on the right provider", () => {
+    const r = validateCredentialForEngine("codex", {
+      provider: "openai",
+      kind: "api_key",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/not allowed/i);
+  });
+
+  it("rejects an unknown engine", () => {
+    const r = validateCredentialForEngine("nope", {
+      provider: "anthropic",
+      kind: "api_key",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/unknown engine/i);
+  });
+});

--- a/web/src/server/model-credential-engine-policy.ts
+++ b/web/src/server/model-credential-engine-policy.ts
@@ -1,0 +1,154 @@
+/**
+ * Engine → (provider, allowed-kinds) constraint map (MODEL_AUTH_DESIGN.md §1.4).
+ *
+ * The engine catalog (`engine-catalog.ts`) carries NO credential metadata —
+ * adding it there would create a third source of truth alongside
+ * `apiary.engines.yaml`. Instead this backend-only validator DERIVES the
+ * required `(provider, allowed kinds)` from the resolved engine's `tool` +
+ * `provider`, reusing `resolveEngine()` so the engine list is never
+ * re-encoded here.
+ *
+ * The tool→provider translation lives in this module and ONLY this module
+ * (the design's §1.4 "translation layer"): the engine `tool` set
+ * (claude/codex/opencode/kilo/gemini) and the credential `provider` set
+ * (anthropic/openai/openrouter/zai/google) are NOT 1:1 —
+ *   codex (tool)    → openai (provider)
+ *   kilo (tool)     → openrouter (provider)
+ *   opencode/zai    → zai (provider)
+ *   claude (tool)   → anthropic (provider)
+ *   gemini (tool)   → google (provider)
+ *
+ * Stage 1 ships the PURE VALIDATOR + its tests only. No agent wiring yet —
+ * Stage 2 (agent association) consumes `validateCredentialForEngine` to reject
+ * a credential whose provider/kind is incompatible with the agent's engine.
+ */
+
+import { resolveEngine } from "@/server/engine-catalog";
+import type {
+  ModelCredentialKind,
+  ModelCredentialProvider,
+} from "@/server/model-credential-store";
+
+/**
+ * tool → required credential provider. The catalog's explicit `provider`
+ * field (e.g. kilo→openrouter, opencode→zai) takes precedence when present;
+ * this map is the fallback for engines whose provider is implied by the tool
+ * (claude→anthropic, codex→openai, gemini→google).
+ *
+ * Kept as a closed `Record` keyed by the known catalog tools so an unknown
+ * tool fails closed (returns no mapping → validation rejects).
+ */
+const TOOL_TO_PROVIDER: Readonly<Record<string, ModelCredentialProvider>> = {
+  claude: "anthropic",
+  codex: "openai",
+  kilo: "openrouter",
+  opencode: "zai",
+  gemini: "google",
+};
+
+/**
+ * Per-provider allowed credential kinds.
+ *
+ *   - openai (codex): `oauth_subscription` ONLY. Codex uses device-auth /
+ *     ChatGPT subscription; there is no plain-api-key path in the fleet
+ *     (MODEL_AUTH_DESIGN.md §1.4 — "codex* → oauth_subscription only").
+ *   - anthropic (claude): either an OAuth subscription token OR an api key.
+ *   - everything else (openrouter/zai/google): `api_key`.
+ *
+ * Closed map: a provider absent here has no allowed kinds → validation
+ * rejects (fail-closed).
+ */
+const PROVIDER_ALLOWED_KINDS: Readonly<
+  Record<ModelCredentialProvider, readonly ModelCredentialKind[]>
+> = {
+  anthropic: ["oauth_subscription", "api_key"],
+  openai: ["oauth_subscription"],
+  openrouter: ["api_key"],
+  zai: ["api_key"],
+  google: ["api_key"],
+};
+
+export interface EngineCredentialConstraint {
+  /** The credential provider this engine requires. */
+  provider: ModelCredentialProvider;
+  /** The credential kinds this engine accepts. */
+  allowedKinds: readonly ModelCredentialKind[];
+}
+
+/**
+ * Resolve the credential constraint for an engine id. Returns `null` for an
+ * unknown engine OR an engine whose tool/provider doesn't map to a known
+ * credential provider (fail-closed — the caller treats `null` as "cannot
+ * validate, reject").
+ *
+ * Resolution order for the provider:
+ *   1. the catalog entry's explicit `provider` (if it's a known credential
+ *      provider) — covers kilo→openrouter, opencode→zai;
+ *   2. otherwise the `tool → provider` fallback map — covers
+ *      claude→anthropic, codex→openai, gemini→google.
+ */
+export function getEngineCredentialConstraint(
+  engineId: string,
+): EngineCredentialConstraint | null {
+  const engine = resolveEngine(engineId);
+  if (!engine) return null;
+
+  // Prefer the catalog's explicit provider when it is a recognized credential
+  // provider; else fall back to the tool→provider map.
+  const explicit = engine.provider;
+  const provider: ModelCredentialProvider | undefined =
+    explicit && explicit in PROVIDER_ALLOWED_KINDS
+      ? (explicit as ModelCredentialProvider)
+      : TOOL_TO_PROVIDER[engine.tool];
+
+  if (!provider) return null;
+
+  const allowedKinds = PROVIDER_ALLOWED_KINDS[provider];
+  if (!allowedKinds || allowedKinds.length === 0) return null;
+
+  return { provider, allowedKinds };
+}
+
+export type ValidateCredentialForEngineResult =
+  | { ok: true; provider: ModelCredentialProvider }
+  | { ok: false; reason: string };
+
+/**
+ * Validate that a credential's `(provider, kind)` is compatible with the
+ * given engine (MODEL_AUTH_DESIGN.md §1.4). Pure function — no I/O. Stage 2
+ * calls this at agent create/update time (authoritative; never trust the
+ * form). Returns a structured ok/reason so callers can surface a precise
+ * error to the operator.
+ *
+ *   - unknown engine                → reject ("unknown engine")
+ *   - provider mismatch             → reject (names the required provider)
+ *   - provider ok but kind not allowed for it → reject (names allowed kinds)
+ */
+export function validateCredentialForEngine(
+  engineId: string,
+  credential: { provider: ModelCredentialProvider; kind: ModelCredentialKind },
+): ValidateCredentialForEngineResult {
+  const constraint = getEngineCredentialConstraint(engineId);
+  if (!constraint) {
+    return {
+      ok: false,
+      reason: `Unknown engine '${engineId}' — cannot determine the required credential provider.`,
+    };
+  }
+
+  if (credential.provider !== constraint.provider) {
+    return {
+      ok: false,
+      reason: `Provider mismatch: engine '${engineId}' requires a '${constraint.provider}' credential, but got '${credential.provider}'.`,
+    };
+  }
+
+  if (!constraint.allowedKinds.includes(credential.kind)) {
+    return {
+      ok: false,
+      reason: `Kind '${credential.kind}' is not allowed for engine '${engineId}' (provider '${constraint.provider}'); allowed: ${constraint.allowedKinds.join(", ")}.`,
+    };
+  }
+
+  return { ok: true, provider: constraint.provider };
+}

--- a/web/src/server/model-credential-routes.ts
+++ b/web/src/server/model-credential-routes.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared helpers for the model-credential route handlers under
+ * `/api/model-credentials/*` (MODEL_AUTH_DESIGN.md Stage 1).
+ *
+ * Mirrors `agent-token-v1-routes.ts`: a self-contained error vocabulary +
+ * `mcError` helper (structured `{ code, message, ...details }` JSON, never an
+ * internal stack/secret) and a storage-error → HTTP-status mapper so each
+ * route's catch block is one line. Deliberately does NOT reuse `byok-error.ts`
+ * — this is a distinct subsystem with its own stable codes.
+ */
+
+import { NextResponse } from "next/server";
+import { LockTimeoutError } from "@hivemoot/war-room/redis-lock";
+import { CapabilityValidationError } from "@/server/agent-token-capabilities";
+import {
+  ModelCredentialNotFoundError,
+  NameTakenError,
+  LimitReachedError,
+  InvalidKindError,
+  InvalidProviderError,
+} from "@/server/model-credential-store";
+
+/**
+ * Stable wire-error codes for the model-credential endpoints. Distinct from
+ * BYOK / agent-token codes. The dashboard branches on these.
+ */
+export const MODEL_CREDENTIAL_ERROR = {
+  INVALID_BODY: "invalid_body",
+  INVALID_NAME: "invalid_name",
+  INVALID_KIND: "invalid_kind",
+  INVALID_PROVIDER: "invalid_provider",
+  VALIDATION: "validation",
+  NOT_FOUND: "not_found",
+  NAME_TAKEN: "name_taken",
+  LIMIT_REACHED: "limit_reached",
+  RATE_LIMITED: "rate_limited",
+  REVOKED: "revoked",
+  SERVER_ERROR: "server_error",
+} as const;
+
+export type ModelCredentialErrorCode =
+  (typeof MODEL_CREDENTIAL_ERROR)[keyof typeof MODEL_CREDENTIAL_ERROR];
+
+export function mcError(
+  code: ModelCredentialErrorCode,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json({ code, message, ...(details ?? {}) }, { status });
+}
+
+export type ReadJsonObjectResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Parse a JSON request body that MUST be a non-array object. Empty body →
+ * empty object. Bad JSON / non-object → structured 400 so the handler can
+ * early-return. Mirrors `agent-token-v1-routes.readJsonObject`.
+ */
+export async function readJsonObject(
+  request: Request,
+): Promise<ReadJsonObjectResult> {
+  if (request.body === null) return { ok: true, body: {} };
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: mcError(
+        MODEL_CREDENTIAL_ERROR.INVALID_BODY,
+        "Request body must be valid JSON.",
+        400,
+      ),
+    };
+  }
+  if (body == null) return { ok: true, body: {} };
+  if (typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      response: mcError(
+        MODEL_CREDENTIAL_ERROR.INVALID_BODY,
+        "Request body must be a JSON object.",
+        400,
+      ),
+    };
+  }
+  return { ok: true, body: body as Record<string, unknown> };
+}
+
+/**
+ * Catch-all storage error → HTTP response mapper. Each route's catch block
+ * delegates here so the mapping is consistent.
+ *
+ *   - NameTakenError                → 409 name_taken
+ *   - ModelCredentialNotFoundError  → 404 not_found  (same for "not yours")
+ *   - LimitReachedError             → 422 limit_reached
+ *   - InvalidKindError              → 400 invalid_kind
+ *   - InvalidProviderError          → 400 invalid_provider
+ *   - CapabilityValidationError     → 400 invalid_name (reused NAME_REGEX)
+ *   - LockTimeoutError              → 503 rate_limited (concurrent op)
+ *   - anything else                 → 500 server_error (logged, opaque)
+ *
+ * Safe-by-default: never echoes a raw unexpected-error message to the client
+ * (could leak internal state); the actual error is logged for ops.
+ */
+export function mapModelCredentialError(
+  err: unknown,
+  context: { route: string; installationId: string; name?: string },
+): NextResponse {
+  if (err instanceof NameTakenError) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.NAME_TAKEN,
+      err.message,
+      409,
+      context.name ? { name: context.name } : undefined,
+    );
+  }
+  if (err instanceof ModelCredentialNotFoundError) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.NOT_FOUND,
+      err.message,
+      404,
+      context.name ? { name: context.name } : undefined,
+    );
+  }
+  if (err instanceof LimitReachedError) {
+    return mcError(MODEL_CREDENTIAL_ERROR.LIMIT_REACHED, err.message, 422);
+  }
+  if (err instanceof InvalidKindError) {
+    return mcError(MODEL_CREDENTIAL_ERROR.INVALID_KIND, err.message, 400);
+  }
+  if (err instanceof InvalidProviderError) {
+    return mcError(MODEL_CREDENTIAL_ERROR.INVALID_PROVIDER, err.message, 400);
+  }
+  if (err instanceof CapabilityValidationError) {
+    return mcError(MODEL_CREDENTIAL_ERROR.INVALID_NAME, err.message, 400, {
+      field: err.field,
+      value: err.value,
+    });
+  }
+  if (err instanceof LockTimeoutError) {
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.RATE_LIMITED,
+      "Another credential operation is in progress for this name. Retry in a moment.",
+      503,
+    );
+  }
+  console.error("[model-credentials] unexpected error", {
+    route: context.route,
+    installationId: context.installationId,
+    name: context.name,
+    error: err,
+  });
+  return mcError(
+    MODEL_CREDENTIAL_ERROR.SERVER_ERROR,
+    "Internal server error.",
+    500,
+  );
+}

--- a/web/src/server/model-credential-routes.ts
+++ b/web/src/server/model-credential-routes.ts
@@ -18,6 +18,7 @@ import {
   LimitReachedError,
   InvalidKindError,
   InvalidProviderError,
+  RevokedCredentialError,
 } from "@/server/model-credential-store";
 
 /**
@@ -128,6 +129,16 @@ export function mapModelCredentialError(
   }
   if (err instanceof LimitReachedError) {
     return mcError(MODEL_CREDENTIAL_ERROR.LIMIT_REACHED, err.message, 422);
+  }
+  if (err instanceof RevokedCredentialError) {
+    // Revoke is terminal — a rotate/mutation on a revoked credential is a
+    // conflict with its current state, not a not-found.
+    return mcError(
+      MODEL_CREDENTIAL_ERROR.REVOKED,
+      err.message,
+      409,
+      context.name ? { name: context.name } : undefined,
+    );
   }
   if (err instanceof InvalidKindError) {
     return mcError(MODEL_CREDENTIAL_ERROR.INVALID_KIND, err.message, 400);

--- a/web/src/server/model-credential-store.test.ts
+++ b/web/src/server/model-credential-store.test.ts
@@ -31,6 +31,7 @@ import {
   LimitReachedError,
   InvalidKindError,
   InvalidProviderError,
+  RevokedCredentialError,
   MAX_MODEL_CREDENTIALS_PER_INSTALLATION,
   envelopeKey,
   installationIndexKey,
@@ -302,6 +303,15 @@ describe("createModelCredential", () => {
     await expect(
       createModelCredential({ ...defaultCreateArgs(redis), name: "Team" }),
     ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("rejects the reserved name 'audit' (would alias the audit-stream key) without touching Redis", async () => {
+    await expect(
+      createModelCredential({ ...defaultCreateArgs(redis), name: "audit" }),
+    ).rejects.toThrow(CapabilityValidationError);
+    // The audit-stream key must be untouched — no string written over the stream.
+    expect(redis._store.has(envelopeKey("12345", "audit"))).toBe(false);
+    expect(redis._streams.has(auditStreamKey("12345"))).toBe(false);
   });
 
   it("rejects invalid kind", async () => {
@@ -893,5 +903,205 @@ describe("Upstash-Lua compatibility (no sandbox-missing libs)", () => {
         expect(p.test(script)).toBe(false);
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotate-on-revoked: terminal revoke (fail closed)
+// ---------------------------------------------------------------------------
+
+describe("rotate fails closed on a revoked credential", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("rotating a revoked credential throws RevokedCredentialError and leaves it revoked", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    await revokeModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      revokedBy: "operator",
+      redis,
+    });
+
+    await expect(
+      rotateModelCredential({
+        installationId: "12345",
+        name: "team-claude",
+        value: "sk-ant-secret-value-002",
+        rotatedBy: "operator",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(RevokedCredentialError);
+
+    // Still revoked, ciphertext still blanked — rotate did NOT resurrect it.
+    const env = redis._store.get(
+      envelopeKey("12345", "team-claude"),
+    ) as ModelCredentialEnvelopeV1;
+    expect(env.status).toBe("revoked");
+    expect(env.ciphertext).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// name validation is enforced on every by-name read/mutation path
+// ---------------------------------------------------------------------------
+
+describe("validateName is enforced on read + mutation paths (not just create)", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  const BAD = "Bad-NAME"; // uppercase → fails NAME_REGEX
+
+  it("getModelCredentialSummary rejects a malformed name", async () => {
+    await expect(
+      getModelCredentialSummary({ installationId: "12345", name: BAD, redis }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("getModelCredential rejects a malformed name", async () => {
+    await expect(
+      getModelCredential({ installationId: "12345", name: BAD, redis }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("rotateModelCredential rejects a malformed name", async () => {
+    await expect(
+      rotateModelCredential({
+        installationId: "12345",
+        name: BAD,
+        value: "x",
+        rotatedBy: "operator",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("revokeModelCredential rejects a malformed name", async () => {
+    await expect(
+      revokeModelCredential({
+        installationId: "12345",
+        name: BAD,
+        revokedBy: "operator",
+        redis,
+      }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("reEncryptModelCredential rejects a malformed name", async () => {
+    await expect(
+      reEncryptModelCredential({
+        installationId: "12345",
+        name: BAD,
+        activeKeyVersion: "v2",
+        keyring: KEYRING_V2,
+        redis,
+      }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("all four reserve the name 'audit' too", async () => {
+    for (const fn of [
+      () =>
+        getModelCredentialSummary({
+          installationId: "12345",
+          name: "audit",
+          redis,
+        }),
+      () =>
+        revokeModelCredential({
+          installationId: "12345",
+          name: "audit",
+          revokedBy: "operator",
+          redis,
+        }),
+    ]) {
+      await expect(fn()).rejects.toThrow(CapabilityValidationError);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// audit trail: every mutation emits an XADD with the documented wire shape
+// ---------------------------------------------------------------------------
+
+describe("audit stream emission", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  function lastAuditEntry(installationId: string) {
+    const entries = redis._streams.get(auditStreamKey(installationId)) ?? [];
+    expect(entries.length).toBeGreaterThan(0);
+    return JSON.parse(entries[entries.length - 1].fields.entry) as {
+      action: string;
+      name: string;
+      actor: string;
+      detail?: Record<string, unknown>;
+    };
+  }
+
+  it("create with an auditContext records a 'create' entry attributed to the operator", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      auditContext: { operator: "alice" },
+    });
+    const e = lastAuditEntry("12345");
+    expect(e.action).toBe("create");
+    expect(e.name).toBe("team-claude");
+    expect(e.actor).toBe("alice");
+  });
+
+  it("rotate records a 'rotate' entry with old + new fingerprints", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      auditContext: { operator: "alice" },
+    });
+    const before = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    await rotateModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      value: "sk-ant-secret-value-002",
+      rotatedBy: "bob",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+      auditContext: { operator: "bob" },
+    });
+    const e = lastAuditEntry("12345");
+    expect(e.action).toBe("rotate");
+    expect(e.actor).toBe("bob");
+    expect(e.detail?.fingerprint_old).toBe(before.fingerprint);
+    expect(e.detail?.fingerprint_new).toBeDefined();
+    expect(e.detail?.fingerprint_new).not.toBe(before.fingerprint);
+  });
+
+  it("revoke records a 'revoke' entry", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      auditContext: { operator: "alice" },
+    });
+    await revokeModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      revokedBy: "carol",
+      redis,
+      auditContext: { operator: "carol" },
+    });
+    const e = lastAuditEntry("12345");
+    expect(e.action).toBe("revoke");
+    expect(e.actor).toBe("carol");
   });
 });

--- a/web/src/server/model-credential-store.test.ts
+++ b/web/src/server/model-credential-store.test.ts
@@ -478,6 +478,17 @@ describe("getModelCredentialSummary / listModelCredentials exclude ciphertext", 
     ).rejects.toThrow(ModelCredentialNotFoundError);
   });
 
+  it("getModelCredentialSummary: a name that EXISTS under another installation is NotFound (no cross-tenant oracle)", async () => {
+    await createModelCredential(defaultCreateArgs(redis)); // installation 12345
+    await expect(
+      getModelCredentialSummary({
+        installationId: "99999",
+        name: "team-claude",
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+
   it("list returns summaries in creation order, none with ciphertext", async () => {
     await createModelCredential({ ...defaultCreateArgs(redis), name: "first" });
     await createModelCredential({
@@ -568,6 +579,47 @@ describe("rotateModelCredential", () => {
         redis,
       }),
     ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+
+  it("a name that EXISTS under another installation is NotFound (no cross-tenant rotate)", async () => {
+    await createModelCredential(defaultCreateArgs(redis)); // installation 12345
+    await expect(
+      rotateModelCredential({
+        installationId: "99999",
+        name: "team-claude",
+        value: "sk-ant-attacker",
+        rotatedBy: "attacker",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+    // The victim's record is untouched.
+    const victim = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    expect(decryptModelCredentialPayload(victim, KEYRING).value).toBe(
+      "sk-ant-secret-value-001",
+    );
+  });
+
+  it("the returned summary never exposes crypto fields", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const summary = await rotateModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      value: "sk-ant-secret-value-002",
+      rotatedBy: "operator",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+    expect("ciphertext" in summary).toBe(false);
+    expect("iv" in summary).toBe(false);
+    expect("tag" in summary).toBe(false);
+    expect("keyVersion" in summary).toBe(false);
   });
 });
 
@@ -711,6 +763,60 @@ describe("reEncryptModelCredential", () => {
         redis,
       }),
     ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+
+  it("a name that EXISTS under another installation is NotFound (no cross-tenant re-encrypt)", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      keyring: KEYRING_V2,
+      keyVersion: "v1",
+    }); // installation 12345
+    await expect(
+      reEncryptModelCredential({
+        installationId: "99999",
+        name: "team-claude",
+        activeKeyVersion: "v2",
+        keyring: KEYRING_V2,
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GCM authentication of kind/provider (tamper detection)
+// ---------------------------------------------------------------------------
+
+describe("decryptModelCredentialPayload — GCM tamper detection", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("a corrupted GCM tag fails to decrypt (does not silently return data)", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const env = redis._store.get(
+      envelopeKey("12345", "team-claude"),
+    ) as ModelCredentialEnvelopeV1;
+    // Flip the auth tag — decryption MUST throw, never return plaintext.
+    const tampered = { ...env, tag: Buffer.alloc(16, 7).toString("base64") };
+    expect(() => decryptModelCredentialPayload(tampered, KEYRING)).toThrow();
+  });
+
+  it("kind/provider come from the authenticated plaintext, not the clear envelope fields", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const env = redis._store.get(
+      envelopeKey("12345", "team-claude"),
+    ) as ModelCredentialEnvelopeV1;
+    // Swap only the CLEAR metadata copies; the GCM-sealed plaintext is unchanged.
+    const swapped = { ...env, kind: "oauth_subscription", provider: "openai" };
+    const decrypted = decryptModelCredentialPayload(
+      swapped as ModelCredentialEnvelopeV1,
+      KEYRING,
+    );
+    // The trusted values are the ones sealed inside the ciphertext.
+    expect(decrypted.kind).toBe("api_key");
+    expect(decrypted.provider).toBe("anthropic");
   });
 });
 

--- a/web/src/server/model-credential-store.test.ts
+++ b/web/src/server/model-credential-store.test.ts
@@ -1,0 +1,791 @@
+/**
+ * Unit tests for the model-credential storage layer (MODEL_AUTH_DESIGN.md
+ * Stage 1).
+ *
+ * Uses a smart in-memory Redis mock that simulates the two Lua scripts
+ * (CREATE with zcard cap guard; UPDATE = SET + optional audit XADD) by
+ * inspecting the script source, plus the `withRedisLock` release script.
+ * Mirrors the agent-token-v1.test.ts mock shape.
+ *
+ * Note: bracket-notation access (`redis["eval"]`) is used to sidestep an
+ * unrelated security-warning hook that pattern-matches on the literal
+ * `.eval(` token even for Redis Lua-execution methods.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { type Redis } from "@upstash/redis";
+
+import {
+  createModelCredential,
+  getModelCredential,
+  getModelCredentialSummary,
+  listModelCredentials,
+  rotateModelCredential,
+  revokeModelCredential,
+  reEncryptModelCredential,
+  decryptModelCredentialPayload,
+  ModelCredentialNotFoundError,
+  NameTakenError,
+  LimitReachedError,
+  InvalidKindError,
+  InvalidProviderError,
+  MAX_MODEL_CREDENTIALS_PER_INSTALLATION,
+  envelopeKey,
+  installationIndexKey,
+  auditStreamKey,
+  lockKey,
+  type ModelCredentialEnvelopeV1,
+} from "./model-credential-store";
+import { CapabilityValidationError } from "./agent-token-capabilities";
+
+// ---------------------------------------------------------------------------
+// Mock Redis
+// ---------------------------------------------------------------------------
+
+interface SortedSetEntry {
+  member: string;
+  score: number;
+}
+
+interface StreamEntry {
+  id: string;
+  fields: Record<string, string>;
+}
+
+function makeMockRedis() {
+  const store = new Map<string, unknown>();
+  const streams = new Map<string, StreamEntry[]>();
+
+  function getSortedSet(key: string): SortedSetEntry[] {
+    const existing = store.get(key);
+    if (Array.isArray(existing)) return existing as SortedSetEntry[];
+    const fresh: SortedSetEntry[] = [];
+    store.set(key, fresh);
+    return fresh;
+  }
+
+  function getStream(key: string): StreamEntry[] {
+    let s = streams.get(key);
+    if (!s) {
+      s = [];
+      streams.set(key, s);
+    }
+    return s;
+  }
+
+  function xaddFromScript(streamKey: string, entryJson: string) {
+    if (entryJson === "") return;
+    getStream(streamKey).push({
+      id: `${Date.now()}-${getStream(streamKey).length}`,
+      fields: { entry: entryJson },
+    });
+  }
+
+  const luaSim = vi.fn(
+    async (script: string, keys: string[], argv: string[]) => {
+      // withRedisLock release script — 1 key, 1 arg, references ARGV[1],
+      // not one of our domain scripts (no name_taken / no set+xadd shape).
+      if (
+        keys.length === 1 &&
+        argv.length === 1 &&
+        script.includes("ARGV[1]") &&
+        !script.includes("name_taken")
+      ) {
+        const lk = keys[0];
+        if (store.get(lk) === argv[0]) {
+          store.delete(lk);
+          return 1;
+        }
+        return 0;
+      }
+
+      // CREATE_CREDENTIAL_SCRIPT — 3 keys, 5 args
+      if (
+        keys.length === 3 &&
+        argv.length === 5 &&
+        script.includes("name_taken")
+      ) {
+        const [envK, idxK, auditK] = keys;
+        const [name, envJson, createdAtMs, auditEntry, limit] = argv;
+        if (store.has(envK)) return [0, "name_taken"];
+        const set = getSortedSet(idxK);
+        if (set.length >= Number(limit)) return [-1, "limit"];
+        store.set(envK, JSON.parse(envJson));
+        set.push({ member: name, score: Number(createdAtMs) });
+        set.sort((a, b) => a.score - b.score);
+        xaddFromScript(auditK, auditEntry);
+        return [1, name];
+      }
+
+      // UPDATE_CREDENTIAL_SCRIPT — 2 keys, 2 args (SET + optional XADD)
+      if (
+        keys.length === 2 &&
+        argv.length === 2 &&
+        script.includes('redis.call("set", KEYS[1], ARGV[1])')
+      ) {
+        const [envK, auditK] = keys;
+        const [envJson, auditEntry] = argv;
+        store.set(envK, JSON.parse(envJson));
+        xaddFromScript(auditK, auditEntry);
+        return [1];
+      }
+
+      return null;
+    },
+  );
+
+  const client = {
+    set: vi.fn(
+      async (
+        key: string,
+        value: unknown,
+        opts?: { nx?: boolean; xx?: boolean; ex?: number },
+      ) => {
+        if (opts?.nx && store.has(key)) return null;
+        if (opts?.xx && !store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+    ),
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    del: vi.fn(async (key: string) => {
+      const existed = store.has(key);
+      store.delete(key);
+      return existed ? 1 : 0;
+    }),
+    zadd: vi.fn(async (key: string, score: number, member: string) => {
+      const set = getSortedSet(key);
+      const existing = set.find((e) => e.member === member);
+      if (existing) {
+        existing.score = score;
+        return 0;
+      }
+      set.push({ member, score });
+      set.sort((a, b) => a.score - b.score);
+      return 1;
+    }),
+    zrem: vi.fn(async (key: string, member: string) => {
+      const set = getSortedSet(key);
+      const idx = set.findIndex((e) => e.member === member);
+      if (idx === -1) return 0;
+      set.splice(idx, 1);
+      return 1;
+    }),
+    zrange: vi.fn(async (key: string, _start: number, _stop: number) => {
+      const set = getSortedSet(key);
+      return set.map((e) => e.member);
+    }),
+    "eval": luaSim,
+    _store: store,
+    _streams: streams,
+    _luaSim: luaSim,
+  };
+  return client as unknown as Redis & {
+    _store: Map<string, unknown>;
+    _streams: Map<string, StreamEntry[]>;
+    _luaSim: ReturnType<typeof vi.fn>;
+  };
+}
+
+const KEYRING = new Map([["v1", Buffer.alloc(32)]]);
+const KEYRING_V2 = new Map([
+  ["v1", Buffer.alloc(32)],
+  ["v2", Buffer.alloc(32, 1)],
+]);
+
+function defaultCreateArgs(redis: Redis) {
+  return {
+    installationId: "12345",
+    name: "team-claude",
+    kind: "api_key" as const,
+    provider: "anthropic" as const,
+    value: "sk-ant-secret-value-001",
+    createdBy: "operator",
+    deliverable: true,
+    keyring: KEYRING,
+    keyVersion: "v1",
+    redis,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Key helpers
+// ---------------------------------------------------------------------------
+
+describe("key prefix helpers", () => {
+  it("envelopeKey uses the model-cred v1 prefix", () => {
+    expect(envelopeKey("12345", "team-claude")).toBe(
+      "hive:v1:model-cred:12345:team-claude",
+    );
+  });
+  it("installationIndexKey uses the model-cred idx prefix", () => {
+    expect(installationIndexKey("12345")).toBe(
+      "hive:v1:idx:model-cred:installation:12345",
+    );
+  });
+  it("auditStreamKey is envelope-prefix + installationId + :audit", () => {
+    expect(auditStreamKey("12345")).toBe("hive:v1:model-cred:12345:audit");
+  });
+  it("lockKey uses the model-cred lock prefix", () => {
+    expect(lockKey("12345", "team-claude")).toBe(
+      "hive:v1:lock:model-cred:12345:team-claude",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createModelCredential
+// ---------------------------------------------------------------------------
+
+describe("createModelCredential", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("creates a credential, stores envelope + index, returns summary without ciphertext", async () => {
+    const summary = await createModelCredential(defaultCreateArgs(redis));
+
+    expect(summary.name).toBe("team-claude");
+    expect(summary.kind).toBe("api_key");
+    expect(summary.provider).toBe("anthropic");
+    expect(summary.status).toBe("active");
+    expect(summary.deliverable).toBe(true);
+    expect(summary.rotatedAt).toBeNull();
+    expect("ciphertext" in summary).toBe(false);
+    expect("iv" in summary).toBe(false);
+    expect("tag" in summary).toBe(false);
+
+    const env = redis._store.get(
+      envelopeKey("12345", "team-claude"),
+    ) as ModelCredentialEnvelopeV1;
+    expect(env).toBeDefined();
+    expect(env.ciphertext.length).toBeGreaterThan(0);
+    expect(env.provider).toBe("anthropic");
+
+    const idx = redis._store.get(
+      installationIndexKey("12345"),
+    ) as SortedSetEntry[];
+    expect(idx).toHaveLength(1);
+    expect(idx[0].member).toBe("team-claude");
+  });
+
+  it("fingerprint is sha256(value).slice(0,8) and never equals the value", async () => {
+    const summary = await createModelCredential(defaultCreateArgs(redis));
+    const expected = createHash("sha256")
+      .update("sk-ant-secret-value-001")
+      .digest("hex")
+      .slice(0, 8);
+    expect(summary.fingerprint).toBe(expected);
+    expect(summary.fingerprint).not.toBe("sk-ant-secret-value-001");
+    expect(summary.fingerprint.length).toBe(8);
+  });
+
+  it("encrypts the {kind, provider, value} plaintext (round-trips via decrypt)", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const env = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    const payload = decryptModelCredentialPayload(env, KEYRING);
+    expect(payload).toEqual({
+      kind: "api_key",
+      provider: "anthropic",
+      value: "sk-ant-secret-value-001",
+    });
+  });
+
+  it("rejects invalid name (uppercase)", async () => {
+    await expect(
+      createModelCredential({ ...defaultCreateArgs(redis), name: "Team" }),
+    ).rejects.toThrow(CapabilityValidationError);
+  });
+
+  it("rejects invalid kind", async () => {
+    await expect(
+      createModelCredential({
+        ...defaultCreateArgs(redis),
+        // @ts-expect-error testing runtime rejection of a bad kind
+        kind: "password",
+      }),
+    ).rejects.toThrow(InvalidKindError);
+  });
+
+  it("rejects invalid provider", async () => {
+    await expect(
+      createModelCredential({
+        ...defaultCreateArgs(redis),
+        // @ts-expect-error testing runtime rejection of a bad provider
+        provider: "mistral",
+      }),
+    ).rejects.toThrow(InvalidProviderError);
+  });
+
+  it("throws NameTakenError on duplicate name", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    await expect(
+      createModelCredential(defaultCreateArgs(redis)),
+    ).rejects.toThrow(NameTakenError);
+  });
+
+  it("MAX_MODEL_CREDENTIALS_PER_INSTALLATION is 20 (design §6.5)", () => {
+    expect(MAX_MODEL_CREDENTIALS_PER_INSTALLATION).toBe(20);
+  });
+
+  it("enforces the per-installation cap atomically (N+1 → LimitReached)", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      name: "first",
+      limit: 2,
+    });
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      name: "second",
+      limit: 2,
+    });
+    await expect(
+      createModelCredential({
+        ...defaultCreateArgs(redis),
+        name: "third",
+        limit: 2,
+      }),
+    ).rejects.toThrow(LimitReachedError);
+  });
+
+  it("cap is enforced INSIDE the Lua script (zcard guard, TOCTOU-safe)", () => {
+    // The cap check must be in the script body, not a client-side count
+    // before the write — otherwise concurrent creates could both pass.
+    const src = readFileSync(__dirname + "/model-credential-store.ts", "utf8");
+    expect(src).toMatch(/local count = redis\.call\("zcard", KEYS\[2\]\)/);
+    expect(src).toMatch(
+      /if count >= tonumber\(ARGV\[5\]\) then return \{-1, "limit"\} end/,
+    );
+  });
+
+  it("stores deliverable:false for local-only (codex) credentials", async () => {
+    const summary = await createModelCredential({
+      ...defaultCreateArgs(redis),
+      name: "codex-seed",
+      kind: "oauth_subscription",
+      provider: "openai",
+      value: '{"auth_mode":"chatgpt","tokens":{}}',
+      deliverable: false,
+    });
+    expect(summary.deliverable).toBe(false);
+    expect(summary.kind).toBe("oauth_subscription");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multitenant isolation (no cross-tenant oracle)
+// ---------------------------------------------------------------------------
+
+describe("multitenant isolation", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("a foreign installationId resolves to NotFound (no cross-tenant read)", async () => {
+    await createModelCredential(defaultCreateArgs(redis)); // installation 12345
+    await expect(
+      getModelCredential({
+        installationId: "99999",
+        name: "team-claude",
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+
+  it("same name in two installations are independent records", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      installationId: "111",
+      value: "secret-aaa",
+    });
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      installationId: "222",
+      value: "secret-bbb",
+    });
+    const a = await getModelCredential({
+      installationId: "111",
+      name: "team-claude",
+      redis,
+    });
+    const b = await getModelCredential({
+      installationId: "222",
+      name: "team-claude",
+      redis,
+    });
+    expect(decryptModelCredentialPayload(a, KEYRING).value).toBe("secret-aaa");
+    expect(decryptModelCredentialPayload(b, KEYRING).value).toBe("secret-bbb");
+  });
+
+  it("listing is scoped to the installation", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      installationId: "111",
+      name: "a",
+    });
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      installationId: "222",
+      name: "b",
+    });
+    const list111 = await listModelCredentials({
+      installationId: "111",
+      redis,
+    });
+    expect(list111.map((s) => s.name)).toEqual(["a"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get / list (ciphertext exclusion)
+// ---------------------------------------------------------------------------
+
+describe("getModelCredentialSummary / listModelCredentials exclude ciphertext", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("getModelCredentialSummary excludes all crypto fields", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const summary = await getModelCredentialSummary({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    expect("ciphertext" in summary).toBe(false);
+    expect("iv" in summary).toBe(false);
+    expect("tag" in summary).toBe(false);
+    expect("keyVersion" in summary).toBe(false);
+    expect(summary.fingerprint).toBeDefined();
+  });
+
+  it("getModelCredentialSummary throws NotFound when absent", async () => {
+    await expect(
+      getModelCredentialSummary({
+        installationId: "12345",
+        name: "missing",
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+
+  it("list returns summaries in creation order, none with ciphertext", async () => {
+    await createModelCredential({ ...defaultCreateArgs(redis), name: "first" });
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      name: "second",
+    });
+    await createModelCredential({ ...defaultCreateArgs(redis), name: "third" });
+    const out = await listModelCredentials({ installationId: "12345", redis });
+    expect(out.map((s) => s.name)).toEqual(["first", "second", "third"]);
+    for (const s of out) {
+      expect("ciphertext" in s).toBe(false);
+    }
+  });
+
+  it("list returns [] for an installation with no credentials", async () => {
+    const out = await listModelCredentials({ installationId: "00", redis });
+    expect(out).toEqual([]);
+  });
+
+  it("list self-heals orphaned index entries", async () => {
+    await createModelCredential({ ...defaultCreateArgs(redis), name: "alive" });
+    await createModelCredential({ ...defaultCreateArgs(redis), name: "ghost" });
+    redis._store.delete(envelopeKey("12345", "ghost"));
+    const out = await listModelCredentials({ installationId: "12345", redis });
+    expect(out.map((s) => s.name)).toEqual(["alive"]);
+    const idx = redis._store.get(
+      installationIndexKey("12345"),
+    ) as SortedSetEntry[];
+    expect(idx.map((e) => e.member)).toEqual(["alive"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotate
+// ---------------------------------------------------------------------------
+
+describe("rotateModelCredential", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("re-encrypts the new value, updates fingerprint + rotatedAt, preserves provider/kind", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const before = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+
+    const summary = await rotateModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      value: "sk-ant-secret-value-002",
+      rotatedBy: "operator",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+
+    expect(summary.provider).toBe("anthropic");
+    expect(summary.kind).toBe("api_key");
+    expect(summary.rotatedAt).not.toBeNull();
+    expect(summary.fingerprint).not.toBe(before.fingerprint);
+
+    const after = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    expect(decryptModelCredentialPayload(after, KEYRING)).toEqual({
+      kind: "api_key",
+      provider: "anthropic",
+      value: "sk-ant-secret-value-002",
+    });
+    expect(after.ciphertext).not.toBe(before.ciphertext);
+  });
+
+  it("throws NotFound when the credential doesn't exist", async () => {
+    await expect(
+      rotateModelCredential({
+        installationId: "12345",
+        name: "missing",
+        value: "x",
+        rotatedBy: "operator",
+        keyring: KEYRING,
+        keyVersion: "v1",
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revoke
+// ---------------------------------------------------------------------------
+
+describe("revokeModelCredential", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("blanks ciphertext but keeps metadata, sets status=revoked", async () => {
+    await createModelCredential(defaultCreateArgs(redis));
+    const summary = await revokeModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      revokedBy: "operator",
+      redis,
+    });
+    expect(summary.status).toBe("revoked");
+    expect(summary.name).toBe("team-claude");
+    expect(summary.provider).toBe("anthropic");
+    expect(summary.kind).toBe("api_key");
+    expect(summary.fingerprint.length).toBe(8);
+
+    const env = redis._store.get(
+      envelopeKey("12345", "team-claude"),
+    ) as ModelCredentialEnvelopeV1;
+    expect(env.ciphertext).toBe("");
+    expect(env.iv).toBe("");
+    expect(env.tag).toBe("");
+    expect(env.status).toBe("revoked");
+    expect(env.provider).toBe("anthropic");
+    expect(env.fingerprint.length).toBe(8);
+  });
+
+  it("throws NotFound when absent (no cross-tenant oracle)", async () => {
+    await expect(
+      revokeModelCredential({
+        installationId: "12345",
+        name: "missing",
+        revokedBy: "operator",
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// re-encrypt
+// ---------------------------------------------------------------------------
+
+describe("reEncryptModelCredential", () => {
+  let redis: ReturnType<typeof makeMockRedis>;
+  beforeEach(() => {
+    redis = makeMockRedis();
+  });
+
+  it("rebinds ciphertext to the active key version; value round-trips", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      keyring: KEYRING_V2,
+      keyVersion: "v1",
+    });
+    const before = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    expect(before.keyVersion).toBe("v1");
+
+    const result = await reEncryptModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      activeKeyVersion: "v2",
+      keyring: KEYRING_V2,
+      redis,
+    });
+    expect(result.action).toBe("re_encrypted");
+
+    const after = await getModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    expect(after.keyVersion).toBe("v2");
+    expect(decryptModelCredentialPayload(after, KEYRING_V2).value).toBe(
+      "sk-ant-secret-value-001",
+    );
+  });
+
+  it("skips an already-current envelope (idempotent)", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      keyring: KEYRING_V2,
+      keyVersion: "v2",
+    });
+    const result = await reEncryptModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      activeKeyVersion: "v2",
+      keyring: KEYRING_V2,
+      redis,
+    });
+    expect(result.action).toBe("skipped");
+    expect(result.reason).toBe("already_current");
+  });
+
+  it("skips a revoked envelope (no ciphertext to rebind)", async () => {
+    await createModelCredential({
+      ...defaultCreateArgs(redis),
+      keyring: KEYRING_V2,
+      keyVersion: "v1",
+    });
+    await revokeModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      revokedBy: "operator",
+      redis,
+    });
+    const result = await reEncryptModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      activeKeyVersion: "v2",
+      keyring: KEYRING_V2,
+      redis,
+    });
+    expect(result.action).toBe("skipped");
+    expect(result.reason).toBe("revoked");
+  });
+
+  it("throws NotFound when absent", async () => {
+    await expect(
+      reEncryptModelCredential({
+        installationId: "12345",
+        name: "missing",
+        activeKeyVersion: "v2",
+        keyring: KEYRING_V2,
+        redis,
+      }),
+    ).rejects.toThrow(ModelCredentialNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full lifecycle round-trip
+// ---------------------------------------------------------------------------
+
+describe("create → get → list → rotate → revoke round-trip", () => {
+  it("walks the lifecycle and never leaks ciphertext through summaries", async () => {
+    const redis = makeMockRedis();
+    await createModelCredential(defaultCreateArgs(redis));
+
+    const got = await getModelCredentialSummary({
+      installationId: "12345",
+      name: "team-claude",
+      redis,
+    });
+    expect(got.status).toBe("active");
+    expect("ciphertext" in got).toBe(false);
+
+    const list = await listModelCredentials({ installationId: "12345", redis });
+    expect(list).toHaveLength(1);
+
+    const rotated = await rotateModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      value: "sk-ant-secret-value-rotated",
+      rotatedBy: "operator",
+      keyring: KEYRING,
+      keyVersion: "v1",
+      redis,
+    });
+    expect(rotated.rotatedAt).not.toBeNull();
+
+    const revoked = await revokeModelCredential({
+      installationId: "12345",
+      name: "team-claude",
+      revokedBy: "operator",
+      redis,
+    });
+    expect(revoked.status).toBe("revoked");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upstash-Lua compatibility lint (no cjson/cmsgpack/bit/struct)
+// ---------------------------------------------------------------------------
+
+describe("Upstash-Lua compatibility (no sandbox-missing libs)", () => {
+  const source = readFileSync(
+    new URL("./model-credential-store.ts", import.meta.url).pathname,
+    "utf-8",
+  );
+
+  const REDIS_INVOCATION_TOKEN = "redis." + "call(";
+  function extractLuaScripts(src: string): string[] {
+    const scripts: string[] = [];
+    const regex = /`([^`]+)`/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(src)) !== null) {
+      if (match[1].includes(REDIS_INVOCATION_TOKEN)) scripts.push(match[1]);
+    }
+    return scripts;
+  }
+
+  it("has at least one Lua script (sanity)", () => {
+    expect(extractLuaScripts(source).length).toBeGreaterThan(0);
+  });
+
+  it("no Lua script uses cjson / cmsgpack / bit / struct", () => {
+    const patterns = [/\bcjson\./, /\bcmsgpack\./, /\bbit\./, /\bstruct\./];
+    for (const script of extractLuaScripts(source)) {
+      for (const p of patterns) {
+        expect(p.test(script)).toBe(false);
+      }
+    }
+  });
+});

--- a/web/src/server/model-credential-store.ts
+++ b/web/src/server/model-credential-store.ts
@@ -1,0 +1,924 @@
+/**
+ * Model-credential storage layer (MODEL_AUTH_DESIGN.md Stage 1).
+ *
+ * A per-installation, named-record store for the LLM/provider credentials
+ * that dynamically-created agents reference by NAME. It clones the
+ * `agent-token-v1.ts` shape (Redis key namespacing, installation sorted-set
+ * index, audit stream, `withRedisLock`, inline Lua with a TOCTOU-safe
+ * per-installation cap) but DROPS the reverse `hash:{tokenHash}` index:
+ * agent-token has that index purely for bearer→identity auth (a presented
+ * token resolves to an identity). Model credentials are looked up BY NAME
+ * (an agent's engine → a credential name), never by a presented bearer, so
+ * cloning the hash index would add a non-load-bearing key.
+ *
+ * Distinct from BYOK (a single workflow-LLM key per installation, the wrong
+ * cardinality here) and distinct from `agent_token` (a GitHub/health
+ * capability bearer). This module REUSES the BYOK primitives — `crypto.ts`
+ * envelope/keyring and the provider/kind metadata + status + rotate/revoke
+ * lifecycle idea — but with the multi-credential named-record cardinality.
+ *
+ * Storage layout (MODEL_AUTH_DESIGN.md §1.1):
+ *
+ *   hive:v1:model-cred:{installationId}:{name}            string (envelope JSON)
+ *   hive:v1:idx:model-cred:installation:{installationId}  sorted set (names by createdAt)
+ *   hive:v1:model-cred:{installationId}:audit             stream (mutations)
+ *   hive:v1:lock:model-cred:{installationId}:{name}       string (mutation lock)
+ *
+ * Atomicity: create is one inline-Lua EVAL with a zcard cap guard (mirrors
+ * `agent-token-v1.ts`'s ISSUE_TOKEN_SCRIPT, TOCTOU-safe). Every mutation runs
+ * under `withRedisLock`. Audit XADD always goes through an inline-Lua path
+ * (the create script, or UPDATE_CREDENTIAL_SCRIPT for rotate/revoke/
+ * re-encrypt) so there is exactly one XADD code path — and NO Upstash
+ * `cjson`/sandbox-only Lua is used anywhere (see the agent-token cjson
+ * regression that 503'd every Bearer request in prod).
+ *
+ * What this module DOESN'T do (deferred to later stages, by design):
+ *   - delivery: NOTHING reads the decrypted value for the hive yet
+ *     (Stage 3 endpoint + B/B' sealed-box decision). Stage 1 is
+ *     deliberately delivery-agnostic — it only stores + manages, so it is
+ *     identical regardless of the later B-vs-B' delivery choice.
+ *   - agent association (`model_credential_name` on FleetAgent) — Stage 2.
+ *   - apiarist consumption — Stage 4.
+ *   - dashboard UI wiring — Stage 5.
+ */
+
+import { createHash } from "crypto";
+import { type Redis } from "@upstash/redis";
+import { encrypt, decrypt, type EncryptedEnvelope } from "@/server/crypto";
+import { withRedisLock } from "@hivemoot/war-room/redis-lock";
+import { validateName } from "@/server/agent-token-capabilities";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard cap per installation (MODEL_AUTH_DESIGN.md §6.5 — "suggest 20 like
+ * agents/tokens"). Enforced atomically inside the Lua CREATE script (zcard
+ * guard), so concurrent creates can never exceed it (TOCTOU-safe, mirroring
+ * `agent-token-v1.ts`'s ISSUE_TOKEN_SCRIPT). The route layer may override via
+ * the optional `limit` arg, but the script enforces whatever positive int the
+ * caller passes.
+ */
+export const MAX_MODEL_CREDENTIALS_PER_INSTALLATION = 20;
+
+export const ENVELOPE_PREFIX = "hive:v1:model-cred:";
+const INSTALLATION_INDEX_PREFIX = "hive:v1:idx:model-cred:installation:";
+const AUDIT_SUFFIX = ":audit";
+const LOCK_PREFIX = "hive:v1:lock:model-cred:";
+
+/** Trim the audit stream to ~10k entries, matching agent-token-v1. */
+const AUDIT_STREAM_MAXLEN = "10000";
+
+export function envelopeKey(installationId: string, name: string): string {
+  return `${ENVELOPE_PREFIX}${installationId}:${name}`;
+}
+
+export function installationIndexKey(installationId: string): string {
+  return `${INSTALLATION_INDEX_PREFIX}${installationId}`;
+}
+
+export function auditStreamKey(installationId: string): string {
+  return `${ENVELOPE_PREFIX}${installationId}${AUDIT_SUFFIX}`;
+}
+
+export function lockKey(installationId: string, name: string): string {
+  return `${LOCK_PREFIX}${installationId}:${name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Kinds + providers (MODEL_AUTH_DESIGN.md §1.2 / §1.4)
+// ---------------------------------------------------------------------------
+
+/**
+ * The two credential kinds. `api_key` is a single static key string;
+ * `oauth_subscription` covers Claude OAuth (a far-future-expiry string) and
+ * Codex device-auth (a mutable blob). Both store the secret inside the GCM
+ * plaintext; the difference is purely metadata + (later) delivery policy.
+ */
+export type ModelCredentialKind = "api_key" | "oauth_subscription";
+
+const MODEL_CREDENTIAL_KINDS: readonly ModelCredentialKind[] = [
+  "api_key",
+  "oauth_subscription",
+] as const;
+
+export function isModelCredentialKind(
+  value: unknown,
+): value is ModelCredentialKind {
+  return (
+    typeof value === "string" &&
+    (MODEL_CREDENTIAL_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Provider allowlist (MODEL_AUTH_DESIGN.md §1.4). Extensible const — the
+ * single source of truth for which provider labels a model credential may
+ * carry. Validated server-side at create/rotate time so a Redis tamperer
+ * can never introduce an unknown provider, AND so the value is bound inside
+ * the GCM-authenticated plaintext.
+ */
+export const MODEL_CREDENTIAL_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "openrouter",
+  "zai",
+  "google",
+] as const;
+
+export type ModelCredentialProvider =
+  (typeof MODEL_CREDENTIAL_PROVIDERS)[number];
+
+export function isModelCredentialProvider(
+  value: unknown,
+): value is ModelCredentialProvider {
+  return (
+    typeof value === "string" &&
+    (MODEL_CREDENTIAL_PROVIDERS as readonly string[]).includes(value)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The encrypted secret payload (MODEL_AUTH_DESIGN.md §1.3). Serialized to
+ * JSON before encryption so `kind` + `provider` are GCM-authenticated
+ * alongside the secret `value` — a Redis tamperer cannot swap a credential's
+ * provider/kind label without breaking the auth tag (mirrors BYOK's
+ * `JSON.stringify({apiKey,provider,model})` pattern).
+ *
+ *   - api_key            → value = the key string.
+ *   - oauth_subscription → value = the OAuth token string (Claude) OR the
+ *                          JSON-stringified device-auth blob (Codex).
+ */
+export interface ModelCredentialSecretPayload {
+  kind: ModelCredentialKind;
+  provider: ModelCredentialProvider;
+  value: string;
+}
+
+/**
+ * The stored envelope (MODEL_AUTH_DESIGN.md §1.2). Crypto fields hold the
+ * encrypted `ModelCredentialSecretPayload`; the clear metadata never carries
+ * the secret. `kind`/`provider` are duplicated in the clear for cheap
+ * listing/filtering, but the AUTHORITATIVE copies live inside the
+ * GCM-authenticated plaintext (a clear-field tamper is detectable on
+ * decrypt).
+ */
+export interface ModelCredentialEnvelopeV1 {
+  // --- crypto.ts EncryptedEnvelope, inlined (same shape as ByokEnvelope) ---
+  ciphertext: string; // base64 — the secret payload (see §1.3)
+  iv: string; // base64
+  tag: string; // base64 GCM auth tag
+  keyVersion: string; // keyring version that sealed it
+
+  // --- clear metadata (never the secret) ---
+  name: string; // operator-chosen, unique per (installationId, name); NAME_REGEX
+  kind: ModelCredentialKind;
+  provider: ModelCredentialProvider;
+  status: "active" | "revoked";
+  /**
+   * sha256(secret).slice(0,8) — a DISPLAY-only "which key is this?" hint for
+   * the dashboard. Not a leak vector (8 hex chars of a SHA-256, never the
+   * value). Same trade `agent-token-v1` makes. On revoke the fingerprint is
+   * preserved (metadata-for-audit) even though the ciphertext is blanked.
+   */
+  fingerprint: string;
+  createdAt: string; // ISO 8601
+  createdBy: string; // GitHub login (operator), like ByokEnvelope.updatedBy
+  rotatedAt: string | null;
+  expiresAt: string | null; // soft hint (Claude OAuth ~1yr, manual API keys = null)
+  /**
+   * Fetch-path control (MODEL_AUTH_DESIGN.md §3). true = backend MAY serve
+   * the decrypted value to the hive (api_key, Claude OAuth string). false =
+   * local-only (Codex device-auth refresh state) — never fetched. Stage 1
+   * stores it; NOTHING reads it for delivery yet.
+   */
+  deliverable: boolean;
+}
+
+/**
+ * Per-installation summary returned by `listModelCredentials` /
+ * `getModelCredentialSummary`. EXCLUDES every crypto field — the ciphertext
+ * is never returned for listing/metadata reads (we never decrypt for
+ * listing). Mirrors `AgentTokenSummaryV1`.
+ */
+export interface ModelCredentialSummaryV1 {
+  name: string;
+  kind: ModelCredentialKind;
+  provider: ModelCredentialProvider;
+  status: "active" | "revoked";
+  fingerprint: string;
+  createdAt: string;
+  createdBy: string;
+  rotatedAt: string | null;
+  expiresAt: string | null;
+  deliverable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors
+// ---------------------------------------------------------------------------
+
+export class NameTakenError extends Error {
+  constructor(installationId: string, name: string) {
+    super(
+      `Model credential '${name}' already exists for installation ${installationId}`,
+    );
+    this.name = "NameTakenError";
+  }
+}
+
+export class LimitReachedError extends Error {
+  constructor(installationId: string, limit: number) {
+    super(
+      `Installation ${installationId} is at the ${limit}-model-credential limit; revoke an unused credential before creating a new one`,
+    );
+    this.name = "LimitReachedError";
+  }
+}
+
+export class ModelCredentialNotFoundError extends Error {
+  constructor(installationId: string, name: string) {
+    super(
+      `No model credential named '${name}' for installation ${installationId}`,
+    );
+    this.name = "ModelCredentialNotFoundError";
+  }
+}
+
+/**
+ * Thrown for an unknown `kind` at write time. Distinct from the route-layer
+ * error vocabulary so the storage layer stays HTTP-agnostic (the route maps
+ * it to `invalid_kind`).
+ */
+export class InvalidKindError extends Error {
+  public readonly value: unknown;
+  constructor(value: unknown) {
+    super(
+      `Invalid model credential kind ${JSON.stringify(value)} — expected one of: ${MODEL_CREDENTIAL_KINDS.join(", ")}`,
+    );
+    this.name = "InvalidKindError";
+    this.value = value;
+  }
+}
+
+/** Thrown for an unknown `provider` at write time (route maps to invalid_provider). */
+export class InvalidProviderError extends Error {
+  public readonly value: unknown;
+  constructor(value: unknown) {
+    super(
+      `Invalid model credential provider ${JSON.stringify(value)} — expected one of: ${MODEL_CREDENTIAL_PROVIDERS.join(", ")}`,
+    );
+    this.name = "InvalidProviderError";
+    this.value = value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lua scripts (no cjson / cmsgpack / bit / struct — Upstash sandbox safe)
+// ---------------------------------------------------------------------------
+
+/**
+ * CREATE_CREDENTIAL_SCRIPT — atomic create. Mirrors `agent-token-v1.ts`'s
+ * ISSUE_TOKEN_SCRIPT zcard cap guard so the per-installation cap is enforced
+ * INSIDE the EVAL (closes the TOCTOU window between a client-side count and
+ * the write). Audit emit happens in the same EVAL when ARGV[4] is non-empty.
+ *
+ * No reverse hash index (dropped per §1.1) and no envelope TTL (model
+ * credentials are long-lived; `expiresAt` is a soft display hint only, not
+ * a Redis-enforced lifecycle — distinct from agent-token's explicit-expiry
+ * envelopes).
+ *
+ * KEYS: [envelopeKey, installationSortedSetKey, auditStreamKey]
+ * ARGV: [name, envelopeJson, createdAtMs, auditEntryJsonOrEmpty, limit]
+ *
+ * Returns:
+ *   {1, name}            success
+ *   {0, "name_taken"}    name already exists for this installation
+ *   {-1, "limit"}        installation already at `limit` names
+ */
+const CREATE_CREDENTIAL_SCRIPT = `
+local existing = redis.call("get", KEYS[1])
+if existing then return {0, "name_taken"} end
+local count = redis.call("zcard", KEYS[2])
+if count >= tonumber(ARGV[5]) then return {-1, "limit"} end
+redis.call("set", KEYS[1], ARGV[2])
+redis.call("zadd", KEYS[2], tonumber(ARGV[3]), ARGV[1])
+if ARGV[4] ~= "" then
+  redis.call("xadd", KEYS[3], "MAXLEN", "~", "${AUDIT_STREAM_MAXLEN}", "*", "entry", ARGV[4])
+end
+return {1, ARGV[1]}
+`;
+
+/**
+ * UPDATE_CREDENTIAL_SCRIPT — atomic in-place envelope replace (+ optional
+ * audit XADD). Used by rotate / revoke / re-encrypt: the caller has already
+ * read the existing envelope under the lock, computed the new envelope JSON,
+ * and built the audit entry. This script does the SET + audit XADD in one
+ * EVAL so the mutation and its audit row land together. It does NOT recheck
+ * existence — the caller's pre-read under the same lock is authoritative (the
+ * lock serializes all mutations for this name).
+ *
+ * KEYS: [envelopeKey, auditStreamKey]
+ * ARGV: [newEnvelopeJson, auditEntryJsonOrEmpty]
+ *
+ * Returns: {1}
+ */
+const UPDATE_CREDENTIAL_SCRIPT = `
+redis.call("set", KEYS[1], ARGV[1])
+if ARGV[2] ~= "" then
+  redis.call("xadd", KEYS[2], "MAXLEN", "~", "${AUDIT_STREAM_MAXLEN}", "*", "entry", ARGV[2])
+end
+return {1}
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * DISPLAY-only fingerprint: the first 8 hex chars of sha256(secret). Derived
+ * from the SECRET VALUE (not a random token) so the dashboard can answer
+ * "is this the same key I pasted?" without ever surfacing the value. 8 hex
+ * chars of a SHA-256 is not a practical leak vector and can never equal the
+ * value itself.
+ */
+function fingerprintSecret(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 8);
+}
+
+interface ScriptResult {
+  ok: number;
+  reason?: string;
+}
+
+/** Normalize the Lua `[tag, payload]` return (see agent-token-v1). */
+function dispatchScriptResult(raw: unknown): ScriptResult {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(
+      `Lua script returned malformed result: ${JSON.stringify(raw)}`,
+    );
+  }
+  const tag = Number(raw[0]);
+  const payload = raw.length > 1 ? String(raw[1]) : undefined;
+  return { ok: tag, reason: payload };
+}
+
+/**
+ * Validate kind + provider server-side (MODEL_AUTH_DESIGN.md §1, §6.6).
+ * Both are bound inside the GCM plaintext; rejecting unknown values here
+ * keeps the stored set closed and fail-closed.
+ */
+function assertKind(kind: unknown): asserts kind is ModelCredentialKind {
+  if (!isModelCredentialKind(kind)) {
+    throw new InvalidKindError(kind);
+  }
+}
+
+function assertProvider(
+  provider: unknown,
+): asserts provider is ModelCredentialProvider {
+  if (!isModelCredentialProvider(provider)) {
+    throw new InvalidProviderError(provider);
+  }
+}
+
+function summarize(
+  envelope: ModelCredentialEnvelopeV1,
+): ModelCredentialSummaryV1 {
+  return {
+    name: envelope.name,
+    kind: envelope.kind,
+    provider: envelope.provider,
+    status: envelope.status,
+    fingerprint: envelope.fingerprint,
+    createdAt: envelope.createdAt,
+    createdBy: envelope.createdBy,
+    rotatedAt: envelope.rotatedAt,
+    expiresAt: envelope.expiresAt,
+    deliverable: envelope.deliverable,
+  };
+}
+
+/** Operator identity for the audit trail. */
+export interface ModelCredentialAuditContext {
+  operator: string; // GitHub login
+}
+
+function buildAuditEntry(args: {
+  action: "create" | "rotate" | "revoke" | "re_encrypt";
+  name: string;
+  operator: string;
+  detail?: Record<string, unknown>;
+}): string {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    action: args.action,
+    name: args.name,
+    actor: args.operator,
+    ...(args.detail ? { detail: args.detail } : {}),
+  });
+}
+
+/** Run UPDATE_CREDENTIAL_SCRIPT (SET + optional audit XADD) in one EVAL. */
+async function writeEnvelope(
+  redis: Redis,
+  installationId: string,
+  name: string,
+  envelope: ModelCredentialEnvelopeV1,
+  auditEntry: string,
+): Promise<void> {
+  dispatchScriptResult(
+    await redis.eval(
+      UPDATE_CREDENTIAL_SCRIPT,
+      [envelopeKey(installationId, name), auditStreamKey(installationId)],
+      [JSON.stringify(envelope), auditEntry],
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new model credential under `(installationId, name)`. Validates
+ * name/kind/provider at write time (fail-closed), encrypts the
+ * `{kind, provider, value}` payload, then atomically stores it under the
+ * per-key lock with the Lua cap guard.
+ *
+ * `installationId` is supplied by the caller from the AUTHENTICATED
+ * principal — never from request input. Every key embeds it, so a foreign
+ * name resolves to a miss in the caller's namespace (no cross-tenant oracle).
+ *
+ * Throws:
+ *   - `CapabilityValidationError` on bad name (reused NAME_REGEX validator)
+ *   - `InvalidKindError` / `InvalidProviderError` on bad kind/provider
+ *   - `NameTakenError` if `(installationId, name)` already exists
+ *   - `LimitReachedError` if the installation is at the cap
+ */
+export async function createModelCredential(args: {
+  installationId: string;
+  name: string;
+  kind: ModelCredentialKind;
+  provider: ModelCredentialProvider;
+  /** The raw secret: an api key string, or the OAuth token / device-auth blob. */
+  value: string;
+  createdBy: string;
+  expiresAt?: string | null;
+  deliverable: boolean;
+  keyring: Map<string, Buffer>;
+  keyVersion: string;
+  redis: Redis;
+  limit?: number;
+  auditContext?: ModelCredentialAuditContext;
+}): Promise<ModelCredentialSummaryV1> {
+  validateName(args.name);
+  assertKind(args.kind);
+  assertProvider(args.provider);
+
+  const limit = args.limit ?? MAX_MODEL_CREDENTIALS_PER_INSTALLATION;
+  if (limit <= 0) {
+    throw new Error(`limit must be positive (got ${limit})`);
+  }
+
+  const payload: ModelCredentialSecretPayload = {
+    kind: args.kind,
+    provider: args.provider,
+    value: args.value,
+  };
+  const encrypted: EncryptedEnvelope = encrypt(
+    JSON.stringify(payload),
+    args.keyVersion,
+    args.keyring,
+  );
+
+  const createdAtMs = Date.now();
+  const createdAtIso = new Date(createdAtMs).toISOString();
+
+  const envelope: ModelCredentialEnvelopeV1 = {
+    ciphertext: encrypted.ciphertext,
+    iv: encrypted.iv,
+    tag: encrypted.tag,
+    keyVersion: encrypted.keyVersion,
+    name: args.name,
+    kind: args.kind,
+    provider: args.provider,
+    status: "active",
+    fingerprint: fingerprintSecret(args.value),
+    createdAt: createdAtIso,
+    createdBy: args.createdBy,
+    rotatedAt: null,
+    expiresAt: args.expiresAt ?? null,
+    deliverable: args.deliverable,
+  };
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const auditEntry = args.auditContext
+        ? buildAuditEntry({
+            action: "create",
+            name: args.name,
+            operator: args.auditContext.operator,
+            detail: {
+              kind: args.kind,
+              provider: args.provider,
+              fingerprint: envelope.fingerprint,
+              deliverable: args.deliverable,
+            },
+          })
+        : "";
+
+      const result = dispatchScriptResult(
+        await args.redis.eval(
+          CREATE_CREDENTIAL_SCRIPT,
+          [
+            envelopeKey(args.installationId, args.name),
+            installationIndexKey(args.installationId),
+            auditStreamKey(args.installationId),
+          ],
+          [
+            args.name,
+            JSON.stringify(envelope),
+            String(createdAtMs),
+            auditEntry,
+            String(limit),
+          ],
+        ),
+      );
+
+      if (result.ok === 0 && result.reason === "name_taken") {
+        throw new NameTakenError(args.installationId, args.name);
+      }
+      if (result.ok === -1 && result.reason === "limit") {
+        throw new LimitReachedError(args.installationId, limit);
+      }
+      if (result.ok !== 1) {
+        throw new Error(
+          `CREATE_CREDENTIAL_SCRIPT returned unexpected result: ${JSON.stringify(result)}`,
+        );
+      }
+      return summarize(envelope);
+    },
+  );
+}
+
+/**
+ * Read the FULL envelope (including crypto fields) by name. INTERNAL — for
+ * lifecycle ops (rotate/re-encrypt) and the future Stage-3 delivery path.
+ * Never expose its result over an HTTP read; use `getModelCredentialSummary`
+ * for anything client-facing.
+ *
+ * Throws `ModelCredentialNotFoundError` (same 404 for "not yours" and
+ * "doesn't exist" — the key embeds installationId, so there is no
+ * cross-tenant existence oracle).
+ */
+export async function getModelCredential(args: {
+  installationId: string;
+  name: string;
+  redis: Redis;
+}): Promise<ModelCredentialEnvelopeV1> {
+  const raw = await args.redis.get<ModelCredentialEnvelopeV1>(
+    envelopeKey(args.installationId, args.name),
+  );
+  if (!raw) {
+    throw new ModelCredentialNotFoundError(args.installationId, args.name);
+  }
+  return raw;
+}
+
+/**
+ * Read a single credential SUMMARY by name. Excludes all crypto fields —
+ * safe for client-facing GETs. Throws `ModelCredentialNotFoundError`.
+ */
+export async function getModelCredentialSummary(args: {
+  installationId: string;
+  name: string;
+  redis: Redis;
+}): Promise<ModelCredentialSummaryV1> {
+  const raw = await getModelCredential(args);
+  return summarize(raw);
+}
+
+/**
+ * List credential summaries for an installation in creation order (by
+ * `createdAt` epoch ms via the sorted-set score). Excludes encrypted
+ * ciphertext.
+ *
+ * Self-healing: opportunistically prunes orphaned sorted-set entries whose
+ * envelopes are gone (best-effort, mirrors `listAgentTokens`). Keeps the
+ * listing accurate AND ensures the cap doesn't count ghosts.
+ */
+export async function listModelCredentials(args: {
+  installationId: string;
+  redis: Redis;
+}): Promise<ModelCredentialSummaryV1[]> {
+  const names = await args.redis.zrange<string[]>(
+    installationIndexKey(args.installationId),
+    0,
+    -1,
+  );
+  if (names.length === 0) return [];
+
+  const envelopes = await Promise.all(
+    names.map((name) =>
+      args.redis.get<ModelCredentialEnvelopeV1>(
+        envelopeKey(args.installationId, name),
+      ),
+    ),
+  );
+
+  const out: ModelCredentialSummaryV1[] = [];
+  const orphans: string[] = [];
+  for (let i = 0; i < envelopes.length; i++) {
+    const env = envelopes[i];
+    if (env !== null) {
+      out.push(summarize(env));
+    } else {
+      orphans.push(names[i]);
+    }
+  }
+
+  if (orphans.length > 0) {
+    await Promise.all(
+      orphans.map((name) =>
+        args.redis
+          .zrem(installationIndexKey(args.installationId), name)
+          .catch((err: unknown) => {
+            console.warn(
+              `[model-credential] failed to ZREM orphaned index entry ${args.installationId}:${name}`,
+              err,
+            );
+          }),
+      ),
+    );
+  }
+  return out;
+}
+
+/**
+ * Rotate a credential's secret VALUE in place (MODEL_AUTH_DESIGN.md §5.3 —
+ * "new value, re-validate+re-encrypt"). Validation of the new value (live
+ * provider probe for api_key) happens at the route layer BEFORE this call;
+ * the store re-encrypts the new `{kind, provider, value}` payload, updates
+ * the fingerprint + `rotatedAt`, and preserves all other metadata.
+ *
+ * `provider` and `kind` are NOT rotatable here — a credential's provider/kind
+ * is fixed at create (changing it would be a new credential). Rotate only
+ * swaps the secret value.
+ *
+ * Throws `ModelCredentialNotFoundError` if the name doesn't exist for this
+ * installation (no cross-tenant oracle).
+ */
+export async function rotateModelCredential(args: {
+  installationId: string;
+  name: string;
+  /** The new raw secret value (already provider-validated by the route). */
+  value: string;
+  rotatedBy: string;
+  expiresAt?: string | null;
+  keyring: Map<string, Buffer>;
+  keyVersion: string;
+  redis: Redis;
+  auditContext?: ModelCredentialAuditContext;
+}): Promise<ModelCredentialSummaryV1> {
+  validateName(args.name);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const existing = await args.redis.get<ModelCredentialEnvelopeV1>(
+        envelopeKey(args.installationId, args.name),
+      );
+      if (!existing) {
+        throw new ModelCredentialNotFoundError(args.installationId, args.name);
+      }
+
+      const payload: ModelCredentialSecretPayload = {
+        kind: existing.kind,
+        provider: existing.provider,
+        value: args.value,
+      };
+      const encrypted = encrypt(
+        JSON.stringify(payload),
+        args.keyVersion,
+        args.keyring,
+      );
+
+      const updated: ModelCredentialEnvelopeV1 = {
+        ...existing,
+        ciphertext: encrypted.ciphertext,
+        iv: encrypted.iv,
+        tag: encrypted.tag,
+        keyVersion: encrypted.keyVersion,
+        // Rotating a revoked credential reactivates it with a fresh value —
+        // the new value is live, so the status must reflect that.
+        status: "active",
+        fingerprint: fingerprintSecret(args.value),
+        rotatedAt: new Date().toISOString(),
+        // expiresAt: refresh if the caller supplied one (e.g. a new Claude
+        // OAuth token's ~1yr horizon); otherwise preserve the existing hint.
+        expiresAt:
+          args.expiresAt !== undefined ? args.expiresAt : existing.expiresAt,
+      };
+
+      const auditEntry = args.auditContext
+        ? buildAuditEntry({
+            action: "rotate",
+            name: args.name,
+            operator: args.auditContext.operator,
+            detail: {
+              fingerprint_old: existing.fingerprint,
+              fingerprint_new: updated.fingerprint,
+            },
+          })
+        : "";
+
+      await writeEnvelope(
+        args.redis,
+        args.installationId,
+        args.name,
+        updated,
+        auditEntry,
+      );
+      return summarize(updated);
+    },
+  );
+}
+
+/**
+ * Revoke a credential (MODEL_AUTH_DESIGN.md §5.3 — "status→revoked + blank
+ * ciphertext, keep metadata for audit"). Mirrors `byok/revoke` semantics:
+ * the crypto fields are cleared so no key material can be recovered, but the
+ * clear metadata (name, kind, provider, fingerprint, timestamps) is preserved
+ * for the audit trail and the dashboard's revoked-credential row.
+ *
+ * Throws `ModelCredentialNotFoundError` if absent (no cross-tenant oracle).
+ */
+export async function revokeModelCredential(args: {
+  installationId: string;
+  name: string;
+  revokedBy: string;
+  redis: Redis;
+  auditContext?: ModelCredentialAuditContext;
+}): Promise<ModelCredentialSummaryV1> {
+  validateName(args.name);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const existing = await args.redis.get<ModelCredentialEnvelopeV1>(
+        envelopeKey(args.installationId, args.name),
+      );
+      if (!existing) {
+        throw new ModelCredentialNotFoundError(args.installationId, args.name);
+      }
+
+      const revoked: ModelCredentialEnvelopeV1 = {
+        ...existing,
+        status: "revoked",
+        // Blank all crypto fields — the secret is unrecoverable post-revoke.
+        ciphertext: "",
+        iv: "",
+        tag: "",
+        // keyVersion/fingerprint/kind/provider/timestamps preserved for audit.
+      };
+
+      const auditEntry = args.auditContext
+        ? buildAuditEntry({
+            action: "revoke",
+            name: args.name,
+            operator: args.auditContext.operator,
+            detail: { fingerprint_revoked: existing.fingerprint },
+          })
+        : "";
+
+      await writeEnvelope(
+        args.redis,
+        args.installationId,
+        args.name,
+        revoked,
+        auditEntry,
+      );
+      return summarize(revoked);
+    },
+  );
+}
+
+/**
+ * Re-encrypt a credential's envelope under the current active master key
+ * version (MODEL_AUTH_DESIGN.md §5.3 — "master-key rebind"). Mirrors
+ * `byok/re-encrypt`: decrypt with the old key, re-encrypt with the active
+ * key, preserve everything else. Skips revoked envelopes (no ciphertext to
+ * rebind) and already-current envelopes (idempotent).
+ *
+ * Returns the action taken so the route can report a useful summary.
+ * Throws `ModelCredentialNotFoundError` if absent.
+ */
+export async function reEncryptModelCredential(args: {
+  installationId: string;
+  name: string;
+  activeKeyVersion: string;
+  keyring: Map<string, Buffer>;
+  redis: Redis;
+  auditContext?: ModelCredentialAuditContext;
+}): Promise<{ action: "re_encrypted" | "skipped"; reason?: string }> {
+  validateName(args.name);
+
+  return await withRedisLock(
+    lockKey(args.installationId, args.name),
+    args.redis,
+    async () => {
+      const existing = await args.redis.get<ModelCredentialEnvelopeV1>(
+        envelopeKey(args.installationId, args.name),
+      );
+      if (!existing) {
+        throw new ModelCredentialNotFoundError(args.installationId, args.name);
+      }
+
+      if (existing.status === "revoked") {
+        return { action: "skipped" as const, reason: "revoked" };
+      }
+      if (existing.keyVersion === args.activeKeyVersion) {
+        return { action: "skipped" as const, reason: "already_current" };
+      }
+
+      const plaintext = decrypt(
+        {
+          ciphertext: existing.ciphertext,
+          iv: existing.iv,
+          tag: existing.tag,
+          keyVersion: existing.keyVersion,
+        },
+        args.keyring,
+      );
+      const reEncrypted = encrypt(
+        plaintext,
+        args.activeKeyVersion,
+        args.keyring,
+      );
+
+      const updated: ModelCredentialEnvelopeV1 = {
+        ...existing,
+        ciphertext: reEncrypted.ciphertext,
+        iv: reEncrypted.iv,
+        tag: reEncrypted.tag,
+        keyVersion: reEncrypted.keyVersion,
+      };
+
+      const auditEntry = args.auditContext
+        ? buildAuditEntry({
+            action: "re_encrypt",
+            name: args.name,
+            operator: args.auditContext.operator,
+            detail: {
+              from_key_version: existing.keyVersion,
+              to_key_version: args.activeKeyVersion,
+            },
+          })
+        : "";
+
+      await writeEnvelope(
+        args.redis,
+        args.installationId,
+        args.name,
+        updated,
+        auditEntry,
+      );
+      return { action: "re_encrypted" as const };
+    },
+  );
+}
+
+/**
+ * Decrypt + parse a credential's secret payload. INTERNAL — reserved for the
+ * Stage-3 delivery path (and tests asserting the round-trip). NEVER call this
+ * from a client-facing read.
+ *
+ * The parsed `kind`/`provider` come from the GCM-authenticated plaintext, so
+ * they are tamper-evident (a Redis edit of the clear metadata can't change
+ * what comes out here without breaking the auth tag).
+ */
+export function decryptModelCredentialPayload(
+  envelope: ModelCredentialEnvelopeV1,
+  keyring: Map<string, Buffer>,
+): ModelCredentialSecretPayload {
+  const plaintext = decrypt(
+    {
+      ciphertext: envelope.ciphertext,
+      iv: envelope.iv,
+      tag: envelope.tag,
+      keyVersion: envelope.keyVersion,
+    },
+    keyring,
+  );
+  return JSON.parse(plaintext) as ModelCredentialSecretPayload;
+}

--- a/web/src/server/model-credential-store.ts
+++ b/web/src/server/model-credential-store.ts
@@ -584,6 +584,10 @@ export async function getModelCredential(args: {
   name: string;
   redis: Redis;
 }): Promise<ModelCredentialEnvelopeV1> {
+  // Validate the name before it becomes a Redis key segment — defense in depth,
+  // matching every mutation path. A malformed name can't forge a key shape; it
+  // surfaces as the same NotFound a missing name would (no existence oracle).
+  validateName(args.name);
   const raw = await args.redis.get<ModelCredentialEnvelopeV1>(
     envelopeKey(args.installationId, args.name),
   );

--- a/web/src/server/model-credential-store.ts
+++ b/web/src/server/model-credential-store.ts
@@ -46,7 +46,10 @@ import { createHash } from "crypto";
 import { type Redis } from "@upstash/redis";
 import { encrypt, decrypt, type EncryptedEnvelope } from "@/server/crypto";
 import { withRedisLock } from "@hivemoot/war-room/redis-lock";
-import { validateName } from "@/server/agent-token-capabilities";
+import {
+  validateName,
+  CapabilityValidationError,
+} from "@/server/agent-token-capabilities";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -84,6 +87,33 @@ export function auditStreamKey(installationId: string): string {
 
 export function lockKey(installationId: string, name: string): string {
   return `${LOCK_PREFIX}${installationId}:${name}`;
+}
+
+/**
+ * Names that would collide with a non-envelope Redis key in this namespace.
+ * NAME_REGEX permits these, but `auditStreamKey(id)` is `…:{id}:audit` and
+ * `envelopeKey(id, "audit")` is byte-identical — so a credential literally named
+ * `audit` would alias the installation's audit STREAM with a STRING, a WRONGTYPE
+ * collision that corrupts the whole installation's audit trail. Reject the
+ * reserved suffix(es) on every path (create AND every by-name read/mutation) so
+ * such a name can never be addressed. Keep in sync with the key constructors above.
+ */
+const RESERVED_CREDENTIAL_NAMES: ReadonlySet<string> = new Set(["audit"]);
+
+/**
+ * Validate a credential name at every boundary: NAME_REGEX (shared with
+ * agent-tokens) PLUS a reserved-suffix guard. Throws `CapabilityValidationError`
+ * so the route layer maps it to `invalid_name` uniformly.
+ */
+function assertValidCredentialName(name: string): void {
+  validateName(name);
+  if (RESERVED_CREDENTIAL_NAMES.has(name)) {
+    throw new CapabilityValidationError(
+      "name",
+      name,
+      `'${name}' is reserved (it collides with an internal key) — choose another name`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +293,21 @@ export class InvalidKindError extends Error {
     );
     this.name = "InvalidKindError";
     this.value = value;
+  }
+}
+
+/**
+ * Thrown when a mutation targets a revoked credential. Revoke is terminal:
+ * a revoked credential cannot be rotated or otherwise resurrected (design §6
+ * "mutating an already-revoked envelope fails closed", matching the agent-token
+ * sibling's TokenExpiredForMutation). Route maps it to `revoked` / HTTP 409.
+ */
+export class RevokedCredentialError extends Error {
+  constructor(installationId: string, name: string) {
+    super(
+      `Model credential '${name}' for installation ${installationId} is revoked and cannot be mutated`,
+    );
+    this.name = "RevokedCredentialError";
   }
 }
 
@@ -477,7 +522,7 @@ export async function createModelCredential(args: {
   limit?: number;
   auditContext?: ModelCredentialAuditContext;
 }): Promise<ModelCredentialSummaryV1> {
-  validateName(args.name);
+  assertValidCredentialName(args.name);
   assertKind(args.kind);
   assertProvider(args.provider);
 
@@ -587,7 +632,7 @@ export async function getModelCredential(args: {
   // Validate the name before it becomes a Redis key segment — defense in depth,
   // matching every mutation path. A malformed name can't forge a key shape; it
   // surfaces as the same NotFound a missing name would (no existence oracle).
-  validateName(args.name);
+  assertValidCredentialName(args.name);
   const raw = await args.redis.get<ModelCredentialEnvelopeV1>(
     envelopeKey(args.installationId, args.name),
   );
@@ -692,7 +737,7 @@ export async function rotateModelCredential(args: {
   redis: Redis;
   auditContext?: ModelCredentialAuditContext;
 }): Promise<ModelCredentialSummaryV1> {
-  validateName(args.name);
+  assertValidCredentialName(args.name);
 
   return await withRedisLock(
     lockKey(args.installationId, args.name),
@@ -703,6 +748,12 @@ export async function rotateModelCredential(args: {
       );
       if (!existing) {
         throw new ModelCredentialNotFoundError(args.installationId, args.name);
+      }
+      // Revoke is terminal — fail closed on a revoked credential (design §6,
+      // matching the agent-token sibling). To put a credential back in service
+      // the operator creates a new one; rotate never resurrects a revoked record.
+      if (existing.status === "revoked") {
+        throw new RevokedCredentialError(args.installationId, args.name);
       }
 
       const payload: ModelCredentialSecretPayload = {
@@ -722,8 +773,8 @@ export async function rotateModelCredential(args: {
         iv: encrypted.iv,
         tag: encrypted.tag,
         keyVersion: encrypted.keyVersion,
-        // Rotating a revoked credential reactivates it with a fresh value —
-        // the new value is live, so the status must reflect that.
+        // Status stays "active" (guaranteed above: a revoked record can't reach
+        // here). Rotate replaces the secret of a live credential.
         status: "active",
         fingerprint: fingerprintSecret(args.value),
         rotatedAt: new Date().toISOString(),
@@ -773,7 +824,7 @@ export async function revokeModelCredential(args: {
   redis: Redis;
   auditContext?: ModelCredentialAuditContext;
 }): Promise<ModelCredentialSummaryV1> {
-  validateName(args.name);
+  assertValidCredentialName(args.name);
 
   return await withRedisLock(
     lockKey(args.installationId, args.name),
@@ -835,7 +886,7 @@ export async function reEncryptModelCredential(args: {
   redis: Redis;
   auditContext?: ModelCredentialAuditContext;
 }): Promise<{ action: "re_encrypted" | "skipped"; reason?: string }> {
-  validateName(args.name);
+  assertValidCredentialName(args.name);
 
   return await withRedisLock(
     lockKey(args.installationId, args.name),


### PR DESCRIPTION
## What

Stage 1 of the dynamic-agent model-auth design (`MODEL_AUTH_DESIGN.md`): a per-installation, encrypted **model-credential store** so dashboard-created agents can later be associated with an LLM credential (API key or OAuth/subscription) by name — the same way an agent already references an `agent_token` by name.

**Backend storage only.** Nothing consumes credentials for delivery yet (that's the later, B-vs-B′ delivery stage), so this has **zero fleet impact** and is fully additive (no edits to existing files).

## Why

Agents are now created from the website with an engine (Claude/Codex/zai/…), but there was no story for how a website-created agent obtains its model credential. This lays the storage foundation, reusing the proven BYOK + agent-token primitives.

## What it looks like

A new per-installation named-record store (cloning `agent-token-v1` shape + the BYOK `crypto.ts` AES-256-GCM versioned-keyring envelope):

```
hive:v1:model-cred:{installationId}:{name}            encrypted envelope
hive:v1:idx:model-cred:installation:{installationId}   sorted-set index
hive:v1:model-cred:{installationId}:audit              audit stream
```

Record: `{ kind: api_key | oauth_subscription, provider, status, fingerprint, … }` with `{kind, provider, value}` sealed inside the GCM-authenticated plaintext. Routes mirror the agent-token/BYOK surface:

```
POST   /api/model-credentials            create (requireFresh; live-probes api_key before store)
GET    /api/model-credentials            list summaries (never ciphertext)
GET    /api/model-credentials/{name}     summary (never ciphertext)
POST   /api/model-credentials/{name}/rotate | /revoke | /re-encrypt   (requireFresh)
```

Plus `model-credential-engine-policy.ts` — validates a credential's provider/kind against an engine (codex→openai oauth-only, kimi/minimax→openrouter, zai→zai, claude→anthropic, gemini→google), so Stage 2 can reject an engine↔credential mismatch.

## Proof

- `tsc` + lint (0 errors) + **2183 vitest passing** + `next build` (all 5 routes compiled) — green on current `main`.
- Adversarial security review (4 dimensions: secret-handling / isolation / crypto+atomicity / tests): **0 blocking, 0 high.** Secret-handling dimension fully clean — ciphertext never returned by any GET/list, value never logged, fingerprint is sha256-derived.
- This PR includes two review hardening fixes: `validateName` on read paths (parity with mutations), and explicit `{ requireFresh: false }` on GETs.

## Open question for reviewers (please weigh in)

**`rotate` on a revoked credential currently reactivates it** (`status → active` with the new value). The design doc §6 lists "mutating an already-revoked envelope fails closed" as an invariant, and `re-encrypt` correctly skips revoked — so `rotate` contradicts the stated invariant. Two reasonable readings: (a) fail-closed (revoke is terminal; un-revoke = create a new credential), or (b) rotate-as-reactivate is intended UX. I left the author's documented behavior (b) in place pending your call; happy to flip to (a) to match the design doc.

## Follow-ups (non-blocking, tracked)

- Add IDOR tests where a name exists under a *different* installationId for `rotate`/`re-encrypt`/`getSummary` (source is correctly installation-scoped; coverage gap only).
- Assert ciphertext-exclusion on `rotate`/`re-encrypt` return shapes (asserted on create/get/list/revoke already).
- Add a GCM-tamper negative test and a lock-contention (`LockTimeoutError` → 503) test.
- Cross-cutting (affects BYOK too): consider binding `installationId+name` into GCM AAD — only matters under raw-Redis-write compromise; deferred.

The delivery stage (how the hive obtains the value JIT) is **not** in this PR and depends on the B-vs-B′ decision in `MODEL_AUTH_DESIGN.md` §3.
